### PR TITLE
Glamorous types (WIP)

### DIFF
--- a/definitions/npm/glamorous_v4.x.x/.flowconfig
+++ b/definitions/npm/glamorous_v4.x.x/.flowconfig
@@ -1,0 +1,5 @@
+[libs]
+flow_v0.57.x-/glamorous_v4.x.x.js
+
+[options]
+suppress_comment=\\(.\\|\n\\)*\\$ExpectError

--- a/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
+++ b/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
@@ -1,0 +1,187 @@
+declare module "glamorous" {
+  declare type SingleOrArray<Properties, T: $Keys<Properties>> = $ObjMap<
+    Properties,
+    <P>(P) => P | P[]
+  >;
+
+  declare type CSSPropertiesCompleteSingle = {|
+    display?: string,
+    color?: string,
+    marginLeft?: number | string
+  |};
+  declare type CSSPropertiesComplete = SingleOrArray<
+    CSSPropertiesCompleteSingle,
+    $Keys<CSSPropertiesCompleteSingle>
+  >;
+  declare export type CSSProperties = {
+    ...CSSPropertiesComplete,
+    [string]: CSSProperties
+  };
+  declare type SVGProperties = {||};
+
+  declare type HTMLTagName =
+    | "a"
+    | "button"
+    | "div"
+    | "footer"
+    | "h1"
+    | "h2"
+    | "img"
+    | "input"
+    | "label"
+    | "li"
+    | "ol"
+    | "section"
+    | "select"
+    | "span"
+    | "table"
+    | "td"
+    | "textarea"
+    | "th"
+    | "tr"
+    | "ul";
+
+  declare type GlamorousOptions<Props, Context, DefaultProps> = $Shape<{|
+    displayName: string,
+    rootEl: string | HTMLElement,
+    filterProps: string[],
+    forwardProps: string[],
+    shouldClassNameUpdate: (
+      props: Props,
+      prevProps: Props,
+      context: Context,
+      prevContext: Context
+    ) => boolean,
+    propsAreCssOverrides?: false,
+    withProps: $Shape<DefaultProps>
+  |}>;
+
+  declare type GlamorousProps = { className?: string, theme?: Object };
+
+  declare export type ExtraGlamorousProps = {
+    /**
+     * Called with the inner element's reference
+     */
+    innerRef?: (instance: any) => void,
+
+    className?: string,
+    /**
+     * Same type as any of the styles provided, will be merged with this
+     * component's styles and take highest priority over the component's
+     * predefined styles
+     */
+    css?: CSSProperties,
+    theme?: Object
+  };
+
+  declare type GlamorousComponentFunctions<ExternalProps, Props> = {
+    /**
+     * Copies the styles of an already created glamorous component with a different tag
+     */
+    withComponent: (
+      component: string | React$Component<Props>
+    ) => GlamorousComponent<ExternalProps, Props>,
+
+    /**
+     * Applies props by default for a component
+     */
+    withProps: <DefaultProps: {}>(
+      props: DefaultProps
+    ) => GlamorousComponent<ExternalProps & $Shape<DefaultProps>, Props>
+  };
+
+  declare export type GlamorousComponent<
+    ExternalProps,
+    Props
+  > = React$StatelessFunctionalComponent<
+    ExternalProps & Props & ExtraGlamorousProps
+  > &
+    GlamorousComponentFunctions<ExternalProps, Props>;
+
+  declare type StyleFunction<Properties, Props> = (
+    props: Props
+  ) =>
+    | Properties
+    | string
+    | Array<Properties | string | StyleFunction<Properties, Props>>;
+
+  declare type StyleArray<Properties, Props> = Array<
+    Properties | string | StyleFunction<Properties, Props>
+  >;
+
+  declare type StaticStyleArray<Properties> = Array<Properties | string>;
+
+  declare type StyleArgument<Properties, Props> =
+    | Properties
+    | string
+    | StyleFunction<Properties, Props>
+    | StyleArray<Properties, Props>;
+
+  declare type StaticStyleArgument<Properties> =
+    | Properties
+    | string
+    | StaticStyleArray<Properties>;
+
+  declare type GlamorousComponentFactory<
+    ExternalProps,
+    Properties,
+    DefaultProps
+  > = {
+    <Props: {}>(
+      ...styles: StyleArgument<
+        Properties,
+        Props & ExternalProps & DefaultProps
+      >[]
+    ): GlamorousComponent<ExternalProps & $Shape<DefaultProps>, Props>
+  };
+
+  declare type GlamorousHTMLComponentFactory<Tag: HTMLTagName> = <Props>(
+    ...styles: StyleArgument<CSSProperties, Props>[]
+  ) => GlamorousComponent<React$ElementProps<Tag>, Props>;
+
+  declare type GlamorousBuiltinComponent<
+    Tag: HTMLTagName
+  > = React$StatelessFunctionalComponent<
+    CSSProperties & ExtraGlamorousProps & React$ElementProps<"span">
+  >;
+
+  declare type Glamorous = {
+    <ExternalProps, Context, DefaultProps: {}>(
+      component: React$ComponentType<ExternalProps & GlamorousProps>,
+      options?: GlamorousOptions<ExternalProps, Context, DefaultProps>
+    ): GlamorousComponentFactory<ExternalProps, CSSProperties, DefaultProps>,
+
+    a: GlamorousHTMLComponentFactory<"a">,
+    button: GlamorousHTMLComponentFactory<"button">,
+    div: GlamorousHTMLComponentFactory<"div">,
+    footer: GlamorousHTMLComponentFactory<"footer">,
+    h1: GlamorousHTMLComponentFactory<"h1">,
+    h2: GlamorousHTMLComponentFactory<"h2">,
+    img: GlamorousHTMLComponentFactory<"img">,
+    input: GlamorousHTMLComponentFactory<"input">,
+    label: GlamorousHTMLComponentFactory<"label">,
+    li: GlamorousHTMLComponentFactory<"li">,
+    ol: GlamorousHTMLComponentFactory<"ol">,
+    section: GlamorousHTMLComponentFactory<"section">,
+    select: GlamorousHTMLComponentFactory<"select">,
+    span: GlamorousHTMLComponentFactory<"span">,
+    table: GlamorousHTMLComponentFactory<"table">,
+    td: GlamorousHTMLComponentFactory<"td">,
+    textarea: GlamorousHTMLComponentFactory<"textarea">,
+    th: GlamorousHTMLComponentFactory<"th">,
+    tr: GlamorousHTMLComponentFactory<"tr">,
+    ul: GlamorousHTMLComponentFactory<"ul">,
+
+    Span: GlamorousBuiltinComponent<"span">
+  };
+
+  declare export var Div: GlamorousBuiltinComponent<"div">;
+  declare export var H1: GlamorousBuiltinComponent<"h1">;
+  declare export var H2: GlamorousBuiltinComponent<"h2">;
+  declare export var H3: GlamorousBuiltinComponent<"h3">;
+  declare export var P: GlamorousBuiltinComponent<"p">;
+  declare export var Span: GlamorousBuiltinComponent<"span">;
+  declare export var Ul: GlamorousBuiltinComponent<"ul">;
+
+  declare export default Glamorous
+}

