### PR TITLE
fix(react-apollo): remove | void from data type

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -902,7 +902,7 @@ declare module "react-apollo" {
     TData = any,
     TVariables = OperationVariables
   > = {
-    data: TData | {||} | void,
+    data: TData | {||},
     loading: boolean,
     error?: ApolloError,
     variables: TVariables,


### PR DESCRIPTION
react-apollo will never pass undefined (https://github.com/apollographql/react-apollo/blob/master/src/Query.tsx#L377)