### PR TITLE
[material-ui] Improve CircularProgress definition

### DIFF
--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
@@ -1397,8 +1397,8 @@ declare module "@material-ui/core/Popover/Popover" {
 }
 
 declare module "@material-ui/core/CircularProgress/CircularProgress" {
-  declare type Color = "primary" | "accent" | "inherit";
-  declare type Mode = "determinate" | "indeterminate";
+  declare type Color = "primary" | "secondary" | "inherit";
+  declare type Mode = "determinate" | "indeterminate" | "static";
 
   declare module.exports: React$ComponentType<{
     classes?: Object,

--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
@@ -1398,7 +1398,8 @@ declare module "@material-ui/core/Popover/Popover" {
 
 declare module "@material-ui/core/CircularProgress/CircularProgress" {
   declare type Color = "primary" | "secondary" | "inherit";
-  declare type Mode = "determinate" | "indeterminate" | "static";
+  declare type Mode = "determinate" | "indeterminate";
+  declare type Variant = "determinate" | "indeterminate" | "static";
 
   declare module.exports: React$ComponentType<{
     classes?: Object,
@@ -1407,10 +1408,11 @@ declare module "@material-ui/core/CircularProgress/CircularProgress" {
     max?: number,
     min?: number,
     mode?: Mode,
-    size?: number,
+    size?: number | string,
     style?: Object,
     thickness?: number,
-    value?: number
+    value?: number,
+    variant?: Variant
   }>;
 }
 

--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
@@ -14,3 +14,10 @@ let button1 = <Button>Click me!</Button>;
 
 // $ExpectError invalid property value.
 let button2 = <Button disableRipple={3} />;
+
+// CircularProgress
+import CircularProgress from "@material-ui/core/CircularProgress";
+let circularProgress1 = <CircularProgress color="secondary" variant="static" />;
+
+// $ExpectError invalid color value.
+let circularProgress2 = <CircularProgress color="black" />;


### PR DESCRIPTION
According to the official [MUI docs](https://material-ui.com/api/circular-progress/), CircularProgress component should have a different set of allowed values for `color` and `mode` props.