### PR TITLE
react-redux: Make leaked types less likely to conflict with user types

### DIFF
--- a/definitions/npm/react-redux_v5.x.x/flow_v0.30.x-v0.52.x/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.30.x-v0.52.x/react-redux_v5.x.x.js
@@ -1,4 +1,4 @@
-import type { Dispatch, Store } from "redux";
+import type { Dispatch as redux$Dispatch, Store as redux$Store } from "redux";
 
 declare module "react-redux" {
   /*
@@ -17,7 +17,7 @@ declare module "react-redux" {
   ) => ((state: S, ownProps: OP) => SP) | SP;
 
   declare type MapDispatchToProps<A, OP: Object, DP: Object> =
-    | ((dispatch: Dispatch<A>, ownProps: OP) => DP)
+    | ((dispatch: redux$Dispatch<A>, ownProps: OP) => DP)
     | DP;
 
   declare type MergeProps<SP, DP: Object, OP: Object, P: Object> = (
@@ -26,7 +26,7 @@ declare module "react-redux" {
     ownProps: OP
   ) => P;
 
-  declare type Context = { store: Store<*, *> };
+  declare type Context = { store: redux$Store<*, *> };
 
   declare type StatelessComponent<P> = (
     props: P,
@@ -60,7 +60,7 @@ declare module "react-redux" {
 
   declare class Provider<S, A> extends React$Component<
     void,
-    { store: Store<S, A>, children?: any },
+    { store: redux$Store<S, A>, children?: any },
     void
   > {}
 
@@ -73,21 +73,21 @@ declare module "react-redux" {
 
   declare function connect<A, OP>(
     ...rest: Array<void> // <= workaround for https://github.com/facebook/flow/issues/2360
-  ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
+  ): Connector<OP, $Supertype<{ dispatch: redux$Dispatch<A> } & OP>>;
 
   declare function connect<A, OP>(
     mapStateToProps: Null,
     mapDispatchToProps: Null,
     mergeProps: Null,
     options: ConnectOptions
-  ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
+  ): Connector<OP, $Supertype<{ dispatch: redux$Dispatch<A> } & OP>>;
 
   declare function connect<S, A, OP, SP>(
     mapStateToProps: MapStateToProps<S, OP, SP>,
     mapDispatchToProps: Null,
     mergeProps: Null,
     options?: ConnectOptions
-  ): Connector<OP, $Supertype<SP & { dispatch: Dispatch<A> } & OP>>;
+  ): Connector<OP, $Supertype<SP & { dispatch: redux$Dispatch<A> } & OP>>;
 
   declare function connect<A, OP, DP>(
     mapStateToProps: Null,

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.53.x-v0.53.x/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.53.x-v0.53.x/react-redux_v5.x.x.js
@@ -1,7 +1,4 @@
-// flow-typed signature: 8db7b853f57c51094bf0ab8b2650fd9c
-// flow-typed version: ab8db5f14d/react-redux_v5.x.x/flow_>=v0.30.x
-
-import type { Dispatch, Store } from "redux";
+import type { Dispatch as redux$Dispatch, Store as redux$Store } from "redux";
 
 declare module "react-redux" {
   /*
@@ -20,7 +17,7 @@ declare module "react-redux" {
   ) => ((state: S, ownProps: OP) => SP) | SP;
 
   declare type MapDispatchToProps<A, OP: Object, DP: Object> =
-    | ((dispatch: Dispatch<A>, ownProps: OP) => DP)
+    | ((dispatch: redux$Dispatch<A>, ownProps: OP) => DP)
     | DP;
 
   declare type MergeProps<SP, DP: Object, OP: Object, P: Object> = (
@@ -29,7 +26,7 @@ declare module "react-redux" {
     ownProps: OP
   ) => P;
 
-  declare type Context = { store: Store<*, *> };
+  declare type Context = { store: redux$Store<*, *> };
 
   declare class ConnectedComponent<OP, P> extends React$Component<OP> {
     static WrappedComponent: Class<React$Component<P>>,
@@ -47,7 +44,7 @@ declare module "react-redux" {
   ) => ConnectedComponentClass<OP, P>;
 
   declare class Provider<S, A> extends React$Component<{
-    store: Store<S, A>,
+    store: redux$Store<S, A>,
     children?: any
   }> {}
 
@@ -65,21 +62,21 @@ declare module "react-redux" {
 
   declare function connect<A, OP>(
     ...rest: Array<void> // <= workaround for https://github.com/facebook/flow/issues/2360
-  ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
+  ): Connector<OP, $Supertype<{ dispatch: redux$Dispatch<A> } & OP>>;
 
   declare function connect<A, OP>(
     mapStateToProps: Null,
     mapDispatchToProps: Null,
     mergeProps: Null,
     options: ConnectOptions
-  ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
+  ): Connector<OP, $Supertype<{ dispatch: redux$Dispatch<A> } & OP>>;
 
   declare function connect<S, A, OP, SP>(
     mapStateToProps: MapStateToProps<S, OP, SP>,
     mapDispatchToProps: Null,
     mergeProps: Null,
     options?: ConnectOptions
-  ): Connector<OP, $Supertype<SP & { dispatch: Dispatch<A> } & OP>>;
+  ): Connector<OP, $Supertype<SP & { dispatch: redux$Dispatch<A> } & OP>>;
 
   declare function connect<A, OP, DP>(
     mapStateToProps: Null,

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.54.x-v0.62.x/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.54.x-v0.62.x/react-redux_v5.x.x.js
@@ -1,4 +1,4 @@
-import type { Dispatch, Store } from "redux";
+import type { Dispatch as redux$Dispatch, Store as redux$Store } from "redux";
 
 declare module "react-redux" {
   /*
@@ -17,7 +17,7 @@ declare module "react-redux" {
   ) => ((state: S, ownProps: OP) => SP) | SP;
 
   declare type MapDispatchToProps<A, OP: Object, DP: Object> =
-    | ((dispatch: Dispatch<A>, ownProps: OP) => DP)
+    | ((dispatch: redux$Dispatch<A>, ownProps: OP) => DP)
     | DP;
 
   declare type MergeProps<SP, DP: Object, OP: Object, P: Object> = (
@@ -26,7 +26,7 @@ declare module "react-redux" {
     ownProps: OP
   ) => P;
 
-  declare type Context = { store: Store<*, *> };
+  declare type Context = { store: redux$Store<*, *> };
 
   declare type ComponentWithDefaultProps<DP: {}, P: {}, CP: P> = Class<
     React$Component<CP>
@@ -65,7 +65,7 @@ declare module "react-redux" {
     ((component: React$ComponentType<P>) => ConnectedComponentClass<OP, P>);
 
   declare class Provider<S, A> extends React$Component<{
-    store: Store<S, A>,
+    store: redux$Store<S, A>,
     children?: any
   }> {}
 
@@ -83,21 +83,21 @@ declare module "react-redux" {
 
   declare function connect<A, OP>(
     ...rest: Array<void> // <= workaround for https://github.com/facebook/flow/issues/2360
-  ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
+  ): Connector<OP, $Supertype<{ dispatch: redux$Dispatch<A> } & OP>>;
 
   declare function connect<A, OP>(
     mapStateToProps: Null,
     mapDispatchToProps: Null,
     mergeProps: Null,
     options: ConnectOptions
-  ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
+  ): Connector<OP, $Supertype<{ dispatch: redux$Dispatch<A> } & OP>>;
 
   declare function connect<S, A, OP, SP>(
     mapStateToProps: MapStateToProps<S, OP, SP>,
     mapDispatchToProps: Null,
     mergeProps: Null,
     options?: ConnectOptions
-  ): Connector<OP, $Supertype<SP & { dispatch: Dispatch<A> } & OP>>;
+  ): Connector<OP, $Supertype<SP & { dispatch: redux$Dispatch<A> } & OP>>;
 
   declare function connect<A, OP, DP>(
     mapStateToProps: Null,

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.63.0-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.63.0-/react-redux_v5.x.x.js
@@ -1,10 +1,10 @@
-import type { Dispatch, Store } from "redux";
+import type { Dispatch as redux$Dispatch, Store as redux$Store } from "redux";
 
 declare module "react-redux" {
   import type { ComponentType, ElementConfig } from 'react';
 
   declare export class Provider<S, A> extends React$Component<{
-    store: Store<S, A>,
+    store: redux$Store<S, A>,
     children?: any
   }> {}
 
@@ -32,7 +32,7 @@ declare module "react-redux" {
 
   declare type MapStateToProps<S: Object, SP: Object, RSP: Object> = (state: S, props: SP) => RSP;
 
-  declare type MapDispatchToProps<A, OP: Object, RDP: Object> = (dispatch: Dispatch<A>, ownProps: OP) => RDP;
+  declare type MapDispatchToProps<A, OP: Object, RDP: Object> = (dispatch: redux$Dispatch<A>, ownProps: OP) => RDP;
 
   declare type MergeProps<SP: Object, DP: Object, MP: Object, RMP: Object> = (
     stateProps: SP,
@@ -50,7 +50,7 @@ declare module "react-redux" {
     storeKey?: string
   |};
 
-  declare type OmitDispatch<Component> = $Diff<Component, {dispatch: Dispatch<*>}>;
+  declare type OmitDispatch<Component> = $Diff<Component, {dispatch: redux$Dispatch<*>}>;
 
   declare export function connect<
     Com: ComponentType<*>,


### PR DESCRIPTION
These are leaking global `Store` and `Dispatch` types currently and ("Store" at least) is a pretty common type name in the Nuclide code base. As a result, if we forget to import our `Store` type, we get this libdef's `any`-typed Store. This makes the names a little more esoteric so that they're less likely to conflict.

Originally, I had tried to just move the imports into the declaration block but that caused errors because redux couldn't be found.