### PR TITLE
remove type for DayOfWeek.valueOf() to prevent error

### DIFF
--- a/definitions/npm/js-joda_v1.8.x/flow_v0.25.x-/js-joda_v1.8.x.js
+++ b/definitions/npm/js-joda_v1.8.x/flow_v0.25.x-/js-joda_v1.8.x.js
@@ -64,8 +64,8 @@ declare module 'js-joda' {
 		static SUNDAY: DayOfWeek;
 		static from(temporal: TemporalAccessor): DayOfWeek;
 		static of(dayOfWeek: number): DayOfWeek;
-		// $ExpectError - Flow doesn't allow changing signatures of parent classes (Object.valueOf) https://github.com/facebook/flow/issues/4953
-		static valueOf(name: string): DayOfWeek;
+		// $FlowFixMe - Flow doesn't allow changing signatures of parent classes (Object.valueOf) https://github.com/facebook/flow/issues/4953
+		// static valueOf(name: string): DayOfWeek;
 		static values(): Array<DayOfWeek>;
 		adjustInto(temporal: TemporalAdjuster): this;
 		equals(other: any): boolean;


### PR DESCRIPTION
Flow does not allow classes that inherit from `Object` to implement `static valueOf(arg)`. Unfortunately, that's what `js-joda` does. It might not be safe, but that's the way it is. Consumers will have to add `$FlowFixMe` around any usage of `valueOf()` in their code for the time being.