### PR TITLE
Fixes prototype method for faker.js

### DIFF
--- a/definitions/npm/faker_v4.x.x/flow_v0.25.x-/faker_v4.x.x.js
+++ b/definitions/npm/faker_v4.x.x/flow_v0.25.x-/faker_v4.x.x.js
@@ -1,8 +1,8 @@
 declare module "faker" {
-  declare type SeedType = void | number | $ReadOnlyArray<number>;
+  declare type SeedType = number | $ReadOnlyArray<number>;
 
   declare module.exports: {
-    seedValue: SeedType,
+    seedValue: ?SeedType,
     seed: (SeedType) => void,
     setLocale: (string) => void,
 

--- a/definitions/npm/faker_v4.x.x/flow_v0.25.x-/faker_v4.x.x.js
+++ b/definitions/npm/faker_v4.x.x/flow_v0.25.x-/faker_v4.x.x.js
@@ -1,5 +1,11 @@
 declare module "faker" {
+  declare type SeedType = void | number | $ReadOnlyArray<number>;
+
   declare module.exports: {
+    seedValue: SeedType,
+    seed: (SeedType) => void,
+    setLocale: (string) => void,
+
     address: {
       zipCode: (localeFormat?: string) => string,
       city: (mustacheTemplate?: string) => string,

--- a/definitions/npm/faker_v4.x.x/flow_v0.25.x-/test_faker_v4.x.x.js
+++ b/definitions/npm/faker_v4.x.x/flow_v0.25.x-/test_faker_v4.x.x.js
@@ -4,7 +4,6 @@ import faker from "faker";
 describe("prototype", () => {
   faker.seed(12);
   faker.seed([1, 2, 3]);
-  faker.seed(undefined);
   faker.seedValue;
   faker.setLocale('ru');
 });

--- a/definitions/npm/faker_v4.x.x/flow_v0.25.x-/test_faker_v4.x.x.js
+++ b/definitions/npm/faker_v4.x.x/flow_v0.25.x-/test_faker_v4.x.x.js
@@ -1,6 +1,14 @@
 import { describe, it } from "flow-typed-test";
 import faker from "faker";
 
+describe("prototype", () => {
+  faker.seed(12);
+  faker.seed([1, 2, 3]);
+  faker.seed(undefined);
+  faker.seedValue;
+  faker.setLocale('ru');
+});
+
 describe("address", () => {
   faker.address.zipCode();
   faker.address.zipCode("localeFormat");


### PR DESCRIPTION
I have added a support of some utility methods and properties.
Closes #2577 

## `seed()`

This method is defined here: https://github.com/Marak/faker.js/blob/master/lib/index.js#L153-L156
It internally calls these implementations of `random.seed()`: https://github.com/Marak/faker.js/blob/master/vendor/mersenne.js#L273-L285

That's why `seed()` can take a `number` or a list of `number`s.

## `seedValue`

Is defined here: https://github.com/Marak/faker.js/blob/master/lib/index.js#L155
By default is `undefined`, so that's why it is marked as `void`.

## `setLocale()`

Is defined here: https://github.com/Marak/faker.js/blob/master/lib/index.js#L149-L151
Takes a locale name, which is `string`.