### PR TITLE
fix: material-ui Modal definition

### DIFF
--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
@@ -1299,7 +1299,7 @@ declare module "@material-ui/core/Modal/Modal" {
     disableBackdrop?: boolean,
     ignoreBackdropClick?: boolean,
     ignoreEscapeKeyUp?: boolean,
-    modalManager: Object,
+    modalManager?: Object,
     onBackdropClick?: Function,
     onEnter?: TransitionCallback,
     onEntering?: TransitionCallback,


### PR DESCRIPTION
In material-ui package Modal element should have optional modalManager prop (it was required).