### PR TITLE
[react-redux] Support static properties hoisting in connect

### DIFF
--- a/definitions/npm/react-redux_v5.x.x/flow_v0.63.0-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.63.0-/react-redux_v5.x.x.js
@@ -27,6 +27,7 @@ declare module "react-redux" {
   RMP = Returned merge props
   CP = Props for returned component
   Com = React Component
+  ST = Static properties of Com
   */
 
   declare type MapStateToProps<S: Object, SP: Object, RSP: Object> = (state: S, props: SP) => RSP;
@@ -54,18 +55,22 @@ declare module "react-redux" {
   declare export function connect<
     Com: ComponentType<*>,
     S: Object,
-    DP: Object,
+    SP: Object,
     RSP: Object,
-    CP: $Diff<OmitDispatch<ElementConfig<Com>>, RSP>
+    CP: $Diff<OmitDispatch<ElementConfig<Com>>, RSP>,
+    ST: {[_: $Keys<Com>]: any}
     >(
-    mapStateToProps: MapStateToProps<S, DP, RSP>,
+    mapStateToProps: MapStateToProps<S, SP, RSP>,
     mapDispatchToProps?: null
-  ): (component: Com) => ComponentType<CP & DP>;
+  ): (component: Com) => ComponentType<CP & SP> & $Shape<ST>;
 
-  declare export function connect<Com: ComponentType<*>>(
+  declare export function connect<
+    Com: ComponentType<*>,
+    ST: {[_: $Keys<Com>]: any}
+    >(
     mapStateToProps?: null,
     mapDispatchToProps?: null
-  ): (component: Com) => ComponentType<OmitDispatch<ElementConfig<Com>>>;
+  ): (component: Com) => ComponentType<OmitDispatch<ElementConfig<Com>>> & $Shape<ST>;
 
   declare export function connect<
     Com: ComponentType<*>,
@@ -75,11 +80,12 @@ declare module "react-redux" {
     SP: Object,
     RSP: Object,
     RDP: Object,
-    CP: $Diff<$Diff<ElementConfig<Com>, RSP>, RDP>
+    CP: $Diff<$Diff<ElementConfig<Com>, RSP>, RDP>,
+    ST: $Subtype<{[_: $Keys<Com>]: any}>
     >(
     mapStateToProps: MapStateToProps<S, SP, RSP>,
     mapDispatchToProps: MapDispatchToProps<A, DP, RDP>
-  ): (component: Com) => ComponentType<CP & SP & DP>;
+  ): (component: Com) => ComponentType<CP & SP & DP> & $Shape<ST>;
 
   declare export function connect<
     Com: ComponentType<*>,
@@ -87,7 +93,8 @@ declare module "react-redux" {
     OP: Object,
     DP: Object,
     PR: Object,
-    CP: $Diff<ElementConfig<Com>, DP>
+    CP: $Diff<ElementConfig<Com>, DP>,
+    ST: $Subtype<{[_: $Keys<Com>]: any}>
     >(
     mapStateToProps?: null,
     mapDispatchToProps: MapDispatchToProps<A, OP, DP>
@@ -95,11 +102,12 @@ declare module "react-redux" {
 
   declare export function connect<
     Com: ComponentType<*>,
-    MDP: Object
+    MDP: Object,
+    ST: $Subtype<{[_: $Keys<Com>]: any}>
     >(
     mapStateToProps?: null,
     mapDispatchToProps: MDP
-  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, MDP>>;
+  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, MDP>> & $Shape<ST>;
 
   declare export function connect<
     Com: ComponentType<*>,
@@ -107,11 +115,12 @@ declare module "react-redux" {
     SP: Object,
     RSP: Object,
     MDP: Object,
-    CP: $Diff<ElementConfig<Com>, RSP>
+    CP: $Diff<ElementConfig<Com>, RSP>,
+    ST: $Subtype<{[_: $Keys<Com>]: any}>
     >(
     mapStateToProps: MapStateToProps<S, SP, RSP>,
     mapDispatchToPRops: MDP
-  ): (component: Com) => ComponentType<$Diff<CP, MDP> & SP>;
+  ): (component: Com) => ComponentType<$Diff<CP, MDP> & SP> & $Shape<ST>;
 
   declare export function connect<
     Com: ComponentType<*>,
@@ -123,12 +132,13 @@ declare module "react-redux" {
     RDP: Object,
     MP: Object,
     RMP: Object,
-    CP: $Diff<ElementConfig<Com>, RMP>
+    CP: $Diff<ElementConfig<Com>, RMP>,
+    ST: $Subtype<{[_: $Keys<Com>]: any}>
     >(
     mapStateToProps: MapStateToProps<S, SP, RSP>,
     mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
     mergeProps: MergeProps<RSP, RDP, MP, RMP>
-  ): (component: Com) => ComponentType<CP & SP & DP & MP>;
+  ): (component: Com) => ComponentType<CP & SP & DP & MP> & $Shape<ST>;
 
   declare export function connect<
     Com: ComponentType<*>,
@@ -141,12 +151,13 @@ declare module "react-redux" {
     MDP: Object,
     MP: Object,
     RMP: Object,
-    CP: $Diff<ElementConfig<Com>, RMP>
+    CP: $Diff<ElementConfig<Com>, RMP>,
+    ST: $Subtype<{[_: $Keys<Com>]: any}>
     >(
     mapStateToProps: MapStateToProps<S, SP, RSP>,
     mapDispatchToProps: MDP,
     mergeProps: MergeProps<RSP, RDP, MP, RMP>
-  ): (component: Com) => ComponentType<CP & SP & DP & MP>;
+  ): (component: Com) => ComponentType<CP & SP & DP & MP> & $Shape<ST>;
 
   declare export function connect<Com: ComponentType<*>,
     A,
@@ -156,13 +167,14 @@ declare module "react-redux" {
     RSP: Object,
     RDP: Object,
     MP: Object,
-    RMP: Object
+    RMP: Object,
+    ST: $Subtype<{[_: $Keys<Com>]: any}>
     >(
     mapStateToProps: ?MapStateToProps<S, SP, RSP>,
     mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
     mergeProps: ?MergeProps<RSP, RDP, MP, RMP>,
     options: ConnectOptions<S, SP & DP & MP, RSP, RMP>
-  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP>;
+  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP> & $Shape<ST>;
 
   declare export function connect<Com: ComponentType<*>,
     A,
@@ -173,13 +185,14 @@ declare module "react-redux" {
     RDP: Object,
     MDP: Object,
     MP: Object,
-    RMP: Object
+    RMP: Object,
+    ST: $Subtype<{[_: $Keys<Com>]: any}>
     >(
     mapStateToProps: ?MapStateToProps<S, SP, RSP>,
     mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
     mergeProps: MDP,
     options: ConnectOptions<S, SP & DP & MP, RSP, RMP>
-  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP>;
+  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP> & $Shape<ST>;
 
   declare export default {
     Provider: typeof Provider,

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.63.0-/test_connect.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.63.0-/test_connect.js
@@ -457,3 +457,33 @@ function testOptions() {
   // $ExpectError wrong key
   connect(null, null, null, {wrongKey: true})(Com);
 }
+
+function testHoistConnectedComponent() {
+  type Props = {passthrough: number, passthroughWithDefaultProp: number, fromStateToProps: string};
+  class Com extends React.Component<Props> {
+    static defaultProps = { passthroughWithDefaultProp: 123 };
+    static myStatic = 1;
+
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = {a: number};
+  type InputProps = {
+    forMapStateToProps: string
+  };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect(mapStateToProps)(Com);
+  // OK without passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  // OK with passthroughWithDefaultProp
+  <Connected passthrough={123} passthroughWithDefaultProp={456} forMapStateToProps={'data'}/>;
+  // OK with declared static property
+  Connected.myStatic;
+}


### PR DESCRIPTION
react-redux connect does hoist not react statics as per https://github.com/reduxjs/react-redux/blob/master/src/components/connectAdvanced.js#L288

So I added support for that in typing as I needed it.

After digging, this fixes #830.

Cheers.