### PR TITLE
[directory-tree_v2.x.x] fix options types error

### DIFF
--- a/definitions/npm/directory-tree_v2.x.x/flow_v0.71.x-/directory-tree_v2.x.x.js
+++ b/definitions/npm/directory-tree_v2.x.x/flow_v0.71.x-/directory-tree_v2.x.x.js
@@ -13,9 +13,9 @@ declare module 'directory-tree' {
   declare type directoryTreeType = (
     path: string,
     options?: {|
-      normalizePath?: (path: string) => string,
-      exclude?: (string | Array<string>),
-      extensions?: Array<string>,
+      normalizePath?: (path: string) => boolean,
+      exclude?: (RegExp | Array<RegExp>),
+      extensions?: RegExp,
     |} | null,
     onEachFile?: (
       item: {|

--- a/definitions/npm/directory-tree_v2.x.x/test_directory-tree_v2.x.x.js
+++ b/definitions/npm/directory-tree_v2.x.x/test_directory-tree_v2.x.x.js
@@ -17,9 +17,9 @@ describe('# directory-tree', () => {
 
   it('use options', () => {
     const useOptions: dirTreeType = dirTree(__dirname, {
-      normalizePath: patthString => patthString,
-      exclude: ['excludePath'],
-      extensions: ['.js'],
+      normalizePath: patthString => true,
+      exclude: /some_path_to_exclude/,
+      extensions: /\.js$/,
     });
   });
 


### PR DESCRIPTION
Use RegExp, not string
[ref](https://www.npmjs.com/package/directory-tree#options).