### PR TITLE
Add params in the distinct method definition

### DIFF
--- a/definitions/npm/knex_v0.14.x/flow_v0.38.x-/knex_v0.14.x.js
+++ b/definitions/npm/knex_v0.14.x/flow_v0.38.x-/knex_v0.14.x.js
@@ -88,7 +88,8 @@ declare class Knex$QueryBuilder<R> mixins Promise<R> {
   crossJoin(column: string, c1: string, operator: string, c2: string): this;
   crossJoin(table: string, builder: Knex$QueryBuilderFn<R>): this;
   joinRaw(sql: string, bindings?: Knex$RawBindings): this;
-  distinct(): this;
+  distinct(column?: Knex$Raw | string): this;
+  distinct(...columns: (Knex$Raw | string)[]): this;
   groupBy(column: string): this;
   groupByRaw(sql: string, bindings?: Knex$RawBindings): this;
   orderBy(column: string, direction?: "desc" | "asc"): this;
@@ -177,6 +178,12 @@ declare type Knex$PostgresConfig = {
 };
 
 declare type Knex$RawBindings = Array<mixed> | { [key: string]: mixed };
+
+declare type Knex$Raw = {
+  client: any,
+  sql: string,
+  bindings?: Knex$RawBindings,
+};
 
 declare type Knex$Mysql2Config = {
   client?: "mysql2",


### PR DESCRIPTION
Hi guys !
Great job on flow-typed, I LOVE IT !!

It seems that the distinct method actually accepts strings as column names as well as raw sql return by the raw method in order to work with the DISTINCT ON statement:
distinct(db.raw('ON my_column'))

What do you think about such a typing for the distinct method ?
Let me know how I can improve my Pull Request ;)

Thx 