### PR TITLE
react-apollo: Fix $call deprecated error on flow 0.75-

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -764,24 +764,22 @@ declare module "react-apollo" {
     ...args: any[]
   ) => string[] | PureQueryOptions[];
 
-  declare export type MutationOpts<TVariables> = {
+  declare export type MutationOpts<TVariables> = {|
     variables?: TVariables,
     optimisticResponse?: Object,
     refetchQueries?: string[] | PureQueryOptions[] | RefetchQueriesProviderFn,
     update?: MutationUpdaterFn<*>,
-    errorPolicy?: ErrorPolicy,
-    $call?: empty // Not function
-  };
+    errorPolicy?: ErrorPolicy
+  |};
 
-  declare export type QueryOpts<TVariables> = {
+  declare export type QueryOpts<TVariables> = {|
     ssr?: boolean,
     variables?: TVariables,
     fetchPolicy?: FetchPolicy,
     pollInterval?: number,
     skip?: boolean,
-    errorPolicy?: ErrorPolicy,
-    $call?: empty // Not function
-  };
+    errorPolicy?: ErrorPolicy
+  |};
 
   declare export interface GraphqlQueryControls<
     TGraphQLVariables = OperationVariables


### PR DESCRIPTION
Remove $call where it was used. $call was being used as a workaround for a union
of objects and a function (https://github.com/facebook/flow/issues/1948#issuecomment-338440545)

A sealed object also resolves this issue and removes the deprecation error