### PR TITLE
fix(lodash) type for sortedUniqBy

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -384,7 +384,7 @@ declare module "lodash" {
     sortedUniq<T>(array?: ?Array<T>): Array<T>;
     sortedUniqBy<T>(
       array?: ?Array<T>,
-      iteratee?: ?(value: T) => mixed
+      iteratee?: ?ValueOnlyIteratee<T>
     ): Array<T>;
     tail<T>(array?: ?Array<T>): Array<T>;
     take<T>(array?: ?Array<T>, n?: ?number): Array<T>;
@@ -1884,10 +1884,7 @@ declare module "lodash/fp" {
     sortedLastIndexOf<T>(value: T): (array: Array<T>) => number;
     sortedLastIndexOf<T>(value: T, array: Array<T>): number;
     sortedUniq<T>(array: Array<T>): Array<T>;
-    sortedUniqBy<T>(
-      iteratee: (value: T) => mixed
-    ): (array: Array<T>) => Array<T>;
-    sortedUniqBy<T>(iteratee: (value: T) => mixed, array: Array<T>): Array<T>;
+    sortedUniqBy<T>(iteratee: ValueOnlyIteratee<T>, array: Array<T>): Array<T>;
     tail<T>(array: Array<T>): Array<T>;
     take<T>(n: number): (array: Array<T>) => Array<T>;
     take<T>(n: number, array: Array<T>): Array<T>;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -211,14 +211,24 @@ declare module "lodash" {
     // Array
     chunk<T>(array?: ?Array<T>, size?: ?number): Array<Array<T>>;
     compact<T, N: ?T>(array?: ?Array<N>): Array<T>;
-    concat<T>(base?: ?$ReadOnlyArray<T>, ...elements: Array<any>): Array<T | any>;
-    difference<T>(array?: ?$ReadOnlyArray<T>, ...values: Array<?$ReadOnlyArray<T>>): Array<T>;
+    concat<T>(
+      base?: ?$ReadOnlyArray<T>,
+      ...elements: Array<any>
+    ): Array<T | any>;
+    difference<T>(
+      array?: ?$ReadOnlyArray<T>,
+      ...values: Array<?$ReadOnlyArray<T>>
+    ): Array<T>;
     differenceBy<T>(
       array?: ?$ReadOnlyArray<T>,
       values?: ?$ReadOnlyArray<T>,
       iteratee?: ?ValueOnlyIteratee<T>
     ): T[];
-    differenceWith<T>(array?: ?$ReadOnlyArray<T>, values?: ?$ReadOnlyArray<T>, comparator?: ?Comparator<T>): T[];
+    differenceWith<T>(
+      array?: ?$ReadOnlyArray<T>,
+      values?: ?$ReadOnlyArray<T>,
+      comparator?: ?Comparator<T>
+    ): T[];
     drop<T>(array?: ?Array<T>, n?: ?number): Array<T>;
     dropRight<T>(array?: ?Array<T>, n?: ?number): Array<T>;
     dropRightWhile<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
@@ -235,7 +245,7 @@ declare module "lodash" {
       fromIndex?: ?number
     ): number;
     findIndex<T>(
-      array: void | null,
+      array: void | null,
       predicate?: ?Predicate<T>,
       fromIndex?: ?number
     ): -1;
@@ -252,16 +262,19 @@ declare module "lodash" {
     // alias of _.head
     first<T>(array: ?$ReadOnlyArray<T>): T;
     flatten<T, X>(array?: ?Array<Array<T> | X>): Array<T | X>;
-    flattenDeep<T>(array?: ?any[]): Array<T>;
-    flattenDepth(array?: ?any[], depth?: ?number): any[];
+    flattenDeep<T>(array?: ?(any[])): Array<T>;
+    flattenDepth(array?: ?(any[]), depth?: ?number): any[];
     fromPairs<A, B>(pairs?: ?Array<[A, B]>): { [key: A]: B };
     head<T>(array: ?$ReadOnlyArray<T>): T;
     indexOf<T>(array: Array<T>, value: T, fromIndex?: number): number;
-    indexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
+    indexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
     initial<T>(array: ?Array<T>): Array<T>;
     intersection<T>(...arrays?: Array<$ReadOnlyArray<T>>): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
-    intersectionBy<T>(a1?: ?$ReadOnlyArray<T>, iteratee?: ?ValueOnlyIteratee<T>): Array<T>;
+    intersectionBy<T>(
+      a1?: ?$ReadOnlyArray<T>,
+      iteratee?: ?ValueOnlyIteratee<T>
+    ): Array<T>;
     intersectionBy<T>(
       a1?: ?$ReadOnlyArray<T>,
       a2?: ?$ReadOnlyArray<T>,
@@ -281,7 +294,10 @@ declare module "lodash" {
       iteratee?: ?ValueOnlyIteratee<T>
     ): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
-    intersectionWith<T>(a1?: ?$ReadOnlyArray<T>, comparator?: ?Comparator<T>): Array<T>;
+    intersectionWith<T>(
+      a1?: ?$ReadOnlyArray<T>,
+      comparator?: ?Comparator<T>
+    ): Array<T>;
     intersectionWith<T>(
       a1?: ?$ReadOnlyArray<T>,
       a2?: ?$ReadOnlyArray<T>,
@@ -301,64 +317,75 @@ declare module "lodash" {
       comparator?: ?Comparator<T>
     ): Array<T>;
     join<T>(array: Array<T>, separator?: ?string): string;
-    join<T>(array: void | null, separator?: ?string): '';
+    join<T>(array: void | null, separator?: ?string): "";
     last<T>(array: ?$ReadOnlyArray<T>): T;
     lastIndexOf<T>(array: Array<T>, value?: ?T, fromIndex?: ?number): number;
-    lastIndexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
+    lastIndexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
     nth<T>(array: T[], n?: ?number): T;
-    nth(array: void | null, n?: ?number): void;
+    nth(array: void | null, n?: ?number): void;
     pull<T>(array: Array<T>, ...values?: Array<?T>): Array<T>;
-    pull<T: void | null>(array: T, ...values?: Array<?any>): T;
+    pull<T: void | null>(array: T, ...values?: Array<?any>): T;
     pullAll<T>(array: Array<T>, values?: ?Array<T>): Array<T>;
-    pullAll<T: void | null>(array: T, values?: ?Array<any>): T;
+    pullAll<T: void | null>(array: T, values?: ?Array<any>): T;
     pullAllBy<T>(
       array: Array<T>,
       values?: ?Array<T>,
       iteratee?: ?ValueOnlyIteratee<T>
     ): Array<T>;
-    pullAllBy<T: void | null>(
+    pullAllBy<T: void | null>(
       array: T,
       values?: ?Array<any>,
       iteratee?: ?ValueOnlyIteratee<any>
     ): T;
-    pullAllWith<T>(array: T[], values?: ?T[], comparator?: ?Function): T[];
-    pullAllWith<T: void | null>(array: T, values?: ?Array<any>, comparator?: ?Function): T;
+    pullAllWith<T>(array: T[], values?: ?(T[]), comparator?: ?Function): T[];
+    pullAllWith<T: void | null>(
+      array: T,
+      values?: ?Array<any>,
+      comparator?: ?Function
+    ): T;
     pullAt<T>(array?: ?Array<T>, ...indexed?: Array<?number>): Array<T>;
     pullAt<T>(array?: ?Array<T>, indexed?: ?Array<number>): Array<T>;
     remove<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
     reverse<T>(array: Array<T>): Array<T>;
-    reverse<T: void | null>(array: T): T;
-    slice<T>(array?: ?$ReadOnlyArray<T>, start?: ?number, end?: ?number): Array<T>;
+    reverse<T: void | null>(array: T): T;
+    slice<T>(
+      array?: ?$ReadOnlyArray<T>,
+      start?: ?number,
+      end?: ?number
+    ): Array<T>;
     sortedIndex<T>(array: Array<T>, value: T): number;
-    sortedIndex<T>(array: void | null, value: ?T): 0;
+    sortedIndex<T>(array: void | null, value: ?T): 0;
     sortedIndexBy<T>(
       array: Array<T>,
       value?: ?T,
       iteratee?: ?ValueOnlyIteratee<T>
     ): number;
     sortedIndexBy<T>(
-      array: void | null,
+      array: void | null,
       value?: ?T,
       iteratee?: ?ValueOnlyIteratee<T>
     ): 0;
     sortedIndexOf<T>(array: Array<T>, value: T): number;
-    sortedIndexOf<T>(array: void | null, value?: ?T): -1;
+    sortedIndexOf<T>(array: void | null, value?: ?T): -1;
     sortedLastIndex<T>(array: Array<T>, value: T): number;
-    sortedLastIndex<T>(array: void | null, value?: ?T): 0;
+    sortedLastIndex<T>(array: void | null, value?: ?T): 0;
     sortedLastIndexBy<T>(
       array: Array<T>,
       value: T,
       iteratee?: ValueOnlyIteratee<T>
     ): number;
     sortedLastIndexBy<T>(
-      array: void | null,
+      array: void | null,
       value?: ?T,
       iteratee?: ?ValueOnlyIteratee<T>
     ): 0;
     sortedLastIndexOf<T>(array: Array<T>, value: T): number;
-    sortedLastIndexOf<T>(array: void | null, value?: ?T): -1;
+    sortedLastIndexOf<T>(array: void | null, value?: ?T): -1;
     sortedUniq<T>(array?: ?Array<T>): Array<T>;
-    sortedUniqBy<T>(array?: ?Array<T>, iteratee?: ?(value: T) => mixed): Array<T>;
+    sortedUniqBy<T>(
+      array?: ?Array<T>,
+      iteratee?: ?(value: T) => mixed
+    ): Array<T>;
     tail<T>(array?: ?Array<T>): Array<T>;
     take<T>(array?: ?Array<T>, n?: ?number): Array<T>;
     takeRight<T>(array?: ?Array<T>, n?: ?number): Array<T>;
@@ -366,7 +393,10 @@ declare module "lodash" {
     takeWhile<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
     union<T>(...arrays?: Array<$ReadOnlyArray<T>>): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
-    unionBy<T>(a1?: ?$ReadOnlyArray<T>, iteratee?: ?ValueOnlyIteratee<T>): Array<T>;
+    unionBy<T>(
+      a1?: ?$ReadOnlyArray<T>,
+      iteratee?: ?ValueOnlyIteratee<T>
+    ): Array<T>;
     unionBy<T>(
       a1?: ?$ReadOnlyArray<T>,
       a2: $ReadOnlyArray<T>,
@@ -452,7 +482,7 @@ declare module "lodash" {
       a4: Array<T>,
       comparator?: Comparator<T>
     ): Array<T>;
-    zip<A, B>(a1?: ?A[], a2?: ?B[]): Array<[A, B]>;
+    zip<A, B>(a1?: ?(A[]), a2?: ?(B[])): Array<[A, B]>;
     zip<A, B, C>(a1: A[], a2: B[], a3: C[]): Array<[A, B, C]>;
     zip<A, B, C, D>(a1: A[], a2: B[], a3: C[], a4: D[]): Array<[A, B, C, D]>;
     zip<A, B, C, D, E>(
@@ -464,9 +494,9 @@ declare module "lodash" {
     ): Array<[A, B, C, D, E]>;
 
     zipObject<K, V>(props: Array<K>, values?: ?Array<V>): { [key: K]: V };
-    zipObject<K, V>(props: void | null, values?: ?Array<V>): {};
+    zipObject<K, V>(props: void | null, values?: ?Array<V>): {};
     zipObjectDeep(props: any[], values?: ?any): Object;
-    zipObjectDeep(props: void | null, values?: ?any): {};
+    zipObjectDeep(props: void | null, values?: ?any): {};
 
     zipWith<A>(a1?: ?Array<A>): Array<[A]>;
     zipWith<T, A>(a1: Array<A>, iteratee: (A) => T): Array<T>;
@@ -506,15 +536,15 @@ declare module "lodash" {
 
     // Collection
     countBy<T>(array: Array<T>, iteratee?: ?ValueOnlyIteratee<T>): Object;
-    countBy<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>): {};
+    countBy<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>): {};
     countBy<T: Object>(object: T, iteratee?: ?ValueOnlyIteratee<T>): Object;
     // alias of _.forEach
     each<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
-    each<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    each<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
     each<T: Object>(object: T, iteratee?: ?OIteratee<T>): T;
     // alias of _.forEachRight
     eachRight<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
-    eachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    eachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
     eachRight<T: Object>(object: T, iteratee?: OIteratee<T>): T;
     every<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): boolean;
     every<T: Object>(object: T, iteratee?: OIteratee<T>): boolean;
@@ -529,7 +559,7 @@ declare module "lodash" {
       fromIndex?: ?number
     ): T | void;
     find<T>(
-      array: void | null,
+      array: void | null,
       predicate?: ?Predicate<T>,
       fromIndex?: ?number
     ): void;
@@ -574,25 +604,29 @@ declare module "lodash" {
       depth?: number
     ): Array<U>;
     forEach<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
-    forEach<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    forEach<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
     forEach<T: Object>(object: T, iteratee?: ?OIteratee<T>): T;
-    forEachRight<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
-    forEachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    forEachRight<T>(
+      array: $ReadOnlyArray<T>,
+      iteratee?: ?Iteratee<T>
+    ): Array<T>;
+    forEachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
     forEachRight<T: Object>(object: T, iteratee?: ?OIteratee<T>): T;
     groupBy<V, T>(
       array: $ReadOnlyArray<T>,
       iteratee?: ?ValueOnlyIteratee<T>
     ): { [key: V]: Array<T> };
-    groupBy(
-      array: void | null,
-      iteratee?: ?ValueOnlyIteratee<any>
-    ): {};
+    groupBy(array: void | null, iteratee?: ?ValueOnlyIteratee<any>): {};
     groupBy<V, A, T: { [id: any]: A }>(
       object: T,
       iteratee?: ValueOnlyIteratee<A>
     ): { [key: V]: Array<A> };
-    includes<T>(array: $ReadOnlyArray<T>, value: T, fromIndex?: ?number): boolean;
-    includes<T>(array: void | null, value?: ?T, fromIndex?: ?number): false;
+    includes<T>(
+      array: $ReadOnlyArray<T>,
+      value: T,
+      fromIndex?: ?number
+    ): boolean;
+    includes<T>(array: void | null, value?: ?T, fromIndex?: ?number): false;
     includes<T: Object>(object: T, value: any, fromIndex?: number): boolean;
     includes(str: string, value: string, fromIndex?: number): boolean;
     invokeMap<T>(
@@ -609,10 +643,7 @@ declare module "lodash" {
       array: $ReadOnlyArray<T>,
       iteratee?: ?ValueOnlyIteratee<T>
     ): { [key: V]: T };
-    keyBy(
-      array: void | null,
-      iteratee?: ?ValueOnlyIteratee<*>
-    ): {};
+    keyBy(array: void | null, iteratee?: ?ValueOnlyIteratee<*>): {};
     keyBy<V, A, I, T: { [id: I]: A }>(
       object: T,
       iteratee?: ?ValueOnlyIteratee<A>
@@ -621,7 +652,7 @@ declare module "lodash" {
     map<T, U>(
       array: ?$ReadOnlyArray<T>,
       iteratee?: ReadOnlyMapIterator<T, U>
-    ): Array<U>,
+    ): Array<U>;
     map<V, T: Object, U>(
       object: ?T,
       iteratee?: OMapIterator<V, T, U>
@@ -664,7 +695,7 @@ declare module "lodash" {
       accumulator?: U
     ): U;
     reduce<T, U>(
-      array: void | null,
+      array: void | null,
       iteratee?: ?(
         accumulator: U,
         value: T,
@@ -672,14 +703,14 @@ declare module "lodash" {
         array: ?Array<T>
       ) => U,
       accumulator?: ?U
-    ): void | null;
+    ): void | null;
     reduce<T: Object, U>(
       object: T,
       iteratee?: (accumulator: U, value: any, key: string, object: T) => U,
       accumulator?: U
     ): U;
     reduceRight<T, U>(
-      array: void | null,
+      array: void | null,
       iteratee?: ?(
         accumulator: U,
         value: T,
@@ -687,7 +718,7 @@ declare module "lodash" {
         array: ?Array<T>
       ) => U,
       accumulator?: ?U
-    ): void | null;
+    ): void | null;
     reduceRight<T, U>(
       array: $ReadOnlyArray<T>,
       iteratee?: ?(
@@ -716,7 +747,7 @@ declare module "lodash" {
     shuffle<V, T: Object>(object: T): Array<V>;
     size(collection: $ReadOnlyArray<any> | Object | string): number;
     some<T>(array: ?$ReadOnlyArray<T>, predicate?: Predicate<T>): boolean;
-    some<T>(array: void | null, predicate?: ?Predicate<T>): false;
+    some<T>(array: void | null, predicate?: ?Predicate<T>): false;
     some<A, T: { [id: any]: A }>(
       object?: ?T,
       predicate?: OPredicate<A, T>
@@ -793,15 +824,15 @@ declare module "lodash" {
     eq(value: any, other: any): boolean;
     gt(value: any, other: any): boolean;
     gte(value: any, other: any): boolean;
-    isArguments(value: void | null): false;
+    isArguments(value: void | null): false;
     isArguments(value: any): boolean;
     isArray(value: Array<any>): true;
     isArray(value: any): false;
     isArrayBuffer(value: ArrayBuffer): true;
     isArrayBuffer(value: any): false;
-    isArrayLike(value: Array<any> | string | {length: number}): true;
+    isArrayLike(value: Array<any> | string | { length: number }): true;
     isArrayLike(value: any): false;
-    isArrayLikeObject(value: {length: number} | Array<any>): true;
+    isArrayLikeObject(value: { length: number } | Array<any>): true;
     isArrayLikeObject(value: any): false;
     isBoolean(value: boolean): true;
     isBoolean(value: any): false;
@@ -811,7 +842,7 @@ declare module "lodash" {
     isDate(value: any): false;
     isElement(value: Element): true;
     isElement(value: any): false;
-    isEmpty(value: void | null | '' | {} | [] | number | boolean): true;
+    isEmpty(value: void | null | "" | {} | [] | number | boolean): true;
     isEmpty(value: any): boolean;
     isEqual(value: any, other: any): boolean;
     isEqualWith<T, U>(
@@ -834,7 +865,7 @@ declare module "lodash" {
     isFunction(value: any): false;
     isInteger(value: number): boolean;
     isInteger(value: any): false;
-    isLength(value: void | null): false;
+    isLength(value: void | null): false;
     isLength(value: any): boolean;
     isMap(value: Map<any, any>): true;
     isMap(value: any): false;
@@ -852,9 +883,9 @@ declare module "lodash" {
     ): boolean;
     isNaN(value: number): boolean;
     isNaN(value: any): false;
-    isNative(value: number | string | void | null | Object): false;
+    isNative(value: number | string | void | null | Object): false;
     isNative(value: any): boolean;
-    isNil(value: void | null): true;
+    isNil(value: void | null): true;
     isNil(value: any): false;
     isNull(value: null): true;
     isNull(value: any): false;
@@ -862,7 +893,7 @@ declare module "lodash" {
     isNumber(value: any): false;
     isObject(value: Object): true;
     isObject(value: any): false;
-    isObjectLike(value: void | null): false;
+    isObjectLike(value: void | null): false;
     isObjectLike(value: any): boolean;
     isPlainObject(value: Object): true;
     isPlainObject(value: any): false;
@@ -887,18 +918,18 @@ declare module "lodash" {
     lt(value: any, other: any): boolean;
     lte(value: any, other: any): boolean;
     toArray(value: any): Array<any>;
-    toFinite(value: void | null): 0;
+    toFinite(value: void | null): 0;
     toFinite(value: any): number;
-    toInteger(value: void | null): 0;
+    toInteger(value: void | null): 0;
     toInteger(value: any): number;
-    toLength(value: void | null): 0;
+    toLength(value: void | null): 0;
     toLength(value: any): number;
-    toNumber(value: void | null): 0;
+    toNumber(value: void | null): 0;
     toNumber(value: any): number;
     toPlainObject(value: any): Object;
-    toSafeInteger(value: void | null): 0;
+    toSafeInteger(value: void | null): 0;
     toSafeInteger(value: any): number;
-    toString(value: void | null): '';
+    toString(value: void | null): "";
     toString(value: any): string;
 
     // Math
@@ -1036,7 +1067,7 @@ declare module "lodash" {
     at(object?: ?Object, ...paths: Array<string>): Array<any>;
     at(object?: ?Object, paths: Array<string>): Array<any>;
     create<T>(prototype: T, properties: Object): $Supertype<T>;
-    create(prototype: any, properties: void | null): {};
+    create(prototype: any, properties: void | null): {};
     defaults(object?: ?Object, ...sources?: Array<?Object>): Object;
     defaultsDeep(object?: ?Object, ...sources?: Array<?Object>): Object;
     // alias for _.toPairs
@@ -1104,7 +1135,7 @@ declare module "lodash" {
       predicate?: ?OPredicate<A, T>
     ): string | void;
     findKey<A, T: { [id: any]: A }>(
-      object: void | null,
+      object: void | null,
       predicate?: ?OPredicate<A, T>
     ): void;
     findLastKey<A, T: { [id: any]: A }>(
@@ -1112,17 +1143,17 @@ declare module "lodash" {
       predicate?: ?OPredicate<A, T>
     ): string | void;
     findLastKey<A, T: { [id: any]: A }>(
-      object: void | null,
+      object: void | null,
       predicate?: ?OPredicate<A, T>
     ): void;
     forIn(object: Object, iteratee?: ?OIteratee<*>): Object;
-    forIn(object: void | null, iteratee?: ?OIteratee<*>): null;
+    forIn(object: void | null, iteratee?: ?OIteratee<*>): null;
     forInRight(object: Object, iteratee?: ?OIteratee<*>): Object;
-    forInRight(object: void | null, iteratee?: ?OIteratee<*>): null;
+    forInRight(object: void | null, iteratee?: ?OIteratee<*>): null;
     forOwn(object: Object, iteratee?: ?OIteratee<*>): Object;
-    forOwn(object: void | null, iteratee?: ?OIteratee<*>): null;
+    forOwn(object: void | null, iteratee?: ?OIteratee<*>): null;
     forOwnRight(object: Object, iteratee?: ?OIteratee<*>): Object;
-    forOwnRight(object: void | null, iteratee?: ?OIteratee<*>): null;
+    forOwnRight(object: void | null, iteratee?: ?OIteratee<*>): null;
     functions(object?: ?Object): Array<string>;
     functionsIn(object?: ?Object): Array<string>;
     get(
@@ -1131,15 +1162,15 @@ declare module "lodash" {
       defaultValue?: any
     ): any;
     has(object: Object, path: Array<string> | string): boolean;
-    has(object: Object, path: void | null): false;
+    has(object: Object, path: void | null): false;
     has(object: void | null, path?: ?Array<string> | ?string): false;
     hasIn(object: Object, path: Array<string> | string): boolean;
-    hasIn(object: Object, path: void | null): false;
+    hasIn(object: Object, path: void | null): false;
     hasIn(object: void | null, path?: ?Array<string> | ?string): false;
     invert(object: Object, multiVal?: ?boolean): Object;
-    invert(object: void | null, multiVal?: ?boolean): {};
+    invert(object: void | null, multiVal?: ?boolean): {};
     invertBy(object: Object, iteratee?: ?Function): Object;
-    invertBy(object: void | null, iteratee?: ?Function): {};
+    invertBy(object: void | null, iteratee?: ?Function): {};
     invoke(
       object?: ?Object,
       path?: ?Array<string> | string,
@@ -1149,9 +1180,9 @@ declare module "lodash" {
     keys(object?: ?Object): Array<string>;
     keysIn(object?: ?Object): Array<string>;
     mapKeys(object: Object, iteratee?: ?OIteratee<*>): Object;
-    mapKeys(object: void | null, iteratee?: ?OIteratee<*>): {};
+    mapKeys(object: void | null, iteratee?: ?OIteratee<*>): {};
     mapValues(object: Object, iteratee?: ?OIteratee<*>): Object;
-    mapValues(object: void | null, iteratee?: ?OIteratee<*>): {};
+    mapValues(object: void | null, iteratee?: ?OIteratee<*>): {};
     merge(object?: ?Object, ...sources?: Array<?Object>): Object;
     mergeWith(): {};
     mergeWith<T: Object, A: Object>(
@@ -1205,41 +1236,36 @@ declare module "lodash" {
     ): Object;
     omit(object?: ?Object, ...props: Array<string>): Object;
     omit(object?: ?Object, props: Array<string>): Object;
-    omitBy<A, T: { [id: any]: A }|{ [id: number]: A }>(
+    omitBy<A, T: { [id: any]: A } | { [id: number]: A }>(
       object: T,
       predicate?: ?OPredicate<A, T>
     ): Object;
-    omitBy<A, T>(
-      object: void | null,
-      predicate?: ?OPredicate<A, T>
-    ): {};
+    omitBy<A, T>(object: void | null, predicate?: ?OPredicate<A, T>): {};
     pick(object?: ?Object, ...props: Array<string>): Object;
     pick(object?: ?Object, props: Array<string>): Object;
-    pickBy<A, T: { [id: any]: A }|{ [id: number]: A }>(
+    pickBy<A, T: { [id: any]: A } | { [id: number]: A }>(
       object: T,
       predicate?: ?OPredicate<A, T>
     ): Object;
-    pickBy<A, T>(
-      object: void | null,
-      predicate?: ?OPredicate<A, T>
-    ): {};
+    pickBy<A, T>(object: void | null, predicate?: ?OPredicate<A, T>): {};
     result(
       object?: ?Object,
       path?: ?Array<string> | string,
       defaultValue?: any
     ): any;
     set(object: Object, path?: ?Array<string> | string, value: any): Object;
-    set<T: void | null>(
+    set<T: void | null>(
       object: T,
       path?: ?Array<string> | string,
-      value?: ?any): T;
+      value?: ?any
+    ): T;
     setWith<T>(
       object: T,
       path?: ?Array<string> | string,
       value: any,
       customizer?: (nsValue: any, key: string, nsObject: T) => any
     ): Object;
-    setWith<T: void | null>(
+    setWith<T: void | null>(
       object: T,
       path?: ?Array<string> | string,
       value?: ?any,
@@ -1253,26 +1279,27 @@ declare module "lodash" {
       accumulator?: any
     ): any;
     transform(
-      collection: void | null,
+      collection: void | null,
       iteratee?: ?OIteratee<*>,
       accumulator?: ?any
     ): {};
     unset(object: Object, path?: ?Array<string> | ?string): boolean;
-    unset(object: void | null, path?: ?Array<string> | ?string): true;
+    unset(object: void | null, path?: ?Array<string> | ?string): true;
     update(object: Object, path: string[] | string, updater: Function): Object;
-    update<T: void | null>(
+    update<T: void | null>(
       object: T,
-      path?: ?string[] | ?string,
-      updater?: ?Function): T;
+      path?: ?(string[]) | ?string,
+      updater?: ?Function
+    ): T;
     updateWith(
       object: Object,
-      path?: ?string[] | ?string,
+      path?: ?(string[]) | ?string,
       updater?: ?Function,
       customizer?: ?Function
     ): Object;
-    updateWith<T: void | null>(
+    updateWith<T: void | null>(
       object: T,
-      path?: ?string[] | ?string,
+      path?: ?(string[]) | ?string,
       updater?: ?Function,
       customizer?: ?Function
     ): T;
@@ -1289,75 +1316,79 @@ declare module "lodash" {
 
     // String
     camelCase(string: string): string;
-    camelCase(string: void | null): '';
+    camelCase(string: void | null): "";
     capitalize(string: string): string;
-    capitalize(string: void | null): '';
+    capitalize(string: void | null): "";
     deburr(string: string): string;
-    deburr(string: void | null): '';
+    deburr(string: void | null): "";
     endsWith(string: string, target?: string, position?: ?number): boolean;
-    endsWith(string: void | null, target?: ?string, position?: ?number): false;
+    endsWith(string: void | null, target?: ?string, position?: ?number): false;
     escape(string: string): string;
-    escape(string: void | null): '';
+    escape(string: void | null): "";
     escapeRegExp(string: string): string;
-    escapeRegExp(string: void | null): '';
+    escapeRegExp(string: void | null): "";
     kebabCase(string: string): string;
-    kebabCase(string: void | null): '';
+    kebabCase(string: void | null): "";
     lowerCase(string: string): string;
-    lowerCase(string: void | null): '';
+    lowerCase(string: void | null): "";
     lowerFirst(string: string): string;
-    lowerFirst(string: void | null): '';
+    lowerFirst(string: void | null): "";
     pad(string?: ?string, length?: ?number, chars?: ?string): string;
     padEnd(string?: ?string, length?: ?number, chars?: ?string): string;
     padStart(string?: ?string, length?: ?number, chars?: ?string): string;
     parseInt(string: string, radix?: ?number): number;
     repeat(string: string, n?: ?number): string;
-    repeat(string: void | null, n?: ?number): '';
+    repeat(string: void | null, n?: ?number): "";
     replace(
       string: string,
       pattern: RegExp | string,
       replacement: ((string: string) => string) | string
     ): string;
     replace(
-      string: void | null,
+      string: void | null,
       pattern?: ?RegExp | ?string,
       replacement: ?((string: string) => string) | ?string
-    ): '';
+    ): "";
     snakeCase(string: string): string;
-    snakeCase(string: void | null): '';
+    snakeCase(string: void | null): "";
     split(
       string?: ?string,
       separator?: ?RegExp | ?string,
       limit?: ?number
     ): Array<string>;
     startCase(string: string): string;
-    startCase(string: void | null): '';
+    startCase(string: void | null): "";
     startsWith(string: string, target?: string, position?: number): boolean;
-    startsWith(string: void | null, target?: ?string, position?: ?number): false;
+    startsWith(
+      string: void | null,
+      target?: ?string,
+      position?: ?number
+    ): false;
     template(string?: ?string, options?: ?TemplateSettings): Function;
     toLower(string: string): string;
-    toLower(string: void | null): '';
+    toLower(string: void | null): "";
     toUpper(string: string): string;
-    toUpper(string: void | null): '';
+    toUpper(string: void | null): "";
     trim(string: string, chars?: string): string;
-    trim(string: void | null, chars?: ?string): '';
+    trim(string: void | null, chars?: ?string): "";
     trimEnd(string: string, chars?: ?string): string;
-    trimEnd(string: void | null, chars?: ?string): '';
+    trimEnd(string: void | null, chars?: ?string): "";
     trimStart(string: string, chars?: ?string): string;
-    trimStart(string: void | null, chars?: ?string): '';
+    trimStart(string: void | null, chars?: ?string): "";
     truncate(string: string, options?: TruncateOptions): string;
-    truncate(string: void | null, options?: ?TruncateOptions): '';
+    truncate(string: void | null, options?: ?TruncateOptions): "";
     unescape(string: string): string;
-    unescape(string: void | null): '';
+    unescape(string: void | null): "";
     upperCase(string: string): string;
-    upperCase(string: void | null): '';
+    upperCase(string: void | null): "";
     upperFirst(string: string): string;
-    upperFirst(string: void | null): '';
+    upperFirst(string: void | null): "";
     words(string?: ?string, pattern?: ?RegExp | ?string): Array<string>;
 
     // Util
     attempt(func: Function, ...args: Array<any>): any;
     bindAll(object: Object, methodNames?: ?Array<string>): Object;
-    bindAll<T: void | null>(object: T, methodNames?: ?Array<string>): T;
+    bindAll<T: void | null>(object: T, methodNames?: ?Array<string>): T;
     bindAll(object: Object, ...methodNames: Array<string>): Object;
     cond(pairs?: ?NestedArray<Function>): Function;
     conforms(source?: ?Object): Function;
@@ -1369,8 +1400,8 @@ declare module "lodash" {
     // NaN is a number instead of its own type, otherwise it would behave like null/void
     defaultTo<T1: number, T2>(value: T1, defaultValue: T2): T1 | T2;
     defaultTo<T1: void | null, T2>(value: T1, defaultValue: T2): T2;
-    flow: ($ComposeReverse & (funcs: Array<Function>) => Function);
-    flowRight: ($Compose & (funcs: Array<Function>) => Function);
+    flow: $ComposeReverse & ((funcs: Array<Function>) => Function);
+    flowRight: $Compose & ((funcs: Array<Function>) => Function);
     identity<T>(value: T): T;
     iteratee(func?: any): Function;
     matches(source?: ?Object): Function;
@@ -1404,7 +1435,7 @@ declare module "lodash" {
     stubObject(): {};
     stubString(): "";
     stubTrue(): true;
-    times(n?: ?number, ...rest?: Array<void | null>): Array<number>;
+    times(n?: ?number, ...rest?: Array<void | null>): Array<number>;
     times<T>(n: number, iteratee: (i: number) => T): Array<T>;
     toPath(value: any): Array<string>;
     uniqueId(prefix?: ?string): string;
@@ -1641,12 +1672,12 @@ declare module "lodash/fp" {
       array: $ReadOnlyArray<T>
     ): T[];
     differenceWith<T>(
-      comparator: Comparator<T>,
+      comparator: Comparator<T>
     ): ((first: $ReadOnly<T>) => (second: $ReadOnly<T>) => T[]) &
       ((first: $ReadOnly<T>, second: $ReadOnly<T>) => T[]);
     differenceWith<T>(
       comparator: Comparator<T>,
-      first: $ReadOnly<T>,
+      first: $ReadOnly<T>
     ): (second: $ReadOnly<T>) => T[];
     differenceWith<T>(
       comparator: Comparator<T>,
@@ -2289,15 +2320,17 @@ declare module "lodash/fp" {
       collection: $ReadOnlyArray<T> | { [id: any]: T }
     ): boolean;
     sortBy<T>(
-      iteratees: | $ReadOnlyArray<Iteratee<T> | OIteratee<T>>
-      | Iteratee<T>
-      | OIteratee<T>
+      iteratees:
+        | $ReadOnlyArray<Iteratee<T> | OIteratee<T>>
+        | Iteratee<T>
+        | OIteratee<T>
     ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => Array<T>;
     sortBy<T>(
-      iteratees: | $ReadOnlyArray<Iteratee<T> | OIteratee<T>>
-      | Iteratee<T>
-      | OIteratee<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T },
+      iteratees:
+        | $ReadOnlyArray<Iteratee<T> | OIteratee<T>>
+        | Iteratee<T>
+        | OIteratee<T>,
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
     ): Array<T>;
 
     // Date
@@ -2764,8 +2797,13 @@ declare module "lodash/fp" {
     forOwnRight(iteratee: OIteratee<*>, object: Object): Object;
     functions(object: Object): Array<string>;
     functionsIn(object: Object): Array<string>;
-    get(path: $ReadOnlyArray<string | number> | string | number): (object: Object | $ReadOnlyArray<any> | void | null) => any;
-    get(path: $ReadOnlyArray<string | number> | string | number, object: Object | $ReadOnlyArray<any> | void | null): any;
+    get(
+      path: $ReadOnlyArray<string | number> | string | number
+    ): (object: Object | $ReadOnlyArray<any> | void | null) => any;
+    get(
+      path: $ReadOnlyArray<string | number> | string | number,
+      object: Object | $ReadOnlyArray<any> | void | null
+    ): any;
     prop(path: Array<string> | string): (object: Object | Array<any>) => any;
     prop(path: Array<string> | string, object: Object | Array<any>): any;
     path(path: Array<string> | string): (object: Object | Array<any>) => any;
@@ -2775,7 +2813,10 @@ declare module "lodash/fp" {
     ): ((
       path: Array<string> | string
     ) => (object: Object | Array<any>) => any) &
-      ((path: Array<string> | string, object: Object | $ReadOnlyArray<any> | void | null) => any);
+      ((
+        path: Array<string> | string,
+        object: Object | $ReadOnlyArray<any> | void | null
+      ) => any);
     getOr(
       defaultValue: any,
       path: Array<string> | string
@@ -3128,10 +3169,10 @@ declare module "lodash/fp" {
     defaultTo<T1: number, T2>(defaultValue: T2, value: T1): T1 | T2;
     defaultTo<T1: void | null, T2>(defaultValue: T2): (value: T1) => T2;
     defaultTo<T1: void | null, T2>(defaultValue: T2, value: T1): T2;
-    flow: ($ComposeReverse & (funcs: Array<Function>) => Function);
-    pipe: ($ComposeReverse & (funcs: Array<Function>) => Function);
-    flowRight: ($Compose & (funcs: Array<Function>) => Function);
-    compose: ($Compose & (funcs: Array<Function>) => Function);
+    flow: $ComposeReverse & ((funcs: Array<Function>) => Function);
+    pipe: $ComposeReverse & ((funcs: Array<Function>) => Function);
+    flowRight: $Compose & ((funcs: Array<Function>) => Function);
+    compose: $Compose & ((funcs: Array<Function>) => Function);
     compose(funcs: Array<Function>): Function;
     identity<T>(value: T): T;
     iteratee(func: any): Function;
@@ -4472,7 +4513,10 @@ declare module "lodash/fp/differenceBy" {
 }
 
 declare module "lodash/fp/differenceWith" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "differenceWith">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "differenceWith"
+  >;
 }
 
 declare module "lodash/fp/drop" {
@@ -4488,7 +4532,10 @@ declare module "lodash/fp/dropRight" {
 }
 
 declare module "lodash/fp/dropRightWhile" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "dropRightWhile">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "dropRightWhile"
+  >;
 }
 
 declare module "lodash/fp/dropWhile" {
@@ -4516,7 +4563,10 @@ declare module "lodash/fp/findLastIndex" {
 }
 
 declare module "lodash/fp/findLastIndexFrom" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findLastIndexFrom">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "findLastIndexFrom"
+  >;
 }
 
 declare module "lodash/fp/first" {
@@ -4568,11 +4618,17 @@ declare module "lodash/fp/intersection" {
 }
 
 declare module "lodash/fp/intersectionBy" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "intersectionBy">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "intersectionBy"
+  >;
 }
 
 declare module "lodash/fp/intersectionWith" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "intersectionWith">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "intersectionWith"
+  >;
 }
 
 declare module "lodash/fp/join" {
@@ -4588,7 +4644,10 @@ declare module "lodash/fp/lastIndexOf" {
 }
 
 declare module "lodash/fp/lastIndexOfFrom" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "lastIndexOfFrom">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "lastIndexOfFrom"
+  >;
 }
 
 declare module "lodash/fp/nth" {
@@ -4640,15 +4699,24 @@ declare module "lodash/fp/sortedIndexOf" {
 }
 
 declare module "lodash/fp/sortedLastIndex" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortedLastIndex">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "sortedLastIndex"
+  >;
 }
 
 declare module "lodash/fp/sortedLastIndexBy" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortedLastIndexBy">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "sortedLastIndexBy"
+  >;
 }
 
 declare module "lodash/fp/sortedLastIndexOf" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortedLastIndexOf">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "sortedLastIndexOf"
+  >;
 }
 
 declare module "lodash/fp/sortedUniq" {
@@ -4676,7 +4744,10 @@ declare module "lodash/fp/takeLast" {
 }
 
 declare module "lodash/fp/takeRightWhile" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "takeRightWhile">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "takeRightWhile"
+  >;
 }
 
 declare module "lodash/fp/takeLastWhile" {
@@ -4728,7 +4799,10 @@ declare module "lodash/fp/xor" {
 }
 
 declare module "lodash/fp/symmetricDifference" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "symmetricDifference">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "symmetricDifference"
+  >;
 }
 
 declare module "lodash/fp/xorBy" {
@@ -4736,7 +4810,10 @@ declare module "lodash/fp/xorBy" {
 }
 
 declare module "lodash/fp/symmetricDifferenceBy" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "symmetricDifferenceBy">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "symmetricDifferenceBy"
+  >;
 }
 
 declare module "lodash/fp/xorWith" {
@@ -4744,7 +4821,10 @@ declare module "lodash/fp/xorWith" {
 }
 
 declare module "lodash/fp/symmetricDifferenceWith" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "symmetricDifferenceWith">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "symmetricDifferenceWith"
+  >;
 }
 
 declare module "lodash/fp/zip" {
@@ -5116,7 +5196,10 @@ declare module "lodash/fp/isArrayLike" {
 }
 
 declare module "lodash/fp/isArrayLikeObject" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isArrayLikeObject">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "isArrayLikeObject"
+  >;
 }
 
 declare module "lodash/fp/isBoolean" {
@@ -5396,7 +5479,10 @@ declare module "lodash/fp/assignWith" {
 }
 
 declare module "lodash/fp/assignInAllWith" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assignInAllWith">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "assignInAllWith"
+  >;
 }
 
 declare module "lodash/fp/extendAllWith" {
@@ -5436,7 +5522,10 @@ declare module "lodash/fp/defaultsDeep" {
 }
 
 declare module "lodash/fp/defaultsDeepAll" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "defaultsDeepAll">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "defaultsDeepAll"
+  >;
 }
 
 declare module "lodash/fp/entries" {
@@ -5784,7 +5873,10 @@ declare module "lodash/fp/trimStart" {
 }
 
 declare module "lodash/fp/trimCharsStart" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "trimCharsStart">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "trimCharsStart"
+  >;
 }
 
 declare module "lodash/fp/truncate" {
@@ -5860,7 +5952,10 @@ declare module "lodash/fp/matches" {
 }
 
 declare module "lodash/fp/matchesProperty" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "matchesProperty">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "matchesProperty"
+  >;
 }
 
 declare module "lodash/fp/propEq" {
@@ -5940,7 +6035,10 @@ declare module "lodash/fp/rangeRight" {
 }
 
 declare module "lodash/fp/rangeStepRight" {
-  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "rangeStepRight">;
+  declare module.exports: $PropertyType<
+    $Exports<"lodash/fp">,
+    "rangeStepRight"
+  >;
 }
 
 declare module "lodash/fp/runInContext" {

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-fp-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-fp-v4.x.x.js
@@ -4,6 +4,8 @@ import assignIn from "lodash/fp/assignIn";
 import extend from "lodash/fp/extend";
 import sortedLastIndexBy from "lodash/fp/sortedLastIndexBy";
 import sortedIndexBy from "lodash/fp/sortedIndexBy";
+import sortedUniq from "lodash/fp/sortedUniq";
+import sortedUniqBy from "lodash/fp/sortedUniqBy";
 import range from "lodash/fp/range";
 import isEqual from "lodash/fp/isEqual";
 import clone from "lodash/fp/clone";
@@ -285,6 +287,18 @@ sortedLastIndexBy(
   [{ x: 4 }, { x: 5 }]
 );
 sortedLastIndexBy("x", { x: 4 }, [{ x: 4 }, { x: 5 }]);
+
+/**
+ * sortedUniq
+ */
+sortedUniq([1, 1, 2]);
+sortedUniq(["a", "b", "b"]);
+
+/**
+ * sortedUniqBy
+ */
+sortedUniqBy(Math.floor, [1.2, 2.1, 2.3]);
+sortedUniqBy("x", [{ x: 1 }, { x: 1 }, { x: 2 }]);
 
 /**
  * extend

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-fp-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-fp-v4.x.x.js
@@ -1,74 +1,72 @@
 // @flow
 
-import assignIn from 'lodash/fp/assignIn';
-import extend from 'lodash/fp/extend';
-import sortedLastIndexBy from 'lodash/fp/sortedLastIndexBy';
-import sortedIndexBy from 'lodash/fp/sortedIndexBy';
-import range from 'lodash/fp/range';
-import isEqual from 'lodash/fp/isEqual';
-import clone from 'lodash/fp/clone';
-import uniqBy from 'lodash/fp/uniqBy';
-import unionBy from 'lodash/fp/unionBy';
-import pullAllBy from 'lodash/fp/pullAllBy';
-import map from 'lodash/fp/map';
-import keyBy from 'lodash/fp/keyBy';
-import getOr from 'lodash/fp/getOr';
-import get from 'lodash/fp/get';
-import intersectionBy from 'lodash/fp/intersectionBy';
-import groupBy from 'lodash/fp/groupBy';
-import findFrom from 'lodash/fp/findFrom';
-import find from 'lodash/fp/find';
-import differenceBy from 'lodash/fp/differenceBy';
-import countBy from 'lodash/fp/countBy';
-import attempt from 'lodash/fp/attempt';
-import filter from 'lodash/fp/filter';
-import xorBy from 'lodash/fp/xorBy';
-import zip from 'lodash/fp/zip';
-import isString from 'lodash/fp/isString';
-import concat from 'lodash/fp/concat';
-import first from 'lodash/fp/first';
-import conformsTo from 'lodash/fp/conformsTo';
-import defaultTo from 'lodash/fp/defaultTo';
-import tap from 'lodash/fp/tap';
-import thru from 'lodash/fp/thru';
-import times from 'lodash/fp/times';
-import flatMap from 'lodash/fp/flatMap';
-import noop from 'lodash/fp/noop';
-import pipe from 'lodash/fp/pipe';
-import compose from 'lodash/fp/compose';
-import includes from 'lodash/fp/includes';
+import assignIn from "lodash/fp/assignIn";
+import extend from "lodash/fp/extend";
+import sortedLastIndexBy from "lodash/fp/sortedLastIndexBy";
+import sortedIndexBy from "lodash/fp/sortedIndexBy";
+import range from "lodash/fp/range";
+import isEqual from "lodash/fp/isEqual";
+import clone from "lodash/fp/clone";
+import uniqBy from "lodash/fp/uniqBy";
+import unionBy from "lodash/fp/unionBy";
+import pullAllBy from "lodash/fp/pullAllBy";
+import map from "lodash/fp/map";
+import keyBy from "lodash/fp/keyBy";
+import getOr from "lodash/fp/getOr";
+import get from "lodash/fp/get";
+import intersectionBy from "lodash/fp/intersectionBy";
+import groupBy from "lodash/fp/groupBy";
+import findFrom from "lodash/fp/findFrom";
+import find from "lodash/fp/find";
+import differenceBy from "lodash/fp/differenceBy";
+import countBy from "lodash/fp/countBy";
+import attempt from "lodash/fp/attempt";
+import filter from "lodash/fp/filter";
+import xorBy from "lodash/fp/xorBy";
+import zip from "lodash/fp/zip";
+import isString from "lodash/fp/isString";
+import concat from "lodash/fp/concat";
+import first from "lodash/fp/first";
+import conformsTo from "lodash/fp/conformsTo";
+import defaultTo from "lodash/fp/defaultTo";
+import tap from "lodash/fp/tap";
+import thru from "lodash/fp/thru";
+import times from "lodash/fp/times";
+import flatMap from "lodash/fp/flatMap";
+import noop from "lodash/fp/noop";
+import pipe from "lodash/fp/pipe";
+import compose from "lodash/fp/compose";
+import includes from "lodash/fp/includes";
 
-filter('x', [{x: 1}, {x: 2}]);
-filter('x')([{x: 1}, {x: 2}]);
-filter('x', {a: {x: 1}, b: {x: 2}});
-filter('x')({a: {x: 1}, b: {x: 2}});
-filter((v: {y?: number}) => v.y)({a: {x: 1}, b: {x: 2}})[0].x;
+filter("x", [{ x: 1 }, { x: 2 }]);
+filter("x")([{ x: 1 }, { x: 2 }]);
+filter("x", { a: { x: 1 }, b: { x: 2 } });
+filter("x")({ a: { x: 1 }, b: { x: 2 } });
+filter((v: { y?: number }) => v.y)({ a: { x: 1 }, b: { x: 2 } })[0].x;
 // $ExpectError
-filter((v: {y: number}) => v.y)({a: {x: 1}, b: {x: 2}});
+filter((v: { y: number }) => v.y)({ a: { x: 1 }, b: { x: 2 } });
 
 /**
  * attempt
  */
-attempt(() => void 0)
-attempt(x => x)
-attempt((x, y, z) => {})
+attempt(() => void 0);
+attempt(x => x);
+attempt((x, y, z) => {});
 
 /**
  * countBy
  */
 countBy(Math.floor, [6.1, 4.2, 6.3]);
-countBy('length', ['one', 'two', 'three']);
-countBy('length')(['one', 'two', 'three']);
-countBy('length')({one: 'one', two: 'two', three: 'three'});
-
+countBy("length", ["one", "two", "three"]);
+countBy("length")(["one", "two", "three"]);
+countBy("length")({ one: "one", two: "two", three: "three" });
 
 /**
  * differenceBy
  */
 differenceBy(Math.floor, ([2.1, 1.2]: $ReadOnlyArray<*>), [2.3, 3.4]);
-differenceBy('x', [{ 'x': 2 }, { 'x': 1 }], [{ 'x': 1 }]);
-differenceBy('x')([{ 'x': 2 }, { 'x': 1 }], [{ 'x': 1 }]);
-
+differenceBy("x", [{ x: 2 }, { x: 1 }], [{ x: 1 }]);
+differenceBy("x")([{ x: 2 }, { x: 1 }], [{ x: 1 }]);
 
 /**
  * find
@@ -76,127 +74,130 @@ differenceBy('x')([{ 'x': 2 }, { 'x': 1 }], [{ 'x': 1 }]);
 find(x => x * 1 == 3, [1, 2, 3]);
 findFrom(x => x == 2, 1, [1, 2, 3]);
 // $ExpectError number cannot be compared to string
-find(x => x == 'a', [1, 2, 3]);
+find(x => x == "a", [1, 2, 3]);
 // $ExpectError number. This type is incompatible with function type.
 find(1, [1, 2, 3]);
 // $ExpectError property `y`. Property not found in object literal
-find(v => v.y == 3, [{x:1}, {x:2}, {x:3}]);
-find(v => v.x == 3, [{x:1}, {x:2}, {x:3}]);
-find((a: number, b: string) => a, {x: 1, y: 2});
-find({ x: 3 }, {x: 1, y: 2});
-find({ x: 3 })({x: 1, y: 2});
+find(v => v.y == 3, [{ x: 1 }, { x: 2 }, { x: 3 }]);
+find(v => v.x == 3, [{ x: 1 }, { x: 2 }, { x: 3 }]);
+find((a: number, b: string) => a, { x: 1, y: 2 });
+find({ x: 3 }, { x: 1, y: 2 });
+find({ x: 3 })({ x: 1, y: 2 });
 
 // $ExpectError undefined. This type is incompatible with object type.
-var result: Object = find('active', users);
+var result: Object = find("active", users);
 
 /**
  * find examples from the official doc
  */
 var users = [
-  { 'user': 'barney',  'age': 36, 'active': true },
-  { 'user': 'fred',    'age': 40, 'active': false },
-  { 'user': 'pebbles', 'age': 1,  'active': true }
+  { user: "barney", age: 36, active: true },
+  { user: "fred", age: 40, active: false },
+  { user: "pebbles", age: 1, active: true }
 ];
 
-find(function(o) { return o.age < 40; }, users);
+find(function(o) {
+  return o.age < 40;
+}, users);
 
 // The `matches` iteratee shorthand.
-find({ 'age': 1, 'active': true }, users);
+find({ age: 1, active: true }, users);
 
 // The `matchesProperty` iteratee shorthand.
-find(['active', false], users);
+find(["active", false], users);
 
 // The `property` iteratee shorthand.
-find('active', users);
-
+find("active", users);
 
 /**
  * groupBy
  */
 var numbersGroupedByMathFloor = groupBy(Math.floor, [6.1, 4.2, 6.3]);
 if (numbersGroupedByMathFloor[6]) {
-  numbersGroupedByMathFloor[6][0] / numbersGroupedByMathFloor[6][1]
+  numbersGroupedByMathFloor[6][0] / numbersGroupedByMathFloor[6][1];
 }
-var stringsGroupedByLength = groupBy('length', ['one', 'two', 'three']);
+var stringsGroupedByLength = groupBy("length", ["one", "two", "three"]);
 if (stringsGroupedByLength[3]) {
   stringsGroupedByLength[3][0].toLowerCase();
 }
-var numbersObj: {[key: string]: number} = {a: 6.1, b: 4.2, c: 6.3};
+var numbersObj: { [key: string]: number } = { a: 6.1, b: 4.2, c: 6.3 };
 var numbersGroupedByMathFloor2 = groupBy(Math.floor, numbersObj);
 if (numbersGroupedByMathFloor2[6]) {
-  numbersGroupedByMathFloor2[6][0] / numbersGroupedByMathFloor2[6][1]
+  numbersGroupedByMathFloor2[6][0] / numbersGroupedByMathFloor2[6][1];
 }
-var stringObj: {[key: string]: string} = {a: 'one', b: 'two', c: 'three'};
-var stringsGroupedByLength2 = groupBy('length', stringObj);
+var stringObj: { [key: string]: string } = { a: "one", b: "two", c: "three" };
+var stringsGroupedByLength2 = groupBy("length", stringObj);
 if (stringsGroupedByLength2[3]) {
   stringsGroupedByLength2[3][0].toLowerCase();
 }
-
 
 /**
  * intersectionBy
  */
 intersectionBy(Math.floor, [2.1, 1.2], [2.3, 3.4]);
-intersectionBy('x', [{ 'x': 1 }], [{ 'x': 2 }, { 'x': 1 }]);
-
+intersectionBy("x", [{ x: 1 }], [{ x: 2 }, { x: 1 }]);
 
 /**
  * get
  */
 
 // Object — examples from lodash docs
-var exampleObjectForGetTest = { 'a': [{ 'b': { 'c': 3 } }] };
-get('a[0].b.c', exampleObjectForGetTest);
-get(['a', '0', 'b', 'c'], exampleObjectForGetTest);
-getOr('default', 'a.b.c', exampleObjectForGetTest);
+var exampleObjectForGetTest = { a: [{ b: { c: 3 } }] };
+get("a[0].b.c", exampleObjectForGetTest);
+get(["a", "0", "b", "c"], exampleObjectForGetTest);
+getOr("default", "a.b.c", exampleObjectForGetTest);
 
 // Array — not documented, but get does support arrays
-get('0', [1, 2, 3]);
+get("0", [1, 2, 3]);
 get(0, [1, 2, 3]);
 get([0], [1, 2, 3]);
-get('[1]', ['foo', 'bar', 'baz']);
-get('2', [{ a: 'foo' }, { b: 'bar' }, { c: 'baz' }]);
-get('3', [[1, 2], [3, 4], [5, 6], [7, 8]]);
-get('3')([[1, 2], [3, 4], [5, 6], [7, 8]]);
+get("[1]", ["foo", "bar", "baz"]);
+get("2", [{ a: "foo" }, { b: "bar" }, { c: "baz" }]);
+get("3", [[1, 2], [3, 4], [5, 6], [7, 8]]);
+get("3")([[1, 2], [3, 4], [5, 6], [7, 8]]);
 
 // Nil - it is safe to perform on nil root values, just like nil values along the "get" path
-get('thing', null);
-get('data', undefined);
-getOr('default', 'stuff', null);
-getOr(12345, 'info', undefined);
+get("thing", null);
+get("data", undefined);
+getOr("default", "stuff", null);
+getOr(12345, "info", undefined);
 
 /**
  * keyBy
  */
-keyBy(function(o) {
-  return String.fromCharCode(o.code);
-}, [
-  { 'dir': 'left', 'code': 97 },
-  { 'dir': 'right', 'code': 100 }
-]);
-keyBy('dir', [
-  { 'dir': 'left', 'code': 97 },
-  { 'dir': 'right', 'code': 100 }
-]);
-keyBy('dir')(([
-  { 'dir': 'left', 'code': 97 },
-  { 'dir': 'right', 'code': 100 }
-]: $ReadOnlyArray<*>));
+keyBy(
+  function(o) {
+    return String.fromCharCode(o.code);
+  },
+  [{ dir: "left", code: 97 }, { dir: "right", code: 100 }]
+);
+keyBy("dir", [{ dir: "left", code: 97 }, { dir: "right", code: 100 }]);
+keyBy("dir")(
+  ([{ dir: "left", code: 97 }, { dir: "right", code: 100 }]: $ReadOnlyArray<*>)
+);
 
 // Example of keying a map of objects by a number type
-type KeyByTest$ByNumber<T: Object> = { [number]: T }
-type KeyByTest$ByNumberMaybe<T: ?Object> = { [number]: T }
-type KeyByTest$Record = { id: number }
-var keyByTest_array: Array<KeyByTest$Record> = [{ id: 4 }, { id: 4 }, { id: 7 }]
+type KeyByTest$ByNumber<T: Object> = { [number]: T };
+type KeyByTest$ByNumberMaybe<T: ?Object> = { [number]: T };
+type KeyByTest$Record = { id: number };
+var keyByTest_array: Array<KeyByTest$Record> = [
+  { id: 4 },
+  { id: 4 },
+  { id: 7 }
+];
 var keyByTest_map: KeyByTest$ByNumber<KeyByTest$Record> = {
   [keyByTest_array[0].id]: keyByTest_array[0],
   [keyByTest_array[1].id]: keyByTest_array[1],
-  [keyByTest_array[2].id]: keyByTest_array[2],
-}
+  [keyByTest_array[2].id]: keyByTest_array[2]
+};
 
-var keyByTest_map2: KeyByTest$ByNumberMaybe<KeyByTest$Record> = keyBy('id', keyByTest_map)
-var keyByTest_map3: KeyByTest$ByNumberMaybe<KeyByTest$Record> = keyBy('id')(keyByTest_map)
-
+var keyByTest_map2: KeyByTest$ByNumberMaybe<KeyByTest$Record> = keyBy(
+  "id",
+  keyByTest_map
+);
+var keyByTest_map3: KeyByTest$ByNumberMaybe<KeyByTest$Record> = keyBy("id")(
+  keyByTest_map
+);
 
 /**
  * map examples from the official doc
@@ -206,118 +207,118 @@ function square(n) {
 }
 
 map(square, [4, 8]);
-map(square, { 'a': 4, 'b': 8 });
+map(square, { a: 4, b: 8 });
 
-var users = [
-  { 'user': 'barney' },
-  { 'user': 'fred' }
-];
+var users = [{ user: "barney" }, { user: "fred" }];
 
 // The `property` iteratee shorthand.
-map('user', users);
-
+map("user", users);
 
 /**
  * pullAllBy
  */
-pullAllBy('x', [{ 'x': 1 }, { 'x': 3 }], [{ 'x': 1 }, { 'x': 2 }, { 'x': 3 }, { 'x': 1 }]);
-pullAllBy('x')([{ 'x': 1 }, { 'x': 3 }])([{ 'x': 1 }, { 'x': 2 }, { 'x': 3 }, { 'x': 1 }]);
-
+pullAllBy("x", [{ x: 1 }, { x: 3 }], [{ x: 1 }, { x: 2 }, { x: 3 }, { x: 1 }]);
+pullAllBy("x")([{ x: 1 }, { x: 3 }])([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 1 }]);
 
 /**
  * unionBy
  */
 unionBy(Math.floor, [2.1], [1.2, 2.3]);
-unionBy('x', [{ 'x': 1 }], [{ 'x': 2 }, { 'x': 1 }]);
-
+unionBy("x", [{ x: 1 }], [{ x: 2 }, { x: 1 }]);
 
 /**
  * uniqBy
  */
 uniqBy(Math.floor, [2.1, 1.2, 2.3]);
-uniqBy('x', [{ 'x': 1 }, { 'x': 2 }, { 'x': 1 }]);
-
+uniqBy("x", [{ x: 1 }, { x: 2 }, { x: 1 }]);
 
 /**
  * clone
  */
-clone({a: 1}).a == 1;
+clone({ a: 1 }).a == 1;
 // $ExpectError property `b`. Property not found in object literal
-clone({a: 1}).b == 1
+clone({ a: 1 }).b == 1;
 // $ExpectError number. This type is incompatible with function type.
-clone({a: 1}).a == 'c';
+clone({ a: 1 }).a == "c";
 
 /**
  * isEqual
  */
-isEqual('a', 'b');
-isEqual({x: 1}, {y: 2});
-isEqual({x: 1})({y: 2});
+isEqual("a", "b");
+isEqual({ x: 1 }, { y: 2 });
+isEqual({ x: 1 })({ y: 2 });
 
 // $ExpectError function type expects no more than 2 arguments
 isEqual(1, 2, 3);
 
-
 /**
  * range
  */
-range(0, 10)[4] == 4
-range(0)(10)[4] == 4
+range(0, 10)[4] == 4;
+range(0)(10)[4] == 4;
 // $ExpectError string. This type is incompatible with number
-range(0, 'a');
+range(0, "a");
 // $ExpectError string cannot be compared to number
-range(0, 10)[4] == 'a';
-
+range(0, 10)[4] == "a";
 
 /**
  * sortedIndexBy
  */
-sortedIndexBy(function(o) { return o.x; }, { 'x': 4 }, [{ 'x': 4 }, { 'x': 5 }]);
-sortedIndexBy('x', { 'x': 4 }, [{ 'x': 4 }, { 'x': 5 }]);
-sortedIndexBy('x')({ 'x': 4 }, [{ 'x': 4 }, { 'x': 5 }]);
-
+sortedIndexBy(
+  function(o) {
+    return o.x;
+  },
+  { x: 4 },
+  [{ x: 4 }, { x: 5 }]
+);
+sortedIndexBy("x", { x: 4 }, [{ x: 4 }, { x: 5 }]);
+sortedIndexBy("x")({ x: 4 }, [{ x: 4 }, { x: 5 }]);
 
 /**
  * sortedLastIndexBy
  */
-sortedLastIndexBy(function(o) { return o.x; }, { 'x': 4 }, [{ 'x': 4 }, { 'x': 5 }]);
-sortedLastIndexBy('x', { 'x': 4 }, [{ 'x': 4 }, { 'x': 5 }]);
+sortedLastIndexBy(
+  function(o) {
+    return o.x;
+  },
+  { x: 4 },
+  [{ x: 4 }, { x: 5 }]
+);
+sortedLastIndexBy("x", { x: 4 }, [{ x: 4 }, { x: 5 }]);
 
 /**
  * extend
  */
-extend({a: 1}, {b: 2}).a
-extend({a: 1})({b: 2}).a
-extend({a: 1}, {b: 2}).b
+extend({ a: 1 }, { b: 2 }).a;
+extend({ a: 1 })({ b: 2 }).a;
+extend({ a: 1 }, { b: 2 }).b;
 // $ExpectError property `c`. Property not found in object literal
-extend({a: 1}, {b: 2}).c
+extend({ a: 1 }, { b: 2 }).c;
 // $ExpectError property `c`. Poperty not found in object literal
-assignIn({a: 1}, {b: 2}).c
+assignIn({ a: 1 }, { b: 2 }).c;
 // $ExpectError property `c`. Poperty not found in object literal
-assignIn({a: 1})({b: 2}).c
-
+assignIn({ a: 1 })({ b: 2 }).c;
 
 /**
  * xorBy
  */
 xorBy(Math.floor, [2.1, 1.2], [2.3, 3.4]);
-xorBy('x', [{ 'x': 1 }], [{ 'x': 2 }, { 'x': 1 }]);
-
+xorBy("x", [{ x: 1 }], [{ x: 2 }, { x: 1 }]);
 
 /**
  * zip
  */
-zip(['a', 'b', 'c'], ['d', 'e', 'f'])[0].length;
-zip(['a', 'b', 'c'], [1, 2, 3])[0].length;
-zip(['a', 'b', 'c'], [1, 2, 3])[0][0] + 'a'
-zip(['a', 'b', 'c'], [1, 2, 3])[0][1] * 10
+zip(["a", "b", "c"], ["d", "e", "f"])[0].length;
+zip(["a", "b", "c"], [1, 2, 3])[0].length;
+zip(["a", "b", "c"], [1, 2, 3])[0][0] + "a";
+zip(["a", "b", "c"], [1, 2, 3])[0][1] * 10;
 // $ExpectError `x` property not found in Array
-zip([{x:1}], [{x:2,y:1}])[0].x
+zip([{ x: 1 }], [{ x: 2, y: 1 }])[0].x;
 // $ExpectError `y` property not found in object literal
-zip([{x:1}], [{x:2,y:1}])[0][0].y
-zip([{x:1}], [{x:2,y:1}])[0][1].y
+zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][0].y;
+zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][1].y;
 // $ExpectError Flow could potentially catch this -- the tuple only has two elements.
-zip([{x:1}], [{x:2,y:1}])[0][2]
+zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][2];
 
 /**
  * isString
@@ -326,19 +327,20 @@ zip([{x:1}], [{x:2,y:1}])[0][2]
 var boolTrue: true;
 var boolFalse: false;
 
-boolTrue  = isString('foo');
-boolFalse = isString(['']);
+boolTrue = isString("foo");
+boolFalse = isString([""]);
 boolFalse = isString({});
 boolFalse = isString(5);
-boolFalse = isString(function(f) { return f });
+boolFalse = isString(function(f) {
+  return f;
+});
 boolFalse = isString();
 boolFalse = isString(true);
 
 // $ExpectError
-boolFalse = isString('');
+boolFalse = isString("");
 // $ExpectError
 boolTrue = isString(undefined);
-
 
 /**
  * find
@@ -347,29 +349,28 @@ find(x => x == 1, [1, 2, 3]);
 // $ExpectError number. This type is incompatible with function type.
 find(1, [1, 2, 3]);
 
-
 // Copy pasted tests from iflow-lodash
-var nums : number[] = [1,2,3,4,5,6];
-var num : number;
-var string : string;
-var bool : bool;
+var nums: number[] = [1, 2, 3, 4, 5, 6];
+var num: number;
+var string: string;
+var bool: boolean;
 
-var nativeSquares : number[];
-var directSquares : number[];
+var nativeSquares: number[];
+var directSquares: number[];
 
-var nativeStrings : string[];
-var directStrings : string[];
+var nativeStrings: string[];
+var directStrings: string[];
 
-var allNums : number[];
-var numsAndStrList : Array<number|string>;
-var mixedList : Array<mixed>;
+var allNums: number[];
+var numsAndStrList: Array<number | string>;
+var mixedList: Array<mixed>;
 allNums = concat(nums, nums);
-numsAndStrList = concat(nums, '123');
-numsAndStrList = concat(nums)('123');
-numsAndStrList = concat(nums)(['123']);
-numsAndStrList = concat(nums, ['123', '456']);
-numsAndStrList = concat(nums, [1,2,3, '456']);
-mixedList = concat(nums, [[1,2,3], '456']);
+numsAndStrList = concat(nums, "123");
+numsAndStrList = concat(nums)("123");
+numsAndStrList = concat(nums)(["123"]);
+numsAndStrList = concat(nums, ["123", "456"]);
+numsAndStrList = concat(nums, [1, 2, 3, "456"]);
+mixedList = concat(nums, [[1, 2, 3], "456"]);
 (concat(1, 2): number[]);
 (concat(1, [2]): number[]);
 (concat([1], [2]): number[]);
@@ -393,53 +394,72 @@ directStrings = map(function(num) {
   return JSON.stringify(num);
 }, nums);
 
-var obj = {a:1, b:2};
-bool = conformsTo({
-  a: function(x:number) {
-    return true;
+var obj = { a: 1, b: 2 };
+bool = conformsTo(
+  {
+    a: function(x: number) {
+      return true;
+    }
   },
-}, obj);
+  obj
+);
 
 num = defaultTo(2, undefined);
-string = defaultTo('str', undefined);
-bool = defaultTo('str', true);
-string = defaultTo(true, 'str');
+string = defaultTo("str", undefined);
+bool = defaultTo("str", true);
+string = defaultTo(true, "str");
 
-num = tap(function(n) { return false; }, 1);
-bool = thru(function(n) { return false; }, 1);
+num = tap(function(n) {
+  return false;
+}, 1);
+bool = thru(function(n) {
+  return false;
+}, 1);
 
 var timesNums: number[];
 
 timesNums = times((i: number) => i, 5);
 timesNums = times((i: number) => i)(5);
 // $ExpectError string. This type is incompatible with number
-var strings : string[] = times((i) => i, 5);
-timesNums = times(function(i: number) { return i + 1; }, 5);
+var strings: string[] = times(i => i, 5);
+timesNums = times(function(i: number) {
+  return i + 1;
+}, 5);
 // $ExpectError string. This type is incompatible with number
-timesNums = times(function(i: number) { return JSON.stringify(i); }, 5);
+timesNums = times(function(i: number) {
+  return JSON.stringify(i);
+}, 5);
 
 // lodash.flatMap for collections and objects
 // this arrow function needs a type annotation due to a bug in flow
 // https://github.com/facebook/flow/issues/1948
 flatMap((n): number[] => [n, n], [1, 2, 3]);
-flatMap(n => [n, n], {a: 1, b: 2});
+flatMap(n => [n, n], { a: 1, b: 2 });
 
 /**
  * noop
  */
 noop();
 noop(1);
-noop('a', 2, [], null);
-(noop: (string) => void);
+noop("a", 2, [], null);
+(noop: string => void);
 (noop: (number, string) => void);
 // $ExpectError functions are contravariant in return types
-(noop: (string) => string);
+(noop: string => string);
 
 const ab = (a: number) => `${a}`;
-const bc = (b: string) => ({b});
-const cd = (c: {b: string}) => [c.b];
-const pipedResult: string[] = pipe(ab, bc, cd)(1);
-const composedResult: string[] = compose(cd, bc, ab)(1);
+const bc = (b: string) => ({ b });
+const cd = (c: { b: string }) => [c.b];
+const pipedResult: string[] = pipe(
+  ab,
+  bc,
+  cd
+)(1);
+const composedResult: string[] = compose(
+  cd,
+  bc,
+  ab
+)(1);
 
 /**
  * includes

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -30,6 +30,8 @@ import pullAllBy from "lodash/pullAllBy";
 import range from "lodash/range";
 import sortedIndexBy from "lodash/sortedIndexBy";
 import sortedLastIndexBy from "lodash/sortedLastIndexBy";
+import sortedUniq from "lodash/sortedUniq";
+import sortedUniqBy from "lodash/sortedUniqBy";
 import tap from "lodash/tap";
 import thru from "lodash/thru";
 import times from "lodash/times";
@@ -299,6 +301,18 @@ sortedLastIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, function(o) {
   return o.x;
 });
 sortedLastIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, "x");
+
+/**
+ * _.sortedUniq
+ */
+sortedUniq([1, 2, 2]);
+sortedUniq(["a", "b", "b"]);
+
+/**
+ * _.sortedUniqBy
+ */
+sortedUniqBy([1.2, 2.1, 2.3], Math.floor);
+sortedUniqBy([{ x: 1 }, { x: 1 }, { x: 2 }], "x");
 
 /**
  * _.extend


### PR DESCRIPTION
Just made minor changes shown below, but I get a huge diff due to eol and don't understand why. Editorconfig says ```end_of_line = lf``` and file is LF. Any ideas on how to fix that?

```
git diff -w
diff --git a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
index 4010684..b01fb61 100644
--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -358,7 +358,7 @@ declare module "lodash" {
     sortedLastIndexOf<T>(array: Array<T>, value: T): number;
     sortedLastIndexOf<T>(array: void | null, value?: ?T): -1;
     sortedUniq<T>(array?: ?Array<T>): Array<T>;
-    sortedUniqBy<T>(array?: ?Array<T>, iteratee?: ?(value: T) => mixed): Array<T>;
+    sortedUniqBy<T>(array?: ?Array<T>, iteratee?: ?ValueOnlyIteratee<T>): Array<T>;
     tail<T>(array?: ?Array<T>): Array<T>;
     take<T>(array?: ?Array<T>, n?: ?number): Array<T>;
     takeRight<T>(array?: ?Array<T>, n?: ?number): Array<T>;
@@ -1853,10 +1853,7 @@ declare module "lodash/fp" {
     sortedLastIndexOf<T>(value: T): (array: Array<T>) => number;
     sortedLastIndexOf<T>(value: T, array: Array<T>): number;
     sortedUniq<T>(array: Array<T>): Array<T>;
-    sortedUniqBy<T>(
-      iteratee: (value: T) => mixed
-    ): (array: Array<T>) => Array<T>;
-    sortedUniqBy<T>(iteratee: (value: T) => mixed, array: Array<T>): Array<T>;
+    sortedUniqBy<T>(iteratee: ValueOnlyIteratee<T>, array: Array<T>): Array<T>;
     tail<T>(array: Array<T>): Array<T>;
     take<T>(n: number): (array: Array<T>) => Array<T>;
     take<T>(n: number, array: Array<T>): Array<T>;
```