### PR TITLE
Support factory types for mapStateToProps and mapDispatchToProps

### DIFF
--- a/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
@@ -30,8 +30,12 @@ declare module "react-redux" {
   */
 
   declare type MapStateToProps<S: Object, SP: Object, RSP: Object> = (state: S, props: SP) => RSP;
+  declare type MapStateToPropsFactory<S, SP, RSP> = () => MapStateToProps<S, SP, RSP>;
+  declare type MapStateToPropsUnion<S, SP, RSP> = MapStateToPropsFactory<S, SP, RSP> | MapStateToProps<S, SP, RSP>;
 
   declare type MapDispatchToProps<A, OP: Object, RDP: Object> = (dispatch: Dispatch<A>, ownProps: OP) => RDP;
+  declare type MapDispatchToPropsFactory<A, OP, RDP> = () => MapDispatchToProps<A, OP, RDP>;
+  declare type MapDispatchToPropsUnion<A, OP, RDP> = MapDispatchToPropsFactory<A, OP, RDP> | MapDispatchToProps<A, OP, RDP>;
 
   declare type MergeProps<SP: Object, DP: Object, MP: Object, RMP: Object> = (
     stateProps: SP,
@@ -58,7 +62,7 @@ declare module "react-redux" {
     RSP: Object,
     CP: $Diff<OmitDispatch<ElementConfig<Com>>, RSP>
     >(
-    mapStateToProps: MapStateToProps<S, DP, RSP>,
+    mapStateToProps: MapStateToPropsUnion<S, DP, RSP>,
     mapDispatchToProps?: null
   ): (component: Com) => ComponentType<CP & DP>;
 
@@ -77,8 +81,8 @@ declare module "react-redux" {
     RDP: Object,
     CP: $Diff<$Diff<ElementConfig<Com>, RSP>, RDP>
     >(
-    mapStateToProps: MapStateToProps<S, SP, RSP>,
-    mapDispatchToProps: MapDispatchToProps<A, DP, RDP>
+    mapStateToProps: MapStateToPropsUnion<S, SP, RSP>,
+    mapDispatchToProps: MapDispatchToPropsUnion<A, DP, RDP>
   ): (component: Com) => ComponentType<CP & SP & DP>;
 
   declare export function connect<
@@ -90,7 +94,7 @@ declare module "react-redux" {
     CP: $Diff<ElementConfig<Com>, DP>
     >(
     mapStateToProps?: null,
-    mapDispatchToProps: MapDispatchToProps<A, OP, DP>
+    mapDispatchToProps: MapDispatchToPropsUnion<A, OP, DP>
   ): (Com) => ComponentType<CP & OP>;
 
   declare export function connect<
@@ -109,7 +113,7 @@ declare module "react-redux" {
     MDP: Object,
     CP: $Diff<ElementConfig<Com>, RSP>
     >(
-    mapStateToProps: MapStateToProps<S, SP, RSP>,
+    mapStateToProps: MapStateToPropsUnion<S, SP, RSP>,
     mapDispatchToPRops: MDP
   ): (component: Com) => ComponentType<$Diff<CP, MDP> & SP>;
 
@@ -125,8 +129,8 @@ declare module "react-redux" {
     RMP: Object,
     CP: $Diff<ElementConfig<Com>, RMP>
     >(
-    mapStateToProps: MapStateToProps<S, SP, RSP>,
-    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
+    mapStateToProps: MapStateToPropsUnion<S, SP, RSP>,
+    mapDispatchToProps: ?MapDispatchToPropsUnion<A, DP, RDP>,
     mergeProps: MergeProps<RSP, RDP, MP, RMP>
   ): (component: Com) => ComponentType<CP & SP & DP & MP>;
 
@@ -140,8 +144,8 @@ declare module "react-redux" {
     MP: Object,
     RMP: Object
     >(
-    mapStateToProps: ?MapStateToProps<S, SP, RSP>,
-    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
+    mapStateToProps: ?MapStateToPropsUnion<S, SP, RSP>,
+    mapDispatchToProps: ?MapDispatchToPropsUnion<A, DP, RDP>,
     mergeProps: ?MergeProps<RSP, RDP, MP, RMP>,
     options: ConnectOptions<S, SP & DP & MP, RSP, RMP>
   ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP>;

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
@@ -29,12 +29,12 @@ declare module "react-redux" {
   Com = React Component
   */
 
-  declare type MapStateToProps<S: Object, SP: Object, RSP: Object> = (state: S, props: SP) => RSP;
-  declare type MapStateToPropsFactory<S, SP, RSP> = () => MapStateToProps<S, SP, RSP>;
+  declare export type MapStateToProps<S: Object, SP: Object, RSP: Object> = (state: S, props: SP) => RSP;
+  declare export type MapStateToPropsFactory<S, SP, RSP> = () => MapStateToProps<S, SP, RSP>;
   declare type MapStateToPropsUnion<S, SP, RSP> = MapStateToPropsFactory<S, SP, RSP> | MapStateToProps<S, SP, RSP>;
 
-  declare type MapDispatchToProps<A, OP: Object, RDP: Object> = (dispatch: Dispatch<A>, ownProps: OP) => RDP;
-  declare type MapDispatchToPropsFactory<A, OP, RDP> = () => MapDispatchToProps<A, OP, RDP>;
+  declare export type MapDispatchToProps<A, OP: Object, RDP: Object> = (dispatch: Dispatch<A>, ownProps: OP) => RDP;
+  declare export type MapDispatchToPropsFactory<A, OP, RDP> = () => MapDispatchToProps<A, OP, RDP>;
   declare type MapDispatchToPropsUnion<A, OP, RDP> = MapDispatchToPropsFactory<A, OP, RDP> | MapDispatchToProps<A, OP, RDP>;
 
   declare type MergeProps<SP: Object, DP: Object, MP: Object, RMP: Object> = (

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/test_connect.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/test_connect.js
@@ -1,6 +1,12 @@
 // @flow
 import React from "react";
-import { connect } from "react-redux";
+import {
+  connect,
+  type MapStateToProps,
+  type MapStateToPropsFactory,
+  type MapDispatchToProps,
+  type MapDispatchToPropsFactory
+} from "react-redux";
 
 function testPassingPropsToConnectedComponent() {
   type Props = {passthrough: number, passthroughWithDefaultProp: number, fromStateToProps: string};
@@ -15,7 +21,7 @@ function testPassingPropsToConnectedComponent() {
   type InputProps = {
     forMapStateToProps: string
   };
-  const mapStateToProps: (State, InputProps) => * = (state: State, props: InputProps) => {
+  const mapStateToProps: MapStateToProps<State, InputProps, *> = (state: State, props: InputProps) => {
     return {
       fromStateToProps: 'str' + state.a
     }
@@ -52,7 +58,7 @@ function testPassingPropsToConnectedComponentWithMapStateToPropsFactory() {
   type InputProps = {
     forMapStateToProps: string
   };
-  const mapStateToProps: () => (State, InputProps) => * = () => (state: State, props: InputProps) => {
+  const mapStateToProps: MapStateToPropsFactory<State, InputProps, *> = () => (state: State, props: InputProps) => {
     return {
       fromStateToProps: 'str' + state.a
     }
@@ -85,7 +91,7 @@ function doesNotRequireDefinedComponentToTypeCheck1case() {
     return <span>{stringProp}</span>;
   };
 
-  const mapStateToProps: (*, *) => * = (state: {}) => ({
+  const mapStateToProps: MapStateToProps<*, *, *> = (state: {}) => ({
     // $ExpectError wrong type for stringProp
     stringProp: false,
   });
@@ -102,7 +108,7 @@ function doesNotRequireDefinedComponentToTypeCheck2case() {
     return <span>{numProp}</span>;
   };
 
-  const mapDispatchToProps: (*, *) => * = () => ({
+  const mapDispatchToProps: MapDispatchToProps<*, *, *> = () => ({
     // $ExpectError wrong type for numProp
     numProp: false,
   });
@@ -120,12 +126,12 @@ function doesNotRequireDefinedComponentToTypeCheck3case() {
     return <span>{stringProp}</span>;
   };
 
-  const mapStateToProps: (*, *) => * = (state: {}) => ({
+  const mapStateToProps: MapStateToProps<*, *, *> = (state: {}) => ({
     // $ExpectError wrong type for stringProp
     stringProp: false,
   });
 
-  const mapDispatchToProps: (*, *) => * = () => ({
+  const mapDispatchToProps: MapDispatchToProps<*, *, *> = () => ({
     // $ExpectError wrong type for numProp
     numProp: false,
   });
@@ -142,7 +148,7 @@ function doesNotRequireDefinedComponentToTypeCheck4case() {
     return <span>{stringProp}</span>;
   };
 
-  const mapStateToProps: (*, *) => * = (state: {}) => ({
+  const mapStateToProps: MapStateToProps<*, *, *> = (state: {}) => ({
     // $ExpectError wrong type for stringProp
     stringProp: false,
   });
@@ -159,8 +165,8 @@ function doesNotRequireDefinedComponentToTypeCheck5case() {
     return <span>{stringProp}</span>;
   };
 
-  const mapStateToProps: (*, *) => * = () => ({});
-  const mapDispatchToProps: (*, *) => * = () => ({});
+  const mapStateToProps: MapStateToProps<*, *, *> = () => ({});
+  const mapDispatchToProps: MapDispatchToProps<*, *, *> = () => ({});
 
   const mergeProps = () => ({
     // $ExpectError wrong type for stringProp
@@ -189,7 +195,7 @@ function testExactProps() {
     passthrough: number,
   |};
 
-  const mapStateToProps: (State, InputProps) => * = (state: State, props: InputProps) => {
+  const mapStateToProps: MapStateToProps<State, InputProps, *> = (state: State, props: InputProps) => {
     return {
       fromStateToProps: 'str' + state.a
     }
@@ -217,7 +223,7 @@ function testWithStatelessFunctionalComponent() {
   type InputProps = {
     forMapStateToProps: string
   };
-  const mapStateToProps: (State, InputProps) => * = (state: State, props: InputProps) => {
+  const mapStateToProps: MapStateToProps<State, InputProps, *> = (state: State, props: InputProps) => {
     return {
       fromStateToProps: 'str' + state.a
     }
@@ -246,7 +252,7 @@ function testMapStateToPropsDoesNotNeedProps() {
   }
 
   type State = {a: string}
-  const mapStateToProps: (*, *) => * = (state: State) => {
+  const mapStateToProps: MapStateToProps<*, *, *> = (state: State) => {
     return {
       fromStateToProps: state.a
     }
@@ -276,13 +282,13 @@ function testMapDispatchToProps() {
 
   type State = {a: number}
   type MapStateToPropsProps = {forMapStateToProps: string}
-  const mapStateToProps: (State, MapStateToPropsProps) => * = (state: State, props: MapStateToPropsProps) => {
+  const mapStateToProps: MapStateToProps<State, MapStateToPropsProps, *> = (state: State, props: MapStateToPropsProps) => {
     return {
       fromMapStateToProps: 'str' + state.a
     }
   }
   type MapDispatchToPropsProps = {forMapDispatchToProps: string}
-  const mapDispatchToProps: (*, MapDispatchToPropsProps) => * = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+  const mapDispatchToProps: MapDispatchToProps<*, MapDispatchToPropsProps, *> = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
     return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
   }
   const Connected = connect(mapStateToProps, mapDispatchToProps)(Com);
@@ -313,13 +319,13 @@ function testMapDispatchToProps() {
 
   type State = { a: number }
   type MapStateToPropsProps = { forMapStateToProps: string }
-  const mapStateToProps: (State, MapStateToPropsProps) => * = (state: State, props: MapStateToPropsProps) => {
+  const mapStateToProps: MapStateToProps<State, MapStateToPropsProps, *> = (state: State, props: MapStateToPropsProps) => {
     return {
       fromMapStateToProps: 'str' + state.a
     }
   }
   type MapDispatchToPropsProps = { forMapDispatchToProps: string }
-  const mapDispatchToProps: () => (*, MapDispatchToPropsProps) => * = () => (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+  const mapDispatchToProps: MapDispatchToPropsFactory<*, MapDispatchToPropsProps, *> = () => (dispatch: *, ownProps: MapDispatchToPropsProps) => {
     return { fromMapDispatchToProps: ownProps.forMapDispatchToProps }
   }
   const Connected = connect(mapStateToProps, mapDispatchToProps)(Com);
@@ -347,7 +353,7 @@ function testMapDispatchToPropsWithoutMapStateToProps() {
   }
 
   type MapDispatchToPropsProps = {forMapDispatchToProps: string};
-  const mapDispatchToProps: (*, MapDispatchToPropsProps) => * = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+  const mapDispatchToProps: MapDispatchToProps<*, MapDispatchToPropsProps, *> = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
     return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
   }
   const Connected = connect(null, mapDispatchToProps)(Com);
@@ -409,7 +415,7 @@ function testMapDispatchToPropsPassesActionCreatorsWithMapStateToProps() {
   }
   type State = {a: number}
   type MapStateToPropsProps = {forMapStateToProps: string}
-  const mapStateToProps: (State, MapStateToPropsProps) => * = (state: State, props: MapStateToPropsProps) => {
+  const mapStateToProps: MapStateToProps<State, MapStateToPropsProps, *> = (state: State, props: MapStateToPropsProps) => {
     return {
       fromMapStateToProps: state.a
     }
@@ -445,13 +451,13 @@ function testMergeProps() {
 
   type State = {a: number}
   type MapStateToPropsProps = {forMapStateToProps: string}
-  const mapStateToProps: (State, MapStateToPropsProps) => * = (state: State, props: MapStateToPropsProps) => {
+  const mapStateToProps: MapStateToProps<State, MapStateToPropsProps, *> = (state: State, props: MapStateToPropsProps) => {
     return {
       fromMapStateToProps: state.a
     }
   }
   type MapDispatchToPropsProps = {forMapDispatchToProps: string}
-  const mapDispatchToProps: (*, MapDispatchToPropsProps) => * = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+  const mapDispatchToProps: MapDispatchToProps<*, MapDispatchToPropsProps, *> = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
     return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
   }
   const mergeProps = (stateProps, dispatchProps, ownProps: {forMergeProps: number}) => {

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/test_connect.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/test_connect.js
@@ -15,7 +15,7 @@ function testPassingPropsToConnectedComponent() {
   type InputProps = {
     forMapStateToProps: string
   };
-  const mapStateToProps = (state: State, props: InputProps) => {
+  const mapStateToProps: (State, InputProps) => * = (state: State, props: InputProps) => {
     return {
       fromStateToProps: 'str' + state.a
     }
@@ -52,7 +52,7 @@ function testPassingPropsToConnectedComponentWithMapStateToPropsFactory() {
   type InputProps = {
     forMapStateToProps: string
   };
-  const mapStateToProps = () => (state: State, props: InputProps) => {
+  const mapStateToProps: () => (State, InputProps) => * = () => (state: State, props: InputProps) => {
     return {
       fromStateToProps: 'str' + state.a
     }
@@ -85,7 +85,7 @@ function doesNotRequireDefinedComponentToTypeCheck1case() {
     return <span>{stringProp}</span>;
   };
 
-  const mapStateToProps = (state: {}) => ({
+  const mapStateToProps: (*, *) => * = (state: {}) => ({
     // $ExpectError wrong type for stringProp
     stringProp: false,
   });
@@ -102,7 +102,7 @@ function doesNotRequireDefinedComponentToTypeCheck2case() {
     return <span>{numProp}</span>;
   };
 
-  const mapDispatchToProps = () => ({
+  const mapDispatchToProps: (*, *) => * = () => ({
     // $ExpectError wrong type for numProp
     numProp: false,
   });
@@ -120,12 +120,12 @@ function doesNotRequireDefinedComponentToTypeCheck3case() {
     return <span>{stringProp}</span>;
   };
 
-  const mapStateToProps = (state: {}) => ({
+  const mapStateToProps: (*, *) => * = (state: {}) => ({
     // $ExpectError wrong type for stringProp
     stringProp: false,
   });
 
-  const mapDispatchToProps = () => ({
+  const mapDispatchToProps: (*, *) => * = () => ({
     // $ExpectError wrong type for numProp
     numProp: false,
   });
@@ -142,7 +142,7 @@ function doesNotRequireDefinedComponentToTypeCheck4case() {
     return <span>{stringProp}</span>;
   };
 
-  const mapStateToProps = (state: {}) => ({
+  const mapStateToProps: (*, *) => * = (state: {}) => ({
     // $ExpectError wrong type for stringProp
     stringProp: false,
   });
@@ -159,8 +159,8 @@ function doesNotRequireDefinedComponentToTypeCheck5case() {
     return <span>{stringProp}</span>;
   };
 
-  const mapStateToProps = () => ({});
-  const mapDispatchToProps = () => ({});
+  const mapStateToProps: (*, *) => * = () => ({});
+  const mapDispatchToProps: (*, *) => * = () => ({});
 
   const mergeProps = () => ({
     // $ExpectError wrong type for stringProp
@@ -189,7 +189,7 @@ function testExactProps() {
     passthrough: number,
   |};
 
-  const mapStateToProps = (state: State, props: InputProps) => {
+  const mapStateToProps: (State, InputProps) => * = (state: State, props: InputProps) => {
     return {
       fromStateToProps: 'str' + state.a
     }
@@ -217,7 +217,7 @@ function testWithStatelessFunctionalComponent() {
   type InputProps = {
     forMapStateToProps: string
   };
-  const mapStateToProps = (state: State, props: InputProps) => {
+  const mapStateToProps: (State, InputProps) => * = (state: State, props: InputProps) => {
     return {
       fromStateToProps: 'str' + state.a
     }
@@ -246,7 +246,7 @@ function testMapStateToPropsDoesNotNeedProps() {
   }
 
   type State = {a: string}
-  const mapStateToProps = (state: State) => {
+  const mapStateToProps: (*, *) => * = (state: State) => {
     return {
       fromStateToProps: state.a
     }
@@ -276,13 +276,13 @@ function testMapDispatchToProps() {
 
   type State = {a: number}
   type MapStateToPropsProps = {forMapStateToProps: string}
-  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+  const mapStateToProps: (State, MapStateToPropsProps) => * = (state: State, props: MapStateToPropsProps) => {
     return {
       fromMapStateToProps: 'str' + state.a
     }
   }
   type MapDispatchToPropsProps = {forMapDispatchToProps: string}
-  const mapDispatchToProps = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+  const mapDispatchToProps: (*, MapDispatchToPropsProps) => * = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
     return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
   }
   const Connected = connect(mapStateToProps, mapDispatchToProps)(Com);
@@ -313,13 +313,13 @@ function testMapDispatchToProps() {
 
   type State = { a: number }
   type MapStateToPropsProps = { forMapStateToProps: string }
-  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+  const mapStateToProps: (State, MapStateToPropsProps) => * = (state: State, props: MapStateToPropsProps) => {
     return {
       fromMapStateToProps: 'str' + state.a
     }
   }
   type MapDispatchToPropsProps = { forMapDispatchToProps: string }
-  const mapDispatchToProps = () => (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+  const mapDispatchToProps: () => (*, MapDispatchToPropsProps) => * = () => (dispatch: *, ownProps: MapDispatchToPropsProps) => {
     return { fromMapDispatchToProps: ownProps.forMapDispatchToProps }
   }
   const Connected = connect(mapStateToProps, mapDispatchToProps)(Com);
@@ -347,7 +347,7 @@ function testMapDispatchToPropsWithoutMapStateToProps() {
   }
 
   type MapDispatchToPropsProps = {forMapDispatchToProps: string};
-  const mapDispatchToProps = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+  const mapDispatchToProps: (*, MapDispatchToPropsProps) => * = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
     return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
   }
   const Connected = connect(null, mapDispatchToProps)(Com);
@@ -409,7 +409,7 @@ function testMapDispatchToPropsPassesActionCreatorsWithMapStateToProps() {
   }
   type State = {a: number}
   type MapStateToPropsProps = {forMapStateToProps: string}
-  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+  const mapStateToProps: (State, MapStateToPropsProps) => * = (state: State, props: MapStateToPropsProps) => {
     return {
       fromMapStateToProps: state.a
     }
@@ -445,13 +445,13 @@ function testMergeProps() {
 
   type State = {a: number}
   type MapStateToPropsProps = {forMapStateToProps: string}
-  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+  const mapStateToProps: (State, MapStateToPropsProps) => * = (state: State, props: MapStateToPropsProps) => {
     return {
       fromMapStateToProps: state.a
     }
   }
   type MapDispatchToPropsProps = {forMapDispatchToProps: string}
-  const mapDispatchToProps = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+  const mapDispatchToProps: (*, MapDispatchToPropsProps) => * = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
     return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
   }
   const mergeProps = (stateProps, dispatchProps, ownProps: {forMergeProps: number}) => {

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/test_connect.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/test_connect.js
@@ -39,6 +39,43 @@ function testPassingPropsToConnectedComponent() {
   connect(mapStateToProps)('');
 }
 
+function testPassingPropsToConnectedComponentWithMapStateToPropsFactory() {
+  type Props = { passthrough: number, passthroughWithDefaultProp: number, fromStateToProps: string };
+  class Com extends React.Component<Props> {
+    static defaultProps = { passthroughWithDefaultProp: 123 };
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = { a: number };
+  type InputProps = {
+    forMapStateToProps: string
+  };
+  const mapStateToProps = () => (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect(mapStateToProps)(Com);
+  <Connected passthrough={123} forMapStateToProps={'data'} passthroughWithDefaultProp={123} />;
+  // OK without passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+  //$ExpectError wrong type for passthrough
+  <Connected passthrough={''} forMapStateToProps={'data'} passthroughWithDefaultProp={123} />;
+  //$ExpectError wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321} passthroughWithDefaultProp={123} />;
+  //$ExpectError wrong type for  passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'} passthroughWithDefaultProp={''} />;
+  //$ExpectError passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$ExpectError forMapStateToProps missing
+  <Connected passthrough={123} />;
+  //$ExpectError takes in only React components
+  connect(mapStateToProps)('');
+}
+
 function doesNotRequireDefinedComponentToTypeCheck1case() {
   type Props = {
     stringProp: string,
@@ -247,6 +284,43 @@ function testMapDispatchToProps() {
   type MapDispatchToPropsProps = {forMapDispatchToProps: string}
   const mapDispatchToProps = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
     return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const Connected = connect(mapStateToProps, mapDispatchToProps)(Com);
+  <Connected passthrough={123} forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$ExpectError passthrough missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$ExpectError forMapStateToProps missing
+  <Connected passthrough={123} forMapDispatchToProps={'more data'} />;
+  //$ExpectError forMapDispatchToProps missing
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+}
+
+function testMapDispatchToProps() {
+  type Props = {
+    passthrough: number,
+    fromMapDispatchToProps: string,
+    fromMapStateToProps: string
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.passthrough}
+        {this.props.fromMapDispatchToProps}
+        {this.props.fromMapStateToProps}
+      </div>;
+    }
+  }
+
+  type State = { a: number }
+  type MapStateToPropsProps = { forMapStateToProps: string }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: 'str' + state.a
+    }
+  }
+  type MapDispatchToPropsProps = { forMapDispatchToProps: string }
+  const mapDispatchToProps = () => (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+    return { fromMapDispatchToProps: ownProps.forMapDispatchToProps }
   }
   const Connected = connect(mapStateToProps, mapDispatchToProps)(Com);
   <Connected passthrough={123} forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;


### PR DESCRIPTION
This fixes #1924 by introducing the factory type for MapStateToProps and MapDispatchToProps, at the expense of having to explicitly declare whether we're using the factory style or not.

I.E. this would require that  the type of mapStateToProps is explicitly declared like such

```javascript
const mapStateToPropsFactory: MapStateToPropsFactory<*, *, *> = () => {
    return (state, props) => {
// (...)
conect(mapStateToPropsFactory)(Component)
```
OR
```javascript
const mapStateToProps: MapStateToProps<*, *, *> = (state) => (
// (...)
conect(mapStateToProps)(Component)
```

Edit: changed the type of `mapStateToProps` and `mapStateToPropsFactory` to match the updates in [1fd1c00](https://github.com/flowtype/flow-typed/pull/2105/commits/1fd1c008534550acb1aaf7b649017d1a8f7c1f11)