--- a/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
+++ b/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
@@ -1,3 +1,5 @@
+// -*- origami-fold-style: triple-braces -*-
+
 declare module "glamorous" {
   declare type SingleOrArray<Properties, T: $Keys<Properties>> = $ObjMap<
     Properties,
@@ -20,6 +22,7 @@ declare module "glamorous" {
   };
   declare type SVGProperties = {||};
 
+  // HTMLTagName {{{
   declare type HTMLTagName =
     | "a"
     | "abbr"
@@ -169,6 +172,7 @@ declare module "glamorous" {
     | "video"
     | "wbr"
     | "xmp";
+  // }}}
 
   declare type ClassComponent<Props, State> = Class<
     React$Component<Props, State>
@@ -307,6 +311,7 @@ declare module "glamorous" {
       options?: GlamorousOptions<OriginalProps, Context, WithProps>
     ): GlamorousComponentFactory<OriginalProps, CSSProperties, {}>,
 
+    // GlamorousHTMLComponentFactories {{{
     a: GlamorousHTMLComponentFactory<"a">,
     abbr: GlamorousHTMLComponentFactory<"abbr">,
     acronym: GlamorousHTMLComponentFactory<"acronym">,
@@ -455,7 +460,9 @@ declare module "glamorous" {
     video: GlamorousHTMLComponentFactory<"video">,
     wbr: GlamorousHTMLComponentFactory<"wbr">,
     xmp: GlamorousHTMLComponentFactory<"xmp">,
+    // }}}
 
+    // GlamorousBuiltinComponents {{{
     A: GlamorousBuiltinComponent<"a">,
     Abbr: GlamorousBuiltinComponent<"abbr">,
     Acronym: GlamorousBuiltinComponent<"acronym">,
@@ -604,8 +611,10 @@ declare module "glamorous" {
     Video: GlamorousBuiltinComponent<"video">,
     Wbr: GlamorousBuiltinComponent<"wbr">,
     Xmp: GlamorousBuiltinComponent<"xmp">
+    // }}}
   };
 
+  // export GlamorousBuiltinComponents {{{
   declare export var A: GlamorousBuiltinComponent<"a">;
   declare export var Abbr: GlamorousBuiltinComponent<"abbr">;
   declare export var Acronym: GlamorousBuiltinComponent<"acronym">;
@@ -754,6 +763,7 @@ declare module "glamorous" {
   declare export var Video: GlamorousBuiltinComponent<"video">;
   declare export var Wbr: GlamorousBuiltinComponent<"wbr">;
   declare export var Xmp: GlamorousBuiltinComponent<"xmp">;
+  // }}}
 
   declare export default Glamorous
 }

--- a/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
+++ b/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
@@ -57,20 +57,20 @@ declare module "glamorous" {
     Props
   > = React$ComponentType<Props> & { defaultProps: DefaultProps };
 
-  declare type GlamorousOptions<Props, Context, DefaultProps> = $Shape<{|
-    displayName: string,
-    rootEl: string | HTMLElement,
-    filterProps: string[],
-    forwardProps: string[],
-    shouldClassNameUpdate: (
+  declare type GlamorousOptions<Props, Context, WithProps> = {|
+    displayName?: string,
+    rootEl?: string | HTMLElement,
+    filterProps?: string[],
+    forwardProps?: string[],
+    shouldClassNameUpdate?: (
       props: Props,
       prevProps: Props,
       context: Context,
       prevContext: Context
     ) => boolean,
     propsAreCssOverrides?: false,
-    withProps: $Shape<DefaultProps>
-  |}>;
+    withProps?: WithProps
+  |};
 
   declare type GlamorousProps = { className?: string, theme?: Object };
 
@@ -115,7 +115,7 @@ declare module "glamorous" {
   declare export type GlamorousComponent<
     OriginalProps,
     Props,
-    DefaultProps: {} | void = void
+    DefaultProps: {} = {}
   > = Class<GlamorousComponentInstance<OriginalProps, Props, DefaultProps>>;
 
   declare type StyleFunction<Properties, Props> = (
@@ -157,26 +157,26 @@ declare module "glamorous" {
 
   declare type GlamorousHTMLComponentFactory<Tag: HTMLTagName> = <Props>(
     ...styles: StyleArgument<CSSProperties, Props>[]
-  ) => GlamorousComponent<React$ElementProps<Tag>, Props, void>;
+  ) => GlamorousComponent<React$ElementProps<Tag>, Props, {}>;
 
   declare type GlamorousBuiltinComponent<Tag: HTMLTagName> = GlamorousComponent<
     {},
     CSSProperties & React$ElementProps<Tag>,
-    void
+    {}
   >;
 
   declare type Glamorous = {
-    <OriginalProps, Context, DefaultProps: {}>(
+    <OriginalProps, Context, DefaultProps, WithProps: {}>(
       component: ComponentWithDefaultProps<
         DefaultProps,
         OriginalProps & GlamorousProps
       >,
-      options?: GlamorousOptions<OriginalProps, Context, DefaultProps>
+      options?: GlamorousOptions<OriginalProps, Context, WithProps>
     ): GlamorousComponentFactory<OriginalProps, CSSProperties, DefaultProps>,
-    <OriginalProps, Context>(
+    <OriginalProps, Context, WithProps: {}>(
       component: React$ComponentType<OriginalProps & GlamorousProps>,
-      options?: GlamorousOptions<OriginalProps, Context, void>
-    ): GlamorousComponentFactory<OriginalProps, CSSProperties, void>,
+      options?: GlamorousOptions<OriginalProps, Context, WithProps>
+    ): GlamorousComponentFactory<OriginalProps, CSSProperties, {}>,
 
     a: GlamorousHTMLComponentFactory<"a">,
     button: GlamorousHTMLComponentFactory<"button">,

--- a/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
+++ b/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
@@ -121,6 +121,9 @@ declare module "glamorous" {
   declare type StyleFunction<Properties, Props> = (
     props: Props
   ) =>
+    | null
+    | false
+    | void
     | Properties
     | string
     | Array<Properties | string | StyleFunction<Properties, Props>>;
@@ -139,11 +142,6 @@ declare module "glamorous" {
     | string
     | StyleFunction<Properties, Props>
     | StyleArray<Properties, Props>;
-
-  declare type StaticStyleArgument<Properties> =
-    | Properties
-    | string
-    | StaticStyleArray<Properties>;
 
   declare type GlamorousComponentFactory<
     OriginalProps,
@@ -164,7 +162,7 @@ declare module "glamorous" {
 
   declare type GlamorousBuiltinComponent<Tag: HTMLTagName> = GlamorousComponent<
     {},
-    CSSProperties & React$ElementProps<Tag>,
+    CSSPropertiesComplete & React$ElementProps<Tag>,
     {}
   >;
 

--- a/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
+++ b/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
@@ -42,6 +42,21 @@ declare module "glamorous" {
     | "tr"
     | "ul";
 
+  declare type ClassComponent<Props, State> = Class<
+    React$Component<Props, State>
+  >;
+
+  declare type ClassComponentWithDefaultProps<
+    DefaultProps,
+    Props,
+    State
+  > = ClassComponent<Props, State> & { defaultProps: DefaultProps };
+
+  declare type ComponentWithDefaultProps<
+    DefaultProps,
+    Props
+  > = React$ComponentType<Props> & { defaultProps: DefaultProps };
+
   declare type GlamorousOptions<Props, Context, DefaultProps> = $Shape<{|
     displayName: string,
     rootEl: string | HTMLElement,
@@ -75,29 +90,33 @@ declare module "glamorous" {
     theme?: Object
   };
 
-  declare type GlamorousComponentFunctions<OriginalProps, Props> = {
+  declare class GlamorousComponentInstance<
+    OriginalProps,
+    Props,
+    DefaultProps
+  > extends React$Component<OriginalProps & Props> {
+    static defaultProps: DefaultProps,
+
     /**
      * Copies the styles of an already created glamorous component with a different tag
      */
-    withComponent: (
+    static withComponent: (
       component: string | React$Component<Props>
     ) => GlamorousComponent<OriginalProps, Props>,
 
     /**
      * Applies props by default for a component
      */
-    withProps: <DefaultProps: {}>(
+    static withProps: <DefaultProps: {}>(
       props: DefaultProps
     ) => GlamorousComponent<OriginalProps & $Shape<DefaultProps>, Props>
-  };
+  }
 
   declare export type GlamorousComponent<
     OriginalProps,
-    Props
-  > = React$StatelessFunctionalComponent<
-    OriginalProps & Props & ExtraGlamorousProps
-  > &
-    GlamorousComponentFunctions<OriginalProps, Props>;
+    Props,
+    DefaultProps: {} | void = void
+  > = Class<GlamorousComponentInstance<OriginalProps, Props, DefaultProps>>;
 
   declare type StyleFunction<Properties, Props> = (
     props: Props
@@ -133,24 +152,31 @@ declare module "glamorous" {
         Properties,
         Props & OriginalProps & DefaultProps
       >[]
-    ): GlamorousComponent<OriginalProps & $Shape<DefaultProps>, Props>
+    ): Class<GlamorousComponentInstance<OriginalProps, Props, DefaultProps>>
   };
 
   declare type GlamorousHTMLComponentFactory<Tag: HTMLTagName> = <Props>(
     ...styles: StyleArgument<CSSProperties, Props>[]
-  ) => GlamorousComponent<React$ElementProps<Tag>, Props>;
+  ) => GlamorousComponent<React$ElementProps<Tag>, Props, void>;
 
-  declare type GlamorousBuiltinComponent<
-    Tag: HTMLTagName
-  > = React$StatelessFunctionalComponent<
-    CSSProperties & ExtraGlamorousProps & React$ElementProps<"span">
+  declare type GlamorousBuiltinComponent<Tag: HTMLTagName> = GlamorousComponent<
+    {},
+    CSSProperties & React$ElementProps<Tag>,
+    void
   >;
 
   declare type Glamorous = {
     <OriginalProps, Context, DefaultProps: {}>(
-      component: React$ComponentType<OriginalProps & GlamorousProps>,
+      component: ComponentWithDefaultProps<
+        DefaultProps,
+        OriginalProps & GlamorousProps
+      >,
       options?: GlamorousOptions<OriginalProps, Context, DefaultProps>
     ): GlamorousComponentFactory<OriginalProps, CSSProperties, DefaultProps>,
+    <OriginalProps, Context>(
+      component: React$ComponentType<OriginalProps & GlamorousProps>,
+      options?: GlamorousOptions<OriginalProps, Context, void>
+    ): GlamorousComponentFactory<OriginalProps, CSSProperties, void>,
 
     a: GlamorousHTMLComponentFactory<"a">,
     button: GlamorousHTMLComponentFactory<"button">,

--- a/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
+++ b/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
@@ -132,6 +132,9 @@ declare module "glamorous" {
   declare type StaticStyleArray<Properties> = Array<Properties | string>;
 
   declare type StyleArgument<Properties, Props> =
+    | null
+    | void
+    | false
     | Properties
     | string
     | StyleFunction<Properties, Props>

--- a/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
+++ b/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
@@ -15,6 +15,7 @@ declare module "glamorous" {
   >;
   declare export type CSSProperties = {
     ...CSSPropertiesComplete,
+    $call?: empty,
     [string]: CSSProperties
   };
   declare type SVGProperties = {||};

--- a/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
+++ b/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
@@ -107,9 +107,9 @@ declare module "glamorous" {
     /**
      * Applies props by default for a component
      */
-    static withProps: <DefaultProps: {}>(
-      props: DefaultProps
-    ) => GlamorousComponent<OriginalProps & $Shape<DefaultProps>, Props>
+    static withProps: <WithProps: $Shape<OriginalProps & Props>>(
+      props: WithProps
+    ) => GlamorousComponent<OriginalProps, Props, DefaultProps & WithProps>
   }
 
   declare export type GlamorousComponent<

--- a/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
+++ b/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
@@ -75,29 +75,29 @@ declare module "glamorous" {
     theme?: Object
   };
 
-  declare type GlamorousComponentFunctions<ExternalProps, Props> = {
+  declare type GlamorousComponentFunctions<OriginalProps, Props> = {
     /**
      * Copies the styles of an already created glamorous component with a different tag
      */
     withComponent: (
       component: string | React$Component<Props>
-    ) => GlamorousComponent<ExternalProps, Props>,
+    ) => GlamorousComponent<OriginalProps, Props>,
 
     /**
      * Applies props by default for a component
      */
     withProps: <DefaultProps: {}>(
       props: DefaultProps
-    ) => GlamorousComponent<ExternalProps & $Shape<DefaultProps>, Props>
+    ) => GlamorousComponent<OriginalProps & $Shape<DefaultProps>, Props>
   };
 
   declare export type GlamorousComponent<
-    ExternalProps,
+    OriginalProps,
     Props
   > = React$StatelessFunctionalComponent<
-    ExternalProps & Props & ExtraGlamorousProps
+    OriginalProps & Props & ExtraGlamorousProps
   > &
-    GlamorousComponentFunctions<ExternalProps, Props>;
+    GlamorousComponentFunctions<OriginalProps, Props>;
 
   declare type StyleFunction<Properties, Props> = (
     props: Props
@@ -124,16 +124,16 @@ declare module "glamorous" {
     | StaticStyleArray<Properties>;
 
   declare type GlamorousComponentFactory<
-    ExternalProps,
+    OriginalProps,
     Properties,
     DefaultProps
   > = {
     <Props: {}>(
       ...styles: StyleArgument<
         Properties,
-        Props & ExternalProps & DefaultProps
+        Props & OriginalProps & DefaultProps
       >[]
-    ): GlamorousComponent<ExternalProps & $Shape<DefaultProps>, Props>
+    ): GlamorousComponent<OriginalProps & $Shape<DefaultProps>, Props>
   };
 
   declare type GlamorousHTMLComponentFactory<Tag: HTMLTagName> = <Props>(
@@ -147,10 +147,10 @@ declare module "glamorous" {
   >;
 
   declare type Glamorous = {
-    <ExternalProps, Context, DefaultProps: {}>(
-      component: React$ComponentType<ExternalProps & GlamorousProps>,
-      options?: GlamorousOptions<ExternalProps, Context, DefaultProps>
-    ): GlamorousComponentFactory<ExternalProps, CSSProperties, DefaultProps>,
+    <OriginalProps, Context, DefaultProps: {}>(
+      component: React$ComponentType<OriginalProps & GlamorousProps>,
+      options?: GlamorousOptions<OriginalProps, Context, DefaultProps>
+    ): GlamorousComponentFactory<OriginalProps, CSSProperties, DefaultProps>,
 
     a: GlamorousHTMLComponentFactory<"a">,
     button: GlamorousHTMLComponentFactory<"button">,

--- a/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
+++ b/definitions/npm/glamorous_v4.x.x/flow_v0.57.x-/glamorous_v4.x.x.js
@@ -22,25 +22,153 @@ declare module "glamorous" {
 
   declare type HTMLTagName =
     | "a"
+    | "abbr"
+    | "acronym"
+    | "address"
+    | "applet"
+    | "area"
+    | "article"
+    | "aside"
+    | "audio"
+    | "b"
+    | "base"
+    | "basefont"
+    | "bdi"
+    | "bdo"
+    | "bgsound"
+    | "big"
+    | "blink"
+    | "blockquote"
+    | "body"
+    | "br"
     | "button"
+    | "canvas"
+    | "caption"
+    | "center"
+    | "cite"
+    | "code"
+    | "col"
+    | "colgroup"
+    | "command"
+    | "content"
+    | "data"
+    | "datalist"
+    | "dd"
+    | "del"
+    | "details"
+    | "dfn"
+    | "dialog"
+    | "dir"
     | "div"
+    | "dl"
+    | "dt"
+    | "element"
+    | "em"
+    | "embed"
+    | "fieldset"
+    | "figcaption"
+    | "figure"
+    | "font"
     | "footer"
+    | "form"
+    | "frame"
+    | "frameset"
     | "h1"
     | "h2"
+    | "h3"
+    | "h4"
+    | "h5"
+    | "h6"
+    | "head"
+    | "header"
+    | "hgroup"
+    | "hr"
+    | "html"
+    | "i"
+    | "iframe"
+    | "image"
     | "img"
     | "input"
+    | "ins"
+    | "isindex"
+    | "kbd"
+    | "keygen"
     | "label"
+    | "legend"
     | "li"
+    | "link"
+    | "listing"
+    | "main"
+    | "map"
+    | "mark"
+    | "marquee"
+    | "math"
+    | "menu"
+    | "menuitem"
+    | "meta"
+    | "meter"
+    | "multicol"
+    | "nav"
+    | "nextid"
+    | "nobr"
+    | "noembed"
+    | "noframes"
+    | "noscript"
+    | "object"
     | "ol"
+    | "optgroup"
+    | "option"
+    | "output"
+    | "p"
+    | "param"
+    | "picture"
+    | "plaintext"
+    | "pre"
+    | "progress"
+    | "q"
+    | "rb"
+    | "rbc"
+    | "rp"
+    | "rt"
+    | "rtc"
+    | "ruby"
+    | "s"
+    | "samp"
+    | "script"
     | "section"
     | "select"
+    | "shadow"
+    | "slot"
+    | "small"
+    | "source"
+    | "spacer"
     | "span"
+    | "strike"
+    | "strong"
+    | "style"
+    | "sub"
+    | "summary"
+    | "sup"
+    | "svg"
     | "table"
+    | "tbody"
     | "td"
+    | "template"
     | "textarea"
+    | "tfoot"
     | "th"
+    | "thead"
+    | "time"
+    | "title"
     | "tr"
-    | "ul";
+    | "track"
+    | "tt"
+    | "u"
+    | "ul"
+    | "var"
+    | "video"
+    | "wbr"
+    | "xmp";
 
   declare type ClassComponent<Props, State> = Class<
     React$Component<Props, State>
@@ -180,36 +308,452 @@ declare module "glamorous" {
     ): GlamorousComponentFactory<OriginalProps, CSSProperties, {}>,
 
     a: GlamorousHTMLComponentFactory<"a">,
+    abbr: GlamorousHTMLComponentFactory<"abbr">,
+    acronym: GlamorousHTMLComponentFactory<"acronym">,
+    address: GlamorousHTMLComponentFactory<"address">,
+    applet: GlamorousHTMLComponentFactory<"applet">,
+    area: GlamorousHTMLComponentFactory<"area">,
+    article: GlamorousHTMLComponentFactory<"article">,
+    aside: GlamorousHTMLComponentFactory<"aside">,
+    audio: GlamorousHTMLComponentFactory<"audio">,
+    b: GlamorousHTMLComponentFactory<"b">,
+    base: GlamorousHTMLComponentFactory<"base">,
+    basefont: GlamorousHTMLComponentFactory<"basefont">,
+    bdi: GlamorousHTMLComponentFactory<"bdi">,
+    bdo: GlamorousHTMLComponentFactory<"bdo">,
+    bgsound: GlamorousHTMLComponentFactory<"bgsound">,
+    big: GlamorousHTMLComponentFactory<"big">,
+    blink: GlamorousHTMLComponentFactory<"blink">,
+    blockquote: GlamorousHTMLComponentFactory<"blockquote">,
+    body: GlamorousHTMLComponentFactory<"body">,
+    br: GlamorousHTMLComponentFactory<"br">,
     button: GlamorousHTMLComponentFactory<"button">,
+    canvas: GlamorousHTMLComponentFactory<"canvas">,
+    caption: GlamorousHTMLComponentFactory<"caption">,
+    center: GlamorousHTMLComponentFactory<"center">,
+    cite: GlamorousHTMLComponentFactory<"cite">,
+    code: GlamorousHTMLComponentFactory<"code">,
+    col: GlamorousHTMLComponentFactory<"col">,
+    colgroup: GlamorousHTMLComponentFactory<"colgroup">,
+    command: GlamorousHTMLComponentFactory<"command">,
+    content: GlamorousHTMLComponentFactory<"content">,
+    data: GlamorousHTMLComponentFactory<"data">,
+    datalist: GlamorousHTMLComponentFactory<"datalist">,
+    dd: GlamorousHTMLComponentFactory<"dd">,
+    del: GlamorousHTMLComponentFactory<"del">,
+    details: GlamorousHTMLComponentFactory<"details">,
+    dfn: GlamorousHTMLComponentFactory<"dfn">,
+    dialog: GlamorousHTMLComponentFactory<"dialog">,
+    dir: GlamorousHTMLComponentFactory<"dir">,
     div: GlamorousHTMLComponentFactory<"div">,
+    dl: GlamorousHTMLComponentFactory<"dl">,
+    dt: GlamorousHTMLComponentFactory<"dt">,
+    element: GlamorousHTMLComponentFactory<"element">,
+    em: GlamorousHTMLComponentFactory<"em">,
+    embed: GlamorousHTMLComponentFactory<"embed">,
+    fieldset: GlamorousHTMLComponentFactory<"fieldset">,
+    figcaption: GlamorousHTMLComponentFactory<"figcaption">,
+    figure: GlamorousHTMLComponentFactory<"figure">,
+    font: GlamorousHTMLComponentFactory<"font">,
     footer: GlamorousHTMLComponentFactory<"footer">,
+    form: GlamorousHTMLComponentFactory<"form">,
+    frame: GlamorousHTMLComponentFactory<"frame">,
+    frameset: GlamorousHTMLComponentFactory<"frameset">,
     h1: GlamorousHTMLComponentFactory<"h1">,
     h2: GlamorousHTMLComponentFactory<"h2">,
+    h3: GlamorousHTMLComponentFactory<"h3">,
+    h4: GlamorousHTMLComponentFactory<"h4">,
+    h5: GlamorousHTMLComponentFactory<"h5">,
+    h6: GlamorousHTMLComponentFactory<"h6">,
+    head: GlamorousHTMLComponentFactory<"head">,
+    header: GlamorousHTMLComponentFactory<"header">,
+    hgroup: GlamorousHTMLComponentFactory<"hgroup">,
+    hr: GlamorousHTMLComponentFactory<"hr">,
+    html: GlamorousHTMLComponentFactory<"html">,
+    i: GlamorousHTMLComponentFactory<"i">,
+    iframe: GlamorousHTMLComponentFactory<"iframe">,
+    image: GlamorousHTMLComponentFactory<"image">,
     img: GlamorousHTMLComponentFactory<"img">,
     input: GlamorousHTMLComponentFactory<"input">,
+    ins: GlamorousHTMLComponentFactory<"ins">,
+    isindex: GlamorousHTMLComponentFactory<"isindex">,
+    kbd: GlamorousHTMLComponentFactory<"kbd">,
+    keygen: GlamorousHTMLComponentFactory<"keygen">,
     label: GlamorousHTMLComponentFactory<"label">,
+    legend: GlamorousHTMLComponentFactory<"legend">,
     li: GlamorousHTMLComponentFactory<"li">,
+    link: GlamorousHTMLComponentFactory<"link">,
+    listing: GlamorousHTMLComponentFactory<"listing">,
+    main: GlamorousHTMLComponentFactory<"main">,
+    map: GlamorousHTMLComponentFactory<"map">,
+    mark: GlamorousHTMLComponentFactory<"mark">,
+    marquee: GlamorousHTMLComponentFactory<"marquee">,
+    math: GlamorousHTMLComponentFactory<"math">,
+    menu: GlamorousHTMLComponentFactory<"menu">,
+    menuitem: GlamorousHTMLComponentFactory<"menuitem">,
+    meta: GlamorousHTMLComponentFactory<"meta">,
+    meter: GlamorousHTMLComponentFactory<"meter">,
+    multicol: GlamorousHTMLComponentFactory<"multicol">,
+    nav: GlamorousHTMLComponentFactory<"nav">,
+    nextid: GlamorousHTMLComponentFactory<"nextid">,
+    nobr: GlamorousHTMLComponentFactory<"nobr">,
+    noembed: GlamorousHTMLComponentFactory<"noembed">,
+    noframes: GlamorousHTMLComponentFactory<"noframes">,
+    noscript: GlamorousHTMLComponentFactory<"noscript">,
+    object: GlamorousHTMLComponentFactory<"object">,
     ol: GlamorousHTMLComponentFactory<"ol">,
+    optgroup: GlamorousHTMLComponentFactory<"optgroup">,
+    option: GlamorousHTMLComponentFactory<"option">,
+    output: GlamorousHTMLComponentFactory<"output">,
+    p: GlamorousHTMLComponentFactory<"p">,
+    param: GlamorousHTMLComponentFactory<"param">,
+    picture: GlamorousHTMLComponentFactory<"picture">,
+    plaintext: GlamorousHTMLComponentFactory<"plaintext">,
+    pre: GlamorousHTMLComponentFactory<"pre">,
+    progress: GlamorousHTMLComponentFactory<"progress">,
+    q: GlamorousHTMLComponentFactory<"q">,
+    rb: GlamorousHTMLComponentFactory<"rb">,
+    rbc: GlamorousHTMLComponentFactory<"rbc">,
+    rp: GlamorousHTMLComponentFactory<"rp">,
+    rt: GlamorousHTMLComponentFactory<"rt">,
+    rtc: GlamorousHTMLComponentFactory<"rtc">,
+    ruby: GlamorousHTMLComponentFactory<"ruby">,
+    s: GlamorousHTMLComponentFactory<"s">,
+    samp: GlamorousHTMLComponentFactory<"samp">,
+    script: GlamorousHTMLComponentFactory<"script">,
     section: GlamorousHTMLComponentFactory<"section">,
     select: GlamorousHTMLComponentFactory<"select">,
+    shadow: GlamorousHTMLComponentFactory<"shadow">,
+    slot: GlamorousHTMLComponentFactory<"slot">,
+    small: GlamorousHTMLComponentFactory<"small">,
+    source: GlamorousHTMLComponentFactory<"source">,
+    spacer: GlamorousHTMLComponentFactory<"spacer">,
     span: GlamorousHTMLComponentFactory<"span">,
+    strike: GlamorousHTMLComponentFactory<"strike">,
+    strong: GlamorousHTMLComponentFactory<"strong">,
+    style: GlamorousHTMLComponentFactory<"style">,
+    sub: GlamorousHTMLComponentFactory<"sub">,
+    summary: GlamorousHTMLComponentFactory<"summary">,
+    sup: GlamorousHTMLComponentFactory<"sup">,
+    svg: GlamorousHTMLComponentFactory<"svg">,
     table: GlamorousHTMLComponentFactory<"table">,
+    tbody: GlamorousHTMLComponentFactory<"tbody">,
     td: GlamorousHTMLComponentFactory<"td">,
+    template: GlamorousHTMLComponentFactory<"template">,
     textarea: GlamorousHTMLComponentFactory<"textarea">,
+    tfoot: GlamorousHTMLComponentFactory<"tfoot">,
     th: GlamorousHTMLComponentFactory<"th">,
+    thead: GlamorousHTMLComponentFactory<"thead">,
+    time: GlamorousHTMLComponentFactory<"time">,
+    title: GlamorousHTMLComponentFactory<"title">,
     tr: GlamorousHTMLComponentFactory<"tr">,
+    track: GlamorousHTMLComponentFactory<"track">,
+    tt: GlamorousHTMLComponentFactory<"tt">,
+    u: GlamorousHTMLComponentFactory<"u">,
     ul: GlamorousHTMLComponentFactory<"ul">,
+    var: GlamorousHTMLComponentFactory<"var">,
+    video: GlamorousHTMLComponentFactory<"video">,
+    wbr: GlamorousHTMLComponentFactory<"wbr">,
+    xmp: GlamorousHTMLComponentFactory<"xmp">,
 
-    Span: GlamorousBuiltinComponent<"span">
+    A: GlamorousBuiltinComponent<"a">,
+    Abbr: GlamorousBuiltinComponent<"abbr">,
+    Acronym: GlamorousBuiltinComponent<"acronym">,
+    Address: GlamorousBuiltinComponent<"address">,
+    Applet: GlamorousBuiltinComponent<"applet">,
+    Area: GlamorousBuiltinComponent<"area">,
+    Article: GlamorousBuiltinComponent<"article">,
+    Aside: GlamorousBuiltinComponent<"aside">,
+    Audio: GlamorousBuiltinComponent<"audio">,
+    B: GlamorousBuiltinComponent<"b">,
+    Base: GlamorousBuiltinComponent<"base">,
+    Basefont: GlamorousBuiltinComponent<"basefont">,
+    Bdi: GlamorousBuiltinComponent<"bdi">,
+    Bdo: GlamorousBuiltinComponent<"bdo">,
+    Bgsound: GlamorousBuiltinComponent<"bgsound">,
+    Big: GlamorousBuiltinComponent<"big">,
+    Blink: GlamorousBuiltinComponent<"blink">,
+    Blockquote: GlamorousBuiltinComponent<"blockquote">,
+    Body: GlamorousBuiltinComponent<"body">,
+    Br: GlamorousBuiltinComponent<"br">,
+    Button: GlamorousBuiltinComponent<"button">,
+    Canvas: GlamorousBuiltinComponent<"canvas">,
+    Caption: GlamorousBuiltinComponent<"caption">,
+    Center: GlamorousBuiltinComponent<"center">,
+    Cite: GlamorousBuiltinComponent<"cite">,
+    Code: GlamorousBuiltinComponent<"code">,
+    Col: GlamorousBuiltinComponent<"col">,
+    Colgroup: GlamorousBuiltinComponent<"colgroup">,
+    Command: GlamorousBuiltinComponent<"command">,
+    Content: GlamorousBuiltinComponent<"content">,
+    Data: GlamorousBuiltinComponent<"data">,
+    Datalist: GlamorousBuiltinComponent<"datalist">,
+    Dd: GlamorousBuiltinComponent<"dd">,
+    Del: GlamorousBuiltinComponent<"del">,
+    Details: GlamorousBuiltinComponent<"details">,
+    Dfn: GlamorousBuiltinComponent<"dfn">,
+    Dialog: GlamorousBuiltinComponent<"dialog">,
+    Dir: GlamorousBuiltinComponent<"dir">,
+    Div: GlamorousBuiltinComponent<"div">,
+    Dl: GlamorousBuiltinComponent<"dl">,
+    Dt: GlamorousBuiltinComponent<"dt">,
+    Element: GlamorousBuiltinComponent<"element">,
+    Em: GlamorousBuiltinComponent<"em">,
+    Embed: GlamorousBuiltinComponent<"embed">,
+    Fieldset: GlamorousBuiltinComponent<"fieldset">,
+    Figcaption: GlamorousBuiltinComponent<"figcaption">,
+    Figure: GlamorousBuiltinComponent<"figure">,
+    Font: GlamorousBuiltinComponent<"font">,
+    Footer: GlamorousBuiltinComponent<"footer">,
+    Form: GlamorousBuiltinComponent<"form">,
+    Frame: GlamorousBuiltinComponent<"frame">,
+    Frameset: GlamorousBuiltinComponent<"frameset">,
+    H1: GlamorousBuiltinComponent<"h1">,
+    H2: GlamorousBuiltinComponent<"h2">,
+    H3: GlamorousBuiltinComponent<"h3">,
+    H4: GlamorousBuiltinComponent<"h4">,
+    H5: GlamorousBuiltinComponent<"h5">,
+    H6: GlamorousBuiltinComponent<"h6">,
+    Head: GlamorousBuiltinComponent<"head">,
+    Header: GlamorousBuiltinComponent<"header">,
+    Hgroup: GlamorousBuiltinComponent<"hgroup">,
+    Hr: GlamorousBuiltinComponent<"hr">,
+    Html: GlamorousBuiltinComponent<"html">,
+    I: GlamorousBuiltinComponent<"i">,
+    Iframe: GlamorousBuiltinComponent<"iframe">,
+    Image: GlamorousBuiltinComponent<"image">,
+    Img: GlamorousBuiltinComponent<"img">,
+    Input: GlamorousBuiltinComponent<"input">,
+    Ins: GlamorousBuiltinComponent<"ins">,
+    Isindex: GlamorousBuiltinComponent<"isindex">,
+    Kbd: GlamorousBuiltinComponent<"kbd">,
+    Keygen: GlamorousBuiltinComponent<"keygen">,
+    Label: GlamorousBuiltinComponent<"label">,
+    Legend: GlamorousBuiltinComponent<"legend">,
+    Li: GlamorousBuiltinComponent<"li">,
+    Link: GlamorousBuiltinComponent<"link">,
+    Listing: GlamorousBuiltinComponent<"listing">,
+    Main: GlamorousBuiltinComponent<"main">,
+    Map: GlamorousBuiltinComponent<"map">,
+    Mark: GlamorousBuiltinComponent<"mark">,
+    Marquee: GlamorousBuiltinComponent<"marquee">,
+    Math: GlamorousBuiltinComponent<"math">,
+    Menu: GlamorousBuiltinComponent<"menu">,
+    Menuitem: GlamorousBuiltinComponent<"menuitem">,
+    Meta: GlamorousBuiltinComponent<"meta">,
+    Meter: GlamorousBuiltinComponent<"meter">,
+    Multicol: GlamorousBuiltinComponent<"multicol">,
+    Nav: GlamorousBuiltinComponent<"nav">,
+    Nextid: GlamorousBuiltinComponent<"nextid">,
+    Nobr: GlamorousBuiltinComponent<"nobr">,
+    Noembed: GlamorousBuiltinComponent<"noembed">,
+    Noframes: GlamorousBuiltinComponent<"noframes">,
+    Noscript: GlamorousBuiltinComponent<"noscript">,
+    Object: GlamorousBuiltinComponent<"object">,
+    Ol: GlamorousBuiltinComponent<"ol">,
+    Optgroup: GlamorousBuiltinComponent<"optgroup">,
+    Option: GlamorousBuiltinComponent<"option">,
+    Output: GlamorousBuiltinComponent<"output">,
+    P: GlamorousBuiltinComponent<"p">,
+    Param: GlamorousBuiltinComponent<"param">,
+    Picture: GlamorousBuiltinComponent<"picture">,
+    Plaintext: GlamorousBuiltinComponent<"plaintext">,
+    Pre: GlamorousBuiltinComponent<"pre">,
+    Progress: GlamorousBuiltinComponent<"progress">,
+    Q: GlamorousBuiltinComponent<"q">,
+    Rb: GlamorousBuiltinComponent<"rb">,
+    Rbc: GlamorousBuiltinComponent<"rbc">,
+    Rp: GlamorousBuiltinComponent<"rp">,
+    Rt: GlamorousBuiltinComponent<"rt">,
+    Rtc: GlamorousBuiltinComponent<"rtc">,
+    Ruby: GlamorousBuiltinComponent<"ruby">,
+    S: GlamorousBuiltinComponent<"s">,
+    Samp: GlamorousBuiltinComponent<"samp">,
+    Script: GlamorousBuiltinComponent<"script">,
+    Section: GlamorousBuiltinComponent<"section">,
+    Select: GlamorousBuiltinComponent<"select">,
+    Shadow: GlamorousBuiltinComponent<"shadow">,
+    Slot: GlamorousBuiltinComponent<"slot">,
+    Small: GlamorousBuiltinComponent<"small">,
+    Source: GlamorousBuiltinComponent<"source">,
+    Spacer: GlamorousBuiltinComponent<"spacer">,
+    Span: GlamorousBuiltinComponent<"span">,
+    Strike: GlamorousBuiltinComponent<"strike">,
+    Strong: GlamorousBuiltinComponent<"strong">,
+    Style: GlamorousBuiltinComponent<"style">,
+    Sub: GlamorousBuiltinComponent<"sub">,
+    Summary: GlamorousBuiltinComponent<"summary">,
+    Sup: GlamorousBuiltinComponent<"sup">,
+    Svg: GlamorousBuiltinComponent<"svg">,
+    Table: GlamorousBuiltinComponent<"table">,
+    Tbody: GlamorousBuiltinComponent<"tbody">,
+    Td: GlamorousBuiltinComponent<"td">,
+    Template: GlamorousBuiltinComponent<"template">,
+    Textarea: GlamorousBuiltinComponent<"textarea">,
+    Tfoot: GlamorousBuiltinComponent<"tfoot">,
+    Th: GlamorousBuiltinComponent<"th">,
+    Thead: GlamorousBuiltinComponent<"thead">,
+    Time: GlamorousBuiltinComponent<"time">,
+    Title: GlamorousBuiltinComponent<"title">,
+    Tr: GlamorousBuiltinComponent<"tr">,
+    Track: GlamorousBuiltinComponent<"track">,
+    Tt: GlamorousBuiltinComponent<"tt">,
+    U: GlamorousBuiltinComponent<"u">,
+    Ul: GlamorousBuiltinComponent<"ul">,
+    Var: GlamorousBuiltinComponent<"var">,
+    Video: GlamorousBuiltinComponent<"video">,
+    Wbr: GlamorousBuiltinComponent<"wbr">,
+    Xmp: GlamorousBuiltinComponent<"xmp">
   };
 
+  declare export var A: GlamorousBuiltinComponent<"a">;
+  declare export var Abbr: GlamorousBuiltinComponent<"abbr">;
+  declare export var Acronym: GlamorousBuiltinComponent<"acronym">;
+  declare export var Address: GlamorousBuiltinComponent<"address">;
+  declare export var Applet: GlamorousBuiltinComponent<"applet">;
+  declare export var Area: GlamorousBuiltinComponent<"area">;
+  declare export var Article: GlamorousBuiltinComponent<"article">;
+  declare export var Aside: GlamorousBuiltinComponent<"aside">;
+  declare export var Audio: GlamorousBuiltinComponent<"audio">;
+  declare export var B: GlamorousBuiltinComponent<"b">;
+  declare export var Base: GlamorousBuiltinComponent<"base">;
+  declare export var Basefont: GlamorousBuiltinComponent<"basefont">;
+  declare export var Bdi: GlamorousBuiltinComponent<"bdi">;
+  declare export var Bdo: GlamorousBuiltinComponent<"bdo">;
+  declare export var Bgsound: GlamorousBuiltinComponent<"bgsound">;
+  declare export var Big: GlamorousBuiltinComponent<"big">;
+  declare export var Blink: GlamorousBuiltinComponent<"blink">;
+  declare export var Blockquote: GlamorousBuiltinComponent<"blockquote">;
+  declare export var Body: GlamorousBuiltinComponent<"body">;
+  declare export var Br: GlamorousBuiltinComponent<"br">;
+  declare export var Button: GlamorousBuiltinComponent<"button">;
+  declare export var Canvas: GlamorousBuiltinComponent<"canvas">;
+  declare export var Caption: GlamorousBuiltinComponent<"caption">;
+  declare export var Center: GlamorousBuiltinComponent<"center">;
+  declare export var Cite: GlamorousBuiltinComponent<"cite">;
+  declare export var Code: GlamorousBuiltinComponent<"code">;
+  declare export var Col: GlamorousBuiltinComponent<"col">;
+  declare export var Colgroup: GlamorousBuiltinComponent<"colgroup">;
+  declare export var Command: GlamorousBuiltinComponent<"command">;
+  declare export var Content: GlamorousBuiltinComponent<"content">;
+  declare export var Data: GlamorousBuiltinComponent<"data">;
+  declare export var Datalist: GlamorousBuiltinComponent<"datalist">;
+  declare export var Dd: GlamorousBuiltinComponent<"dd">;
+  declare export var Del: GlamorousBuiltinComponent<"del">;
+  declare export var Details: GlamorousBuiltinComponent<"details">;
+  declare export var Dfn: GlamorousBuiltinComponent<"dfn">;
+  declare export var Dialog: GlamorousBuiltinComponent<"dialog">;
+  declare export var Dir: GlamorousBuiltinComponent<"dir">;
   declare export var Div: GlamorousBuiltinComponent<"div">;
+  declare export var Dl: GlamorousBuiltinComponent<"dl">;
+  declare export var Dt: GlamorousBuiltinComponent<"dt">;
+  declare export var Element: GlamorousBuiltinComponent<"element">;
+  declare export var Em: GlamorousBuiltinComponent<"em">;
+  declare export var Embed: GlamorousBuiltinComponent<"embed">;
+  declare export var Fieldset: GlamorousBuiltinComponent<"fieldset">;
+  declare export var Figcaption: GlamorousBuiltinComponent<"figcaption">;
+  declare export var Figure: GlamorousBuiltinComponent<"figure">;
+  declare export var Font: GlamorousBuiltinComponent<"font">;
+  declare export var Footer: GlamorousBuiltinComponent<"footer">;
+  declare export var Form: GlamorousBuiltinComponent<"form">;
+  declare export var Frame: GlamorousBuiltinComponent<"frame">;
+  declare export var Frameset: GlamorousBuiltinComponent<"frameset">;
   declare export var H1: GlamorousBuiltinComponent<"h1">;
   declare export var H2: GlamorousBuiltinComponent<"h2">;
   declare export var H3: GlamorousBuiltinComponent<"h3">;
+  declare export var H4: GlamorousBuiltinComponent<"h4">;
+  declare export var H5: GlamorousBuiltinComponent<"h5">;
+  declare export var H6: GlamorousBuiltinComponent<"h6">;
+  declare export var Head: GlamorousBuiltinComponent<"head">;
+  declare export var Header: GlamorousBuiltinComponent<"header">;
+  declare export var Hgroup: GlamorousBuiltinComponent<"hgroup">;
+  declare export var Hr: GlamorousBuiltinComponent<"hr">;
+  declare export var Html: GlamorousBuiltinComponent<"html">;
+  declare export var I: GlamorousBuiltinComponent<"i">;
+  declare export var Iframe: GlamorousBuiltinComponent<"iframe">;
+  declare export var Image: GlamorousBuiltinComponent<"image">;
+  declare export var Img: GlamorousBuiltinComponent<"img">;
+  declare export var Input: GlamorousBuiltinComponent<"input">;
+  declare export var Ins: GlamorousBuiltinComponent<"ins">;
+  declare export var Isindex: GlamorousBuiltinComponent<"isindex">;
+  declare export var Kbd: GlamorousBuiltinComponent<"kbd">;
+  declare export var Keygen: GlamorousBuiltinComponent<"keygen">;
+  declare export var Label: GlamorousBuiltinComponent<"label">;
+  declare export var Legend: GlamorousBuiltinComponent<"legend">;
+  declare export var Li: GlamorousBuiltinComponent<"li">;
+  declare export var Link: GlamorousBuiltinComponent<"link">;
+  declare export var Listing: GlamorousBuiltinComponent<"listing">;
+  declare export var Main: GlamorousBuiltinComponent<"main">;
+  declare export var Map: GlamorousBuiltinComponent<"map">;
+  declare export var Mark: GlamorousBuiltinComponent<"mark">;
+  declare export var Marquee: GlamorousBuiltinComponent<"marquee">;
+  declare export var Math: GlamorousBuiltinComponent<"math">;
+  declare export var Menu: GlamorousBuiltinComponent<"menu">;
+  declare export var Menuitem: GlamorousBuiltinComponent<"menuitem">;
+  declare export var Meta: GlamorousBuiltinComponent<"meta">;
+  declare export var Meter: GlamorousBuiltinComponent<"meter">;
+  declare export var Multicol: GlamorousBuiltinComponent<"multicol">;
+  declare export var Nav: GlamorousBuiltinComponent<"nav">;
+  declare export var Nextid: GlamorousBuiltinComponent<"nextid">;
+  declare export var Nobr: GlamorousBuiltinComponent<"nobr">;
+  declare export var Noembed: GlamorousBuiltinComponent<"noembed">;
+  declare export var Noframes: GlamorousBuiltinComponent<"noframes">;
+  declare export var Noscript: GlamorousBuiltinComponent<"noscript">;
+  declare export var Object: GlamorousBuiltinComponent<"object">;
+  declare export var Ol: GlamorousBuiltinComponent<"ol">;
+  declare export var Optgroup: GlamorousBuiltinComponent<"optgroup">;
+  declare export var Option: GlamorousBuiltinComponent<"option">;
+  declare export var Output: GlamorousBuiltinComponent<"output">;
   declare export var P: GlamorousBuiltinComponent<"p">;
+  declare export var Param: GlamorousBuiltinComponent<"param">;
+  declare export var Picture: GlamorousBuiltinComponent<"picture">;
+  declare export var Plaintext: GlamorousBuiltinComponent<"plaintext">;
+  declare export var Pre: GlamorousBuiltinComponent<"pre">;
+  declare export var Progress: GlamorousBuiltinComponent<"progress">;
+  declare export var Q: GlamorousBuiltinComponent<"q">;
+  declare export var Rb: GlamorousBuiltinComponent<"rb">;
+  declare export var Rbc: GlamorousBuiltinComponent<"rbc">;
+  declare export var Rp: GlamorousBuiltinComponent<"rp">;
+  declare export var Rt: GlamorousBuiltinComponent<"rt">;
+  declare export var Rtc: GlamorousBuiltinComponent<"rtc">;
+  declare export var Ruby: GlamorousBuiltinComponent<"ruby">;
+  declare export var S: GlamorousBuiltinComponent<"s">;
+  declare export var Samp: GlamorousBuiltinComponent<"samp">;
+  declare export var Script: GlamorousBuiltinComponent<"script">;
+  declare export var Section: GlamorousBuiltinComponent<"section">;
+  declare export var Select: GlamorousBuiltinComponent<"select">;
+  declare export var Shadow: GlamorousBuiltinComponent<"shadow">;
+  declare export var Slot: GlamorousBuiltinComponent<"slot">;
+  declare export var Small: GlamorousBuiltinComponent<"small">;
+  declare export var Source: GlamorousBuiltinComponent<"source">;
+  declare export var Spacer: GlamorousBuiltinComponent<"spacer">;
   declare export var Span: GlamorousBuiltinComponent<"span">;
+  declare export var Strike: GlamorousBuiltinComponent<"strike">;
+  declare export var Strong: GlamorousBuiltinComponent<"strong">;
+  declare export var Style: GlamorousBuiltinComponent<"style">;
+  declare export var Sub: GlamorousBuiltinComponent<"sub">;
+  declare export var Summary: GlamorousBuiltinComponent<"summary">;
+  declare export var Sup: GlamorousBuiltinComponent<"sup">;
+  declare export var Svg: GlamorousBuiltinComponent<"svg">;
+  declare export var Table: GlamorousBuiltinComponent<"table">;
+  declare export var Tbody: GlamorousBuiltinComponent<"tbody">;
+  declare export var Td: GlamorousBuiltinComponent<"td">;
+  declare export var Template: GlamorousBuiltinComponent<"template">;
+  declare export var Textarea: GlamorousBuiltinComponent<"textarea">;
+  declare export var Tfoot: GlamorousBuiltinComponent<"tfoot">;
+  declare export var Th: GlamorousBuiltinComponent<"th">;
+  declare export var Thead: GlamorousBuiltinComponent<"thead">;
+  declare export var Time: GlamorousBuiltinComponent<"time">;
+  declare export var Title: GlamorousBuiltinComponent<"title">;
+  declare export var Tr: GlamorousBuiltinComponent<"tr">;
+  declare export var Track: GlamorousBuiltinComponent<"track">;
+  declare export var Tt: GlamorousBuiltinComponent<"tt">;
+  declare export var U: GlamorousBuiltinComponent<"u">;
   declare export var Ul: GlamorousBuiltinComponent<"ul">;
+  declare export var Var: GlamorousBuiltinComponent<"var">;
+  declare export var Video: GlamorousBuiltinComponent<"video">;
+  declare export var Wbr: GlamorousBuiltinComponent<"wbr">;
+  declare export var Xmp: GlamorousBuiltinComponent<"xmp">;
 
   declare export default Glamorous
 }

--- a/definitions/npm/glamorous_v4.x.x/test_glamorous.js
+++ b/definitions/npm/glamorous_v4.x.x/test_glamorous.js
@@ -14,28 +14,35 @@ const margin = ({ ml }: { ml: number }) => ({
   marginLeft: ml
 });
 
-glamorous.div({});
-// $ExpectError
+// No css properties
+(glamorous.div(): GlamorousComponent<React$ElementProps<"div">, {}>);
+(glamorous.div({}): GlamorousComponent<React$ElementProps<"div">, {}>);
+// $ExpectError: Invalid css properties
 glamorous.div({ notCSS: true });
 
+// Valid css properties
 (glamorous.div({ color: "red" }): GlamorousComponent<
   React$ElementProps<"div">,
   {}
 >);
 
+// A style function
 (glamorous.div(canBeBlue): GlamorousComponent<
   React$ElementProps<"div">,
   { isBlue: boolean }
 >);
 
+// Multiple style functions
 (glamorous.div(canBeBlue, margin): GlamorousComponent<
   React$ElementProps<"div">,
   { isBlue: boolean, ml: number }
 >);
 
 const MyDiv = glamorous.div(canBeBlue);
+// $ExpectError: Enforce style function required props
+<MyDiv />;
 <MyDiv isBlue />;
-// $ExpectError
+// $ExpectError: Enforce style function prop types
 <MyDiv isBlue={3} />;
 
 (glamorous(MyDiv)(margin): GlamorousComponent<

--- a/definitions/npm/glamorous_v4.x.x/test_glamorous.js
+++ b/definitions/npm/glamorous_v4.x.x/test_glamorous.js
@@ -55,15 +55,15 @@ glamorous(MyDiv, {
   forwardProps: ["a", "b"],
   shouldClassNameUpdate: (props, previousProps, context, previousContext) =>
     true,
-  propsAreCssOverrides: false,
-  withProps: {
-    isBlue: true
-  }
+  propsAreCssOverrides: false
+  // withProps: {
+  //   isBlue: true
+  // }
 })();
 
 <Span marginLeft={3} />;
 // $ExpectError
-<Span marginLeft={{}} />;
+<Span marginLeft={true} />;
 <glamorous.Span marginLeft={3} />;
 
 const css: CSSProperties = {
@@ -90,3 +90,21 @@ const StyledClassComponent = glamorous(ClassComponent)();
 // $ExpectError
 <StyledClassComponent />;
 <StyledClassComponent x={3} />;
+
+class ClassComponentWithDefaults extends React.Component<{
+  x: number,
+  className?: string,
+  theme?: Object
+}> {
+  static defaultProps = { x: 3 };
+  render() {
+    return null;
+  }
+}
+
+const StyledClassComponentWithDefaults = glamorous(
+  ClassComponentWithDefaults
+)();
+
+<StyledClassComponentWithDefaults />;
+// <StyledClassComponentWithDefaults x="3" />;

--- a/definitions/npm/glamorous_v4.x.x/test_glamorous.js
+++ b/definitions/npm/glamorous_v4.x.x/test_glamorous.js
@@ -117,3 +117,22 @@ const StyledClassComponentWithDefaults = glamorous(
 <StyledClassComponentWithDefaults x={3} />;
 // $ExpectError
 <StyledClassComponentWithDefaults x="3" />;
+
+const ClassComponentWithProps = StyledClassComponent.withProps({ x: 3 });
+
+// withProps extends default props
+<ClassComponentWithProps />;
+// withProps props can be overridden
+<ClassComponentWithProps x={4} />;
+// $ExpectError: withProps preserves prop types
+<ClassComponentWithProps x="3" />;
+
+const ClassComponentWithNoProps = StyledClassComponent.withProps({});
+<ClassComponentWithNoProps x={4} />;
+// $ExpectError: withProps preserves propTypes
+<ClassComponentWithNoProps />;
+// $ExpectError: withProps preserves propTypes
+<ClassComponentWithNoProps x="3" />;
+
+// $ExpectError: withProps only accepts props that exist
+StyledClassComponent.withProps({ notAProp: 3 });

--- a/definitions/npm/glamorous_v4.x.x/test_glamorous.js
+++ b/definitions/npm/glamorous_v4.x.x/test_glamorous.js
@@ -1,0 +1,65 @@
+// @flow
+import * as React from "react";
+import glamorous, { Span, type GlamorousComponent } from "glamorous";
+
+const canBeBlue = ({ isBlue }: { isBlue: boolean }) => ({
+  color: isBlue ? "blue" : "red"
+});
+
+const margin = ({ ml }: { ml: number }) => ({
+  marginLeft: ml
+});
+
+glamorous.div({});
+// $ExpectError
+glamorous.div({ notCSS: true });
+
+(glamorous.div({ color: "red" }): GlamorousComponent<
+  React$ElementProps<"div">,
+  {}
+>);
+
+(glamorous.div(canBeBlue): GlamorousComponent<
+  React$ElementProps<"div">,
+  { isBlue: boolean }
+>);
+
+(glamorous.div(canBeBlue, margin): GlamorousComponent<
+  React$ElementProps<"div">,
+  { isBlue: boolean, ml: number }
+>);
+
+const MyDiv = glamorous.div(canBeBlue);
+<MyDiv isBlue />;
+// $ExpectError
+<MyDiv isBlue={3} />;
+
+(glamorous(MyDiv)(margin): GlamorousComponent<
+  React$ElementProps<typeof MyDiv>,
+  { isBlue: boolean, ml: number }
+>);
+
+(MyDiv.withComponent("span"): GlamorousComponent<
+  React$ElementProps<"span">,
+  { isBlue: boolean }
+>);
+
+glamorous(MyDiv, {
+  displayName: "MyGlamorousDiv",
+  rootEl: "div",
+  filterProps: ["a", "b"],
+  forwardProps: ["a", "b"],
+  shouldClassNameUpdate: (props, previousProps, context, previousContext) =>
+    true,
+  propsAreCssOverrides: false,
+  withProps: {
+    isBlue: true
+  }
+})();
+
+<Span marginLeft={3} />;
+// $ExpectError
+<Span marginLeft={{}} />;
+<glamorous.Span marginLeft={3} />;
+
+glamorous.div({ ":first-child": { color: "blue" } });

--- a/definitions/npm/glamorous_v4.x.x/test_glamorous.js
+++ b/definitions/npm/glamorous_v4.x.x/test_glamorous.js
@@ -74,3 +74,19 @@ const css: CSSProperties = {
 };
 
 glamorous.div({ ":first-child": { color: "blue" } });
+
+class ClassComponent extends React.Component<{
+  x: number,
+  className?: string,
+  theme?: Object
+}> {
+  render() {
+    return null;
+  }
+}
+
+const StyledClassComponent = glamorous(ClassComponent)();
+
+// $ExpectError
+<StyledClassComponent />;
+<StyledClassComponent x={3} />;

--- a/definitions/npm/glamorous_v4.x.x/test_glamorous.js
+++ b/definitions/npm/glamorous_v4.x.x/test_glamorous.js
@@ -16,6 +16,9 @@ const margin = ({ ml }: { ml: number }) => ({
 
 // No css properties
 (glamorous.div(): GlamorousComponent<React$ElementProps<"div">, {}>);
+(glamorous.div(null): GlamorousComponent<React$ElementProps<"div">, {}>);
+(glamorous.div(undefined): GlamorousComponent<React$ElementProps<"div">, {}>);
+(glamorous.div(false): GlamorousComponent<React$ElementProps<"div">, {}>);
 (glamorous.div({}): GlamorousComponent<React$ElementProps<"div">, {}>);
 // $ExpectError: Invalid css properties
 glamorous.div({ notCSS: true });

--- a/definitions/npm/glamorous_v4.x.x/test_glamorous.js
+++ b/definitions/npm/glamorous_v4.x.x/test_glamorous.js
@@ -55,10 +55,10 @@ glamorous(MyDiv, {
   forwardProps: ["a", "b"],
   shouldClassNameUpdate: (props, previousProps, context, previousContext) =>
     true,
-  propsAreCssOverrides: false
-  // withProps: {
-  //   isBlue: true
-  // }
+  propsAreCssOverrides: false,
+  withProps: {
+    isBlue: true
+  }
 })();
 
 <Span marginLeft={3} />;
@@ -107,4 +107,6 @@ const StyledClassComponentWithDefaults = glamorous(
 )();
 
 <StyledClassComponentWithDefaults />;
-// <StyledClassComponentWithDefaults x="3" />;
+<StyledClassComponentWithDefaults x={3} />;
+// $ExpectError
+<StyledClassComponentWithDefaults x="3" />;

--- a/definitions/npm/glamorous_v4.x.x/test_glamorous.js
+++ b/definitions/npm/glamorous_v4.x.x/test_glamorous.js
@@ -14,32 +14,52 @@ const margin = ({ ml }: { ml: number }) => ({
   marginLeft: ml
 });
 
-// No css properties
-(glamorous.div(): GlamorousComponent<React$ElementProps<"div">, {}>);
-(glamorous.div(null): GlamorousComponent<React$ElementProps<"div">, {}>);
-(glamorous.div(undefined): GlamorousComponent<React$ElementProps<"div">, {}>);
-(glamorous.div(false): GlamorousComponent<React$ElementProps<"div">, {}>);
-(glamorous.div({}): GlamorousComponent<React$ElementProps<"div">, {}>);
-// $ExpectError: Invalid css properties
-glamorous.div({ notCSS: true });
+// CSS Properties
+{
+  // No css properties
+  (glamorous.div(): GlamorousComponent<React$ElementProps<"div">, {}>);
+  (glamorous.div(null): GlamorousComponent<React$ElementProps<"div">, {}>);
+  (glamorous.div(undefined): GlamorousComponent<React$ElementProps<"div">, {}>);
+  (glamorous.div(false): GlamorousComponent<React$ElementProps<"div">, {}>);
+  (glamorous.div({}): GlamorousComponent<React$ElementProps<"div">, {}>);
+  // $ExpectError: Invalid css properties
+  glamorous.div({ notCSS: true });
 
-// Valid css properties
-(glamorous.div({ color: "red" }): GlamorousComponent<
-  React$ElementProps<"div">,
-  {}
->);
+  // Valid css properties
+  (glamorous.div({ color: "red" }): GlamorousComponent<
+    React$ElementProps<"div">,
+    {}
+  >);
+}
 
-// A style function
-(glamorous.div(canBeBlue): GlamorousComponent<
-  React$ElementProps<"div">,
-  { isBlue: boolean }
->);
+// Style functions
+{
+  // A style function
+  (glamorous.div(canBeBlue): GlamorousComponent<
+    React$ElementProps<"div">,
+    { isBlue: boolean }
+  >);
 
-// Multiple style functions
-(glamorous.div(canBeBlue, margin): GlamorousComponent<
-  React$ElementProps<"div">,
-  { isBlue: boolean, ml: number }
->);
+  // Multiple style functions
+  (glamorous.div(canBeBlue, margin): GlamorousComponent<
+    React$ElementProps<"div">,
+    { isBlue: boolean, ml: number }
+  >);
+
+  // Styles functions that can return falsy values
+  (glamorous.div(() => false): GlamorousComponent<
+    React$ElementProps<"div">,
+    {}
+  >);
+  (glamorous.div(() => undefined): GlamorousComponent<
+    React$ElementProps<"div">,
+    {}
+  >);
+  (glamorous.div(() => null): GlamorousComponent<
+    React$ElementProps<"div">,
+    {}
+  >);
+}
 
 const MyDiv = glamorous.div(canBeBlue);
 // $ExpectError: Enforce style function required props
@@ -71,10 +91,15 @@ glamorous(MyDiv, {
   }
 })();
 
-<Span marginLeft={3} />;
-// $ExpectError
-<Span marginLeft={true} />;
-<glamorous.Span marginLeft={3} />;
+// Built-in components
+{
+  <Span>children</Span>;
+  <Span css={{ marginLeft: 3 }} />;
+  <Span marginLeft={3} />;
+  // $ExpectError
+  <Span marginLeft={true} />;
+  <glamorous.Span marginLeft={3} />;
+}
 
 const css: CSSProperties = {
   color: "blue",

--- a/definitions/npm/glamorous_v4.x.x/test_glamorous.js
+++ b/definitions/npm/glamorous_v4.x.x/test_glamorous.js
@@ -1,6 +1,10 @@
 // @flow
 import * as React from "react";
-import glamorous, { Span, type GlamorousComponent } from "glamorous";
+import glamorous, {
+  Span,
+  type GlamorousComponent,
+  type CSSProperties
+} from "glamorous";
 
 const canBeBlue = ({ isBlue }: { isBlue: boolean }) => ({
   color: isBlue ? "blue" : "red"
@@ -61,5 +65,12 @@ glamorous(MyDiv, {
 // $ExpectError
 <Span marginLeft={{}} />;
 <glamorous.Span marginLeft={3} />;
+
+const css: CSSProperties = {
+  color: "blue",
+  foo: {
+    color: "blue"
+  }
+};
 
 glamorous.div({ ":first-child": { color: "blue" } });


### PR DESCRIPTION
This is a work in progress, but I wanted to get a PR up for visibility.

This adds types for glamorous. At the moment, it only adds a couple css properties because having all of the properties in there makes the file cumbersome to work with.

@GAntoine is it possible to split a libdef into multiple files?

Dev with:

```bash
fswatch -l 0.1 -0 . | xargs -0 -n1 -I {} bash -c 'clear && flow --include-warnings'
```

Glamorous tracking issue here: https://github.com/paypal/glamorous/issues/348