### PR TITLE
Move creation of .flow-bins-cache to earlier in test cycle

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -492,10 +492,6 @@ async function runTestGroup(
     );
   }
 
-  if (!(await fs.exists(BIN_DIR))) {
-    await fs.mkdir(BIN_DIR);
-  }
-
   try {
     await fs.mkdir(testDirPath);
 
@@ -681,6 +677,10 @@ export function setup(yargs: Yargs) {
 }
 
 export async function run(argv: Args): Promise<number> {
+  if (!(await fs.exists(BIN_DIR))) {
+    await fs.mkdir(BIN_DIR);
+  }
+
   if (!isInFlowTypedRepo()) {
     console.log(
       'This command only works in a clone of flowtype/flow-typed. ' +


### PR DESCRIPTION
Before this commit, the folder was created in runTestGroup (if it did
not exist before). However, it was accessed before that, making the
tests crash if the folder was not manually created.

This commit moves the creation to the first thing in the test run.

This is only a problem when you check out and run the build the first time, but it took me a while to figure out what was wrong.

I'm using OSX, maybe the folder creation works differently on other platforms.