### PR TITLE
Improvements to Firebase v5 definitions

### DIFF
--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
@@ -67,6 +67,7 @@ declare class $npm$firebase$App {
   auth(): $npm$firebase$auth$Auth;
   database(): $npm$firebase$database$Database;
   storage(): $npm$firebase$storage$Storage;
+  firestore(): $npm$firebase$firestore$Firestore;
   delete(): Promise<void>;
 }
 
@@ -476,7 +477,8 @@ declare interface $npm$firebase$firestore$QueryListenOptions {
   includeMetadataChanges: boolean;
   includeQueryMetadataChanges: boolean;
 }
-declare type $npm$firebase$firestore$observer = (snapshot: $npm$firebase$firestore$DocumentSnapshot) => void | Promise<void>;
+declare type $npm$firebase$firestore$documentObserver = (snapshot: $npm$firebase$firestore$DocumentSnapshot) => void | Promise<void>;
+declare type $npm$firebase$firestore$queryObserver = (snapshot: $npm$firebase$firestore$QuerySnapshot) => void | Promise<void>;
 declare type $npm$firebase$firestore$observerError = (error: $npm$firebase$Error) => void | Promise<void>;
 
 declare class $npm$firebase$firestore$Query {
@@ -486,9 +488,9 @@ declare class $npm$firebase$firestore$Query {
   get(): Promise<$npm$firebase$firestore$QuerySnapshot>;
   limit(limit: number): $npm$firebase$firestore$Query;
   onSnapshot(
-    optionsOrObserverOrOnNext: $npm$firebase$firestore$QueryListenOptions | $npm$firebase$firestore$observer,
+    optionsOrObserverOrOnNext: $npm$firebase$firestore$QueryListenOptions | $npm$firebase$firestore$queryObserver,
     observerOrOnNextOrOnError?: | $npm$firebase$firestore$QueryListenOptions
-    | $npm$firebase$firestore$observer
+    | $npm$firebase$firestore$queryObserver
     | $npm$firebase$firestore$observerError,
     onError?: $npm$firebase$firestore$observerError
   ): Function;
@@ -505,7 +507,7 @@ declare class $npm$firebase$firestore$CollectionReference extends $npm$firebase$
   constructor(): $npm$firebase$firestore$CollectionReference;
   id: string;
   parent: $npm$firebase$firestore$DocumentReference | null;
-  add(data: {}): Promise<mixed>;
+  add(data: Object): Promise<mixed>;
   doc(documentPath?: string): $npm$firebase$firestore$DocumentReference;
 }
 
@@ -521,18 +523,18 @@ declare class $npm$firebase$firestore$DocumentReference {
   delete(): Promise<void>;
   get(): Promise<$npm$firebase$firestore$DocumentSnapshot>;
   onSnapshot(
-    optionsOrObserverOrOnNext: $npm$firebase$firestore$QueryListenOptions | $npm$firebase$firestore$observer,
+    optionsOrObserverOrOnNext: $npm$firebase$firestore$QueryListenOptions | $npm$firebase$firestore$documentObserver,
     observerOrOnNextOrOnError?: | $npm$firebase$firestore$QueryListenOptions
-    | $npm$firebase$firestore$observer
+    | $npm$firebase$firestore$documentObserver
     | $npm$firebase$firestore$observerError,
     onError?: $npm$firebase$firestore$observerError
   ): Function;
-  set(data: {}, options?: { merge: boolean } | null): Promise<void>;
+  set(data: Object, options?: { merge: boolean } | null): Promise<void>;
   update(...args: Array<any>): Promise<void>;
 }
 
 declare class $npm$firebase$firestore$DocumentSnapshot {
-  data(): {};
+  data(): Object;
   get(fieldpath: typeof $npm$firebase$firestore$FieldPath): any;
   exists: boolean;
   id: string;
@@ -596,7 +598,7 @@ declare interface $npm$firebase$firestore$Transaction {
   get(documentRef: $npm$firebase$firestore$DocumentReference): Promise<$npm$firebase$firestore$DocumentSnapshot>;
   set(
     documentRef: $npm$firebase$firestore$DocumentReference,
-    data: {},
+    data: Object,
     options?: { merge: boolean }
   ): $npm$firebase$firestore$Transaction;
   update(documentRef: $npm$firebase$firestore$DocumentReference, ...args: Array<any>): $npm$firebase$firestore$Transaction;
@@ -607,7 +609,7 @@ declare interface $npm$firebase$firestore$WriteBatch {
   delete(documentRef: $npm$firebase$firestore$DocumentReference): $npm$firebase$firestore$WriteBatch;
   set(
     documentRef: $npm$firebase$firestore$DocumentReference,
-    data: {},
+    data: Object,
     options?: { merge: boolean }
   ): $npm$firebase$firestore$WriteBatch;
   update(documentRef: $npm$firebase$firestore$DocumentReference, ...args: Array<any>): $npm$firebase$firestore$WriteBatch;

--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
@@ -477,6 +477,7 @@ declare interface $npm$firebase$firestore$QueryListenOptions {
   includeMetadataChanges: boolean;
   includeQueryMetadataChanges: boolean;
 }
+
 declare type $npm$firebase$firestore$documentObserver = (snapshot: $npm$firebase$firestore$DocumentSnapshot) => void | Promise<void>;
 declare type $npm$firebase$firestore$queryObserver = (snapshot: $npm$firebase$firestore$QuerySnapshot) => void | Promise<void>;
 declare type $npm$firebase$firestore$observerError = (error: $npm$firebase$Error) => void | Promise<void>;


### PR DESCRIPTION
This builds on #2308 and adds the following changes:

  - Adds the `app.firestore()` function to get the associated Firestore instance for an initialized App.
  - Fixes argument types for the callback passed to `onSnapshot()` to allow `QuerySnapshot`.
  - Changes the `data` parameter to be typed as `Object` instead of `{}`, allowing access to keys (instead of assuming that data is an empty object).

/cc @meafmira @meafmira