### PR TITLE
fix(lodash_v4.x.x): fix bad types for omitBy/pickBy

### DIFF
--- a/definitions/npm/lodash-es_v4.x.x/flow_v0.63.x-/lodash-es_v4.x.x.js
+++ b/definitions/npm/lodash-es_v4.x.x/flow_v0.63.x-/lodash-es_v4.x.x.js
@@ -1199,8 +1199,8 @@ declare module "lodash-es" {
     object: T,
     predicate?: ?OPredicate<A, T>
   ): Object;
-  declare export function omitBy<A, T: void | null>(
-    object: T,
+  declare export function omitBy<A, T>(
+    object: void | null,
     predicate?: ?OPredicate<A, T>
   ): {};
   declare export function pick(object?: ?Object, ...props: Array<string>): Object;
@@ -1209,8 +1209,8 @@ declare module "lodash-es" {
     object: T,
     predicate?: ?OPredicate<A, T>
   ): Object;
-  declare export function pickBy<A, T: void | null>(
-    object: T,
+  declare export function pickBy<A, T>(
+    object: void | null,
     predicate?: ?OPredicate<A, T>
   ): {};
   declare export function result(

--- a/definitions/npm/lodash-es_v4.x.x/flow_v0.63.x-/test_lodash-es-v4.x.x.js
+++ b/definitions/npm/lodash-es_v4.x.x/flow_v0.63.x-/test_lodash-es-v4.x.x.js
@@ -25,6 +25,8 @@ import {
   map,
   memoize,
   noop,
+  omitBy,
+  pickBy,
   pullAllBy,
   range,
   sortedIndexBy,
@@ -466,3 +468,17 @@ debounced = debounce(() => {});
 var pairs: [string, number][];
 pairs = toPairs({ a: 12, b: 100 });
 pairs = toPairsIn({ a: 12, b: 100 });
+
+/**
+ * _.pickBy
+ */
+(pickBy({a: 2, b: 3, c: 4}, num => num % 2): {[prop: string]: number});
+(pickBy(null, num => num % 2): {});
+(pickBy(undefined, num => num % 2): {});
+
+/**
+ * _.omitBy
+ */
+(omitBy({a: 2, b: 3, c: 4}, num => num % 2): {[prop: string]: number});
+(omitBy(null, num => num % 2): {});
+(omitBy(undefined, num => num % 2): {});

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -1209,8 +1209,8 @@ declare module "lodash" {
       object: T,
       predicate?: ?OPredicate<A, T>
     ): Object;
-    omitBy<A, T: void | null>(
-      object: T,
+    omitBy<A, T>(
+      object: void | null,
       predicate?: ?OPredicate<A, T>
     ): {};
     pick(object?: ?Object, ...props: Array<string>): Object;
@@ -1219,8 +1219,8 @@ declare module "lodash" {
       object: T,
       predicate?: ?OPredicate<A, T>
     ): Object;
-    pickBy<A, T: void | null>(
-      object: T,
+    pickBy<A, T>(
+      object: void | null,
       predicate?: ?OPredicate<A, T>
     ): {};
     result(

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -25,6 +25,8 @@ import map from "lodash/map";
 import memoize from "lodash/memoize";
 import noop from "lodash/noop";
 import pullAllBy from "lodash/pullAllBy";
+import pickBy from "lodash/pickBy";
+import omitBy from "lodash/omitBy";
 import range from "lodash/range";
 import sortedIndexBy from "lodash/sortedIndexBy";
 import sortedLastIndexBy from "lodash/sortedLastIndexBy";
@@ -462,3 +464,21 @@ debounced = debounce(() => {});
 var pairs: [string, number][];
 pairs = toPairs({ a: 12, b: 100 });
 pairs = toPairsIn({ a: 12, b: 100 });
+
+/**
+ * _.pickBy
+ */
+(pickBy([2, 3, 4], num => num % 2): Array<number>);
+// $ExpectError
+pickBy([2, 3, 4], (str: string) => str.startsWith('foo'));
+(pickBy(null, num => num % 2): void | null);
+(pickBy(undefined, num => num % 2): void | null);
+
+/**
+ * _.omitBy
+ */
+(omitBy([2, 3, 4], num => num % 2): Array<number>);
+// $ExpectError
+omitBy([2, 3, 4], (str: string) => str.startsWith('foo'));
+(omitBy(null, num => num % 2): void | null);
+(omitBy(undefined, num => num % 2): void | null);

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -468,17 +468,17 @@ pairs = toPairsIn({ a: 12, b: 100 });
 /**
  * _.pickBy
  */
-(pickBy([2, 3, 4], num => num % 2): Array<number>);
+(pickBy({a: 2, b: 3, c: 4}, num => num % 2): {[prop: string]: number});
 // $ExpectError
-pickBy([2, 3, 4], (str: string) => str.startsWith('foo'));
+pickBy({a: 2, b: 3, c: 4}, (str: string) => str.startsWith('foo'));
 (pickBy(null, num => num % 2): void | null);
 (pickBy(undefined, num => num % 2): void | null);
 
 /**
  * _.omitBy
  */
-(omitBy([2, 3, 4], num => num % 2): Array<number>);
+(omitBy({a: 2, b: 3, c: 4}, num => num % 2): {[prop: string]: number});
 // $ExpectError
-omitBy([2, 3, 4], (str: string) => str.startsWith('foo'));
+omitBy({a: 2, b: 3, c: 4}, (str: string) => str.startsWith('foo'));
 (omitBy(null, num => num % 2): void | null);
 (omitBy(undefined, num => num % 2): void | null);

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -24,9 +24,9 @@ import keyBy from "lodash/keyBy";
 import map from "lodash/map";
 import memoize from "lodash/memoize";
 import noop from "lodash/noop";
-import pullAllBy from "lodash/pullAllBy";
-import pickBy from "lodash/pickBy";
 import omitBy from "lodash/omitBy";
+import pickBy from "lodash/pickBy";
+import pullAllBy from "lodash/pullAllBy";
 import range from "lodash/range";
 import sortedIndexBy from "lodash/sortedIndexBy";
 import sortedLastIndexBy from "lodash/sortedLastIndexBy";
@@ -469,16 +469,12 @@ pairs = toPairsIn({ a: 12, b: 100 });
  * _.pickBy
  */
 (pickBy({a: 2, b: 3, c: 4}, num => num % 2): {[prop: string]: number});
-// $ExpectError
-pickBy({a: 2, b: 3, c: 4}, (str: string) => str.startsWith('foo'));
-(pickBy(null, num => num % 2): void | null);
-(pickBy(undefined, num => num % 2): void | null);
+(pickBy(null, num => num % 2): {});
+(pickBy(undefined, num => num % 2): {});
 
 /**
  * _.omitBy
  */
 (omitBy({a: 2, b: 3, c: 4}, num => num % 2): {[prop: string]: number});
-// $ExpectError
-omitBy({a: 2, b: 3, c: 4}, (str: string) => str.startsWith('foo'));
-(omitBy(null, num => num % 2): void | null);
-(omitBy(undefined, num => num % 2): void | null);
+(omitBy(null, num => num % 2): {});
+(omitBy(undefined, num => num % 2): {});


### PR DESCRIPTION
Fixes problems like
```
Cannot call `pickBy` because undefined [1] is incompatible with object type [2] in type argument `T`.
```

Somebody constrainted `T: void | null` for the case where the input object is not defined, but that means it won't accept a predicate that takes a defined object.