### PR TITLE
fix `lodash-es.get` iface to be consistent to `lodash.get` definitions

### DIFF
--- a/definitions/npm/lodash-es_v4.x.x/flow_v0.63.x-/lodash-es_v4.x.x.js
+++ b/definitions/npm/lodash-es_v4.x.x/flow_v0.63.x-/lodash-es_v4.x.x.js
@@ -1117,7 +1117,7 @@ declare module "lodash-es" {
   declare export function functionsIn(object?: ?Object): Array<string>;
   declare export function get(
     object?: ?Object | ?$ReadOnlyArray<any> | void | null,
-    path?: ?$ReadOnlyArray<string> | string,
+    path?: ?$ReadOnlyArray<string | number> | string | number,
     defaultValue?: any
   ): any;
   declare export function has(object: Object, path: Array<string> | string): boolean;

--- a/definitions/npm/lodash-es_v4.x.x/flow_v0.63.x-/test_lodash-es-v4.x.x.js
+++ b/definitions/npm/lodash-es_v4.x.x/flow_v0.63.x-/test_lodash-es-v4.x.x.js
@@ -171,8 +171,8 @@ get([[1, 2], [3, 4], [5, 6], [7, 8]], "3");
 get(null, 'thing');
 get(undefined, 'data');
 
-// Second argument must be string when looking for array items by index
-// $ExpectError number This type is incompatible with union: ?array type | string
+// Path argument may also be a numeric index (flow-typed/flow-typed/pull/2444)
+// It's definitely safe: get → baseGet → castPath → stringToPath → toString
 get([1, 2, 3], 0);
 
 /**


### PR DESCRIPTION
Related to: #2444 2490