### PR TITLE
Improve checks for connect in react-redux@5.x.x 

### DIFF
--- a/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
@@ -27,6 +27,7 @@ declare module "react-redux" {
   RMP = Returned merge props
   CP = Props for returned component
   Com = React Component
+  P = Props of Com
   */
 
   declare type MapStateToProps<S: Object, SP: Object, RSP: Object> = (state: S, props: SP) => RSP;
@@ -52,10 +53,11 @@ declare module "react-redux" {
   declare type OmitDispatch<Component> = $Diff<Component, {dispatch: Dispatch<*>}>;
 
   declare export function connect<
-    Com: ComponentType<*>,
+    P: Object,
+    Com: ComponentType<P>,
     S: Object,
     DP: Object,
-    RSP: Object,
+    RSP: $Shape<P>,
     CP: $Diff<OmitDispatch<ElementConfig<Com>>, RSP>
     >(
     mapStateToProps: MapStateToProps<S, DP, RSP>,
@@ -68,13 +70,14 @@ declare module "react-redux" {
   ): (component: Com) => ComponentType<OmitDispatch<ElementConfig<Com>>>;
 
   declare export function connect<
-    Com: ComponentType<*>,
+    P: Object,
+    Com: ComponentType<P>,
     A,
     S: Object,
     DP: Object,
     SP: Object,
-    RSP: Object,
-    RDP: Object,
+    RSP: $Shape<P>,
+    RDP: $Shape<P>,
     CP: $Diff<$Diff<ElementConfig<Com>, RSP>, RDP>
     >(
     mapStateToProps: MapStateToProps<S, SP, RSP>,
@@ -82,11 +85,11 @@ declare module "react-redux" {
   ): (component: Com) => ComponentType<CP & SP & DP>;
 
   declare export function connect<
-    Com: ComponentType<*>,
+    P: Object,
+    Com: ComponentType<P>,
     A,
     OP: Object,
-    DP: Object,
-    PR: Object,
+    DP: $Shape<P>,
     CP: $Diff<ElementConfig<Com>, DP>
     >(
     mapStateToProps?: null,
@@ -94,19 +97,21 @@ declare module "react-redux" {
   ): (Com) => ComponentType<CP & OP>;
 
   declare export function connect<
-    Com: ComponentType<*>,
-    MDP: Object
+    P: Object,
+    Com: ComponentType<P>,
+    MDP: $Shape<P>
     >(
     mapStateToProps?: null,
     mapDispatchToProps: MDP
   ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, MDP>>;
 
   declare export function connect<
-    Com: ComponentType<*>,
+    P: Object,
+    Com: ComponentType<P>,
     S: Object,
     SP: Object,
-    RSP: Object,
-    MDP: Object,
+    RSP: $Shape<P>,
+    MDP: $Shape<P>,
     CP: $Diff<ElementConfig<Com>, RSP>
     >(
     mapStateToProps: MapStateToProps<S, SP, RSP>,
@@ -114,7 +119,8 @@ declare module "react-redux" {
   ): (component: Com) => ComponentType<$Diff<CP, MDP> & SP>;
 
   declare export function connect<
-    Com: ComponentType<*>,
+    P: Object,
+    Com: ComponentType<P>,
     A,
     S: Object,
     DP: Object,
@@ -122,7 +128,7 @@ declare module "react-redux" {
     RSP: Object,
     RDP: Object,
     MP: Object,
-    RMP: Object,
+    RMP: $Shape<P>,
     CP: $Diff<ElementConfig<Com>, RMP>
     >(
     mapStateToProps: MapStateToProps<S, SP, RSP>,
@@ -130,7 +136,9 @@ declare module "react-redux" {
     mergeProps: MergeProps<RSP, RDP, MP, RMP>
   ): (component: Com) => ComponentType<CP & SP & DP & MP>;
 
-  declare export function connect<Com: ComponentType<*>,
+  declare export function connect<
+    P: Object,
+    Com: ComponentType<P>,
     A,
     S: Object,
     DP: Object,
@@ -138,7 +146,7 @@ declare module "react-redux" {
     RSP: Object,
     RDP: Object,
     MP: Object,
-    RMP: Object
+    RMP: $Shape<P>
     >(
     mapStateToProps: ?MapStateToProps<S, SP, RSP>,
     mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/test_connect.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/test_connect.js
@@ -411,3 +411,370 @@ function testOptions() {
   // $ExpectError wrong key
   connect(null, null, null, {wrongKey: true})(Com);
 }
+
+function testAllowsKnownPropInMapStateToProps() {
+  type Props = {
+    str: string
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {num: number, str: string};
+
+  const mapStateToProps = (state: State) => {
+    return {
+      str: state.str
+    }
+  };
+
+  connect(mapStateToProps)(Com);
+}
+
+function testForbidsLiteralOfInvalidTypeInMapStateToProps() {
+  type Props = {
+    // $ExpectError string is incompatible with number
+    str: string
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {num: number, str: string};
+
+  const mapStateToPropsWithLiteralOfInvalidType = (state: State) => {
+    return {
+      str: 123
+    }
+  };
+
+  // $ExpectError string is incompatible with number
+  connect(mapStateToPropsWithLiteralOfInvalidType)(Com);
+}
+
+function testForbidsStateProperyOfInvalidTypeInMapStateToProps() {
+  type Props = {
+    str: string
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {num: number, str: string};
+
+  const mapStateToPropsWithStatePropertyOfInvalidType = (state: State) => {
+    return {
+      str: state.num
+    }
+  };
+
+  // $ExpectError string is incompatible with number
+  connect(mapStateToPropsWithStatePropertyOfInvalidType)(Com);
+}
+
+function testForbidsSelectorWithInvalidReturnTypeInMapStateToProps() {
+  type Props = {
+    str: string
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {num: number, str: string};
+
+  function selectorReturningNumber(state: State): number {
+    return state.num
+  }
+
+  const mapStateToPropsWithSelectorWithInvalidTypeReturnValue = (state: State) => {
+    return {
+      str: selectorReturningNumber(state)
+    }
+  };
+
+  // $ExpectError string is incompatible with number
+  connect(mapStateToPropsWithSelectorWithInvalidTypeReturnValue)(Com);
+}
+
+function testForbidsUnknownPropInMapStateToProps() {
+  type Props = {
+    str: string
+  };
+
+  // $ExpectError undefined prop notThere
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {num: number, str: string};
+
+  const mapStateToPropsWithUnknownProp = (state: State) => {
+    // $ExpectError undefined prop notThere
+    return {
+      str: state.str,
+      notThere: 123
+    }
+  };
+
+  // $ExpectError notThere is missing in Props
+  connect(mapStateToPropsWithUnknownProp)(Com);
+}
+
+function testAllowsKnownPropInMapDispatchToProps() {
+  type Props = {
+    strToNumber: string => number
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.strToNumber("123")}</div>;
+    }
+  }
+
+  const mapDispatchToProps = (dispatch: *) => {
+    return {
+      strToNumber: (str: string) => 123
+    }
+  };
+
+  connect(null, mapDispatchToProps)(Com);
+}
+
+function testForbidsInvalidTypeInMapDispatchToProps() {
+  type Props = {
+    // $ExpectError string is incompatible with number
+    strToNumber: string => number
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.strToNumber("123")}</div>;
+    }
+  }
+
+  const mapDispatchToPropsWithInvalidType = (dispatch: *) => {
+    // $ExpectError string is incompatible with number
+    return {
+      strToNumber: (num: number) => 123
+    }
+  };
+
+  // $ExpectError string is incompatible with number
+  connect(null, mapDispatchToPropsWithInvalidType)(Com);
+}
+
+function testForbidsUnknownPropInMapDispatchToProps() {
+  type Props = {
+    strToNumber: string => number
+  };
+
+  // $ExpectError undefined prop notThere
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.strToNumber("123")}</div>;
+    }
+  }
+
+  const mapDispatchToPropsWithUnknownProp = (dispatch: *) => {
+    // $ExpectError undefined prop notThere
+    return {
+      strToNumber: (str: string) => 123,
+      notThere: (num: number) => 123
+    }
+  };
+
+  // $ExpectError notThere is missing in Props
+  connect(null, mapDispatchToPropsWithUnknownProp)(Com);
+}
+
+function testAllowsKnownPropInMapDispatchToPropsObject() {
+  type Props = {
+    onChange: string => mixed
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div onClick={() => this.props.onChange("123")}>Call</div>;
+    }
+  }
+
+  const mapDispatchToProps = {
+    onChange: (str: string) => ({ action: 'CHANGE', payload: str })
+  };
+
+  connect(null, mapDispatchToProps)(Com);
+}
+
+function testForbidsInvalidTypeInMapDispatchToPropsObject() {
+  type Props = {
+    strToNumber: string => number
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.strToNumber("123")}</div>;
+    }
+  }
+
+  const mapDispatchToPropsWithInvalidType = {
+    strToNumber: (num: number) => 123
+  };
+
+  // $ExpectError string is incompatible with number
+  connect(null, mapDispatchToPropsWithInvalidType)(Com);
+}
+
+function testForbidsUnknownPropInMapDispatchToPropsObject() {
+  type Props = {
+    strToNumber: string => number
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.strToNumber("123")}</div>;
+    }
+  }
+
+  const mapDispatchToPropsWithUnknownProp = {
+    strToNumber: (str: string) => 123,
+    notThere: (num: number) => 123
+  };
+
+  // $ExpectError notThere is missing in Props
+  connect(null, mapDispatchToPropsWithUnknownProp)(Com);
+}
+
+function testAllowsKnownPropsInMergeProps() {
+  type Props = {
+    str: string,
+    strToNumber: string => number
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str} {this.props.strToNumber("123")}</div>;
+    }
+  }
+
+  type State = {num: number, str: string};
+
+  const mapStateToProps = (state: State) => {
+    return {
+      // Allows arbitrary props in this case
+      strForMerge: state.str
+    }
+  };
+
+  const mapDispatchToProps = (dispatch: *) => {
+    return {
+      // Allows arbitrary props in this case
+      strToNumberForMerge: (str: string) => 123
+    }
+  };
+
+  const mergeProps = function(stateProps, dispatchProps) {
+    return {
+      str: stateProps.strForMerge,
+      strToNumber: dispatchProps.strToNumberForMerge
+    }
+  }
+
+  connect(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
+}
+
+function testForbidsInvalidTypeInMergeProps() {
+  type Props = {
+    // $ExpectError string is incompatible with number
+    str: string,
+    strToNumber: string => number
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str} {this.props.strToNumber("123")}</div>;
+    }
+  }
+
+  type State = {num: number, str: string};
+
+  const mapStateToProps = (state: State) => {
+    return {
+      // Allows arbitrary props in this case
+      strForMerge: state.str
+    }
+  };
+
+  const mapDispatchToProps = (dispatch: *) => {
+    return {
+      // Allows arbitrary props in this case
+      strToNumberForMerge: (str: string) => 123
+    }
+  };
+
+  const mergePropsWithInvalidType = function(stateProps, dispatchProps) {
+    // $ExpectError string is incompatible with number
+    return {
+      str: 123,
+      strToNumber: dispatchProps.strToNumberForMerge,
+    }
+  }
+
+  // $ExpectError string is incompatible with number
+  connect(mapStateToProps, mapDispatchToProps, mergePropsWithInvalidType)(Com);
+}
+
+function testForbidsUnknownPropsInMergeProps() {
+  type Props = {
+    str: string,
+    strToNumber: string => number
+  };
+
+  // $ExpectError undefined prop notThere
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str} {this.props.strToNumber("123")}</div>;
+    }
+  }
+
+  type State = {num: number, str: string};
+
+  const mapStateToProps = (state: State) => {
+    return {
+      // Allows arbitrary props in this case
+      strForMerge: state.str
+    }
+  };
+
+  const mapDispatchToProps = (dispatch: *) => {
+    return {
+      // Allows arbitrary props in this case
+      strToNumberForMerge: (str: string) => 123
+    }
+  };
+
+  const mergePropsWithUnknownProp = function(stateProps, dispatchProps) {
+    // $ExpectError undefined prop notThere
+    return {
+      str: stateProps.strForMerge,
+      strToNumber: dispatchProps.strToNumberForMerge,
+      notThere: 3
+    }
+  }
+
+  // $ExpectError notThere is missing in Props
+  connect(mapStateToProps, mapDispatchToProps, mergePropsWithUnknownProp)(Com);
+}


