### PR TITLE
Fix ElementType in react-bootstrap

### DIFF
--- a/definitions/npm/react-bootstrap_v0.32.x/flow_v0.53.x-/react-bootstrap_v0.32.x.js
+++ b/definitions/npm/react-bootstrap_v0.32.x/flow_v0.53.x-/react-bootstrap_v0.32.x.js
@@ -1,5 +1,5 @@
 declare module "react-bootstrap" {
-  import type { Node, Element, ElementType, Component, Ref } from 'react';
+  import type { Component, Ref } from 'react';
   declare type BsSize = 'lg' | 'large' | 'sm' | 'small';
   declare type BsStyle = 'lg' | 'large' | 'sm' | 'small' | 'xs' | 'xsmall';
   declare type TriggerType = 'click' | 'hover' | 'focus';

--- a/definitions/npm/react-bootstrap_v0.32.x/flow_v0.53.x-/react-bootstrap_v0.32.x.js
+++ b/definitions/npm/react-bootstrap_v0.32.x/flow_v0.53.x-/react-bootstrap_v0.32.x.js
@@ -1,8 +1,7 @@
 declare module "react-bootstrap" {
-  import type { Node, Element, Component, Ref } from 'react';
+  import type { Node, Element, ElementType, Component, Ref } from 'react';
   declare type BsSize = 'lg' | 'large' | 'sm' | 'small';
   declare type BsStyle = 'lg' | 'large' | 'sm' | 'small' | 'xs' | 'xsmall';
-  declare type ElementType = string;
   declare type TriggerType = 'click' | 'hover' | 'focus';
   declare export class Alert extends React$Component<{
     onDismiss: Function,
@@ -32,7 +31,7 @@ declare module "react-bootstrap" {
     disabled?: boolean,
     block?: boolean,
     onClick?: Function,
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     href?: string,
     type?: 'button' | 'reset' | 'submit',
     bsStyle?: 'default' | 'primary' | 'success' | 'info' | 'warning' | 'danger' | 'link',
@@ -68,7 +67,7 @@ declare module "react-bootstrap" {
   }> {}
 
   declare class CarouselItem extends React$Component<{
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     bsClass?: string
   }> {}
 
@@ -126,7 +125,7 @@ declare module "react-bootstrap" {
   declare export class Dropdown extends React$Component<{
     dropup?: boolean,
     id: string | number,
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     disabled?: boolean,
     pullRight?: boolean,
     pullRight?: boolean,
@@ -163,7 +162,7 @@ declare module "react-bootstrap" {
   }> {}
 
   declare class FormControlStatic extends React$Component<{
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     bsClass?: string
   }> {}
 
@@ -172,7 +171,7 @@ declare module "react-bootstrap" {
   }> {}
 
   declare export class FormControl extends React$Component<{
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     type?: string,
     id?: string,
     inputRef?: Ref<'input'>,
@@ -214,7 +213,7 @@ declare module "react-bootstrap" {
   declare export class Form extends React$Component<{
     horizontal?: boolean,
     inline?: boolean,
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     bsClass?: string
   }> {}
 
@@ -252,7 +251,7 @@ declare module "react-bootstrap" {
   }> {}
 
   declare export class Jumbotron extends React$Component<{
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     bsClass?: string
   }> {}
 
@@ -262,7 +261,7 @@ declare module "react-bootstrap" {
   }> {}
 
   declare export class ListGroup extends React$Component<{
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     bsClass?: string
   }> {}
 
@@ -281,7 +280,7 @@ declare module "react-bootstrap" {
 
   declare class MediaBody extends React$Component<{
     align?: 'top' | 'middle' | 'bottom',
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     bsClass?: string
   }> {}
   declare class MediaLeft extends React$Component<{
@@ -289,7 +288,7 @@ declare module "react-bootstrap" {
     bsClass?: string
   }> {}
   declare export class Media extends React$Component<{
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     bsClass?: string
   }> {
     static Body: Class<MediaBody>;
@@ -308,15 +307,15 @@ declare module "react-bootstrap" {
     bsClass?: string
   }> {}
   declare class Title extends React$Component<{
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     bsClass?: string
   }> {}
   declare class Body extends React$Component<{
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     bsClass?: string
   }> {}
   declare class Footer extends React$Component<{
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     bsClass?: string
   }> {}
   declare export class Modal extends React$Component<{
@@ -324,7 +323,7 @@ declare module "react-bootstrap" {
     backdropClassName?: string,
     keyboard?: boolean,
     animation?: boolean,
-    dialogComponentClass?: ElementType,
+    dialogComponentClass?: React$ElementType,
     autoFocus?: boolean,
     enforceFocus?: boolean,
     restoreFocus?: boolean,
@@ -388,7 +387,7 @@ declare module "react-bootstrap" {
     staticTop?: boolean,
     inverse?: boolean,
     fluid?: boolean,
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     onToggle?: Function,
     onSelect?: Function,
     collapseOnSelect?: boolean,
@@ -409,7 +408,7 @@ declare module "react-bootstrap" {
     show?: boolean,
     rootClose?: boolean,
     onHide?: Function,
-    animation?: boolean | ElementType,
+    animation?: boolean | React$ElementType,
     onEnter?: Function,
     onEntering?: Function,
     onEntered?: Function,
@@ -446,19 +445,19 @@ declare module "react-bootstrap" {
     bsClass?: string
   }> {}
 
-  
+
   declare class PaginationLast extends React$Component<{
     bsClass?: string
   }> {}
-  
+
   declare class PaginationPrev extends React$Component<{
     bsClass?: string
   }> {}
-  
+
   declare class PaginationNext extends React$Component<{
     bsClass?: string
   }> {}
-  
+
   declare class PaginationEllipsis extends React$Component<{
     bsClass?: string
   }> {}
@@ -475,7 +474,7 @@ declare module "react-bootstrap" {
   }
 
   declare class PanelHeading extends React$Component<{
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     bsClass?: string,
 
   }> {}
@@ -484,7 +483,7 @@ declare module "react-bootstrap" {
     bsClass?: string
   }> {}
   declare class PanelTitle extends React$Component<{
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     toggle?: boolean,
     bsClass?: string
   }> {}
@@ -499,7 +498,7 @@ declare module "react-bootstrap" {
   }> {}
   declare class PanelToggle extends React$Component<{
     onClick?: Function,
-    componentClass?: ElementType
+    componentClass?: React$ElementType
   }> {}
   declare class PanelFooter extends React$Component<{
     bsClass?: string
@@ -587,8 +586,8 @@ declare module "react-bootstrap" {
   }> {}
 
   declare export class TabContent extends React$Component<{
-    componentClass?: ElementType,
-    animation?: boolean | ElementType,
+    componentClass?: React$ElementType,
+    animation?: boolean | React$ElementType,
     mountOnEnter?: boolean,
     unmountOnExit?: boolean,
     bsClass?: string
@@ -678,17 +677,17 @@ declare module "react-bootstrap" {
 
   declare export class Grid extends React$Component<{
     fluid?: boolean,
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     bsClass?: string
   }> {}
 
   declare export class Row extends React$Component<{
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     bsClass?: string
   }> {}
 
   declare export class Col extends React$Component<{
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     xs?: number,
     sm?: number,
     md?: number,
@@ -713,7 +712,7 @@ declare module "react-bootstrap" {
   }> {}
 
   declare export class Row extends React$Component<{
-    componentClass?: ElementType,
+    componentClass?: React$ElementType,
     visibleXsBlock?: boolean,
     visibleSmBlock?: boolean,
     visibleMdBlock?: boolean,

--- a/definitions/npm/react-bootstrap_v0.32.x/flow_v0.53.x-/test_react-bootstrap_v0.32.x.js
+++ b/definitions/npm/react-bootstrap_v0.32.x/flow_v0.53.x-/test_react-bootstrap_v0.32.x.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Dropdown, Overlay, FormControl, Checkbox, Radio } from 'react-bootstrap';
+import { Button, Dropdown, Overlay, FormControl, Checkbox, Radio } from 'react-bootstrap';
 
 
 // normal components works
@@ -13,3 +13,13 @@ import { Dropdown, Overlay, FormControl, Checkbox, Radio } from 'react-bootstrap
 (<FormControl inputRef={(ref) => {(ref: ?HTMLInputElement)}}/>: React.Node);
 (<Checkbox inputRef={(ref) => {(ref: ?HTMLInputElement)}} />: React.Node);
 (<Radio inputRef={(ref) => {(ref: ?HTMLInputElement)}} />: React.Node);
+
+// componentClass accepts a string or a React Component
+(<Button componentClass={Button} />: React.Node);
+(<Button componentClass="Button" />: React.Node);
+
+class NotAReactComponent {}
+
+// But should reject a valid identifier that isn't a React component
+// $ExpectError
+(<Button componentClass={NotAReactComponent} />: React.Node);


### PR DESCRIPTION
react-bootstrap uses the elementType proptype from this package: https://github.com/react-bootstrap/prop-types-extra/blob/master/src/elementType.js, which declares elementType as string or a React component. 

As written, the libdef will only accept strings, so this should fix that. 