### PR TITLE
@material-ui/core: fix withStyles types

### DIFF
--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
@@ -1845,17 +1845,12 @@ declare module "@material-ui/core/styles/withStyles" {
   declare module.exports: (
     stylesOrCreator: Object,
     options?: Options
-  ) => <
-    OwnProps: {},
-    Props: $Supertype<
-      OwnProps & {
-        classes: { +[string]: string },
-        innerRef: React$Ref<React$ElementType>
-      }
-    >
-  >(
+  ) => <Props: {}>(
     Component: React$ComponentType<Props>
-  ) => React$ComponentType<OwnProps>;
+  ) => React$ComponentType<$Diff<Props, {
+    classes?: Object,
+    innerRef?: React$Ref<React$ElementType>
+  }>>;
 }
 
 declare module "@material-ui/core/styles/withTheme" {

--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
@@ -8,6 +8,7 @@ import AppBar from "@material-ui/core/AppBar";
 import Button from "@material-ui/core/Button";
 
 import Typography from "@material-ui/core/Typography";
+import withStyles from "@material-ui/core/styles/withStyles";
 
 // $ExpectError invalid color value.
 let appBar = <AppBar color="black" />;
@@ -20,3 +21,32 @@ let button2 = <Button disableRipple={3} />;
 // $ExpectError invalid variant
 let typography1 = <Typography variant="wrong" />
 let typography2 = <Typography variant="headline" />
+
+// withStyles - remove prop "classes" from Props
+class TestComponent extends React.Component<{
+  classes: {},
+  requiredProp: string
+}> {}
+const CustomTestComponent = withStyles({})(TestComponent)
+
+function renderTestComponentWithError () {
+  return (
+    // $ExpectError is missing required prop
+    <CustomTestComponent />
+  )
+}
+
+function renderTestComponent () {
+  return (
+    // doesn't require the prop classes
+    <CustomTestComponent requiredProp='test' />
+  )
+}
+
+const DoubleStyledComponent = withStyles({})(CustomTestComponent)
+function renderDoubleStyledComponent () {
+  return (
+    // doesn't require the prop classes
+    <DoubleStyledComponent requiredProp='test' />
+  )
+}


### PR DESCRIPTION
Whenever I wrap a component with **withStyles** flow just stops identifying any errors with the wrapped components