### PR TITLE
include the definition for empty()

### DIFF
--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -1631,6 +1631,7 @@ declare module "rxjs" {
       input: rxjs$ObservableInput<T>,
       scheduler?: rxjs$SchedulerClass
     ): rxjs$Observable<T>,
+    empty<+T>(): rxjs$Observable<T>,
     timer(
       initialDelay: number | Date,
       period?: number,


### PR DESCRIPTION
A very simple `empty()` definition. I'll be making PRs for more and more creation methods for rx shortly, all as individual PRs to ensure these move forward gradually. cc @radex @tobilen

Helps with #2285