### PR TITLE
chore: update mockReturnValue comment

### DIFF
--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
@@ -62,7 +62,7 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
    */
   mockReturnThis(): void,
   /**
-   * Deprecated: use jest.fn(() => value) instead
+   * Accepts a value that will be returned whenever the mock function is called.
    */
   mockReturnValue(value: TReturn): JestMockFn<TArguments, TReturn>,
   /**


### PR DESCRIPTION
function is no longer deprecated according to the update since 2017
https://github.com/facebook/jest/pull/3993/files?short_path=c39fe85#diff-c39fe854e3daabd39ee1401ad74bf8ae