### PR TITLE
Resolve @material-ui/core incompatible prop type

### DIFF
--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
@@ -2507,7 +2507,7 @@ declare module "@material-ui/core/withWidth/withWidth" {
     noSSR?: boolean,
     initialWidth?: Breakpoint,
     resizeInterval?: number
-  |}) => <Props: {}>(
+  |}) => <Props: { width: Breakpoint }>(
     Component: React$ComponentType<Props>
   ) => React$ComponentType<$Diff<Props, { width: Breakpoint }>>;
 }


### PR DESCRIPTION
This patch resolves an issue with `@material-ui/core/withWidth/withWidth` which caused the following error:

```
Cannot call `withWidth()` because undefined property `width` [1] is incompatible with enum [2].

   src/components/Responsive/index.js:45:16
     45| export default withWidth()(Responsive)
                        ^^^^^^^^^^^^^^^^^^^^^^^

References:
   flow-typed/npm/@material-ui/core_v1.x.x.js:2513:18
   2513|   |}) => <Props: {}>(
                          ^^ [1]
   flow-typed/npm/@material-ui/core_v1.x.x.js:2515:50
   2515|   ) => React$ComponentType<$Diff<Props, { width: Breakpoint }>>;
                                                          ^^^^^^^^^^ [2]
```