### PR TITLE
Use /bin/sh instead of /bin/bash for better portability

### DIFF
--- a/build_and_test_cli.sh
+++ b/build_and_test_cli.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -o errexit
+#!/bin/sh
+set -e
 
 cd definitions
 yarn install

--- a/quick_run_def_tests.sh
+++ b/quick_run_def_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Run this "quick test" script when you want a faster feedback loop on tests for your libdef. This script runs the
 # libdef tests for any *changed* libdefs. (Also, it only runs tests against the most recent flow version libdef.)
@@ -8,6 +8,6 @@
 #
 # Usage: `$ ./quick_run_def_tests`
 
-set -o errexit
+set -e
 
 node cli/dist/cli.js run-tests --onlyChanged

--- a/travis.sh
+++ b/travis.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-#set -o errexit
+#!/bin/sh
+#set -e
 
 cd definitions && \
 yarn install && \


### PR DESCRIPTION
All three scripts are POSIX-sh compliant, so it's unnecessary to require
specifically bash, they works on any POSIX shell. Not every unix system
comes with bash preinstalled and even less install bash executable into
/bin. /bin/sh is defined by POSIX, so more portable.