### PR TITLE
add the ability to refine types from Ramda's filter

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
@@ -407,13 +407,25 @@ declare module ramda {
     ) => UnaryFn<A, C>) &
     (<A, B>(ab: UnaryFn<A, B>) => UnaryFn<A, B>);
 
-  declare type Filter = (<K, V, T: Array<V> | { [key: K]: V }>(
-    fn: UnaryPredicateFn<V>,
-    xs: T
-  ) => T) &
-    (<K, V, T: Array<V> | { [key: K]: V }>(
-      fn: UnaryPredicateFn<V>
-    ) => (xs: T) => T);
+  // This kind of filter allows us to do type refinement on the result, but we
+  // still need Filter so that non-refining predicates still pass a type check.
+  declare type RefineFilter =
+    & (<K, V, P: $Pred<1>, T: Array<V> | { [key: K]: V }>(
+      fn: P,
+      xs: T
+    ) => Array<$Refine<V, P, 1>>)
+    & (<K, V, P: $Pred<1>, T: Array<V> | { [key: K]: V }>(
+      fn: P
+    ) => (xs: T) => Array<$Refine<V, P, 1>>)
+
+  declare type Filter =
+    & (<K, V, T: Array<V> | { [key: K]: V }>(
+      fn: UnaryPredicateFn<V>,
+      xs: T
+    ) => T)
+    & (<K, V, T: Array<V> | { [key: K]: V }>(
+      fn: UnaryPredicateFn<V>,
+    ) => (xs: T) => T)
 
   declare class Monad<T> {
     chain: Function;
@@ -471,7 +483,15 @@ declare module ramda {
   declare var sum: UnaryFn<Array<number>, number>;
 
   // Filter
-  declare var filter: Filter;
+  // To refine with filter, be sure to import the RefineFilter type, and cast
+  // filter to a RefineFilter.
+  // ex:
+  // import { type RefineFilter, filter } from 'ramda'
+  // const notNull = (x): bool %checks => x != null
+  // const ns: Array<number> = (filter: RefineFilter)(notNull, [1, 2, null])
+  declare var filter: RefineFilter & Filter;
+  // reject doesn't get RefineFilter since it performs the opposite work of
+  // filter, and we don't have a kind of $NotPred type.
   declare var reject: Filter;
 
   // *String

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_list.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_list.js
@@ -172,7 +172,19 @@ const str: string = "hello world";
     it('fails when type refinement is incorrect', () => {
       const isString = (x): bool %checks => typeof x === 'string'
       // $ExpectError
-      const ns: Array<number> = (filter: RefineFilter)(notNull, ['1', 2])
+      const ns: Array<number> = (filter: RefineFilter)(isString, ['1', 2])
+    })
+
+    it('fails when attempting to refine from a non $Pred predicate', () => {
+      const isNumber = (x) => typeof x === 'number'
+      // $ExpectError
+      const ns: Array<number> = filter(isNumber, ['1', 2])
+    })
+
+    it('does not accept predicates missing %checks when using RefineFilter', () => {
+      const isNumber = (x) => typeof x === 'number'
+      // $ExpectError
+      const ns: Array<number> = (filter: RefineFilter)(isNumber, ['1', 2])
     })
   })
 

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_list.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_list.js
@@ -1,6 +1,7 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
 import _, {
+  type RefineFilter,
   compose,
   pipe,
   curry,
@@ -147,12 +148,34 @@ const str: string = "hello world";
   const findxs6: number = _.findLastIndex(_.propEq("a", 2), os);
   const findxs7: number = _.findLastIndex(_.propEq("a", 4))(os);
 
-  const s: Array<number> = filter(x => x > 1, [1, 2]);
-  const s1: Array<string> = _.filter(x => x === "2", ["2", "3"]);
-  const s3: { [key: string]: string } = _.filter(x => x === "2", {
-    a: "2",
-    b: "3"
-  });
+  describe('filter', () => {
+    it('perserves the element type in the predicate and result array (number)', () => {
+      const s: Array<number> = filter(x => x > 1, [1, 2]);
+    })
+
+    it('perserves the element type in the predicate and result array (number)', () => {
+      const s: Array<string> = _.filter(x => x === "2", ["2", "3"]);
+    })
+
+    it('filters objects by passing the value to the predicate', () => {
+      const s: { [key: string]: string } = _.filter(x => x === "2", {
+        a: "2",
+        b: "3"
+      });
+    })
+
+    it('refines the element type using the predicate', () => {
+      const notNull = (x): bool %checks => x != null
+      const ns: Array<number> = (filter: RefineFilter)(notNull, [1, 2, null])
+    })
+
+    it('fails when type refinement is incorrect', () => {
+      const isString = (x): bool %checks => typeof x === 'string'
+      // $ExpectError
+      const ns: Array<number> = (filter: RefineFilter)(notNull, ['1', 2])
+    })
+  })
+
   const s4 = _.find(x => x === "2", ["1", "2"]);
   //$ExpectError
   const s5: ?{ [key: string]: string } = _.find(x => x === "2", { a: 1, b: 2 });


### PR DESCRIPTION
We can't really do `reject` here since it's an inversion, and I'm not aware of any special `$Not<T>` just yet.

Currently, you can't do this in Ramda with Flow:
``` javascript
import { filter, map } from 'ramda'
const ns = filter(n => n != null, [1, 2, null])
map(n => n.toString(), ns) // n can be null so you can't do .toString()
```

There's a small concession to make it work: You have to indicate that you actually want to do a refinement. This is because refinement predicates are considered a different type than ordinary predicates.
``` javascript
import { type RefineFilter, filter, map } from 'ramda'
const notNull = (x: mixed): bool %checks  => n !=null
const ns = (filter: RefineFilter)(notNull, [1, 2, null])
map(n => n.toString(), ns) // works
```