### PR TITLE
react-modal: Fix signature of props.onRequestClose

### DIFF
--- a/definitions/npm/react-modal_v3.1.x/flow_v0.54.1-/react-modal_v3.1.x.js
+++ b/definitions/npm/react-modal_v3.1.x/flow_v0.54.1-/react-modal_v3.1.x.js
@@ -33,7 +33,7 @@ declare module 'react-modal' {
     },
     appElement?: HTMLElement | string | null,
     onAfterOpen?: () => void | Promise<void>,
-    onRequestClose?: () => void,
+    onRequestClose?: (SyntheticMouseEvent<>) => void,
     aria?: {
       [key: string]: string
     },

--- a/definitions/npm/react-modal_v3.1.x/flow_v0.54.1-/react-modal_v3.1.x.js
+++ b/definitions/npm/react-modal_v3.1.x/flow_v0.54.1-/react-modal_v3.1.x.js
@@ -33,7 +33,7 @@ declare module 'react-modal' {
     },
     appElement?: HTMLElement | string | null,
     onAfterOpen?: () => void | Promise<void>,
-    onRequestClose?: (SyntheticMouseEvent<>) => void,
+    onRequestClose?: (SyntheticMouseEvent<> | SyntheticKeyboardEvent<>) => void,
     aria?: {
       [key: string]: string
     },

--- a/definitions/npm/react-modal_v3.1.x/flow_v0.54.1-/react-modal_v3.1.x.js
+++ b/definitions/npm/react-modal_v3.1.x/flow_v0.54.1-/react-modal_v3.1.x.js
@@ -33,7 +33,7 @@ declare module 'react-modal' {
     },
     appElement?: HTMLElement | string | null,
     onAfterOpen?: () => void | Promise<void>,
-    onRequestClose?: (SyntheticMouseEvent<> | SyntheticKeyboardEvent<>) => void,
+    onRequestClose?: (SyntheticEvent<>) => void,
     aria?: {
       [key: string]: string
     },

--- a/definitions/npm/react-modal_v3.1.x/test_react-modal_v3.1.x.js
+++ b/definitions/npm/react-modal_v3.1.x/test_react-modal_v3.1.x.js
@@ -76,6 +76,7 @@ ReactModal.setAppElement(1);
 <ReactModal onAfterOpen={1} />;
 
 <ReactModal onRequestClose={() => { }} />;
+<ReactModal onRequestClose={e => { }} />;
 // $ExpectError
 <ReactModal onRequestClose={1} />;
 


### PR DESCRIPTION
This PR makes it possible for `props.onRequestClose()` to receive an `Event` object.

`props.onRequestClose()` will be called by `requestClose()` at [here](https://github.com/reactjs/react-modal/blob/master/src/components/ModalPortal.js#L287) and it will be called by handlers of both `onClick` and `onKeyDown`.
Therefore, `props.onRequestClose()` will receive either `SyntheticMouseEvent` or `SyntheticKeyboardEvent`.