### PR TITLE
react-redux_v5.x.x: fix typo in connect declare

### DIFF
--- a/definitions/npm/react-redux_v5.x.x/flow_v0.63.0-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.63.0-/react-redux_v5.x.x.js
@@ -119,7 +119,7 @@ declare module "react-redux" {
     ST: $Subtype<{[_: $Keys<Com>]: any}>
     >(
     mapStateToProps: MapStateToProps<S, SP, RSP>,
-    mapDispatchToPRops: MDP
+    mapDispatchToProps: MDP
   ): (component: Com) => ComponentType<$Diff<CP, MDP> & SP> & $Shape<ST>;
 
   declare export function connect<


### PR DESCRIPTION
`mapDispatchToPRops` -> `mapDispatchToProps`
changed it in `react-redux_v5.x.x` -> `flow_v0.63.0-`