### PR TITLE
remove type param from axios such that responses and requests are all now mixed

### DIFF
--- a/definitions/npm/axios_v0.11.x/flow_v0.25.x-v0.74.x/axios_v0.11.x.js
+++ b/definitions/npm/axios_v0.11.x/flow_v0.25.x-v0.74.x/axios_v0.11.x.js
@@ -1,5 +1,5 @@
 declare module "axios" {
-  declare interface AxiosXHRConfigBase<T> {
+  declare interface AxiosXHRConfigBase {
     headers?: Object;
     maxContentLength?: number;
     params?: Object;
@@ -10,59 +10,59 @@ declare module "axios" {
       | "json"
       | "text"
       | "stream";
-    transformReponse?: <U>(data: T) => U;
-    transformRequest?: <U>(data: T) => U | Array<<U>(data: T) => U>;
+    transformResponse?: <U>(data: mixed) => U;
+    transformRequest?: <U>(data: mixed) => U | Array<<U>(data: mixed) => U>;
     validateStatus?: ?(status: number) => boolean;
     withCredentials?: boolean;
     xsrfCookieName?: string;
     xsrfHeaderName?: string;
   }
-  declare interface AxiosXHRConfig<T> extends AxiosXHRConfigBase<T> {
-    data?: T;
+  declare interface AxiosXHRConfig extends AxiosXHRConfigBase {
+    data?: mixed;
     method?: string;
     url: string;
   }
-  declare class AxiosXHR<T> {
-    config: AxiosXHRConfig<T>;
-    data: T;
+  declare class AxiosXHR {
+    config: AxiosXHRConfig;
+    data: mixed;
     headers: Object;
     status: number;
     statusText: string;
     request: mixed; //this is the request object, not really typed currently.
   }
   declare class AxiosInterceptorIdent extends String {}
-  declare class AxiosRequestInterceptor<T> {
+  declare class AxiosRequestInterceptor {
     use(
       successHandler: ?(
-        response: AxiosXHRConfig<T>
-      ) => Promise<AxiosXHRConfig<*>> | AxiosXHRConfig<*>,
+        response: AxiosXHRConfig
+      ) => Promise<AxiosXHRConfig> | AxiosXHRConfig,
       errorHandler: ?(error: mixed) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
-  declare class AxiosResponseInterceptor<T> {
+  declare class AxiosResponseInterceptor {
     use(
-      successHandler: ?(response: AxiosXHR<T>) => mixed,
+      successHandler: ?(response: AxiosXHR) => mixed,
       errorHandler: ?(error: mixed) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
   declare class Axios {
-    constructor<T>(config: AxiosXHRConfigBase<T>): Promise<T>;
-    <T>(config: AxiosXHRConfigBase<T>): Promise<T>;
-    get: <T>(url: string, config?: AxiosXHRConfigBase<T>) => Promise<T>;
-    delete: <T>(url: string, config?: AxiosXHRConfigBase<T>) => Promise<T>;
-    head: <T>(url: string, config?: AxiosXHRConfigBase<T>) => Promise<T>;
-    post: <T>(
+    constructor(config: AxiosXHRConfigBase): Promise<AxiosXHR>;
+    (config: AxiosXHRConfigBase): Promise<AxiosXHR>;
+    get: (url: string, config?: AxiosXHRConfigBase) => Promise<AxiosXHR>;
+    delete: (url: string, config?: AxiosXHRConfigBase) => Promise<AxiosXHR>;
+    head: (url: string, config?: AxiosXHRConfigBase) => Promise<AxiosXHR>;
+    post: (
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T>
-    ) => Promise<T>;
-    put: <T>(
+      config?: AxiosXHRConfigBase
+    ) => Promise<AxiosXHR>;
+    put: (
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T>
-    ) => Promise<T>;
+      config?: AxiosXHRConfigBase
+    ) => Promise<AxiosXHR>;
     interceptors: {
       request: AxiosRequestInterceptor<mixed>,
       response: AxiosResponseInterceptor<mixed>

--- a/definitions/npm/axios_v0.13.x/flow_v0.25.x-v0.74.x/axios_v0.13.x.js
+++ b/definitions/npm/axios_v0.13.x/flow_v0.25.x-v0.74.x/axios_v0.13.x.js
@@ -1,6 +1,6 @@
 declare module 'axios' {
-  declare interface AxiosXHRConfigBase<T> {
-    adapter?: <T>(config: AxiosXHRConfig<T>) => Promise<AxiosXHR<T>>;
+  declare interface AxiosXHRConfigBase {
+    adapter?: (config: AxiosXHRConfig) => Promise<AxiosXHR>;
     auth?: {
         username: string,
         password: string
@@ -13,8 +13,8 @@ declare module 'axios' {
     params?: Object;
     paramsSerializer?: (params: Object) => string;
     responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
-    transformResponse?: Array<<U>(data: T) => U>;
-    transformRequest?: Array<<U>(data: T) => U|Array<<U>(data: T) => U>>;
+    transformResponse?: Array<<U>(data: mixed) => U>;
+    transformRequest?: Array<<U>(data: mixed) => U|Array<<U>(data: mixed) => U>>;
     timeout?: number;
     validateStatus?: (status: number) => boolean,
     withCredentials?: boolean;
@@ -23,65 +23,65 @@ declare module 'axios' {
     httpAgent?: mixed; // Missing the type in the core flow node libdef
     httpsAgent?: mixed; // Missing the type in the core flow node libdef
   }
-  declare type $AxiosXHRConfigBase<T> = AxiosXHRConfigBase<T>;
-  declare interface AxiosXHRConfig<T> extends AxiosXHRConfigBase<T> {
-    data?: T;
-    method?: string;
-    url: string;
-  }
-  declare type $AxiosXHRConfig<T> = AxiosXHRConfig<T>;
-  declare class AxiosXHR<T> {
-    config: AxiosXHRConfig<T>;
-    data: T;
+  declare type $AxiosXHRConfigBase = AxiosXHRConfigBase;
+  declare type AxiosXHRConfig = {
+    data?: mixed,
+    method?: string,
+    url: string,
+  } & AxiosXHRConfigBase;
+  declare type $AxiosXHRConfig = AxiosXHRConfig;
+  declare class AxiosXHR {
+    config: AxiosXHRConfig;
+    data: mixed;
     headers: Object;
     status: number;
     statusText: string,
     request: http$ClientRequest | XMLHttpRequest
   }
-  declare type $AxiosXHR<T> = $AxiosXHR<T>;
+  declare type $AxiosXHR = $AxiosXHR;
   declare class AxiosInterceptorIdent extends String {}
-  declare class AxiosRequestInterceptor<T> {
+  declare class AxiosRequestInterceptor {
     use(
-      successHandler: ?(response: AxiosXHRConfig<T>) => Promise<AxiosXHRConfig<*>> | AxiosXHRConfig<*>,
+      successHandler: ?(response: AxiosXHRConfig) => Promise<AxiosXHRConfig> | AxiosXHRConfig,
       errorHandler: ?(error: mixed) => mixed,
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
-  declare class AxiosResponseInterceptor<T> {
+  declare class AxiosResponseInterceptor {
     use(
-      successHandler: ?(response: AxiosXHR<T>) => mixed,
+      successHandler: ?(response: AxiosXHR) => mixed,
       errorHandler: ?(error: mixed) => mixed,
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
-  declare type AxiosPromise<T> = Promise<AxiosXHR<T>>;
+  declare type AxiosPromise = Promise<AxiosXHR>;
   declare class Axios {
-    constructor<T>(config?: AxiosXHRConfigBase<T>): void;
-    $call: <T>(config: AxiosXHRConfig<T> | string, config?: AxiosXHRConfig<T>) => AxiosPromise<T>;
-    request<T>(config: AxiosXHRConfig<T>): AxiosPromise<T>;
-    delete<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    get<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    head<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    post<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    put<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    patch<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
+    constructor(config?: AxiosXHRConfigBase): void;
+    $call: (config: AxiosXHRConfig | string, config?: AxiosXHRConfig) => AxiosPromise;
+    request(config: AxiosXHRConfig): AxiosPromise;
+    delete(url: string, config?: AxiosXHRConfigBase): AxiosPromise;
+    get(url: string, config?: AxiosXHRConfigBase): AxiosPromise;
+    head(url: string, config?: AxiosXHRConfigBase): AxiosPromise;
+    post(url: string, data?: mixed, config?: AxiosXHRConfigBase): AxiosPromise;
+    put(url: string, data?: mixed, config?: AxiosXHRConfigBase): AxiosPromise;
+    patch(url: string, data?: mixed, config?: AxiosXHRConfigBase): AxiosPromise;
     interceptors: {
       request: AxiosRequestInterceptor<mixed>,
       response: AxiosResponseInterceptor<mixed>,
     };
   }
 
-  declare class AxiosError<T> extends Error {
-    config: AxiosXHRConfig<T>;
-    response: AxiosXHR<T>;
+  declare class AxiosError extends Error {
+    config: AxiosXHRConfig;
+    response: AxiosXHR;
     code?: string;
   }
 
-  declare type $AxiosError<T> = AxiosError<T>;
+  declare type $AxiosError = AxiosError;
 
   declare interface AxiosExport extends Axios {
       Axios: typeof Axios;
-      create(config?: AxiosXHRConfigBase<any>): Axios;
+      create(config?: AxiosXHRConfigBase): Axios;
       all: typeof Promise.all;
       spread(callback: Function): (arr: Array<any>) => Function
   }

--- a/definitions/npm/axios_v0.13.x/test_axios-v0.13.js
+++ b/definitions/npm/axios_v0.13.x/test_axios-v0.13.js
@@ -31,7 +31,7 @@ axios.get('/user', {
     ID: 12345
   }
 }).then((res) => {
-    res.data[0];
+    res.data;
 });
 
 // Send a POST request

--- a/definitions/npm/axios_v0.15.x/flow_v0.25.x-v0.74.x/axios_v0.15.x.js
+++ b/definitions/npm/axios_v0.15.x/flow_v0.25.x-v0.74.x/axios_v0.15.x.js
@@ -21,8 +21,8 @@ declare module "axios" {
     reason?: Cancel;
     throwIfRequested(): void;
   }
-  declare interface AxiosXHRConfigBase<T> {
-    adapter?: <T>(config: AxiosXHRConfig<T>) => Promise<AxiosXHR<T>>;
+  declare interface AxiosXHRConfigBase {
+    adapter?: (config: AxiosXHRConfig) => Promise<AxiosXHR>;
     auth?: {
       username: string,
       password: string
@@ -46,72 +46,72 @@ declare module "axios" {
       | "text"
       | "stream";
     timeout?: number;
-    transformRequest?: Array<<U>(data: T) => U | Array<<U>(data: T) => U>>;
-    transformResponse?: Array<<U>(data: T) => U>;
+    transformRequest?: Array<<U>(data: mixed) => U | Array<<U>(data: mixed) => U>>;
+    transformResponse?: Array<<U>(data: mixed) => U>;
     validateStatus?: (status: number) => boolean;
     withCredentials?: boolean;
     xsrfCookieName?: string;
     xsrfHeaderName?: string;
   }
-  declare type $AxiosXHRConfigBase<T> = AxiosXHRConfigBase<T>;
-  declare interface AxiosXHRConfig<T> extends AxiosXHRConfigBase<T> {
-    data?: T;
-    method?: string;
-    url: string;
-  }
-  declare type $AxiosXHRConfig<T> = AxiosXHRConfig<T>;
-  declare class AxiosXHR<T> {
-    config: AxiosXHRConfig<T>;
-    data: T;
+  declare type $AxiosXHRConfigBase = AxiosXHRConfigBase;
+  declare type AxiosXHRConfig = {
+    data?: mixed,
+    method?: string,
+    url: string,
+  } & AxiosXHRConfigBase;
+  declare type $AxiosXHRConfig = AxiosXHRConfig;
+  declare class AxiosXHR {
+    config: AxiosXHRConfig;
+    data: mixed;
     headers: Object;
     status: number;
     statusText: string;
     request: http$ClientRequest | XMLHttpRequest;
   }
-  declare type $AxiosXHR<T> = $AxiosXHR<T>;
+  declare type $AxiosXHR = $AxiosXHR;
   declare type AxiosInterceptorIdent = number;
-  declare class AxiosRequestInterceptor<T> {
+  declare class AxiosRequestInterceptor {
     use(
       successHandler: ?(
-        response: AxiosXHRConfig<T>
-      ) => Promise<AxiosXHRConfig<*>> | AxiosXHRConfig<*>,
+        response: AxiosXHRConfig
+      ) => Promise<AxiosXHRConfig> | AxiosXHRConfig,
       errorHandler: ?(error: mixed) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
-  declare class AxiosResponseInterceptor<T> {
+  declare class AxiosResponseInterceptor {
     use(
-      successHandler: ?(response: AxiosXHR<T>) => mixed,
+      successHandler: ?(response: AxiosXHR) => mixed,
       errorHandler: ?(error: mixed) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
-  declare type AxiosPromise<T> = Promise<AxiosXHR<T>>;
+  declare type AxiosPromise = Promise<AxiosXHR>;
   declare class Axios {
-    constructor<T>(config?: AxiosXHRConfigBase<T>): void;
-    $call: <T>(
-      config: AxiosXHRConfig<T> | string,
-      config?: AxiosXHRConfig<T>
-    ) => AxiosPromise<T>;
-    request<T>(config: AxiosXHRConfig<T>): AxiosPromise<T>;
-    delete<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    get<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    head<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    post<T>(
+    constructor(config?: AxiosXHRConfigBase): void;
+    $call: (
+      config: AxiosXHRConfig | string,
+      config?: AxiosXHRConfig
+    ) => AxiosPromise;
+    request(config: AxiosXHRConfig): AxiosPromise;
+    delete(url: string, config?: AxiosXHRConfigBase): AxiosPromise;
+    get(url: string, config?: AxiosXHRConfigBase): AxiosPromise;
+    head(url: string, config?: AxiosXHRConfigBase): AxiosPromise;
+    post(
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T>
-    ): AxiosPromise<T>;
-    put<T>(
+      config?: AxiosXHRConfigBase
+    ): AxiosPromise;
+    put(
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T>
-    ): AxiosPromise<T>;
-    patch<T>(
+      config?: AxiosXHRConfigBase
+    ): AxiosPromise;
+    patch(
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T>
-    ): AxiosPromise<T>;
+      config?: AxiosXHRConfigBase
+    ): AxiosPromise;
     interceptors: {
       request: AxiosRequestInterceptor<mixed>,
       response: AxiosResponseInterceptor<mixed>
@@ -119,13 +119,13 @@ declare module "axios" {
     defaults: { headers: Object } & AxiosXHRConfig<*>;
   }
 
-  declare class AxiosError<T> extends Error {
-    config: AxiosXHRConfig<T>;
-    response: AxiosXHR<T>;
+  declare class AxiosError extends Error {
+    config: AxiosXHRConfig;
+    response: AxiosXHR;
     code?: string;
   }
 
-  declare type $AxiosError<T> = AxiosError<T>;
+  declare type $AxiosError = AxiosError;
 
   declare interface AxiosExport extends Axios {
     Axios: typeof Axios;

--- a/definitions/npm/axios_v0.15.x/test_axios-v0.15.js
+++ b/definitions/npm/axios_v0.15.x/test_axios-v0.15.js
@@ -52,7 +52,7 @@ axios.get('/user', {
     ID: 12345
   }
 }).then((res) => {
-    res.data[0];
+    res.data;
 });
 
 // Send a POST request

--- a/definitions/npm/axios_v0.16.x/flow_v0.75.x-/axios_v0.16.x.js
+++ b/definitions/npm/axios_v0.16.x/flow_v0.75.x-/axios_v0.16.x.js
@@ -21,8 +21,8 @@ declare module "axios" {
     reason?: Cancel;
     throwIfRequested(): void;
   }
-  declare interface AxiosXHRConfigBase<T> {
-    adapter?: <T>(config: AxiosXHRConfig<T>) => Promise<AxiosXHR<T>>;
+  declare interface AxiosXHRConfigBase {
+    adapter?: (config: AxiosXHRConfig) => Promise<AxiosXHR>;
     auth?: {
       username: string,
       password: string
@@ -46,97 +46,97 @@ declare module "axios" {
       | "text"
       | "stream";
     timeout?: number;
-    transformRequest?: Array<<U>(data: T) => U | Array<<U>(data: T) => U>>;
-    transformResponse?: Array<<U>(data: T) => U>;
+    transformRequest?: Array<<U>(data: mixed) => U | Array<<U>(data: mixed) => U>>;
+    transformResponse?: Array<<U>(data: mixed) => U>;
     validateStatus?: (status: number) => boolean;
     withCredentials?: boolean;
     xsrfCookieName?: string;
     xsrfHeaderName?: string;
   }
-  declare type $AxiosXHRConfigBase<T> = AxiosXHRConfigBase<T>;
-  declare interface AxiosXHRConfig<T> extends AxiosXHRConfigBase<T> {
-    data?: T;
-    method?: string;
-    url: string;
-  }
-  declare type $AxiosXHRConfig<T> = AxiosXHRConfig<T>;
-  declare class AxiosXHR<T> {
-    config: AxiosXHRConfig<T>;
-    data: T;
+  declare type $AxiosXHRConfigBase = AxiosXHRConfigBase;
+  declare type AxiosXHRConfig = {
+    data?: mixed,
+    method?: string,
+    url: string,
+  } & AxiosXHRConfigBase;
+  declare type $AxiosXHRConfig = AxiosXHRConfig;
+  declare class AxiosXHR {
+    config: AxiosXHRConfig;
+    data: mixed;
     headers?: Object;
     status: number;
     statusText: string;
     request: http$ClientRequest | XMLHttpRequest;
   }
-  declare type $AxiosXHR<T> = AxiosXHR<T>;
+  declare type $AxiosXHR = AxiosXHR;
   declare type AxiosInterceptorIdent = number;
-  declare class AxiosRequestInterceptor<T> {
+  declare class AxiosRequestInterceptor {
     use(
       successHandler: ?(
-        response: AxiosXHRConfig<T>
-      ) => Promise<AxiosXHRConfig<*>> | AxiosXHRConfig<*>,
+        response: AxiosXHRConfig
+      ) => Promise<AxiosXHRConfig> | AxiosXHRConfig,
       errorHandler: ?(error: mixed) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
-  declare class AxiosResponseInterceptor<T> {
+  declare class AxiosResponseInterceptor {
     use(
-      successHandler: ?(response: AxiosXHR<T>) => mixed,
-      errorHandler: ?(error: $AxiosError<any>) => mixed
+      successHandler: ?(response: AxiosXHR) => mixed,
+      errorHandler: ?(error: $AxiosError) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
-  declare type AxiosPromise<T> = Promise<AxiosXHR<T>>;
+  declare type AxiosPromise = Promise<AxiosXHR>;
   declare class Axios {
-    constructor<T>(config?: AxiosXHRConfigBase<T>): void;
-    [[call]]<T>(
-      config: AxiosXHRConfig<T> | string,
-      config?: AxiosXHRConfig<T>
-    ): AxiosPromise<T>;
-    request<T>(config: AxiosXHRConfig<T>): AxiosPromise<T>;
-    delete<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    get<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    head<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    post<T>(
+    constructor(config?: AxiosXHRConfigBase): void;
+    [[call]](
+      config: AxiosXHRConfig | string,
+      config?: AxiosXHRConfig
+    ): AxiosPromise;
+    request(config: AxiosXHRConfig): AxiosPromise;
+    delete(url: string, config?: AxiosXHRConfigBase): AxiosPromise;
+    get(url: string, config?: AxiosXHRConfigBase): AxiosPromise;
+    head(url: string, config?: AxiosXHRConfigBase): AxiosPromise;
+    post(
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T>
-    ): AxiosPromise<T>;
-    put<T>(
+      config?: AxiosXHRConfigBase
+    ): AxiosPromise;
+    put(
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T>
-    ): AxiosPromise<T>;
-    patch<T>(
+      config?: AxiosXHRConfigBase
+    ): AxiosPromise;
+    patch(
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T>
-    ): AxiosPromise<T>;
+      config?: AxiosXHRConfigBase
+    ): AxiosPromise;
     interceptors: {
-      request: AxiosRequestInterceptor<mixed>,
-      response: AxiosResponseInterceptor<mixed>
+      request: AxiosRequestInterceptor,
+      response: AxiosResponseInterceptor
     };
-    defaults: { headers: Object } & AxiosXHRConfig<*>;
+    defaults: { headers: Object } & AxiosXHRConfig;
   }
 
-  declare class AxiosError<T> extends Error {
-    config: AxiosXHRConfig<T>;
-    response: AxiosXHR<T>;
+  declare class AxiosError extends Error {
+    config: AxiosXHRConfig;
+    response: AxiosXHR;
     code?: string;
   }
 
-  declare type $AxiosError<T> = AxiosError<T>;
+  declare type $AxiosError = AxiosError;
 
   declare interface AxiosExport extends Axios {
-    [[call]]<T>(
-      config: AxiosXHRConfig<T> | string,
-      config?: AxiosXHRConfig<T>
-    ): AxiosPromise<T>;
+    [[call]](
+      config: AxiosXHRConfig | string,
+      config?: AxiosXHRConfig
+    ): AxiosPromise;
     Axios: typeof Axios;
     Cancel: Class<Cancel>;
     CancelToken: Class<CancelToken>;
     isCancel(value: any): boolean;
-    create(config?: AxiosXHRConfigBase<any>): Axios;
+    create(config?: AxiosXHRConfigBase): Axios;
     all: typeof Promise.all;
     spread(callback: Function): (arr: Array<any>) => Function;
   }

--- a/definitions/npm/axios_v0.16.x/test_axios-v0.16.js
+++ b/definitions/npm/axios_v0.16.x/test_axios-v0.16.js
@@ -52,7 +52,7 @@ axios.get('/user', {
     ID: 12345
   }
 }).then((res) => {
-    res.data[0];
+    res.data;
 });
 
 // Send a POST request

--- a/definitions/npm/axios_v0.17.x/flow_v0.75.x-/axios_v0.17.x.js
+++ b/definitions/npm/axios_v0.17.x/flow_v0.75.x-/axios_v0.17.x.js
@@ -21,8 +21,8 @@ declare module "axios" {
     reason?: Cancel;
     throwIfRequested(): void;
   }
-  declare interface AxiosXHRConfigBase<T> {
-    adapter?: <T>(config: AxiosXHRConfig<T>) => Promise<AxiosXHR<T>>;
+  declare interface AxiosXHRConfigBase {
+    adapter?: (config: AxiosXHRConfig) => Promise<AxiosXHR>;
     auth?: {
       username: string,
       password: string
@@ -46,98 +46,98 @@ declare module "axios" {
       | "text"
       | "stream";
     timeout?: number;
-    transformRequest?: Array<<U>(data: T) => U | Array<<U>(data: T) => U>>;
-    transformResponse?: Array<<U>(data: T) => U>;
+    transformRequest?: Array<<U>(data: mixed) => U | Array<<U>(data: mixed) => U>>;
+    transformResponse?: Array<<U>(data: mixed) => U>;
     validateStatus?: (status: number) => boolean;
     withCredentials?: boolean;
     xsrfCookieName?: string;
     xsrfHeaderName?: string;
   }
-  declare type $AxiosXHRConfigBase<T> = AxiosXHRConfigBase<T>;
-  declare interface AxiosXHRConfig<T> extends AxiosXHRConfigBase<T> {
-    data?: T;
-    method?: string;
-    url: string;
-  }
-  declare type $AxiosXHRConfig<T> = AxiosXHRConfig<T>;
-  declare class AxiosXHR<T> {
-    config: AxiosXHRConfig<T>;
-    data: T;
+  declare type $AxiosXHRConfigBase = AxiosXHRConfigBase;
+  declare type AxiosXHRConfig = {
+    data?: mixed,
+    method?: string,
+    url: string,
+  } & AxiosXHRConfigBase;
+  declare type $AxiosXHRConfig = AxiosXHRConfig;
+  declare class AxiosXHR {
+    config: AxiosXHRConfig;
+    data: mixed;
     headers?: Object;
     status: number;
     statusText: string;
     request: http$ClientRequest | XMLHttpRequest;
   }
-  declare type $AxiosXHR<T> = AxiosXHR<T>;
+  declare type $AxiosXHR = AxiosXHR;
   declare type AxiosInterceptorIdent = number;
-  declare class AxiosRequestInterceptor<T> {
+  declare class AxiosRequestInterceptor {
     use(
       successHandler: ?(
-        response: AxiosXHRConfig<T>
-      ) => Promise<AxiosXHRConfig<*>> | AxiosXHRConfig<*>,
+        response: AxiosXHRConfig
+      ) => Promise<AxiosXHRConfig> | AxiosXHRConfig,
       errorHandler: ?(error: mixed) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
-  declare class AxiosResponseInterceptor<T> {
+  declare class AxiosResponseInterceptor {
     use(
-      successHandler: ?(response: AxiosXHR<T>) => mixed,
-      errorHandler: ?(error: $AxiosError<any>) => mixed
+      successHandler: ?(response: AxiosXHR) => mixed,
+      errorHandler: ?(error: $AxiosError) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
-  declare type AxiosPromise<T> = Promise<AxiosXHR<T>>;
+  declare type AxiosPromise = Promise<AxiosXHR>;
   declare class Axios {
-    constructor<T>(config?: AxiosXHRConfigBase<T>): void;
-    [[call]]<T>(
-      config: AxiosXHRConfig<T> | string,
-      config?: AxiosXHRConfig<T>
-    ): AxiosPromise<T>;
-    request<T>(config: AxiosXHRConfig<T>): AxiosPromise<T>;
-    delete<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    get<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    head<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    post<T>(
+    constructor(config?: AxiosXHRConfigBase): void;
+    [[call]](
+      config: AxiosXHRConfig | string,
+      config?: AxiosXHRConfig
+    ): AxiosPromise;
+    request(config: AxiosXHRConfig): AxiosPromise;
+    delete(url: string, config?: AxiosXHRConfigBase): AxiosPromise;
+    get(url: string, config?: AxiosXHRConfigBase): AxiosPromise;
+    head(url: string, config?: AxiosXHRConfigBase): AxiosPromise;
+    post(
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T>
-    ): AxiosPromise<T>;
-    put<T>(
+      config?: AxiosXHRConfigBase
+    ): AxiosPromise;
+    put(
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T>
-    ): AxiosPromise<T>;
-    patch<T>(
+      config?: AxiosXHRConfigBase
+    ): AxiosPromise;
+    patch(
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T>
-    ): AxiosPromise<T>;
+      config?: AxiosXHRConfigBase
+    ): AxiosPromise;
     interceptors: {
       request: AxiosRequestInterceptor<mixed>,
       response: AxiosResponseInterceptor<mixed>
     };
-    defaults: { headers: Object } & AxiosXHRConfig<*>;
+    defaults: { headers: Object } & AxiosXHRConfig;
   }
 
-  declare class AxiosError<T> extends Error {
-    config: AxiosXHRConfig<T>;
+  declare class AxiosError extends Error {
+    config: AxiosXHRConfig;
     request?: http$ClientRequest | XMLHttpRequest;
-    response?: AxiosXHR<T>;
+    response?: AxiosXHR;
     code?: string;
   }
 
-  declare type $AxiosError<T> = AxiosError<T>;
+  declare type $AxiosError = AxiosError;
 
   declare interface AxiosExport extends Axios {
-    [[call]]<T>(
-      config: AxiosXHRConfig<T> | string,
-      config?: AxiosXHRConfig<T>
-    ): AxiosPromise<T>;
+    [[call]](
+      config: AxiosXHRConfig | string,
+      config?: AxiosXHRConfig
+    ): AxiosPromise;
     Axios: typeof Axios;
     Cancel: Class<Cancel>;
     CancelToken: Class<CancelToken>;
     isCancel(value: any): boolean;
-    create(config?: AxiosXHRConfigBase<any>): Axios;
+    create(config?: AxiosXHRConfigBase): Axios;
     all: typeof Promise.all;
     spread(callback: Function): (arr: Array<any>) => Function;
   }

--- a/definitions/npm/axios_v0.17.x/test_axios-v0.17.js
+++ b/definitions/npm/axios_v0.17.x/test_axios-v0.17.js
@@ -52,7 +52,7 @@ axios.get('/user', {
     ID: 12345
   }
 }).then((res) => {
-    res.data[0];
+    res.data;
 });
 
 // Send a POST request

--- a/definitions/npm/axios_v0.18.x/flow_v0.75.x-/axios_v0.18.x.js
+++ b/definitions/npm/axios_v0.18.x/flow_v0.75.x-/axios_v0.18.x.js
@@ -1,6 +1,6 @@
 declare module "axios" {
-  declare interface AxiosTransformer<T> {
-    (data: T, headers?: Object): Object;
+  declare interface AxiosTransformer {
+    (data: mixed, headers?: Object): Object;
   }
   declare interface ProxyConfig {
     host: string;
@@ -28,8 +28,8 @@ declare module "axios" {
     reason?: Cancel;
     throwIfRequested(): void;
   }
-  declare interface AxiosXHRConfigBase<T,R = T> {
-    adapter?: <T,R>(config: AxiosXHRConfig<T,R>) => Promise<AxiosXHR<T,R>>;
+  declare interface AxiosXHRConfigBase {
+    adapter?: (config: AxiosXHRConfig) => Promise<AxiosXHR>;
     auth?: {
       username: string,
       password: string
@@ -53,92 +53,93 @@ declare module "axios" {
       | "text"
       | "stream";
     timeout?: number;
-    transformRequest?: AxiosTransformer<T> | Array<AxiosTransformer<T>>;
-    transformResponse?: AxiosTransformer<R> | Array<AxiosTransformer<R>>;
+    transformRequest?: AxiosTransformer | Array<AxiosTransformer>;
+    transformResponse?: AxiosTransformer | Array<AxiosTransformer>;
     validateStatus?: (status: number) => boolean;
     withCredentials?: boolean;
     xsrfCookieName?: string;
     xsrfHeaderName?: string;
   }
-  declare type $AxiosXHRConfigBase<T,R = T> = AxiosXHRConfigBase<T,R>;
-  declare interface AxiosXHRConfig<T,R = T> extends AxiosXHRConfigBase<T,R> {
-    data?: T;
+  declare type $AxiosXHRConfigBase = AxiosXHRConfigBase;
+  declare type AxiosXHRConfig = {
+    data?: mixed,
     method?: string;
-    url: string;
-  }
-  declare type $AxiosXHRConfig<T,R = T> = AxiosXHRConfig<T,R>;
-  declare class AxiosXHR<T,R = T> {
-    config: AxiosXHRConfig<T,R>;
-    data: R;
+    url: string,
+  } & AxiosXHRConfigBase;
+
+  declare type $AxiosXHRConfig = AxiosXHRConfig;
+  declare class AxiosXHR {
+    config: AxiosXHRConfig;
+    data: mixed;
     headers?: Object;
     status: number;
     statusText: string;
     request: http$ClientRequest | XMLHttpRequest;
   }
-  declare type $AxiosXHR<T,R = T> = AxiosXHR<T,R>;
+  declare type $AxiosXHR = AxiosXHR;
   declare type AxiosInterceptorIdent = number;
-  declare class AxiosRequestInterceptor<T,R = T> {
+  declare class AxiosRequestInterceptor {
     use(
       successHandler: ?(
-        response: AxiosXHRConfig<T,R>
-      ) => Promise<AxiosXHRConfig<*,*>> | AxiosXHRConfig<*,*>,
+        response: AxiosXHRConfig
+      ) => Promise<AxiosXHRConfig> | AxiosXHRConfig,
       errorHandler: ?(error: mixed) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
-  declare class AxiosResponseInterceptor<T,R = T> {
+  declare class AxiosResponseInterceptor {
     use(
-      successHandler: ?(response: AxiosXHR<T,R>) => mixed,
+      successHandler: ?(response: AxiosXHR) => mixed,
       errorHandler: ?(error: $AxiosError<any>) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
-  declare type AxiosPromise<T,R = T> = Promise<AxiosXHR<T,R>>;
+  declare type AxiosPromise = Promise<AxiosXHR>;
   declare class Axios {
-    constructor<T,R>(config?: AxiosXHRConfigBase<T,R>): void;
-    [[call]]<T,R>(config: AxiosXHRConfig<T,R> | string, config?: AxiosXHRConfig<T,R>): AxiosPromise<T,R>;
-    request<T,R>(config: AxiosXHRConfig<T,R>): AxiosPromise<T,R>;
-    delete<T,R>(url: string, config?: AxiosXHRConfigBase<T,R>): AxiosPromise<T,R>;
-    get<T,R>(url: string, config?: AxiosXHRConfigBase<T,R>): AxiosPromise<T,R>;
-    head<T,R>(url: string, config?: AxiosXHRConfigBase<T,R>): AxiosPromise<T,R>;
-    post<T,R>(
+    constructor(config?: AxiosXHRConfigBase): void;
+    [[call]](config: AxiosXHRConfig | string, config?: AxiosXHRConfig): AxiosPromise;
+    request(config: AxiosXHRConfig): AxiosPromise;
+    delete(url: string, config?: AxiosXHRConfigBase): AxiosPromise;
+    get(url: string, config?: AxiosXHRConfigBase): AxiosPromise;
+    head(url: string, config?: AxiosXHRConfigBase): AxiosPromise;
+    post(
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T,R>
-    ): AxiosPromise<T,R>;
-    put<T,R>(
+      config?: AxiosXHRConfigBase
+    ): AxiosPromise;
+    put(
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T,R>
-    ): AxiosPromise<T,R>;
-    patch<T,R>(
+      config?: AxiosXHRConfigBase
+    ): AxiosPromise;
+    patch(
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T,R>
-    ): AxiosPromise<T,R>;
+      config?: AxiosXHRConfigBase
+    ): AxiosPromise;
     interceptors: {
       request: AxiosRequestInterceptor<mixed>,
       response: AxiosResponseInterceptor<mixed>
     };
-    defaults: { headers: Object } & AxiosXHRConfig<*,*>;
+    defaults: { headers: Object } & AxiosXHRConfig;
   }
 
-  declare class AxiosError<T,R = T> extends Error {
-    config: AxiosXHRConfig<T,R>;
+  declare class AxiosError extends Error {
+    config: AxiosXHRConfig;
     request?: http$ClientRequest | XMLHttpRequest;
-    response?: AxiosXHR<T,R>;
+    response?: AxiosXHR;
     code?: string;
   }
 
-  declare type $AxiosError<T,R = T> = AxiosError<T,R>;
+  declare type $AxiosError = AxiosError;
 
   declare interface AxiosExport extends Axios {
-    [[call]]<T,R>(config: AxiosXHRConfig<T,R> | string, config?: AxiosXHRConfig<T,R>): AxiosPromise<T,R>;
+    [[call]](config: AxiosXHRConfig | string, config?: AxiosXHRConfig): AxiosPromise;
     Axios: typeof Axios;
     Cancel: Class<Cancel>;
     CancelToken: Class<CancelToken>;
     isCancel(value: any): boolean;
-    create(config?: AxiosXHRConfigBase<any, any>): Axios;
+    create(config?: AxiosXHRConfigBase): Axios;
     all: typeof Promise.all;
     spread(callback: Function): (arr: Array<any>) => Function;
   }

--- a/definitions/npm/axios_v0.18.x/test_axios_v0.18.x.js
+++ b/definitions/npm/axios_v0.18.x/test_axios_v0.18.x.js
@@ -53,7 +53,7 @@ axios.get('/user', {
     ID: 12345
   }
 }).then((res) => {
-    res.data[0];
+    res.data;
 });
 
 // Send a POST request
@@ -87,15 +87,3 @@ axios.all([
     // $ExpectError
     (a: string);
 })
-
-const promise1: AxiosPromise<{ foo: string }, { bar: string }> = axios({ url: '/', method: 'post', data: { foo: 'bar' }})
-promise1.then(({ data }) => {
-  (data.bar: string);
-  // $ExpectError
-  data.foo;
-});
-
-const promise2: AxiosPromise<{ foo: number }> = axios({ url: '/', method: 'post', data: { foo: 1 }})
-promise2.then(({ data }) => {
-  data.foo + 1;
-});


### PR DESCRIPTION
`eslint` was complaining so I had to bypass the check - there's something it doesn't like about the `[[call]]` syntax, even though this is now preferred to `$call`. This might be related to #2405. I did not change the `[[call]]` syntax, so I'm not sure this worked prior.

This PR removes the polymorphic types for `axios`. This both decouples the request and response payloads (a possible regression of #1975), and improves soundness by moving the validation/deserialization to the consumer (or a blind `any` cast, which is really what was going on before).

Addresses #2461.