### PR TITLE
react-dnd definition: Add DragDropContextProvider

### DIFF
--- a/definitions/npm/react-dnd_v2.x.x/flow_v0.53.x-/react-dnd_v2.x.x.js
+++ b/definitions/npm/react-dnd_v2.x.x/flow_v0.53.x-/react-dnd_v2.x.x.js
@@ -198,6 +198,16 @@ declare module "react-dnd" {
   // Drag Drop Context
   // ----------------------------------------------------------------------
 
+	declare type ProviderProps = {
+		backend: mixed,
+		children: React$Element<any>,
+		window?: Object
+	};
+
+	declare class DragDropContextProvider<ProviderProps> extends React$Component<ProviderProps> {
+		props: ProviderProps;
+	};
+  
   declare function DragDropContext<OP: {}, CP: {}>(
     backend: mixed
   ): Connector<$Supertype<OP & CP>, CP>;

--- a/definitions/npm/react-dnd_v2.x.x/flow_v0.53.x-/react-dnd_v2.x.x.js
+++ b/definitions/npm/react-dnd_v2.x.x/flow_v0.53.x-/react-dnd_v2.x.x.js
@@ -206,7 +206,7 @@ declare module "react-dnd" {
 
 	declare class DragDropContextProvider<ProviderProps> extends React$Component<ProviderProps> {
 		props: ProviderProps;
-	};
+	}
   
   declare function DragDropContext<OP: {}, CP: {}>(
     backend: mixed


### PR DESCRIPTION
Adds a definition for react-dnd's DragDropContextProvider component.

Here's the component's docs:
http://react-dnd.github.io/react-dnd/docs-drag-drop-context-provider.html

And its source:
https://github.com/react-dnd/react-dnd/blob/master/packages/react-dnd/src/DragDropContextProvider.js

The prop typing mirrors the source's PropTypes. Let me know if anything is missing.