### PR TITLE
React-navigation: fixed flow type error with React$

### DIFF
--- a/definitions/npm/react-navigation_v2.x.x/flow_v0.60.x-/react-navigation_v2.x.x.js
+++ b/definitions/npm/react-navigation_v2.x.x/flow_v0.60.x-/react-navigation_v2.x.x.js
@@ -565,7 +565,7 @@ declare module 'react-navigation' {
     State: NavigationState,
     Options: {},
     Props: {}
-  > = React$ComponentType<{
+  > = React$StatelessFunctionalComponent<{
     ...Props,
     ...NavigationContainerProps<State, Options>,
   }> &


### PR DESCRIPTION
I just created a new react native project (0.56) and added react-navigation (2.7.0) and flow libdef `react-navigation_v2.x.x`.
As a result, I get a type error when I try to use the result of `createDrawerNavigator` (or the others).
 
``` bash
yarn flow status
yarn run v1.7.0
$ /Users/.../.../.../App/node_modules/.bin/flow status
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/app.js:18:13

Cannot instantiate React.Element because in type argument ElementType:
 • Either a callable signature is missing in statics of React.Component [1] but exists in
   React.StatelessFunctionalComponent [2].
 • Or a callable signature is missing in withRouter [3] but exists in
   React.StatelessFunctionalComponent [2].
 • Or a callable signature is missing in withOptionalNavigationOptions [4] but exists in
   React.StatelessFunctionalComponent [2].
 • Or React.StatelessFunctionalComponent [1] is incompatible with statics of React.Component [5].
 • Or withRouter [3] is incompatible with statics of React.Component [5].
 • Or withOptionalNavigationOptions [4] is incompatible with statics of React.Component [5].

     src/app.js
      15│ type Props = {}
      16│ export default class App extends Component<Props> {
      17│   render() {
      18│     return <Navigator />
      19│   }
      20│ }
      21│

     flow-typed/npm/react-navigation_v2.x.x.js
 [1] 571│   > = React$ComponentType<{
     572│     ...Props,
     573│     ...NavigationContainerProps<State, Options>
     574│   }> &
 [3] 575│     withRouter<State, Options> &
 [4] 576│     withOptionalNavigationOptions<Options>

     /private/tmp/flow/flowlib_34616c66/react.js
 [2] 160│   | React$StatelessFunctionalComponent<any>
 [5] 161│   | Class<React$Component<any, any>>;



Found 1 error

Only showing the most relevant union/intersection branches.
To see all branches, re-run Flow with --show-all-branches
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

After some researching, I replaced the `React$` inside the libdef with `React.` plus `import * as React from "react"`. This is fixing the type error for me.

Is this the right solution for this? Or are there any better ways?