### PR TITLE
lodash: allow number as argument to get, getOr

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -1127,7 +1127,7 @@ declare module "lodash" {
     functionsIn(object?: ?Object): Array<string>;
     get(
       object?: ?Object | ?$ReadOnlyArray<any> | void | null,
-      path?: ?$ReadOnlyArray<string> | string,
+      path?: ?$ReadOnlyArray<string | number> | string | number,
       defaultValue?: any
     ): any;
     has(object: Object, path: Array<string> | string): boolean;
@@ -2764,8 +2764,8 @@ declare module "lodash/fp" {
     forOwnRight(iteratee: OIteratee<*>, object: Object): Object;
     functions(object: Object): Array<string>;
     functionsIn(object: Object): Array<string>;
-    get(path: $ReadOnlyArray<string> | string): (object: Object | $ReadOnlyArray<any> | void | null) => any;
-    get(path: $ReadOnlyArray<string> | string, object: Object | $ReadOnlyArray<any> | void | null): any;
+    get(path: $ReadOnlyArray<string | number> | string | number): (object: Object | $ReadOnlyArray<any> | void | null) => any;
+    get(path: $ReadOnlyArray<string | number> | string | number, object: Object | $ReadOnlyArray<any> | void | null): any;
     prop(path: Array<string> | string): (object: Object | Array<any>) => any;
     prop(path: Array<string> | string, object: Object | Array<any>): any;
     path(path: Array<string> | string): (object: Object | Array<any>) => any;
@@ -2773,16 +2773,16 @@ declare module "lodash/fp" {
     getOr(
       defaultValue: any
     ): ((
-      path: Array<string> | string
+      path: Array<string | number> | string | number
     ) => (object: Object | Array<any>) => any) &
       ((path: Array<string> | string, object: Object | $ReadOnlyArray<any> | void | null) => any);
     getOr(
       defaultValue: any,
-      path: Array<string> | string
+      path: Array<string | number> | string | number
     ): (object: Object | $ReadOnlyArray<any> | void | null) => any;
     getOr(
       defaultValue: any,
-      path: Array<string> | string,
+      path: Array<string | number> | string | number,
       object: Object | $ReadOnlyArray<any> | void | null
     ): any;
     propOr(


### PR DESCRIPTION
Fixes #2128.

lodash coerces arguments to `get` and `getOr` with `toKey`, meaning that numbers are valid argumnets to `get` and `getOr`.