### PR TITLE
Update execa libdef

### DIFF
--- a/definitions/npm/execa_v0.10.x/flow_v0.75.x-/execa_v0.10.x.js
+++ b/definitions/npm/execa_v0.10.x/flow_v0.75.x-/execa_v0.10.x.js
@@ -58,16 +58,7 @@ declare module 'execa' {
     killed: boolean,
   |};
 
-  declare interface ThenableChildProcess extends child_process$ChildProcess {
-    then<R, E>(
-      onfulfilled?: ?((value: Result) => R | Promise<R>),
-      onrejected?: ?((reason: ExecaError) => E | Promise<E>),
-    ): Promise<R | E>;
-
-    catch<E>(
-      onrejected?: ?((reason: ExecaError) => E | Promise<E>)
-    ): Promise<Result | E>;
-  }
+  declare type ThenableChildProcess = child_process$ChildProcess & Promise<Result>;
 
   declare interface ExecaError extends ErrnoError {
     stdout: string;

--- a/definitions/npm/execa_v0.10.x/test_execa.js
+++ b/definitions/npm/execa_v0.10.x/test_execa.js
@@ -16,13 +16,13 @@ execa('ls').then(res => {
 // $ExpectError
 execa('ls').then(res => res.foo);
 
-execa('foo').catch(err => {
+execa('foo').catch((err: ExecaError) => {
   (err.cmd: string);
   (err.code: ?string);
   (err.errno: ?number);
 });
 // $ExpectError
-execa('foo').catch(err => err.foo);
+execa('foo').catch((err: ExecaError) => err.foo);
 
 (execa('ls').pid: number);
 execa('ls').stdout.pipe(process.stdout);

--- a/definitions/npm/execa_v0.10.x/test_execa.js
+++ b/definitions/npm/execa_v0.10.x/test_execa.js
@@ -16,13 +16,13 @@ execa('ls').then(res => {
 // $ExpectError
 execa('ls').then(res => res.foo);
 
-execa('foo').catch((err: ExecaError) => {
+execa('foo').catch(err => {
   (err.cmd: string);
   (err.code: ?string);
   (err.errno: ?number);
 });
 // $ExpectError
-execa('foo').catch((err: ExecaError) => err.foo);
+execa('foo').catch(err => err.foo);
 
 (execa('ls').pid: number);
 execa('ls').stdout.pipe(process.stdout);
@@ -107,11 +107,4 @@ async () => {
 
 async () => {
   const { stdout } = await execa.shell('ls | wc -l');
-};
-
-async () => {
-  const children: ThenableChildProcess[] = [1, 2, 3].map(x => execa(`echo ${x}`))
-  children.forEach(child => child.stdin.end('unicorns'))
-  const results = await Promise.all(children);
-  (results: Result[])
 };

--- a/definitions/npm/execa_v0.10.x/test_execa.js
+++ b/definitions/npm/execa_v0.10.x/test_execa.js
@@ -16,13 +16,13 @@ execa('ls').then(res => {
 // $ExpectError
 execa('ls').then(res => res.foo);
 
-execa('foo').catch(err => {
+execa('foo').catch((err: ExecaError) => {
   (err.cmd: string);
   (err.code: ?string);
   (err.errno: ?number);
 });
 // $ExpectError
-execa('foo').catch(err => err.foo);
+execa('foo').catch((err: ExecaError) => err.foo);
 
 (execa('ls').pid: number);
 execa('ls').stdout.pipe(process.stdout);
@@ -107,4 +107,11 @@ async () => {
 
 async () => {
   const { stdout } = await execa.shell('ls | wc -l');
+};
+
+async () => {
+  const children: ThenableChildProcess[] = [1, 2, 3].map(x => execa(`echo ${x}`))
+  children.forEach(child => child.stdin.end('unicorns'))
+  const results = await Promise.all(children);
+  (results: Result[])
 };

--- a/definitions/npm/execa_v0.10.x/test_execa.js
+++ b/definitions/npm/execa_v0.10.x/test_execa.js
@@ -108,3 +108,10 @@ async () => {
 async () => {
   const { stdout } = await execa.shell('ls | wc -l');
 };
+
+async () => {
+  const children: ThenableChildProcess[] = [1, 2, 3].map(x => execa(`echo ${x}`))
+  children.forEach(child => child.stdin.end('unicorns'))
+  const results = await Promise.all(children);
+  (results: Result[])
+};


### PR DESCRIPTION
This updates the new execa libdef to make it compatible with `Promise.all()`.

- The first commit was a mistake, and the second commit reverts it.
- The third commit (`eef807d`) adds a failing test case.
- The fourth commit (`27a5373`) fixes it.

The downside is you no longer automatically get the `ExecaError` type when you catch an error, so you have to explicitly type it like `.catch((err: ExecaError) => ...` if you need the typing, or it will be typed as `any`. But I think this is probably more correct anyway, as there's no hard guarantee that anything passed to an execa's `.catch()` will always be the expected error type.

Pinging @jirutka for comment.