### PR TITLE
[material-ui] Improve CircularProgress definition

### DIFF
--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
@@ -1394,8 +1394,9 @@ declare module "@material-ui/core/Popover/Popover" {
 }
 
 declare module "@material-ui/core/CircularProgress/CircularProgress" {
-  declare type Color = "primary" | "accent" | "inherit";
+  declare type Color = "primary" | "secondary" | "inherit";
   declare type Mode = "determinate" | "indeterminate";
+  declare type Variant = "determinate" | "indeterminate" | "static";
 
   declare module.exports: React$ComponentType<{
     classes?: Object,
@@ -1404,10 +1405,11 @@ declare module "@material-ui/core/CircularProgress/CircularProgress" {
     max?: number,
     min?: number,
     mode?: Mode,
-    size?: number,
+    size?: number | string,
     style?: Object,
     thickness?: number,
-    value?: number
+    value?: number,
+    variant?: Variant
   }>;
 }
 

--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
@@ -9,6 +9,7 @@ import Button from "@material-ui/core/Button";
 
 import Typography from "@material-ui/core/Typography";
 import withStyles from "@material-ui/core/styles/withStyles";
+import CircularProgress from "@material-ui/core/CircularProgress";
 
 // $ExpectError invalid color value.
 let appBar = <AppBar color="black" />;
@@ -50,3 +51,8 @@ function renderDoubleStyledComponent () {
     <DoubleStyledComponent requiredProp='test' />
   )
 }
+
+let circularProgress1 = <CircularProgress color="secondary" variant="static" />;
+
+// $ExpectError invalid color value.
+let circularProgress2 = <CircularProgress color="black" />;


### PR DESCRIPTION
According to the official [MUI docs](https://material-ui.com/api/circular-progress/), CircularProgress component should have a different set of allowed values for `color` prop and may have an optional `variant` prop.
I'm not sure about `mode` which seems to be a legacy prop. Maybe it should be removed from a type definition?