### PR TITLE
Remove deprecated static property from axios

### DIFF
--- a/definitions/npm/axios_v0.15.x/flow_v0.25.x-/axios_v0.15.x.js
+++ b/definitions/npm/axios_v0.15.x/flow_v0.25.x-/axios_v0.15.x.js
@@ -16,7 +16,7 @@ declare module "axios" {
   }
   declare class CancelToken {
     constructor(executor: (cancel: Canceler) => void): CancelToken;
-    static source(): CancelTokenSource;
+    source(): CancelTokenSource;
     promise: Promise<Cancel>;
     reason?: Cancel;
     throwIfRequested(): void;

--- a/definitions/npm/axios_v0.16.x/flow_v0.25.x-/axios_v0.16.x.js
+++ b/definitions/npm/axios_v0.16.x/flow_v0.25.x-/axios_v0.16.x.js
@@ -16,7 +16,7 @@ declare module "axios" {
   }
   declare class CancelToken {
     constructor(executor: (cancel: Canceler) => void): CancelToken;
-    static source(): CancelTokenSource;
+    source(): CancelTokenSource;
     promise: Promise<Cancel>;
     reason?: Cancel;
     throwIfRequested(): void;

--- a/definitions/npm/axios_v0.17.x/flow_v0.25.x-/axios_v0.17.x.js
+++ b/definitions/npm/axios_v0.17.x/flow_v0.25.x-/axios_v0.17.x.js
@@ -16,7 +16,7 @@ declare module "axios" {
   }
   declare class CancelToken {
     constructor(executor: (cancel: Canceler) => void): CancelToken;
-    static source(): CancelTokenSource;
+    source(): CancelTokenSource;
     promise: Promise<Cancel>;
     reason?: Cancel;
     throwIfRequested(): void;

--- a/definitions/npm/axios_v0.18.x/flow_v0.25.x-/axios_v0.18.x.js
+++ b/definitions/npm/axios_v0.18.x/flow_v0.25.x-/axios_v0.18.x.js
@@ -23,7 +23,7 @@ declare module "axios" {
   }
   declare class CancelToken {
     constructor(executor: (cancel: Canceler) => void): CancelToken;
-    static source(): CancelTokenSource;
+    source(): CancelTokenSource;
     promise: Promise<Cancel>;
     reason?: Cancel;
     throwIfRequested(): void;


### PR DESCRIPTION
Flow 62 removed support for static properties. The use of a static proprty in this typedef causes flow to error immediately. This fixes it by removing `static`.

<img width="951" alt="screen shot 2018-05-08 at 1 34 06 pm" src="https://user-images.githubusercontent.com/5637592/39784297-c85459e4-52cc-11e8-9d2a-4781711bc8df.png">
