### PR TITLE
react-apollo: Fix QueryRenderProps updateQuery.

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -923,9 +923,8 @@ declare module "react-apollo" {
       options: SubscribeToMoreOptions<TData, any, any>
     ) => () => void,
     updateQuery: (
-      previousResult: TData,
-      options: { variables: TVariables }
-    ) => TData,
+      mapFn: (previousResult: TData, options: { variables: TVariables }) => TData
+    ) => any,
     client: ApolloClient<any>
   };
 

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
@@ -415,6 +415,23 @@ describe("<Query />", () => {
       </HeroQueryComp>;
     });
   });
+
+  describe("updateQuery", () => {
+    it("works", () => {
+      <HeroQueryComp query={HERO_QUERY} variables={{ episode: "episode" }}>
+        {({ updateQuery }) => {
+          // $ExpectError updateQuery return type must match previous result type
+          updateQuery((previousResult, options) => ({ hello: 'flow' }))
+          const renameHero = (newName: string) => updateQuery((previousResult, options) => {
+            // $ExpectError Cannot get `options.unknownProperty` because property `unknownProperty` is missing in options
+            const a = options.unknownProperty
+            const { variables } = options
+            return { ...previousResult, name: newName }
+          })
+        }}
+      </HeroQueryComp>;
+    })
+  })
 });
 
 type HeroSubcriptionVariables = {


### PR DESCRIPTION
The `updateQuery` property is a function that accepts a map function as a single argument.
Beware that also the [documentation](https://www.apollographql.com/docs/react/api/react-apollo.html#query-render-prop) is not correct.