### PR TITLE
Update @storybook/react_v3.x.x libdef

### DIFF
--- a/definitions/npm/@storybook/react_v3.x.x/flow_v0.28.x-/react_v3.x.x.js
+++ b/definitions/npm/@storybook/react_v3.x.x/flow_v0.28.x-/react_v3.x.x.js
@@ -1,13 +1,14 @@
 type NodeModule = typeof module;
 
 declare module '@storybook/react' {
-  declare type Renderable = React$Element<any>;
-  declare type RenderFunction = () => Renderable;
+  declare type Renderable = React$Node;
+  declare type RenderFunction = (context: Context) => Renderable;
+  declare type Context = { kind: string, story: string };
 
   declare type StoryDecorator = (
     story: RenderFunction,
-    context: { kind: string, story: string }
-  ) => Renderable | null;
+    context: Context
+  ) => Renderable;
 
   declare interface Story {
     add(storyName: string, callback: RenderFunction): Story,
@@ -29,6 +30,7 @@ declare module '@storybook/react' {
   declare function setAddon(addon: Object): void;
   declare function storiesOf(name: string, module: NodeModule): Story;
   declare function storiesOf<T>(name: string, module: NodeModule): Story & T;
+  declare function forceReRender(): void;
 
   declare function getStorybook(): Array<StoryBucket>;
 }

--- a/definitions/npm/@storybook/react_v3.x.x/test_react_v3.x.x.js
+++ b/definitions/npm/@storybook/react_v3.x.x/test_react_v3.x.x.js
@@ -6,6 +6,13 @@ storiesOf('div', module)
   .add('empty', () => (
     <div />
   ))
+  .add('unwrapping arguments', ({ kind, story }) => (
+    <div>{kind} {story}</div>
+  ))
+  // $ExpectError
+  .add('unwrapping too many arguments', ({ kind, story, foo }) => (
+    <div>{kind} {story} {foo}</div>
+  ))
   // $ExpectError
   .add(123, () => (
     <div />


### PR DESCRIPTION
Downloading the libdefs made my current project crash because it lacked two things:

1. The exported `forceReRender` function
2. A first argument to the `.add`-method of the Story interface.

I've added these.