### PR TITLE
[js-cookie]: change getJSON type to Object

### DIFF
--- a/definitions/npm/js-cookie_v2.x.x/flow_v0.38.x-/js-cookie_v2.x.x.js
+++ b/definitions/npm/js-cookie_v2.x.x/flow_v0.38.x-/js-cookie_v2.x.x.js
@@ -16,7 +16,7 @@ declare module 'js-cookie' {
         get(...args: Array<void>): { [key: string]: string };
         get(name: string, ...args: Array<void>): string | void;
         remove(name: string, options?: CookieOptions): void;
-        getJSON(name: string): mixed;
+        getJSON(name: string): Object;
         withConverter(converter: ConverterFunc | ConverterObj): this;
         noConflict(): this;
     }

--- a/definitions/npm/js-cookie_v2.x.x/flow_v0.38.x-/test_js-cookie-v2.x.x.js
+++ b/definitions/npm/js-cookie_v2.x.x/flow_v0.38.x-/test_js-cookie-v2.x.x.js
@@ -29,7 +29,6 @@ Cookie.set('data', {
 // $ExpectError
 Cookie.getJson();
 
-// $ExpectError
 const data: Object = Cookie.getJSON('data');
 
 


### PR DESCRIPTION
It seems that `Object` is a correct return type for js-cookie `.getJSON` method as it will always try to return a parsed JSON object [source](https://github.com/js-cookie/js-cookie/blob/master/src/js.cookie.js#L147).
While getting a string with `.getJSON` [might be possible](https://github.com/js-cookie/js-cookie/blob/master/src/js.cookie.js#L128) I don't think it is a valid return type as for non JSON cookies `.get` method should be used.

This PR is related to the issue #2478 