### PR TITLE
Allow `moment.utc(undefined)` calls

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_v0.28.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.28.x-/moment_v2.x.x.js
@@ -1,26 +1,26 @@
 type moment$MomentOptions = {
-  y?: number|string,
-  year?: number|string,
-  years?: number|string,
-  M?: number|string,
-  month?: number|string,
-  months?: number|string,
-  d?: number|string,
-  day?: number|string,
-  days?: number|string,
-  date?: number|string,
-  h?: number|string,
-  hour?: number|string,
-  hours?: number|string,
-  m?: number|string,
-  minute?: number|string,
-  minutes?: number|string,
-  s?: number|string,
-  second?: number|string,
-  seconds?: number|string,
-  ms?: number|string,
-  millisecond?: number|string,
-  milliseconds?: number|string,
+  y?: number | string,
+  year?: number | string,
+  years?: number | string,
+  M?: number | string,
+  month?: number | string,
+  months?: number | string,
+  d?: number | string,
+  day?: number | string,
+  days?: number | string,
+  date?: number | string,
+  h?: number | string,
+  hour?: number | string,
+  hours?: number | string,
+  m?: number | string,
+  minute?: number | string,
+  minutes?: number | string,
+  s?: number | string,
+  second?: number | string,
+  seconds?: number | string,
+  ms?: number | string,
+  millisecond?: number | string,
+  milliseconds?: number | string,
 };
 
 type moment$MomentObject = {
@@ -37,11 +37,11 @@ type moment$MomentCreationData = {
   input: string,
   format: string,
   locale: Object,
-  isUTC: bool,
-  strict: bool,
+  isUTC: boolean,
+  strict: boolean,
 };
 
-type moment$CalendarFormat = string | (moment: moment$Moment) => string;
+type moment$CalendarFormat = string | ((moment: moment$Moment) => string);
 
 type moment$CalendarFormats = {
   sameDay?: moment$CalendarFormat,
@@ -52,7 +52,7 @@ type moment$CalendarFormats = {
   sameElse?: moment$CalendarFormat,
 };
 
-type moment$Inclusivity = '()' | '[)' | '()' | '(]' | '[]'
+type moment$Inclusivity = '()' | '[)' | '()' | '(]' | '[]';
 
 declare class moment$LocaleData {
   months(moment: moment$Moment): string;
@@ -63,10 +63,18 @@ declare class moment$LocaleData {
   weekdaysMin(moment: moment$Moment): string;
   weekdaysParse(weekDay: string): number;
   longDateFormat(dateFormat: string): string;
-  isPM(date: string): bool;
-  meridiem(hours: number, minutes: number, isLower: bool): string;
-  calendar(key: 'sameDay'|'nextDay'|'lastDay'|'nextWeek'|'prevWeek'|'sameElse', moment: moment$Moment): string;
-  relativeTime(number: number, withoutSuffix: bool, key: 's'|'m'|'mm'|'h'|'hh'|'d'|'dd'|'M'|'MM'|'y'|'yy', isFuture: bool): string;
+  isPM(date: string): boolean;
+  meridiem(hours: number, minutes: number, isLower: boolean): string;
+  calendar(
+    key: 'sameDay' | 'nextDay' | 'lastDay' | 'nextWeek' | 'prevWeek' | 'sameElse',
+    moment: moment$Moment
+  ): string;
+  relativeTime(
+    number: number,
+    withoutSuffix: boolean,
+    key: 's' | 'm' | 'mm' | 'h' | 'hh' | 'd' | 'dd' | 'M' | 'MM' | 'y' | 'yy',
+    isFuture: boolean
+  ): string;
   pastFuture(diff: any, relTime: string): string;
   ordinal(number: number): string;
   preparse(str: string): any;
@@ -77,7 +85,7 @@ declare class moment$LocaleData {
   firstDayOfYear(): number;
 }
 declare class moment$MomentDuration {
-  humanize(suffix?: bool): string;
+  humanize(suffix?: boolean): string;
   milliseconds(): number;
   asMilliseconds(): number;
   seconds(): number;
@@ -92,33 +100,39 @@ declare class moment$MomentDuration {
   asMonths(): number;
   years(): number;
   asYears(): number;
-  add(value: number|moment$MomentDuration|Object, unit?: string): this;
-  subtract(value: number|moment$MomentDuration|Object, unit?: string): this;
+  add(value: number | moment$MomentDuration | Object, unit?: string): this;
+  subtract(value: number | moment$MomentDuration | Object, unit?: string): this;
   as(unit: string): number;
   get(unit: string): number;
   toJSON(): string;
   toISOString(): string;
-  isValid(): bool;
+  isValid(): boolean;
 }
 declare class moment$Moment {
   static ISO_8601: string;
-  static (string?: string, format?: string|Array<string>, locale?: string, strict?: bool): moment$Moment;
   static (
-      initDate: ?Object|number|Date|Array<number>|moment$Moment|string,
-      validFormats?: ?Array<string>|string,
-      locale?: ?boolean|string,
-      strict?: ?boolean|string
+    string?: string,
+    format?: string | Array<string>,
+    strict?: boolean
+  ): moment$Moment;
+  static (
+    string?: string,
+    format?: string | Array<string>,
+    locale?: string,
+    strict?: boolean
+  ): moment$Moment;
+  static (
+    initDate: ?Object | number | Date | Array<number> | moment$Moment | string | void
   ): moment$Moment;
   static unix(seconds: number): moment$Moment;
-  static utc(): moment$Moment;
-  static utc(number: number|Array<number>): moment$Moment;
-  static utc(str: string, str2?: string|Array<string>, str3?: string): moment$Moment;
+  static utc(void): moment$Moment;
+  static utc(number: number | Array<number>): moment$Moment;
+  static utc(str: string, str2?: string | Array<string>, str3?: string): moment$Moment;
   static utc(moment: moment$Moment): moment$Moment;
   static utc(date: Date): moment$Moment;
+  static parseZone(): moment$Moment;
   static parseZone(rawDate: string): moment$Moment;
   parseZone(): moment$Moment;
-  isValid(): bool;
-  invalidAt(): 0|1|2|3|4|5|6;
   creationData(): moment$MomentCreationData;
   millisecond(number: number): this;
   milliseconds(number: number): this;
@@ -140,8 +154,8 @@ declare class moment$Moment {
   dates(number: number): this;
   date(): number;
   dates(): number;
-  day(day: number|string): this;
-  days(day: number|string): this;
+  day(day: number | string): this;
+  days(day: number | string): this;
   day(): number;
   days(): number;
   weekday(number: number): this;
@@ -181,21 +195,41 @@ declare class moment$Moment {
   static max(dates: Array<moment$Moment>): moment$Moment;
   static min(...dates: Array<moment$Moment>): moment$Moment;
   static min(dates: Array<moment$Moment>): moment$Moment;
-  add(value: number|moment$MomentDuration|moment$Moment|Object, unit?: string): this;
-  subtract(value: number|moment$MomentDuration|moment$Moment|string|Object, unit?: string): this;
+  add(
+    value: number | moment$MomentDuration | moment$Moment | Object,
+    unit?: string
+  ): this;
+  subtract(
+    value: number | moment$MomentDuration | moment$Moment | string | Object,
+    unit?: string
+  ): this;
   startOf(unit: string): this;
   endOf(unit: string): this;
   local(): this;
   utc(): this;
-  utcOffset(offset: number|string, keepLocalTime?: boolean, keepMinutes?: boolean): this;
+  utcOffset(
+    offset: number | string,
+    keepLocalTime?: boolean,
+    keepMinutes?: boolean
+  ): this;
   utcOffset(): number;
   format(format?: string): string;
-  fromNow(removeSuffix?: bool): string;
-  from(value: moment$Moment|string|number|Date|Array<number>, removePrefix?: bool): string;
-  toNow(removePrefix?: bool): string;
-  to(value: moment$Moment|string|number|Date|Array<number>, removePrefix?: bool): string;
+  fromNow(removeSuffix?: boolean): string;
+  from(
+    value: moment$Moment | string | number | Date | Array<number>,
+    removePrefix?: boolean
+  ): string;
+  toNow(removePrefix?: boolean): string;
+  to(
+    value: moment$Moment | string | number | Date | Array<number>,
+    removePrefix?: boolean
+  ): string;
   calendar(refTime?: any, formats?: moment$CalendarFormats): string;
-  diff(date: moment$Moment|string|number|Date|Array<number>, format?: string, floating?: bool): number;
+  diff(
+    date: moment$Moment | string | number | Date | Array<number>,
+    format?: string,
+    floating?: boolean
+  ): number;
   valueOf(): number;
   unix(): number;
   daysInMonth(): number;
@@ -204,22 +238,40 @@ declare class moment$Moment {
   toJSON(): string;
   toISOString(): string;
   toObject(): moment$MomentObject;
-  isBetween(from: moment$Moment|string|number|Date|Array<number>, to: moment$Moment|string|number|Date|Array<number>, units?: string, inclusivity?: moment$Inclusivity): bool;
-  isBefore(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
-  isSame(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
-  isAfter(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
-  isSameOrBefore(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
-  isSameOrAfter(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
-  isDST(): bool;
-  isDSTShifted(): bool;
-  isLeapYear(): bool;
+  isBefore(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean;
+  isSame(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean;
+  isAfter(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean;
+  isSameOrBefore(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean;
+  isSameOrAfter(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean;
+  isBetween(
+    fromDate: moment$Moment | string | number | Date | Array<number>,
+    toDate?: ?moment$Moment | string | number | Date | Array<number>,
+    granularity?: ?string,
+    inclusion?: ?string
+  ): boolean;
+  isDST(): boolean;
+  isDSTShifted(): boolean;
+  isLeapYear(): boolean;
   clone(): moment$Moment;
-  static isMoment(obj: any): bool;
-  static isDate(obj: any): bool;
   static updateLocale(locale: string, localeData?: ?Object): void;
   static locale(locale?: string, localeData?: Object): string;
   static locale(locales: Array<string>): string;
-  locale(locale: string, customization?: Object|null): moment$Moment;
+  locale(locale: string, customization?: Object | null): moment$Moment;
   locale(): string;
   static months(): Array<string>;
   static monthsShort(): Array<string>;
@@ -232,8 +284,8 @@ declare class moment$Moment {
   static weekdaysShort(): string;
   static weekdaysMin(): string;
   static localeData(key?: string): moment$LocaleData;
-  static duration(value: number|Object|string, unit?: string): moment$MomentDuration;
-  static isDuration(obj: any): bool;
+  static duration(value: number | Object | string, unit?: string): moment$MomentDuration;
+  static isDuration(obj: any): boolean;
   static normalizeUnits(unit: string): string;
   static invalid(object: any): moment$Moment;
 }

--- a/definitions/npm/moment_v2.x.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.x.x/test_moment-v2.js
@@ -1,71 +1,104 @@
 // @flow
-import moment from "moment";
+import moment from 'moment';
+import { describe, it } from 'flow-typed-test';
 
-// Parse
-const m3: moment = moment([123, 123]);
+describe('moment', () => {
+  it('moment()', () => {
+    let m: moment;
+    m = moment();
+    m = moment('2018-01-01');
+    m = moment([123, 123]);
+    m = moment(undefined);
+  });
 
-// $ExpectError
-moment.unix("1234");
+  it('moment.utc()', () => {
+    let m: moment;
+    m = moment.utc();
+    m = moment.utc('2018-01-01');
+    m = moment.utc([123, 123]);
+    m = moment.utc(undefined);
+  });
 
-// Display
-const A: Date = moment().toDate();
-const x: string = moment().toISOString();
+  it('moment.unix()', () => {
+    // $ExpectError
+    moment.unix('1234');
+  });
 
-// Get + Set
-// $ExpectError
-moment().millisecond().seconds();
-moment().milliseconds(100).seconds();
+  it('export raw values', () => {
+    const A: Date = moment().toDate();
+    const x: string = moment().toISOString();
+  });
 
-// Manipulate
-const m1: moment = moment().add(2, "day");
-moment().add({ day: 1 });
-const m2: moment = moment().subtract(1, "s");
-moment().subtract({ day: 1 });
-const m: moment = moment.utc();
+  it('Get + Set', () => {
+    // Get + Set
+    // $ExpectError
+    moment()
+      .millisecond()
+      .seconds();
+    moment()
+      .milliseconds(100)
+      .seconds();
+  });
 
-// Query
-moment().isBefore();
-moment().isSame();
-moment().isAfter();
-moment().isSameOrBefore();
-moment().isSameOrAfter();
-moment.isDate(new Date());
+  it('Manipulate', () => {
+    // Manipulate
+    const m1: moment = moment().add(2, 'day');
+    moment().add({ day: 1 });
+    const m2: moment = moment().subtract(1, 's');
+    moment().subtract({ day: 1 });
+  });
 
-// CalendarTime
-moment().calendar(null, {
-  sameDay: "HH:mm"
+  it('Query', () => {
+    moment().isBefore();
+    moment().isSame();
+    moment().isAfter();
+    moment().isSameOrBefore();
+    moment().isSameOrAfter();
+    moment.isDate(new Date());
+    moment().isBefore(new Date(), 'day');
+    moment().isSame(new Date(), 'day');
+  });
+
+  it('moment.calendar()', () => {
+    moment().calendar(null, {
+      sameDay: 'HH:mm',
+    });
+    moment().calendar(null, {
+      sameDay: () => 'HH:mm',
+    });
+    // $ExpectError
+    moment().calendar(null, {
+      sameDay: (a: number) => 'HH:mm',
+    });
+    // $ExpectError
+    moment().calendar(null, {
+      sameDay: 2,
+    });
+    // $ExpectError
+    moment().calendar(null, {
+      // $ExpectError (>=0.56.0)
+      sameElse: () => {},
+    });
+  });
+
+  it('moment.utcOffset()', () => {
+    let n: number;
+    n = moment().utcOffset();
+    n = m.utcOffset(0).utcOffset();
+    n = m.utcOffset(-1.5).utcOffset();
+    n = m.utcOffset(-90).utcOffset();
+    n = m.utcOffset('-01:30').utcOffset();
+    n = m.utcOffset('+00:10').utcOffset();
+
+    // Optional 2nd and 3rd arguments
+    n = m.utcOffset(0, true).utcOffset();
+    n = m.utcOffset(0, false).utcOffset();
+    n = m.utcOffset(0, true, true).utcOffset();
+  });
+
+  it('moment.locale()', () => {
+    const getLocale: string = moment.locale();
+    const setLocale: string = moment.locale('en');
+    const setArrayLocale: string = moment.locale(['en', 'de']);
+  });
 });
-moment().calendar(null, {
-  sameDay: () => "HH:mm"
-});
-// $ExpectError
-moment().calendar(null, {
-  sameDay: (a: number) => "HH:mm"
-});
-// $ExpectError
-moment().calendar(null, {
-  sameDay: 2
-});
-// $ExpectError
-moment().calendar(null, {
-  // $ExpectError (>=0.56.0)
-  sameElse: () => {}
-});
-
-// UTC offsets
-let n: number;
-n = moment().utcOffset();
-n = m.utcOffset(0).utcOffset();
-n = m.utcOffset(-1.5).utcOffset();
-n = m.utcOffset(-90).utcOffset();
-n = m.utcOffset("-01:30").utcOffset();
-n = m.utcOffset("+00:10").utcOffset();
-
-// Optional 2nd and 3rd arguments
-n = m.utcOffset(0, true).utcOffset();
-n = m.utcOffset(0, false).utcOffset();
-n = m.utcOffset(0, true, true).utcOffset();
-
-const getLocale: string = moment.locale();
-const setLocale: string = moment.locale("en");
-const setArrayLocale: string = moment.locale(["en", "de"]);


### PR DESCRIPTION
`moment.utc(undefined)` does the same as `moment.utc()`, so I feel it'd be convenient to not error on such a use case.