### PR TITLE
fix(react-apollo): fix refetchQueries types

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -270,7 +270,7 @@ declare module "react-apollo" {
     context?: any;
   }
 
-  declare type RefetchQueryDescription = Array<string | PureQueryOptions>;
+  declare export type RefetchQueryDescription = $ReadOnlyArray<string | PureQueryOptions>;
 
   declare interface MutationBaseOptions<T = { [key: string]: any }> {
     optimisticResponse?: Object | Function;
@@ -762,12 +762,12 @@ declare module "react-apollo" {
 
   declare export type RefetchQueriesProviderFn = (
     ...args: any[]
-  ) => string[] | PureQueryOptions[];
+  ) => RefetchQueryDescription
 
   declare export type MutationOpts<TVariables> = {|
     variables?: TVariables,
     optimisticResponse?: Object,
-    refetchQueries?: string[] | PureQueryOptions[] | RefetchQueriesProviderFn,
+    refetchQueries?: RefetchQueryDescription | RefetchQueriesProviderFn,
     update?: MutationUpdaterFn<*>,
     errorPolicy?: ErrorPolicy
   |};
@@ -983,7 +983,7 @@ declare module "react-apollo" {
   > = (options: {
     variables?: TVariables,
     optimisticResponse?: Object,
-    refetchQueries?: string[] | PureQueryOptions[] | RefetchQueriesProviderFn,
+    refetchQueries?: RefetchQueryDescription | RefetchQueriesProviderFn,
     update?: MutationUpdaterFn<TData>
   }) => Promise<void | FetchResult<TData>>;
 
@@ -1010,7 +1010,7 @@ declare module "react-apollo" {
     update?: MutationUpdaterFn<TData>,
     ignoreResults?: boolean,
     optimisticResponse?: Object,
-    refetchQueries?: string[] | PureQueryOptions[] | RefetchQueriesProviderFn,
+    refetchQueries?: RefetchQueryDescription | RefetchQueriesProviderFn,
     onCompleted?: (data: TData) => mixed,
     onError?: (error: ApolloError) => mixed,
     context?: { [string]: any }

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
@@ -17,7 +17,8 @@ import {
   type ChildProps,
   type GraphqlData,
   type PureQueryOptions,
-  type SubscriptionResult
+  type SubscriptionResult,
+  type RefetchQueryDescription,
 } from "react-apollo";
 
 const gql = (strings, ...args) => {}; // graphql-tag stub
@@ -593,7 +594,7 @@ describe("<Mutation />", () => {
         query: HERO_QUERY,
         variables: { episode: "episode" }
       };
-      const refetchQueries: PureQueryOptions[] = [queryOption];
+      const refetchQueries: RefetchQueryDescription = [queryOption, 'foo'];
 
       <UpdateHeroMutationComp
         mutation={HERO_MUTATION}


### PR DESCRIPTION
Use `$ReadOnlyArray<string | PureQueryOptions>` rather than `string[] | PureQueryOptions[]`.