### PR TITLE
Fix concatMap optional parameters

### DIFF
--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -898,7 +898,7 @@ declare module "rxjs/operators" {
     ): rxjs$Observable<T> => rxjs$Observable<U>;
     concatMap<+T, U, V>(
       f: (value: T, index: number) => rxjs$ObservableInput<U>,
-      resultSelector: (
+      resultSelector?: (
         outerValue: T,
         innerValue: U,
         outerIndex: number,


### PR DESCRIPTION
Apologies if this is incorrect but I thought I'd have a go at it myself rather than drop another issue into the mix.

Makes concatMap's resultSelector param optional as per http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-concatMap