### PR TITLE
Add Observable.combineAll to RxJS 5 Type Definitions

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
@@ -547,6 +547,9 @@ declare class rxjs$Observable<+T> {
     onCompleted: ?() => mixed
   ): rxjs$Subscription;
 
+  combineAll<U>(): rxjs$Observable<U>;
+  combineAll<U>(project: (...values: any[]) => U): rxjs$Observable<U>;
+
   static combineLatest<A, B>(
     a: rxjs$Observable<A>,
     resultSelector: (a: A) => B

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -726,6 +726,9 @@ declare class rxjs$Observable<+T> {
     onCompleted: ?() => mixed
   ): rxjs$Subscription;
 
+  combineAll<U>(): rxjs$Observable<U>;
+  combineAll<U>(project: (...values: any[]) => U): rxjs$Observable<U>;
+
   static combineLatest<A, B>(
     a: rxjs$Observable<A>,
     resultSelector: (a: A) => B

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -48,6 +48,12 @@ numbers.letBind(_numbers => 3);
 // $ExpectError -- .switch can't assert that it's operating on observables, but it can at least trace the type.
 (numbers.map(number => Observable.of(number)).switch(): Observable<string>);
 
+let dualNumbers = Observable.of(numbers, numbers);
+(dualNumbers.combineAll(): Observable<[number, number]>);
+// $ExpectError -- should return an Observable<string>
+(dualNumbers.combineAll((a, b) => `${a}-${b}`): Observable<number>);
+(dualNumbers.combineAll((a, b) => `${a}-${b}`): Observable<string>);
+
 const combined: Observable<{ n: number, s: string }> = Observable.combineLatest(
   numbers,
   strings,


### PR DESCRIPTION
I've added type definitions for [`Observable.combineAll`](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-combineAll). The type definition is pretty lax - combineAll is supposed to operate on `Observable<Observable<T>>`, but I'm unsure if there's any way to enforce that. Other similar operators like `mergeAll` and `concatAll` don't enforce this currently.