### PR TITLE
[WIP]: Add missing imports from main entry point of rxjs

### DIFF
--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -1631,7 +1631,9 @@ declare module "rxjs" {
       input: rxjs$ObservableInput<T>,
       scheduler?: rxjs$SchedulerClass
     ): rxjs$Observable<T>,
+    of<+T>(...values: T[]): rxjs$Observable<T>,
     empty<+T>(): rxjs$Observable<T>,
+    never<+T>(): rxjs$Observable<T>,
     bindNodeCallback<U>(
       callbackFunc: (callback: (err: any, result: U) => any) => any,
       selector?: void,
@@ -1712,6 +1714,45 @@ declare module "rxjs" {
       period?: number,
       scheduler?: rxjs$SchedulerClass
     ): rxjs$Observable<number>,
+    interval(
+      period?: number,
+      scheduler?: rxjs$SchedulerClass
+    ): rxjs$Observable<number>,
+    range(
+      start?: number,
+      count?: number,
+      scheduler?: rxjs$SchedulerClass
+    ): rxjs$Observable<number>,
+    merge: (<+T, U>(
+      source0: rxjs$Observable<T>,
+      source1: rxjs$Observable<U>
+    ) => rxjs$Observable<T | U>) &
+      (<+T, U, V>(
+      source0: rxjs$Observable<T>,
+      source1: rxjs$Observable<U>,
+      source2: rxjs$Observable<V>
+    ) => rxjs$Observable<T | U | V>) &
+      (<+T>(...sources: rxjs$Observable<T>[]) => rxjs$Observable<T>),
+    fromEvent: (<+T>(
+      element: any,
+      eventName: string,
+      ...none: Array<void>
+    ) => rxjs$Observable<T>) & (<+T>(
+      element: any,
+      eventName: string,
+      options: rxjs$EventListenerOptions,
+      ...none: Array<void>
+    ) => rxjs$Observable<T>) & (<+T>(
+      element: any,
+      eventName: string,
+      selector: () => T,
+      ...none: Array<void>
+    ) => rxjs$Observable<T>) & (<+T>(
+      element: any,
+      eventName: string,
+      options: rxjs$EventListenerOptions,
+      selector: () => T
+    ) => rxjs$Observable<T>);
     Observable: typeof rxjs$Observable,
     Observer: typeof rxjs$Observer,
     ConnectableObservable: typeof rxjs$ConnectableObservable,

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
@@ -1,22 +1,38 @@
 /* @flow */
 
 import {
-  AnonymousSubject,
   Observable,
+  Subject,
+  of,
+  from,
+  interval,
+  never,
+  empty,
+  range,
+  merge,
+  fromEvent,
+  AnonymousSubject,
   Observer,
   Scheduler,
-  Subject,
+  throwError,
   Subscriber
 } from "rxjs";
-import { distinct, startWith, repeat, mergeMap, concatMap, switchMap, groupBy, defaultIfEmpty, timeoutWith, buffer, bufferCount, exhaustMap, bufferWhen, bufferToggle } from 'rxjs/operators'
-import { of } from 'rxjs/observable/of';
-import { timer } from 'rxjs/observable/timer';
-import { interval } from 'rxjs/observable/interval';
-import { from } from 'rxjs/observable/from';
-import { range } from 'rxjs/observable/range';
-import { fromEvent } from 'rxjs/observable/fromEvent';
-import { empty } from 'rxjs/observable/empty';
-import { never } from 'rxjs/observable/never';
+import {
+  distinct,
+  startWith,
+  repeat,
+  mergeMap,
+  concatMap,
+  switchMap,
+  groupBy,
+  defaultIfEmpty,
+  timeoutWith,
+  buffer,
+  bufferCount,
+  exhaustMap,
+  bufferWhen,
+  bufferToggle,
+} from 'rxjs/operators'
 
 const numbers = of(1);
 Observable.create(observer => {
@@ -51,9 +67,16 @@ const anonymousSubject: AnonymousSubject<number> = new AnonymousSubject(
   of(3)
 );
 anonymousSubject.next(5);
+
+const results: Array<number> = anonymousSubject.toArray();
+
 anonymousSubject.error(new Error());
 
 const fromObservable: Observable<number> = from(Promise.resolve(1));
+
+const mergedObservable: Observable<number> = merge(distinct1, distinct2);
+
+const errorObservable: Observable<Error> = throwError(new Error());
 
 // Standard projection operators
 const project: Array<Observable<string>> = [


### PR DESCRIPTION
This PR adds some more missing observable creator functions that are now supposed to be imported through the main entry point to flow-typed.

There are still a lot more, but im getting to it as i stumble over them