### PR TITLE
Fix options for react-redux_v5

### DIFF
--- a/definitions/npm/react-redux_v5.x.x/flow_v0.30.x-v0.52.x/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.30.x-v0.52.x/react-redux_v5.x.x.js
@@ -64,9 +64,33 @@ declare module "react-redux" {
     void
   > {}
 
+  declare function areStatesEqual(
+    nextState?: Object,
+    state?: Object,
+  ): boolean;
+
+  declare function areStatesEqual(
+    nextOwnProps?: Object,
+    ownProps?: Object,
+  ): boolean;
+
+  declare function areStatePropsEqual(
+    nextStateProps?: Object,
+    stateProps?: Object,
+  ): boolean;
+
+  declare function areMergedPropsEqual(
+    nextMergedProps?: Object,
+    mergedProps?: Object,
+  ): boolean;
+
   declare type ConnectOptions = {
     pure?: boolean,
-    withRef?: boolean
+    areStatesEqual?: areStatesEqual,
+    areOwnPropsEqual?: areOwnPropsEqual,
+    areStatePropsEqual?: areStatePropsEqual,
+    areMergedPropsEqual?: areMergedPropsEqual,
+    storeKey?: string,
   };
 
   declare type Null = null | void;

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.30.x-v0.52.x/test_connect.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.30.x-v0.52.x/test_connect.js
@@ -77,12 +77,60 @@ const CC3 = connect()(C3);
 // connect(null, null, nul, options)
 //
 
+/** Test: pure */
 connect(null, null, null, { pure: true })(C1);
 // $ExpectError
 connect(null, null, null, { pure: 1 })(C1); // wrong type
-connect(null, null, null, { withRef: true })(C1);
+
+/** Test: areStatesEqual */
+connect(null, null, null, { areStatesEqual: (nextState = {}, state = {}) => true })(C1);
 // $ExpectError
-connect(null, null, null, { withRef: 1 })(C1); // wrong type
+connect(null, null, null, { areStatesEqual: 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatesEqual: (nextState = {}, state = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatesEqual: (nextState = 1, state = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatesEqual: (nextState = {}, state = 1) => 1 })(C1); // wrong type
+
+/** Test: areOwnPropsEqual */
+connect(null, null, null, { areOwnPropsEqual: (nextOwnProps = {}, ownProps = {}) => true })(C1);
+// $ExpectError
+connect(null, null, null, { areOwnPropsEqual: 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areOwnPropsEqual: (nextOwnProps = {}, ownProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areOwnPropsEqual: (nextOwnProps = 1, ownProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areOwnPropsEqual: (nextOwnProps = {}, ownProps = 1) => 1 })(C1); // wrong type
+
+/** Test: areStatePropsEqual */
+connect(null, null, null, { areStatePropsEqual: (nextStateProps = {}, stateProps = {}) => true })(C1);
+// $ExpectError
+connect(null, null, null, { areStatePropsEqual: 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatePropsEqual: (nextStateProps = {}, stateProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatePropsEqual: (nextStateProps = 1, stateProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatePropsEqual: (nextStateProps = {}, stateProps = 1) => 1 })(C1); // wrong type
+
+/** Test: areMergedPropsEqual */
+connect(null, null, null, { areMergedPropsEqual: (nextMergedProps = {}, mergedProps = {}) => true })(C1);
+// $ExpectError
+connect(null, null, null, { areMergedPropsEqual: 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areMergedPropsEqual: (nextMergedProps = {}, mergedProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areMergedPropsEqual: (nextMergedProps = 1, mergedProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areMergedPropsEqual: (nextMergedProps = {}, mergedProps = 1) => 1 })(C1); // wrong type
+
+/** Test: storeKey */
+connect(null, null, null, { storeKey: 'test' })(C1);
+// $ExpectError
+connect(null, null, null, { storeKey: 1 })(C1);
+
 const CC4 = connect(null, null, null, {})(C1);
 <CC4 a={1} b="s" />;
 // $ExpectError

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.53.x-v0.53.x/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.53.x-v0.53.x/react-redux_v5.x.x.js
@@ -56,9 +56,33 @@ declare module "react-redux" {
     subKey?: string
   ): Provider<*, *>;
 
+  declare function areStatesEqual(
+    nextState?: Object,
+    state?: Object,
+  ): boolean;
+
+  declare function areStatesEqual(
+    nextOwnProps?: Object,
+    ownProps?: Object,
+  ): boolean;
+
+  declare function areStatePropsEqual(
+    nextStateProps?: Object,
+    stateProps?: Object,
+  ): boolean;
+
+  declare function areMergedPropsEqual(
+    nextMergedProps?: Object,
+    mergedProps?: Object,
+  ): boolean;
+
   declare type ConnectOptions = {
     pure?: boolean,
-    withRef?: boolean
+    areStatesEqual?: areStatesEqual,
+    areOwnPropsEqual?: areOwnPropsEqual,
+    areStatePropsEqual?: areStatePropsEqual,
+    areMergedPropsEqual?: areMergedPropsEqual,
+    storeKey?: string,
   };
 
   declare type Null = null | void;

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.53.x-v0.53.x/test_connect.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.53.x-v0.53.x/test_connect.js
@@ -76,12 +76,60 @@ const CC3 = connect()(C3);
 // connect(null, null, nul, options)
 //
 
+/** Test: pure */
 connect(null, null, null, { pure: true })(C1);
 // $ExpectError
 connect(null, null, null, { pure: 1 })(C1); // wrong type
-connect(null, null, null, { withRef: true })(C1);
+
+/** Test: areStatesEqual */
+connect(null, null, null, { areStatesEqual: (nextState = {}, state = {}) => true })(C1);
 // $ExpectError
-connect(null, null, null, { withRef: 1 })(C1); // wrong type
+connect(null, null, null, { areStatesEqual: 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatesEqual: (nextState = {}, state = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatesEqual: (nextState = 1, state = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatesEqual: (nextState = {}, state = 1) => 1 })(C1); // wrong type
+
+/** Test: areOwnPropsEqual */
+connect(null, null, null, { areOwnPropsEqual: (nextOwnProps = {}, ownProps = {}) => true })(C1);
+// $ExpectError
+connect(null, null, null, { areOwnPropsEqual: 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areOwnPropsEqual: (nextOwnProps = {}, ownProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areOwnPropsEqual: (nextOwnProps = 1, ownProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areOwnPropsEqual: (nextOwnProps = {}, ownProps = 1) => 1 })(C1); // wrong type
+
+/** Test: areStatePropsEqual */
+connect(null, null, null, { areStatePropsEqual: (nextStateProps = {}, stateProps = {}) => true })(C1);
+// $ExpectError
+connect(null, null, null, { areStatePropsEqual: 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatePropsEqual: (nextStateProps = {}, stateProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatePropsEqual: (nextStateProps = 1, stateProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatePropsEqual: (nextStateProps = {}, stateProps = 1) => 1 })(C1); // wrong type
+
+/** Test: areMergedPropsEqual */
+connect(null, null, null, { areMergedPropsEqual: (nextMergedProps = {}, mergedProps = {}) => true })(C1);
+// $ExpectError
+connect(null, null, null, { areMergedPropsEqual: 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areMergedPropsEqual: (nextMergedProps = {}, mergedProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areMergedPropsEqual: (nextMergedProps = 1, mergedProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areMergedPropsEqual: (nextMergedProps = {}, mergedProps = 1) => 1 })(C1); // wrong type
+
+/** Test: storeKey */
+connect(null, null, null, { storeKey: 'test' })(C1);
+// $ExpectError
+connect(null, null, null, { storeKey: 1 })(C1);
+
 const CC4 = connect(null, null, null, {})(C1);
 <CC4 a={1} b="s" />;
 // $ExpectError

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.54.x-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.54.x-/react-redux_v5.x.x.js
@@ -74,9 +74,33 @@ declare module "react-redux" {
     subKey?: string
   ): Provider<*, *>;
 
+  declare function areStatesEqual(
+    nextState?: Object,
+    state?: Object,
+  ): boolean;
+
+  declare function areStatesEqual(
+    nextOwnProps?: Object,
+    ownProps?: Object,
+  ): boolean;
+
+  declare function areStatePropsEqual(
+    nextStateProps?: Object,
+    stateProps?: Object,
+  ): boolean;
+
+  declare function areMergedPropsEqual(
+    nextMergedProps?: Object,
+    mergedProps?: Object,
+  ): boolean;
+
   declare type ConnectOptions = {
     pure?: boolean,
-    withRef?: boolean
+    areStatesEqual?: areStatesEqual,
+    areOwnPropsEqual?: areOwnPropsEqual,
+    areStatePropsEqual?: areStatePropsEqual,
+    areMergedPropsEqual?: areMergedPropsEqual,
+    storeKey?: string,
   };
 
   declare type Null = null | void;

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.54.x-/test_connect.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.54.x-/test_connect.js
@@ -105,12 +105,60 @@ const CC3 = connect()(C3);
 // connect(null, null, nul, options)
 //
 
+/** Test: pure */
 connect(null, null, null, { pure: true })(C1);
 // $ExpectError
 connect(null, null, null, { pure: 1 })(C1); // wrong type
-connect(null, null, null, { withRef: true })(C1);
+
+/** Test: areStatesEqual */
+connect(null, null, null, { areStatesEqual: (nextState = {}, state = {}) => true })(C1);
 // $ExpectError
-connect(null, null, null, { withRef: 1 })(C1); // wrong type
+connect(null, null, null, { areStatesEqual: 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatesEqual: (nextState = {}, state = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatesEqual: (nextState = 1, state = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatesEqual: (nextState = {}, state = 1) => 1 })(C1); // wrong type
+
+/** Test: areOwnPropsEqual */
+connect(null, null, null, { areOwnPropsEqual: (nextOwnProps = {}, ownProps = {}) => true })(C1);
+// $ExpectError
+connect(null, null, null, { areOwnPropsEqual: 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areOwnPropsEqual: (nextOwnProps = {}, ownProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areOwnPropsEqual: (nextOwnProps = 1, ownProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areOwnPropsEqual: (nextOwnProps = {}, ownProps = 1) => 1 })(C1); // wrong type
+
+/** Test: areStatePropsEqual */
+connect(null, null, null, { areStatePropsEqual: (nextStateProps = {}, stateProps = {}) => true })(C1);
+// $ExpectError
+connect(null, null, null, { areStatePropsEqual: 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatePropsEqual: (nextStateProps = {}, stateProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatePropsEqual: (nextStateProps = 1, stateProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areStatePropsEqual: (nextStateProps = {}, stateProps = 1) => 1 })(C1); // wrong type
+
+/** Test: areMergedPropsEqual */
+connect(null, null, null, { areMergedPropsEqual: (nextMergedProps = {}, mergedProps = {}) => true })(C1);
+// $ExpectError
+connect(null, null, null, { areMergedPropsEqual: 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areMergedPropsEqual: (nextMergedProps = {}, mergedProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areMergedPropsEqual: (nextMergedProps = 1, mergedProps = {}) => 1 })(C1); // wrong type
+// $ExpectError
+connect(null, null, null, { areMergedPropsEqual: (nextMergedProps = {}, mergedProps = 1) => 1 })(C1); // wrong type
+
+/** Test: storeKey */
+connect(null, null, null, { storeKey: 'test' })(C1);
+// $ExpectError
+connect(null, null, null, { storeKey: 1 })(C1);
+
 const CC4 = connect(null, null, null, {})(C1);
 <CC4 a={1} b="s" />;
 // $ExpectError


### PR DESCRIPTION
In react-redux v5 we have a new or different options object, the one currently described in flow-typed is the options object for `connectAdvanced`. The current options according to the API are described [here](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options). Please bare with me since this is my first PR to flow-typed and I don't use flow myself so I had a bit of trouble running the tests, but I think they should be fine. (Just making this PR to do a PR to a library I'm using).