### PR DESCRIPTION
I found that, with the current definitions, the return values of `mapStateToProps`, `mapDispatchToProps` and `mergeProps` are not checked against the wrapped component as I would have expected.

## Example

Given a component that takes a string prop, trying to pass a number for that prop in `mapStateToProps` fails as expected:

```jsx
  type Props = {
    str: string
  };

  class Com extends React.Component<Props> {
    render() {
      return <div>{this.props.str}</div>;
    }
  }

  type State = {num: number, str: string};

  const mapStateToProps = (state: State) => {
    return { // error
      str: 123
    }
  };

  connect(mapStateToProps)(Com);
```
But soon as a property from state or a selector function is used instead of the number literal, no errors are detected anymore:

```jsx
  type Props = {
    str: string
  };

  class Com extends React.Component<Props> {
    render() {
      return <div>{this.props.str}</div>;
    }
  }

  type State = {num: number, str: string};

  const mapStateToProps = (state: State) => {
    return { // no error
      str: state.num
    }
  };

  connect(mapStateToProps)(Com);
```

Same basically holds for the other parameters of `connect`. There are also cases where unknown props are not detected correctly. 

As a result misspelled props or selector functions with incompatible return values go unnoticed.

I've created a branch with some examples that I'd expect to result in errors, but which pass except for simple cases:

