### PR TITLE
react-apollo: fix stopPolling()

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -918,7 +918,7 @@ declare module "react-apollo" {
       ) => Promise<ApolloQueryResult<TData2>>),
     load: () => void,
     startPolling: (interval: number) => void,
-    stopPolling: (interval: number) => void,
+    stopPolling: () => void,
     subscribeToMore: (
       options: SubscribeToMoreOptions<TData, any, any>
     ) => () => void,


### PR DESCRIPTION
`stopPolling()` does not take an argument. For reference:
https://www.apollographql.com/docs/react/essentials/queries.html#render-prop
https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/ObservableQuery.ts#L500