### PR TITLE
[rxjs_v6] Add static concat export to rxjs

### DIFF
--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -1627,6 +1627,7 @@ declare class rxjs$UnsubscriptionError extends Error {}
 
 declare module "rxjs" {
   declare module.exports: {
+    concat<+T>(...sources: rxjs$Observable<T>[]): rxjs$Observable<T>,
     from<+T>(
       input: rxjs$ObservableInput<T>,
       scheduler?: rxjs$SchedulerClass

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
@@ -3,6 +3,7 @@
 import {
   Observable,
   Subject,
+  concat,
   of,
   from,
   timer,


### PR DESCRIPTION
According to the [official migration guide](https://github.com/ReactiveX/rxjs/blob/master/docs_app/content/guide/v6/migration.md#howto-convert-deprecated-methods) for rxjs v6 static `concat` function should be available for import directly from `rxjs` package.