### PR TITLE
type(formik): improve withFormik hoc type hinting

### DIFF
--- a/definitions/npm/formik_v0.11.x/flow_v0.59.x-/formik_v0.11.x.js
+++ b/definitions/npm/formik_v0.11.x/flow_v0.59.x-/formik_v0.11.x.js
@@ -1,6 +1,4 @@
 declare module "formik" {
-  import type { ComponentType } from "react";
-
   declare export type FormikErrors<Values> = {
     [field: $Keys<Values>]: ?string
   };
@@ -81,6 +79,11 @@ declare module "formik" {
     initialValues?: Values,
 
     /**
+     * Reset handler
+     */
+    onReset?: (values: Values, formikActions: FormikActions<Values>) => void,
+
+    /**
      * Submission handler
      */
     onSubmit: (values: Values, formikActions: FormikActions<Values>) => any,
@@ -88,7 +91,7 @@ declare module "formik" {
     /**
      * Form component to render
      */
-    component?: React$ComponentType<FormikProps<Values> | void>,
+    component?: React$ComponentType<FormikProps<Values>> | React$Node,
 
     /**
      * Render prop (works like React router's <Route render={props =>} />)
@@ -230,15 +233,51 @@ declare module "formik" {
 
   declare export var Form: React$StatelessFunctionalComponent<any>;
 
-  declare export function withFormik<Props, Values>({
+  /**
+   * Formik actions + { props }
+   */
+  declare export type FormikBag<P, V> = { props: P } & FormikActions<V>;
+
+  /**
+   * withFormik() configuration options. Backwards compatible.
+   */
+  declare export type WithFormikConfig<
+    Props,
+    Values,
+  > = FormikSharedConfig & {
+    /**
+     * Set the display name of the component. Useful for React DevTools.
+     */
+    displayName?: string,
+
+    /**
+     * Submission handler
+     */
+    handleSubmit: (values: Values, formikBag: FormikBag<Props, Values>) => void,
+
+    /**
+     * Map props to the form values
+     */
     mapPropsToValues?: (props: Props) => Values,
-    handleSubmit?: (
-      values: Values,
-      goodies: FormikActions<Values> & { props: Props }
-    ) => Promise<void> | void,
-    validate?: (values: Values, props: Props) => { [field: string]: any },
-    validationSchema?: (props: Props) => any
-  }): (
-    ComponentType<Props>
-  ) => ComponentType<$Diff<Props, FormikProps<Values>>>;
+
+    /**
+     * A Yup Schema or a function that returns a Yup schema
+     */
+    validationSchema?: any | ((props: Props) => any),
+
+    /**
+     * Validation function. Must return an error object or promise that
+     * throws an error object where that object keys map to corresponding value.
+     */
+    validate?: (values: Values) => void | FormikErrors<Values> | Promise<any>,
+  }
+
+  declare type TypeOrVoid = <V>(V) => (V | void)
+
+  declare export function withFormik<
+    Props,
+    Values,
+  >(WithFormikConfig<React$ComponentType<Props>, Values>): (
+    Component: React$ComponentType<Props>
+  ) => React$ComponentType<$Diff<Props, $ObjMap<FormikProps<Values>, TypeOrVoid>>>;
 }


### PR DESCRIPTION
This makes the formik definition more close to the TS one at their repo.

Also changes `React.*` to use `React$*` since the first does not work correctly because imports insides type definitions do not work correctly.

This also types the `withFormik` hoc correctly, to take into consideration the following:

> Note: If foo does not exist in Props you will get an error! $Diff<{}, { foo: number }> will be an error. To work around this use a union with void, see: $Diff<{}, { foo: number | void }>. An optional prop will not completely remove foo. $Diff<{ foo: number }, { foo?: number }> is { foo?: number } instead of {}.

https://flow.org/en/docs/react/hoc/#toc-injecting-props-with-a-higher-order-component

I have a question tho, I've created a `TypeOrVoid` type helper, but have not exported it, is it going to pollute the global scope? Or if they are not exported they are scoped to the file?

Asking that because I saw for example on `styled-components` type definitions, where they declare the types using something like `$npm$styledComponents$blah`