### PR TITLE
fix: react-apollo: don't constrain ignored return type of user-passed…

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -60,7 +60,7 @@ declare module "react-apollo" {
       link: ApolloLink,
       queryDeduplication?: boolean,
       store: DataStore<TStore>,
-      onBroadcast?: () => void,
+      onBroadcast?: () => any,
       ssrMode?: boolean
     }): this;
 
@@ -186,7 +186,7 @@ declare module "react-apollo" {
       document: DocumentNode,
       variables: any,
       updateQueries: { [queryId: string]: QueryWithUpdater },
-      update: ((proxy: DataProxy, mutationResult: Object) => void) | void,
+      update: ((proxy: DataProxy, mutationResult: Object) => any) | void,
       optimisticResponse: Object | Function | void
     }): void;
     markMutationResult(mutation: {
@@ -195,7 +195,7 @@ declare module "react-apollo" {
       document: DocumentNode,
       variables: any,
       updateQueries: { [queryId: string]: QueryWithUpdater },
-      update: ((proxy: DataProxy, mutationResult: Object) => void) | void
+      update: ((proxy: DataProxy, mutationResult: Object) => any) | void
     }): void;
     markMutationComplete({
       mutationId: string,
@@ -324,20 +324,20 @@ declare module "react-apollo" {
         variables: TSubscriptionVariables
       }
     ) => TData,
-    onError?: (error: Error) => void
+    onError?: (error: Error) => any
   };
 
   declare export type MutationUpdaterFn<T = OperationVariables> = (
     proxy: DataProxy,
     mutationResult: FetchResult<T>
-  ) => void;
+  ) => any;
 
   declare export type NetworkStatus = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
   declare export type QueryListener = (
     queryStoreValue: QueryStoreValue,
     newData?: any
-  ) => void;
+  ) => any;
 
   declare export type QueryStoreValue = {
     document: DocumentNode,
@@ -506,12 +506,12 @@ declare module "react-apollo" {
 
   declare class Observable<T> {
     subscribe(
-      observerOrNext: ((value: T) => void) | ZenObservableObserver<T>,
-      error?: (error: any) => void,
-      complete?: () => void
+      observerOrNext: ((value: T) => any) | ZenObservableObserver<T>,
+      error?: (error: any) => any,
+      complete?: () => any
     ): ZenObservableSubscription;
 
-    forEach(fn: (value: T) => void): Promise<void>;
+    forEach(fn: (value: T) => any): Promise<void>;
 
     map<R>(fn: (value: T) => R): Observable<R>;
 
@@ -564,7 +564,7 @@ declare module "react-apollo" {
 
   declare type ZenObservableSubscriber<T> = (
     observer: ZenObservableSubscriptionObserver<T>
-  ) => void | (() => void) | SubscriptionLINK;
+  ) => any | (() => any) | SubscriptionLINK;
 
   declare interface ZenObservableObservableLike<T> {
     subscribe?: ZenObservableSubscriber<T>;
@@ -607,9 +607,9 @@ declare module "react-apollo" {
     writeData(options: CacheWriteDataOptions): void;
   }
 
-  declare type Transaction<T> = (c: ApolloCache<T>) => void;
+  declare type Transaction<T> = (c: ApolloCache<T>) => any;
 
-  declare type CacheWatchCallback = (newData: any) => void;
+  declare type CacheWatchCallback = (newData: any) => any;
 
   declare interface CacheEvictionResult {
     success: boolean;
@@ -1011,8 +1011,8 @@ declare module "react-apollo" {
     ignoreResults?: boolean,
     optimisticResponse?: Object,
     refetchQueries?: string[] | PureQueryOptions[] | RefetchQueriesProviderFn,
-    onCompleted?: (data: TData) => void,
-    onError?: (error: ApolloError) => void,
+    onCompleted?: (data: TData) => any,
+    onError?: (error: ApolloError) => any,
     context?: { [string]: any }
   }> {}
 }

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -43,7 +43,7 @@ declare module "react-apollo" {
       fetchResults?: boolean
     ): Promise<ApolloQueryResult<T>>;
     updateQuery(
-      mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => any
+      mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => mixed
     ): void;
     stopPolling(): void;
     startPolling(pollInterval: number): void;
@@ -60,7 +60,7 @@ declare module "react-apollo" {
       link: ApolloLink,
       queryDeduplication?: boolean,
       store: DataStore<TStore>,
-      onBroadcast?: () => any,
+      onBroadcast?: () => mixed,
       ssrMode?: boolean
     }): this;
 
@@ -186,7 +186,7 @@ declare module "react-apollo" {
       document: DocumentNode,
       variables: any,
       updateQueries: { [queryId: string]: QueryWithUpdater },
-      update: ((proxy: DataProxy, mutationResult: Object) => any) | void,
+      update: ((proxy: DataProxy, mutationResult: Object) => mixed) | void,
       optimisticResponse: Object | Function | void
     }): void;
     markMutationResult(mutation: {
@@ -195,7 +195,7 @@ declare module "react-apollo" {
       document: DocumentNode,
       variables: any,
       updateQueries: { [queryId: string]: QueryWithUpdater },
-      update: ((proxy: DataProxy, mutationResult: Object) => any) | void
+      update: ((proxy: DataProxy, mutationResult: Object) => mixed) | void
     }): void;
     markMutationComplete({
       mutationId: string,
@@ -324,20 +324,20 @@ declare module "react-apollo" {
         variables: TSubscriptionVariables
       }
     ) => TData,
-    onError?: (error: Error) => any
+    onError?: (error: Error) => mixed
   };
 
   declare export type MutationUpdaterFn<T = OperationVariables> = (
     proxy: DataProxy,
     mutationResult: FetchResult<T>
-  ) => any;
+  ) => mixed;
 
   declare export type NetworkStatus = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
   declare export type QueryListener = (
     queryStoreValue: QueryStoreValue,
     newData?: any
-  ) => any;
+  ) => mixed;
 
   declare export type QueryStoreValue = {
     document: DocumentNode,
@@ -432,7 +432,7 @@ declare module "react-apollo" {
     writeQuery(options: DataProxyWriteQueryOptions): void;
     writeFragment(options: DataProxyWriteFragmentOptions): void;
     writeData(options: DataProxyWriteDataOptions): void;
-    __actionHookForDevTools(cb: () => any): void;
+    __actionHookForDevTools(cb: () => mixed): void;
     __requestRaw(payload: GraphQLRequest): Observable<ExecutionResult<>>;
     initQueryManager(): void;
     resetStore(): Promise<Array<ApolloQueryResult<any>> | null>;
@@ -506,12 +506,12 @@ declare module "react-apollo" {
 
   declare class Observable<T> {
     subscribe(
-      observerOrNext: ((value: T) => any) | ZenObservableObserver<T>,
-      error?: (error: any) => any,
-      complete?: () => any
+      observerOrNext: ((value: T) => mixed) | ZenObservableObserver<T>,
+      error?: (error: any) => mixed,
+      complete?: () => mixed
     ): ZenObservableSubscription;
 
-    forEach(fn: (value: T) => any): Promise<void>;
+    forEach(fn: (value: T) => mixed): Promise<void>;
 
     map<R>(fn: (value: T) => R): Observable<R>;
 
@@ -556,15 +556,15 @@ declare module "react-apollo" {
   }
 
   declare interface ZenObservableObserver<T> {
-    start?: (subscription: ZenObservableSubscription) => any;
-    next?: (value: T) => void;
-    error?: (errorValue: any) => void;
-    complete?: () => void;
+    start?: (subscription: ZenObservableSubscription) => mixed;
+    next?: (value: T) => mixed;
+    error?: (errorValue: any) => mixed;
+    complete?: () => mixed;
   }
 
   declare type ZenObservableSubscriber<T> = (
     observer: ZenObservableSubscriptionObserver<T>
-  ) => any | (() => any) | SubscriptionLINK;
+  ) => mixed | (() => mixed) | SubscriptionLINK;
 
   declare interface ZenObservableObservableLike<T> {
     subscribe?: ZenObservableSubscriber<T>;
@@ -607,9 +607,9 @@ declare module "react-apollo" {
     writeData(options: CacheWriteDataOptions): void;
   }
 
-  declare type Transaction<T> = (c: ApolloCache<T>) => any;
+  declare type Transaction<T> = (c: ApolloCache<T>) => mixed;
 
-  declare type CacheWatchCallback = (newData: any) => any;
+  declare type CacheWatchCallback = (newData: any) => mixed;
 
   declare interface CacheEvictionResult {
     success: boolean;
@@ -797,7 +797,7 @@ declare module "react-apollo" {
     stopPolling: () => void;
     subscribeToMore: (options: SubscribeToMoreOptions<any, any>) => () => void;
     updateQuery: (
-      mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => any
+      mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => mixed
     ) => void;
   }
 
@@ -924,7 +924,7 @@ declare module "react-apollo" {
     ) => () => void,
     updateQuery: (
       mapFn: (previousResult: TData, options: { variables: TVariables }) => TData
-    ) => any,
+    ) => mixed,
     client: ApolloClient<any>
   };
 
@@ -1011,8 +1011,8 @@ declare module "react-apollo" {
     ignoreResults?: boolean,
     optimisticResponse?: Object,
     refetchQueries?: string[] | PureQueryOptions[] | RefetchQueriesProviderFn,
-    onCompleted?: (data: TData) => any,
-    onError?: (error: ApolloError) => any,
+    onCompleted?: (data: TData) => mixed,
+    onError?: (error: ApolloError) => mixed,
     context?: { [string]: any }
   }> {}
 }


### PR DESCRIPTION
… functions

@TLadd please don't ever stipulate `void` for the return type of a user-passed function, *except, perhaps, if it's necessary to ensure that the function completes synchronously.*

I have a lot of invalid errors in my code because of this.

It's perfectly reasonable to pass an async function for many callbacks, and constraining the return type to `void` in those cases causes a pointless error when an async function is passed (since async functions return a `Promise`.

It also causes annoying errors when passing an arrow function that calls something else which happens to return non-void.
I also often call `apollo-magic-refetch` in my `update` functions.  It returns a `Promise` which obviously is ignored by `Mutation`, but let's not have this cause a flow error please.

If whatever calls the user-defined function doesn't care about its result or synchronous completion, the return type should be `any`.

The use of `| void` also seems suspiciously prevalent in these types.  Are you sure that in all of those cases the value can be `undefined` but not `null`?