### PR TITLE
Make redux-actions support thunks

### DIFF
--- a/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/redux-actions_v2.x.x.js
+++ b/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/redux-actions_v2.x.x.js
@@ -30,13 +30,13 @@ declare module "redux-actions" {
 
   declare function createAction<T, A, P>(
     type: T,
-    payloadCreator: (...rest: A) => P,
+    payloadCreator: (...rest: A) => Promise<P> | P,
     $?: empty
   ): {(...rest: A): { type: T, payload: P, error?: boolean }, +toString: () => T};
 
   declare function createAction<T, A, P, M>(
     type: T,
-    payloadCreator: (...rest: A) => P,
+    payloadCreator: (...rest: A) => Promise<P> | P,
     metaCreator: (...rest: A) => M
   ): {(...rest: A): { type: T, payload: P, error?: boolean, meta: M }, +toString: () => T};
 

--- a/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/test_createAction.js
+++ b/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/test_createAction.js
@@ -72,10 +72,23 @@ function test_createAction_withPayloadCreator() {
   ]);
   const a2 = action2("foo", 2, 3);
 
-  assert(a.payload, (x: [string, string]) => {});
+  assert(a2.payload, (x: [string, string]) => {});
 
   // $ExpectError
-  assert(a.payload, (x: string) => {});
+  assert(a2.payload, (x: string) => {});
+
+  // In case redux-actions is used in combination with redux-thunk,
+  // the `payloadCreator` can return a promise.
+  const action3 = createAction(INCREMENT, (x: string, y: number, z: number) => Promise.resolve([
+    x,
+    x
+  ]));
+  const a3 = action3("foo", 2, 3);
+
+  assert(a3.payload, (x: [string, string]) => {});
+
+  // $ExpectError
+  assert(a3.payload, (x: string) => {});
 
   (action.toString(): 'INCREMENT');
   // $ExpectError wrong type

--- a/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/test_handleAction.js
+++ b/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/test_handleAction.js
@@ -8,10 +8,23 @@ const NOT_INCREMENT = 'NOT_INCREMENT'
 
 const increment = createAction(INCREMENT, (x: number) => x)
 
+// In case redux-actions is used in combination with redux-thunk,
+// the `payloadCreator` can return a promise.
+const incrementThunk = createAction(INCREMENT, (x: number) => Promise.resolve(x))
+
 const initState = { count: 0 }
 
 function test_handleAction() {
   const reducer = handleAction(INCREMENT, (state, action: ActionType<typeof increment>) => {
+    assert(action.payload, (x: number) => {})
+
+    // $ExpectError
+    assert(action.payload, (x: string) => {})
+  }, initState)
+}
+
+function test_handleAction_thunk() {
+  const reducer = handleAction(INCREMENT, (state, action: ActionType<typeof incrementThunk>) => {
     assert(action.payload, (x: number) => {})
 
     // $ExpectError

--- a/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/test_handleActions.js
+++ b/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/test_handleActions.js
@@ -5,9 +5,11 @@ import type { ActionType, Reducer } from "redux-actions";
 
 const INCREMENT = "INCREMENT";
 const INCREMENT2 = "INCREMENT2";
+const INCREMENT3 = "INCREMENT3";
 
 const increment = createAction(INCREMENT, (x: number) => x);
 const increment2 = createAction(INCREMENT2, (x: number, y: string) => x);
+const increment3 = createAction(INCREMENT3, (x: number, y: string) => Promise.resolve(x));
 const decrement = createAction("DECREMENT", (x: number) => x);
 
 type StateType = { count: number };
@@ -21,6 +23,13 @@ function test_handleActions() {
       },
 
       [String(increment2)]: (state: StateType, action: ActionType<typeof increment2>): StateType => {
+        assert(action.payload, (x: number) => {});
+        return {
+          count: state.count + action.payload
+        };
+      },
+
+      [INCREMENT3]: (state: StateType, action: ActionType<typeof increment3>): StateType => {
         assert(action.payload, (x: number) => {});
         return {
           count: state.count + action.payload


### PR DESCRIPTION
In case [redux-actions](https://github.com/redux-utilities/redux-actions) is used in combination with [redux-thunk](https://github.com/reduxjs/redux-thunk), the `payloadCreator` can return a promise (that will be resolved by redux-thunk).  
This case is currently not supported by the actual `redux-actions` definitions.

This PR updates the return type of the `payloadCreator` to be either a payload object or a promise, which now allows to use `ActionType` to type thunks.

```js
const incrementThunk = createAction('INCREMENT', (x: number) => Promise.resolve(x))

handleAction('INCREMENT', (state, action: ActionType<typeof incrementThunk>) => {
  // action.payload will have type `number`
}, {})
```