### PR TITLE
Added client to MutationResult

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -991,7 +991,8 @@ declare module "react-apollo" {
     loading: boolean,
     error?: ApolloError,
     data?: TData,
-    called: boolean
+    called: boolean,
+    client: ApolloClient<any>
   };
 
   declare export type MutationRenderPropFunction<TData, TVariables> = (

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
@@ -516,7 +516,7 @@ describe("<Mutation />", () => {
       <Mutation variables={vars} mutation={HERO_QUERY}>
         {(
           update: MutationFunction<Res, Vars>,
-          { data }: MutationResult<Res>
+          { data, client }: MutationResult<Res>
         ) => {
           // $ExpectError Cannot get `data.res`
           data.res;
@@ -525,6 +525,7 @@ describe("<Mutation />", () => {
           }
           const d1: Res = data;
           const s: string = data.res;
+          client;
         }}
       </Mutation>
     );


### PR DESCRIPTION
According to https://github.com/apollographql/react-apollo/blob/master/src/Mutation.tsx#L17

cc @budde377 

Edit: Hm, tests failed for node8, but can't see why. Is there any way to trigger another build?