### PR TITLE
 Fix random.boolean return type

### DIFF
--- a/definitions/npm/faker_v4.x.x/flow_v0.25.x-/faker_v4.x.x.js
+++ b/definitions/npm/faker_v4.x.x/flow_v0.25.x-/faker_v4.x.x.js
@@ -246,7 +246,7 @@ declare module "faker" {
         field: Key
       ) => Value,
       uuid: () => string,
-      boolean: () => string,
+      boolean: () => boolean,
       word: (type?: string) => string,
       words: (count?: number) => string,
       image: () => string,


### PR DESCRIPTION
The return type for faker.random.boolean() is string. It should be boolean.