### PR TITLE
fix(react-apollo): fix QueryRenderProps data type for recent versions of flow

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -902,7 +902,7 @@ declare module "react-apollo" {
     TData = any,
     TVariables = OperationVariables
   > = {
-    data: TData | {||} | void,
+    data: $Shape<TData>,
     loading: boolean,
     error?: ApolloError,
     variables: TVariables,


### PR DESCRIPTION
react-apollo passes an empty object before data is loaded; data will never be undefined.

However, using `| {||}` just isn't going to work with recent versions of flow (see https://github.com/flow-typed/flow-typed/pull/2172#issuecomment-409831959)

I think `$Shape<TData>` is the only viable option here.