### PR TITLE
Add jest styled components `toHaveStyleRule` typing

### DIFF
--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
@@ -91,7 +91,7 @@ type JestAsymmetricEqualityType = {
   /**
    * A custom Jasmine equality tester
    */
-  asymmetricMatch(value: mixed): boolean
+  asymmetricMatch(value: any): boolean
 };
 
 type JestCallsType = {
@@ -140,9 +140,15 @@ type JestTestName = string | Function;
 /**
  *  Plugin: jest-styled-components
  */
+type AsymmetricMatcher = {
+  $$typeof: Symbol;
+  sample?: string | RegExp | Object | Array<any> | Function;
+}
+
 type JestStyledComponentsMatcherValue =
   | string
   | RegExp
+  | AsymmetricMatcher
   | typeof undefined;
 
 type JestStyledComponentsMatcherOptions = {
@@ -1043,7 +1049,7 @@ declare var expect: {
   addSnapshotSerializer(pluginModule: JestPrettyFormatPlugin): void,
   assertions(expectedAssertions: number): void,
   hasAssertions(): void,
-  any(value: mixed): JestAsymmetricEqualityType,
+  any(value: any): JestAsymmetricEqualityType,
   anything(): any,
   arrayContaining(value: Array<mixed>): Array<mixed>,
   objectContaining(value: Object): Object,
@@ -1071,7 +1077,7 @@ declare var jest: JestObjectType;
  */
 declare var jasmine: {
   DEFAULT_TIMEOUT_INTERVAL: number,
-  any(value: mixed): JestAsymmetricEqualityType,
+  any(value: any): JestAsymmetricEqualityType,
   anything(): any,
   arrayContaining(value: Array<mixed>): Array<mixed>,
   clock(): JestClockType,

--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
@@ -91,7 +91,7 @@ type JestAsymmetricEqualityType = {
   /**
    * A custom Jasmine equality tester
    */
-  asymmetricMatch(value: any): boolean
+  asymmetricMatch(value: mixed): boolean
 };
 
 type JestCallsType = {
@@ -140,15 +140,11 @@ type JestTestName = string | Function;
 /**
  *  Plugin: jest-styled-components
  */
-type AsymmetricMatcher = {
-  $$typeof: Symbol;
-  sample?: string | RegExp | Object | Array<any> | Function;
-}
 
 type JestStyledComponentsMatcherValue =
   | string
+  | JestAsymmetricEqualityType
   | RegExp
-  | AsymmetricMatcher
   | typeof undefined;
 
 type JestStyledComponentsMatcherOptions = {
@@ -525,7 +521,13 @@ type JestExtendedMatchersType = {
 };
 
 interface JestExpectType {
-  not: JestExpectType & EnzymeMatchersType & DomTestingLibraryType & JestJQueryMatchersType & JestExtendedMatchersType & JestStyledComponentsMatchersType,
+  not:
+    & JestExpectType
+    & EnzymeMatchersType
+    & DomTestingLibraryType
+    & JestJQueryMatchersType
+    & JestStyledComponentsMatchersType
+    & JestExtendedMatchersType,
   /**
    * If you have a mock function, you can use .lastCalledWith to test what
    * arguments it was last called with.
@@ -1042,14 +1044,22 @@ type JestPrettyFormatPlugins = Array<JestPrettyFormatPlugin>;
 /** The expect function is used every time you want to test a value */
 declare var expect: {
   /** The object that you want to make assertions against */
-  (value: any): JestExpectType & JestPromiseType & EnzymeMatchersType & DomTestingLibraryType & JestJQueryMatchersType & JestExtendedMatchersType & JestStyledComponentsMatchersType,
+  (value: any):
+    & JestExpectType
+    & JestPromiseType
+    & EnzymeMatchersType
+    & DomTestingLibraryType
+    & JestJQueryMatchersType
+    & JestStyledComponentsMatchersType
+    & JestExtendedMatchersType,
+
   /** Add additional Jasmine matchers to Jest's roster */
   extend(matchers: { [name: string]: JestMatcher }): void,
   /** Add a module that formats application-specific data structures. */
   addSnapshotSerializer(pluginModule: JestPrettyFormatPlugin): void,
   assertions(expectedAssertions: number): void,
   hasAssertions(): void,
-  any(value: any): JestAsymmetricEqualityType,
+  any(value: mixed): JestAsymmetricEqualityType,
   anything(): any,
   arrayContaining(value: Array<mixed>): Array<mixed>,
   objectContaining(value: Object): Object,
@@ -1077,7 +1087,7 @@ declare var jest: JestObjectType;
  */
 declare var jasmine: {
   DEFAULT_TIMEOUT_INTERVAL: number,
-  any(value: any): JestAsymmetricEqualityType,
+  any(value: mixed): JestAsymmetricEqualityType,
   anything(): any,
   arrayContaining(value: Array<mixed>): Array<mixed>,
   clock(): JestClockType,

--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
@@ -138,6 +138,28 @@ type JestPromiseType = {
 type JestTestName = string | Function;
 
 /**
+ *  Plugin: jest-styled-components
+ */
+type JestStyledComponentsMatcherValue =
+  | string
+  | RegExp
+  | typeof undefined;
+
+type JestStyledComponentsMatcherOptions = {
+  media?: string;
+  modifier?: string;
+  supports?: string;
+}
+
+type JestStyledComponentsMatchersType = {
+  toHaveStyleRule(
+    property: string,
+    value: JestStyledComponentsMatcherValue,
+    options?: JestStyledComponentsMatcherOptions
+  ): void,
+};
+
+/**
  *  Plugin: jest-enzyme
  */
 type EnzymeMatchersType = {
@@ -497,7 +519,7 @@ type JestExtendedMatchersType = {
 };
 
 interface JestExpectType {
-  not: JestExpectType & EnzymeMatchersType & DomTestingLibraryType & JestJQueryMatchersType & JestExtendedMatchersType,
+  not: JestExpectType & EnzymeMatchersType & DomTestingLibraryType & JestJQueryMatchersType & JestExtendedMatchersType & JestStyledComponentsMatchersType,
   /**
    * If you have a mock function, you can use .lastCalledWith to test what
    * arguments it was last called with.
@@ -1014,7 +1036,7 @@ type JestPrettyFormatPlugins = Array<JestPrettyFormatPlugin>;
 /** The expect function is used every time you want to test a value */
 declare var expect: {
   /** The object that you want to make assertions against */
-  (value: any): JestExpectType & JestPromiseType & EnzymeMatchersType & DomTestingLibraryType & JestJQueryMatchersType & JestExtendedMatchersType,
+  (value: any): JestExpectType & JestPromiseType & EnzymeMatchersType & DomTestingLibraryType & JestJQueryMatchersType & JestExtendedMatchersType & JestStyledComponentsMatchersType,
   /** Add additional Jasmine matchers to Jest's roster */
   extend(matchers: { [name: string]: JestMatcher }): void,
   /** Add a module that formats application-specific data structures. */

--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
@@ -249,6 +249,46 @@ expect([1, 2, 3]).toHaveLength(3);
 })();
 
 /**
+ *  Plugin: jest-styled-components
+ */
+// $ExpectError
+import { mount } from "enzyme";
+// $ExpectError
+import styled from "styled-components";
+
+const ColoredSpan = styled.span`
+  color: red;
+`;
+
+const ButtonWithBreakpoint = styled.button`
+  @media (max-width: 640px) {
+    &:hover {
+      color: red;
+    }
+  }
+`;
+
+const styledWrapper = mount(<ColoredSpan />);
+
+expect(styledWrapper).toHaveStyleRule('color', 'red');
+
+expect(styledWrapper).not.toHaveStyleRule('cursor', expect.any(String));
+
+expect(mount(<ButtonWithBreakpoint />)).toHaveStyleRule(
+  'color', 'red', {
+    media: '(max-width:640px)',
+    modifier: ':hover',
+  }
+);
+
+// $ExpectError
+expect(styledWrapper).toHaveStyleRule();
+
+// $ExpectError
+expect(styledWrapper).toHaveStyleRule({backgroundColor: 'red'});
+
+
+/**
  *  Plugin: jest-enzyme
  */
 


### PR DESCRIPTION
Adds typings for the `toHaveStyleRule` matcher from https://github.com/styled-components/jest-styled-components