https://github.com/flowtype/flow-typed/compare/master...tf:redux-selector-problem-2

I deliberately did not put in `$ExpectError` comments, so that the current error messages are visible. The Travis build is quite noisy since all of the tests for the `flow_v0.54.x-v0.61.x` and `flow-v0.62.x` variant are failing on `master`, but here's the relevant part:

https://travis-ci.org/tf/flow-typed/jobs/367131347#L1834

## Proposed Solution

Looking at the way `connect` is defined at the moment, the main problem IMO is that the return value of  `mapStateToProps` etc. is not directly related to the wrapped components prop types:

```js
  declare type MapStateToProps<S: Object, SP: Object, RSP: Object> = (state: S, props: SP) => RSP;

  declare export function connect<
    Com: ComponentType<*>,
    S: Object,
    DP: Object,
    RSP: Object,  // <== no direct relation to Com
    CP: $Diff<OmitDispatch<ElementConfig<Com>>, RSP>
    >(
    mapStateToProps: MapStateToProps<S, DP, RSP>,
    mapDispatchToProps?: null
  ): (component: Com) => ComponentType<CP & DP>;
```
At least when no `mergeProps` function is present, `mapStateToProps` and `mapDispatchToProps` should only be allowed to return valid props for the component. This PR therefore makes the following changes:

```js
  declare export function connect<
    P: Object, // <==
    Com: ComponentType<P>, // <== Introduce a type variable for the props of Com
    S: Object,
    DP: Object,
    RSP: $Shape<P>, // <== Allow only those props in state props
    CP: $Diff<OmitDispatch<ElementConfig<Com>>, RSP>
    >(
    mapStateToProps: MapStateToProps<S, DP, RSP>,
    mapDispatchToProps?: null
  ): (component: Com) => ComponentType<CP & DP>;
```

See also http://sitr.us/2015/05/31/advanced-features-in-flow.html#shapet.

If `mergeProps` is present, `mapStateToProps` and `mapDispatchToProps` are still allowed to return arbitrary data. Only the return value of `mergeProps` itself has to match the shape of the wrapped component's props.

The PR contains more valid and invalid examples.

The test failures either come from the `react-redux_v5.x.x/flow_v0.54.x-v0.61.x/` directory, which is not altered by this PR or Flow 0.62, which appears to have problem importing `ElementConfig` from `react`. For 0.63 and above tests pass. This problem also exists on `master`. 

