### PR TITLE
Fix the return type of date addon-knobs/date

### DIFF
--- a/definitions/npm/@storybook/addon-knobs_v3.x.x/flow_all/addon-knobs_v3.x.x.js
+++ b/definitions/npm/@storybook/addon-knobs_v3.x.x/flow_all/addon-knobs_v3.x.x.js
@@ -6,7 +6,7 @@ declare module "@storybook/addon-knobs/react" {
   declare function boolean(string, boolean, ?GroupId): boolean;
   declare function button(string, ((?{}) => void), ?GroupId): void;
   declare function color(string, string, ?GroupId): string;
-  declare function date(string, Date, ?GroupId): Date;
+  declare function date(string, Date, ?GroupId): number;
   declare function number(string, number, ?{ range?: boolean, min?: number, max?: number, step?: number }, ?GroupId): number;
   declare function object(string, any, ?GroupId): any;
   declare function select<T>(string, Array<T> | { [T]: string }, T, ?GroupId): T;

--- a/definitions/npm/@storybook/addon-knobs_v3.x.x/test_addon-knobs_v3.x.x.js
+++ b/definitions/npm/@storybook/addon-knobs_v3.x.x/test_addon-knobs_v3.x.x.js
@@ -45,12 +45,12 @@ colorVal = color("Color with non-string default", 0);
 let badColorVal: number = color("Color", "#ffffff");
 
 // date
-let dateVal: Date;
+let dateVal: number;
 dateVal = date("Date", new Date());
 // $ExpectError
 dateVal = date("Date with non-date default", "2018-01-01");
 // $ExpectError
-let badDateVal: string = date("Date assigned to non-date variable", new Date());
+let badDateVal: string = date("Date assigned to non-number variable", new Date());
 
 // number
 let numberVal: number;


### PR DESCRIPTION
This Storybook knob exposes the date value using `getTime`/`valueOf` methods, ie. number of seconds from 1970, not a Date object.

The default value gets transformed to a number here: https://github.com/storybooks/storybook/blob/master/addons/knobs/src/index.js#L60
When you change the value using the knob, it gets transformed to a number here: https://github.com/storybooks/storybook/blob/master/addons/knobs/src/components/types/Date/index.js#L17