### PR TITLE
fix generics for bluebird Promise.all

### DIFF
--- a/definitions/npm/bluebird_v3.x.x/flow_v0.70.x-/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.70.x-/bluebird_v3.x.x.js
@@ -54,8 +54,8 @@ declare class Bluebird$Promise<+R> extends Promise<R> {
   static Defer: Class<Bluebird$Defer>;
   static PromiseInspection: Class<Bluebird$PromiseInspection<*>>;
 
-  static all<T, Elem: $Promisable<T>>(
-    Promises: Iterable<Elem> | $Promisable<Iterable<Elem>>
+  static all<T>(
+    Promises: Iterable<$Promisable<T>> | $Promisable<Iterable<$Promisable<T>>>
   ): Bluebird$Promise<Array<T>>;
   static props(
     input: Object | Map<*, *> | $Promisable<Object | Map<*, *>>


### PR DESCRIPTION
From flow version 0.76.0 resolution of subtyping polymorphic types is more strict. See https://github.com/facebook/flow/releases