### PR TITLE
fix type coverage on react-redux's connect

### DIFF
--- a/definitions/npm/react-redux_v5.x.x/flow_v0.63.0-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.63.0-/react-redux_v5.x.x.js
@@ -1,7 +1,17 @@
-import type { Dispatch, Store } from "redux";
-
 declare module "react-redux" {
   import type { ComponentType, ElementConfig } from 'react';
+
+  // These types are copied directly from the redux libdef. Importing them in
+  // this libdef causes a loss in type coverage.
+  declare type DispatchAPI<A> = (action: A) => A;
+  declare type Dispatch<A: { type: $Subtype<string> }> = DispatchAPI<A>;
+  declare type Reducer<S, A> = (state: S | void, action: A) => S;
+  declare type Store<S, A, D = Dispatch<A>> = {
+    dispatch: D;
+    getState(): S;
+    subscribe(listener: () => void): () => void;
+    replaceReducer(nextReducer: Reducer<S, A>): void
+  };
 
   declare export class Provider<S, A> extends React$Component<{
     store: Store<S, A>,
@@ -57,7 +67,7 @@ declare module "react-redux" {
     S: Object,
     SP: Object,
     RSP: Object,
-    CP: $Diff<OmitDispatch<ElementConfig<Com>>, RSP>,
+    CP: $Diff<ElementConfig<Com>, RSP>,
     ST: {[_: $Keys<Com>]: any}
     >(
     mapStateToProps: MapStateToProps<S, SP, RSP>,

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.63.0-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.63.0-/react-redux_v5.x.x.js
@@ -60,14 +60,14 @@ declare module "react-redux" {
     storeKey?: string
   |};
 
-  declare type OmitDispatch<Component> = $Diff<Component, {dispatch: Dispatch<*>}>;
+  declare type OmitDispatch<Component> = $Diff<Component, {dispatch?: Dispatch<*>}>;
 
   declare export function connect<
     Com: ComponentType<*>,
     S: Object,
     SP: Object,
     RSP: Object,
-    CP: $Diff<ElementConfig<Com>, RSP>,
+    CP: $Diff<OmitDispatch<ElementConfig<Com>>, RSP>,
     ST: {[_: $Keys<Com>]: any}
     >(
     mapStateToProps: MapStateToProps<S, SP, RSP>,


### PR DESCRIPTION
When I upgraded to `react-redux` to 5, we had a drop in type coverage on `connect`. From some experimentation I found that it's resulting from the type import within the libdef. The types imported from redux aren't overly complex and I understand them to be relatively stable, so I've copied them in directly.

I've tested this on my internal repo and found the coverage is applied again. I don't know how to express that as a test in the `flow-typed` suite, however. I tried adding `flow-strict` to the test files as well as `[strict]` settings to `cli/.flow-config`, but still no joy. I'd love any other suggestions anyone can think of.