### PR TITLE
Fix type of react css-transition children to accept a function of transition status

### DIFF
--- a/definitions/npm/react-transition-group_v2.x.x/flow_v0.60.x-/react-transition-group_v2.x.x.js
+++ b/definitions/npm/react-transition-group_v2.x.x/flow_v0.60.x-/react-transition-group_v2.x.x.js
@@ -60,6 +60,6 @@ declare module 'react-transition-group' {
   declare export class CSSTransition extends React$Component<TransitionProps & {
     in?: boolean,
     classNames: string | CSSTransitionClassNames,
-    children?: React$Node,
+    children?: ((status: TransitionStatus) => React$Node) | React$Node,
   }> {}
 }

--- a/definitions/npm/react-transition-group_v2.x.x/test_react-transition-group.js
+++ b/definitions/npm/react-transition-group_v2.x.x/test_react-transition-group.js
@@ -151,6 +151,16 @@ describe('CSS/Transition', () => {
       </CSSTransition>;
     })
 
+    it('should accept a function child of the current status to react node', () => {
+      <CSSTransition
+        in
+        timeout={ 1 }
+        classNames='fade'
+      >
+        {status => (<div>{status}</div>)}
+      </CSSTransition>;
+    });
+
     it('should accept alternative parameters', () => {
       <CSSTransition
         timeout={ { enter: 1, exit: 1 } }


### PR DESCRIPTION
This resolves #2466.