### PR TITLE
Fix Bluebird.all for flow 0.76+

### DIFF
--- a/definitions/npm/bluebird_v3.x.x/flow_v0.70.x-/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.70.x-/bluebird_v3.x.x.js
@@ -54,8 +54,8 @@ declare class Bluebird$Promise<+R> extends Promise<R> {
   static Defer: Class<Bluebird$Defer>;
   static PromiseInspection: Class<Bluebird$PromiseInspection<*>>;
 
-  static all<T, Elem: $Promisable<T>>(
-    Promises: Iterable<Elem> | $Promisable<Iterable<Elem>>
+  static all<T>(
+    Promises: $Promisable<Iterable<$Promisable<T>>>
   ): Bluebird$Promise<Array<T>>;
   static props(
     input: Object | Map<*, *> | $Promisable<Object | Map<*, *>>


### PR DESCRIPTION
Similar to https://github.com/flow-typed/flow-typed/pull/2509, but will be actively trying to get the travis checks to pass.

This solves an issue with stricter rules on generics introduced in flow 0.76.

Bigger question: Is there any reason why the arg for Bluebird.all is typed as `T | $Promisable<T>` instead of `$Promisable<T>` since `$Promisable` is already a type alias for `Promise<T> | T`?