### PR TITLE
Fix outdated React Native libdefs for Styled Components

### DIFF
--- a/definitions/npm/styled-components_v2.x.x/flow_v0.25.x-v0.41.x/styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/flow_v0.25.x-v0.41.x/styled-components_v2.x.x.js
@@ -218,6 +218,7 @@ declare module 'styled-components/native' {
     DrawerLayoutAndroid: StyledComponent,
     FlatList: StyledComponent,
     Image: StyledComponent,
+    ImageBackground: StyledComponent,
     ImageEditor: StyledComponent,
     ImageStore: StyledComponent,
     KeyboardAvoidingView: StyledComponent,

--- a/definitions/npm/styled-components_v2.x.x/flow_v0.25.x-v0.41.x/styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/flow_v0.25.x-v0.41.x/styled-components_v2.x.x.js
@@ -225,7 +225,6 @@ declare module 'styled-components/native' {
     ListView: StyledComponent,
     MapView: StyledComponent,
     Modal: StyledComponent,
-    Navigator: StyledComponent,
     NavigatorIOS: StyledComponent,
     Picker: StyledComponent,
     PickerIOS: StyledComponent,

--- a/definitions/npm/styled-components_v2.x.x/flow_v0.42.x-v0.52.x/styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/flow_v0.42.x-v0.52.x/styled-components_v2.x.x.js
@@ -280,7 +280,6 @@ type $npm$styledComponents$StyledComponentsNativeComponentList = {|
   ListView:                     $npm$styledComponents$StyledComponentsNativeComponentListValue,
   MapView:                      $npm$styledComponents$StyledComponentsNativeComponentListValue,
   Modal:                        $npm$styledComponents$StyledComponentsNativeComponentListValue,
-  Navigator:                    $npm$styledComponents$StyledComponentsNativeComponentListValue,
   NavigatorIOS:                 $npm$styledComponents$StyledComponentsNativeComponentListValue,
   Picker:                       $npm$styledComponents$StyledComponentsNativeComponentListValue,
   PickerIOS:                    $npm$styledComponents$StyledComponentsNativeComponentListValue,

--- a/definitions/npm/styled-components_v2.x.x/flow_v0.42.x-v0.52.x/styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/flow_v0.42.x-v0.52.x/styled-components_v2.x.x.js
@@ -273,6 +273,7 @@ type $npm$styledComponents$StyledComponentsNativeComponentList = {|
   DrawerLayoutAndroid:          $npm$styledComponents$StyledComponentsNativeComponentListValue,
   FlatList:                     $npm$styledComponents$StyledComponentsNativeComponentListValue,
   Image:                        $npm$styledComponents$StyledComponentsNativeComponentListValue,
+  ImageBackground:              $npm$styledComponents$StyledComponentsNativeComponentListValue,
   ImageEditor:                  $npm$styledComponents$StyledComponentsNativeComponentListValue,
   ImageStore:                   $npm$styledComponents$StyledComponentsNativeComponentListValue,
   KeyboardAvoidingView:         $npm$styledComponents$StyledComponentsNativeComponentListValue,

--- a/definitions/npm/styled-components_v2.x.x/flow_v0.53.x-/styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/flow_v0.53.x-/styled-components_v2.x.x.js
@@ -316,6 +316,7 @@ type $npm$styledComponents$StyledComponentsNativeComponentList = {|
   DrawerLayoutAndroid:          $npm$styledComponents$StyledComponentsNativeComponentListValue,
   FlatList:                     $npm$styledComponents$StyledComponentsNativeComponentListValue,
   Image:                        $npm$styledComponents$StyledComponentsNativeComponentListValue,
+  ImageBackground:              $npm$styledComponents$StyledComponentsNativeComponentListValue,
   ImageEditor:                  $npm$styledComponents$StyledComponentsNativeComponentListValue,
   ImageStore:                   $npm$styledComponents$StyledComponentsNativeComponentListValue,
   KeyboardAvoidingView:         $npm$styledComponents$StyledComponentsNativeComponentListValue,

--- a/definitions/npm/styled-components_v2.x.x/flow_v0.53.x-/styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/flow_v0.53.x-/styled-components_v2.x.x.js
@@ -323,7 +323,6 @@ type $npm$styledComponents$StyledComponentsNativeComponentList = {|
   ListView:                     $npm$styledComponents$StyledComponentsNativeComponentListValue,
   MapView:                      $npm$styledComponents$StyledComponentsNativeComponentListValue,
   Modal:                        $npm$styledComponents$StyledComponentsNativeComponentListValue,
-  Navigator:                    $npm$styledComponents$StyledComponentsNativeComponentListValue,
   NavigatorIOS:                 $npm$styledComponents$StyledComponentsNativeComponentListValue,
   Picker:                       $npm$styledComponents$StyledComponentsNativeComponentListValue,
   PickerIOS:                    $npm$styledComponents$StyledComponentsNativeComponentListValue,


### PR DESCRIPTION
- [x] Removed Navigator (was deprecated in [v0.44.3](https://github.com/facebook/react-native/releases?after=v0.45.1))
- [x] Added [ImageBackground](https://github.com/facebook/react-native/blob/master/Libraries/Image/ImageBackground.js) (was added in [v0.46.4](https://github.com/facebook/react-native/releases?after=v0.48.0-rc.0))