### PR TITLE
include the definition for bindNodeCallback()

### DIFF
--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -1632,6 +1632,81 @@ declare module "rxjs" {
       scheduler?: rxjs$SchedulerClass
     ): rxjs$Observable<T>,
     empty<+T>(): rxjs$Observable<T>,
+    bindNodeCallback<U>(
+      callbackFunc: (callback: (err: any, result: U) => any) => any,
+      selector?: void,
+      scheduler?: rxjs$SchedulerClass
+    ): () => rxjs$Observable<U>,
+    bindNodeCallback<T, U>(
+      callbackFunc: (v1: T, callback: (err: any, result: U) => any) => any,
+      selector?: void,
+      scheduler?: rxjs$SchedulerClass
+    ): (v1: T) => rxjs$Observable<U>,
+    bindNodeCallback<T, T2, U>(
+      callbackFunc: (
+        v1: T,
+        v2: T2,
+        callback: (err: any, result: U) => any
+      ) => any,
+      selector?: void,
+      scheduler?: rxjs$SchedulerClass
+    ): (v1: T, v2: T2) => rxjs$Observable<U>,
+    bindNodeCallback<T, T2, T3, U>(
+      callbackFunc: (
+        v1: T,
+        v2: T2,
+        v3: T3,
+        callback: (err: any, result: U) => any
+      ) => any,
+      selector?: void,
+      scheduler?: rxjs$SchedulerClass
+    ): (v1: T, v2: T2, v3: T3) => rxjs$Observable<U>,
+    bindNodeCallback<T, T2, T3, T4, U>(
+      callbackFunc: (
+        v1: T,
+        v2: T2,
+        v3: T3,
+        v4: T4,
+        callback: (err: any, result: U) => any
+      ) => any,
+      selector?: void,
+      scheduler?: rxjs$SchedulerClass
+    ): (v1: T, v2: T2, v3: T3, v4: T4) => rxjs$Observable<U>,
+    bindNodeCallback<T, T2, T3, T4, T5, U>(
+      callbackFunc: (
+        v1: T,
+        v2: T2,
+        v3: T3,
+        v4: T4,
+        v5: T5,
+        callback: (err: any, result: U) => any
+      ) => any,
+      selector?: void,
+      scheduler?: rxjs$SchedulerClass
+    ): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => rxjs$Observable<U>,
+    bindNodeCallback<T, T2, T3, T4, T5, T6, U>(
+      callbackFunc: (
+        v1: T,
+        v2: T2,
+        v3: T3,
+        v4: T4,
+        v5: T5,
+        v6: T6,
+        callback: (err: any, result: U) => any
+      ) => any,
+      selector?: void,
+      scheduler?: rxjs$SchedulerClass
+    ): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => rxjs$Observable<U>,
+    bindNodeCallback<T>(
+      callbackFunc: Function,
+      selector?: void,
+      scheduler?: rxjs$SchedulerClass
+    ): (...args: Array<any>) => rxjs$Observable<T>,
+    bindNodeCallback<T>(
+      callbackFunc: Function,
+      selector?: (...args: Array<any>) => T,
+      scheduler?: rxjs$SchedulerClass
+    ): (...args: Array<any>) => rxjs$Observable<T>,
     timer(
       initialDelay: number | Date,
       period?: number,


### PR DESCRIPTION
Adds top level definition for `bindNodeCallback()` creation method for rxjs. 

Follow on PR to #2462 and helps with #2285. 😄 