### PR TITLE
styled-components: allow detailed types for Theme

### DIFF
--- a/definitions/npm/styled-components_v1.4.x/flow_v0.25.x-v0.52.x/styled-components_v1.4.x.js
+++ b/definitions/npm/styled-components_v1.4.x/flow_v0.25.x-v0.52.x/styled-components_v1.4.x.js
@@ -9,7 +9,7 @@ type $npm$styledComponents$StyledComponent = (
 ) => ReactClass<*>;
 
 
-type $npm$styledComponents$Theme = {[key: string]: mixed};
+type $npm$styledComponents$Theme = {+[key: string]: mixed};
 type $npm$styledComponents$ThemeProviderProps = {
   theme: $npm$styledComponents$Theme | ((outerTheme: $npm$styledComponents$Theme) => void)
 };

--- a/definitions/npm/styled-components_v2.x.x/flow_v0.25.x-v0.41.x/styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/flow_v0.25.x-v0.41.x/styled-components_v2.x.x.js
@@ -9,7 +9,7 @@ type $npm$styledComponents$StyledComponent = (
 ) => ReactClass<*>;
 
 
-type $npm$styledComponents$Theme = {[key: string]: mixed};
+type $npm$styledComponents$Theme = {+[key: string]: mixed};
 type $npm$styledComponents$ThemeProviderProps = {
   theme: $npm$styledComponents$Theme | ((outerTheme: $npm$styledComponents$Theme) => void)
 };

--- a/definitions/npm/styled-components_v2.x.x/flow_v0.42.x-v0.52.x/styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/flow_v0.42.x-v0.52.x/styled-components_v2.x.x.js
@@ -61,7 +61,7 @@ type $npm$styledComponents$WithTheme =
   & $npm$styledComponents$WithThemeReactComponentClassUndefinedDefaultProps
   & $npm$styledComponents$WithThemeReactComponentFunctional
 
-type $npm$styledComponents$Theme = {[key: string]: mixed};
+type $npm$styledComponents$Theme = {+[key: string]: mixed};
 type $npm$styledComponents$ThemeProviderProps = {
   theme: $npm$styledComponents$Theme | ((outerTheme: $npm$styledComponents$Theme) => void)
 };

--- a/definitions/npm/styled-components_v2.x.x/flow_v0.53.x-v0.74.x/styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/flow_v0.53.x-v0.74.x/styled-components_v2.x.x.js
@@ -108,7 +108,7 @@ type $npm$styledComponents$WithTheme =
   & $npm$styledComponents$WithThemeReactComponentFunctionalUndefinedDefaultProps
 
 // ---- MISC ----
-type $npm$styledComponents$Theme = {[key: string]: mixed};
+type $npm$styledComponents$Theme = {+[key: string]: mixed};
 type $npm$styledComponents$ThemeProviderProps = {
   theme: $npm$styledComponents$Theme | ((outerTheme: $npm$styledComponents$Theme) => void)
 };

--- a/definitions/npm/styled-components_v2.x.x/flow_v0.75.x-/styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/flow_v0.75.x-/styled-components_v2.x.x.js
@@ -108,7 +108,7 @@ type $npm$styledComponents$WithTheme =
   & $npm$styledComponents$WithThemeReactComponentFunctionalUndefinedDefaultProps
 
 // ---- MISC ----
-type $npm$styledComponents$Theme = {[key: string]: mixed};
+type $npm$styledComponents$Theme = {+[key: string]: mixed};
 type $npm$styledComponents$ThemeProviderProps = {
   theme: $npm$styledComponents$Theme | ((outerTheme: $npm$styledComponents$Theme) => void)
 };

--- a/definitions/npm/styled-components_v3.x.x/flow_v0.57.x-v0.74.x/styled-components_v3.x.x.js
+++ b/definitions/npm/styled-components_v3.x.x/flow_v0.57.x-v0.74.x/styled-components_v3.x.x.js
@@ -108,7 +108,7 @@ type $npm$styledComponents$WithTheme =
   & $npm$styledComponents$WithThemeReactComponentFunctionalUndefinedDefaultProps
 
 // ---- MISC ----
-type $npm$styledComponents$Theme = {[key: string]: mixed};
+type $npm$styledComponents$Theme = {+[key: string]: mixed};
 type $npm$styledComponents$ThemeProviderProps = {
   theme: $npm$styledComponents$Theme | ((outerTheme: $npm$styledComponents$Theme) => void)
 };

--- a/definitions/npm/styled-components_v3.x.x/flow_v0.75.x-/styled-components_v3.x.x.js
+++ b/definitions/npm/styled-components_v3.x.x/flow_v0.75.x-/styled-components_v3.x.x.js
@@ -108,7 +108,7 @@ type $npm$styledComponents$WithTheme =
   & $npm$styledComponents$WithThemeReactComponentFunctionalUndefinedDefaultProps
 
 // ---- MISC ----
-type $npm$styledComponents$Theme = {[key: string]: mixed};
+type $npm$styledComponents$Theme = {+[key: string]: mixed};
 type $npm$styledComponents$ThemeProviderProps = {
   theme: $npm$styledComponents$Theme | ((outerTheme: $npm$styledComponents$Theme) => void)
 };


### PR DESCRIPTION
Related to: https://github.com/styled-components/styled-components/issues/1785

_**tl;dr**_: the current definition of  `styledComponents$Theme` misses a covariant modifier that would allows more specific type definition for the Theme