### PR TITLE
query string: add missing sort key to StringifyOptions

### DIFF
--- a/definitions/npm/query-string_v5.1.x/flow_v0.32.x-/query-string_v5.1.x.js
+++ b/definitions/npm/query-string_v5.1.x/flow_v0.32.x-/query-string_v5.1.x.js
@@ -8,6 +8,7 @@ declare module 'query-string' {
     arrayFormat?: ArrayFormat,
     encode?: boolean,
     strict?: boolean,
+    sort?: false | <A, B>(A, B) => number,
   |}
 
   declare module.exports: {

--- a/definitions/npm/query-string_v6.x.x/flow_v0.32.x-/query-string_v6.x.x.js
+++ b/definitions/npm/query-string_v6.x.x/flow_v0.32.x-/query-string_v6.x.x.js
@@ -8,6 +8,7 @@ declare module 'query-string' {
     arrayFormat?: ArrayFormat,
     encode?: boolean,
     strict?: boolean,
+    sort?: false | <A, B>(A, B) => number,
   |}
 
   declare module.exports: {


### PR DESCRIPTION
Per documentation, stringify function accepts a sort option which can either turn off the sorting or accept a custom sorter https://www.npmjs.com/package/query-string#sort
This has been available since 5.1