### PR TITLE
(lodash_v4.x.x) Add cancel/flush methods to debounced (by debounce and throttle)

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.28.x-v0.37.x/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.28.x-v0.37.x/lodash_v4.x.x.js
@@ -472,7 +472,7 @@ declare module "lodash" {
       func: Function,
       wait?: number,
       options?: DebounceOptions
-    ): Function;
+    ): Function & {cancel: () => void, flush: () => void};
     defer(func: Function, ...args?: Array<any>): number;
     delay(func: Function, wait: number, ...args?: Array<any>): number;
     flip(func: Function): Function;
@@ -492,7 +492,7 @@ declare module "lodash" {
       func: Function,
       wait?: number,
       options?: ThrottleOptions
-    ): Function;
+    ): Function & {cancel: () => void, flush: () => void};
     unary(func: Function): Function;
     wrap(value: any, wrapper: Function): Function;
 

--- a/definitions/npm/lodash_v4.x.x/flow_v0.38.x-v0.46.x/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.38.x-v0.46.x/lodash_v4.x.x.js
@@ -494,7 +494,7 @@ declare module "lodash" {
       func: Function,
       wait?: number,
       options?: DebounceOptions
-    ): Function;
+    ): Function & {cancel: () => void, flush: () => void};
     defer(func: Function, ...args?: Array<any>): number;
     delay(func: Function, wait: number, ...args?: Array<any>): number;
     flip(func: Function): Function;
@@ -514,7 +514,7 @@ declare module "lodash" {
       func: Function,
       wait?: number,
       options?: ThrottleOptions
-    ): Function;
+    ): Function & {cancel: () => void, flush: () => void};
     unary(func: Function): Function;
     wrap(value: any, wrapper: Function): Function;
 

--- a/definitions/npm/lodash_v4.x.x/flow_v0.47.x-v0.54.x/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.47.x-v0.54.x/lodash_v4.x.x.js
@@ -708,7 +708,7 @@ declare module "lodash" {
       func: Function,
       wait?: number,
       options?: DebounceOptions
-    ): Function;
+    ): Function & {cancel: () => void, flush: () => void};
     defer(func: Function, ...args?: Array<any>): number;
     delay(func: Function, wait: number, ...args?: Array<any>): number;
     flip(func: Function): Function;
@@ -728,7 +728,7 @@ declare module "lodash" {
       func: Function,
       wait?: number,
       options?: ThrottleOptions
-    ): Function;
+    ): Function & {cancel: () => void, flush: () => void};
     unary(func: Function): Function;
     wrap(value: any, wrapper: Function): Function;
 

--- a/definitions/npm/lodash_v4.x.x/flow_v0.47.x-v0.54.x/test_lodash-fp-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.47.x-v0.54.x/test_lodash-fp-v4.x.x.js
@@ -399,3 +399,12 @@ const ab = (a: number) => `${a}`;
 const bc = (b: string) => ({b});
 const cd = (c: {b: string}) => [c.b];
 const pipedResult: string[] = _.pipe(ab, bc, cd)(1);
+
+/**
+ * debounce
+ */
+const debounced = _.debounce(100)(() => {});
+debounced.cancel();
+debounced.flush();
+// $ExpectError allows to call unknown method on debounced
+debounced.foobar();

--- a/definitions/npm/lodash_v4.x.x/flow_v0.47.x-v0.54.x/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.47.x-v0.54.x/test_lodash-v4.x.x.js
@@ -32,6 +32,7 @@ import times from 'lodash/times';
 import toPairs from "lodash/toPairs";
 import toPairsIn from "lodash/toPairsIn";
 import flatMap from 'lodash/flatMap';
+import debounce from 'lodash/debounce';
 
 /**
  * _.attempt
@@ -408,3 +409,14 @@ noop('a', 2, [], null);
 var pairs: [string, number][];
 pairs = toPairs({ a: 12, b: 100 });
 pairs = toPairsIn({ a: 12, b: 100 });
+
+/**
+ * _.debounce
+ */
+var debounced: (a: number) => string = debounce((a: number) => "foo");
+// $ExpectError debounce retains type information
+debounced = debounce(() => {});
+debounced.cancel();
+debounced.flush();
+// $ExpectError allows to call unknown method on debounced
+debounced.foobar();

--- a/definitions/npm/lodash_v4.x.x/flow_v0.55.x-v0.62.x/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.55.x-v0.62.x/lodash_v4.x.x.js
@@ -207,6 +207,8 @@ declare module "lodash" {
     | ((item: T, key: string, object: O) => U)
     | propertyIterateeShorthand;
 
+  declare type Debounced<F> = F & {cancel: () => void, flush: () => void};
+
   declare class Lodash {
     // Array
     chunk<T>(array?: ?Array<T>, size?: ?number): Array<Array<T>>;
@@ -745,7 +747,7 @@ declare module "lodash" {
     curry: Curry;
     curry(func: Function, arity?: number): Function;
     curryRight(func: Function, arity?: number): Function;
-    debounce<F: Function>(func: F, wait?: number, options?: DebounceOptions): F;
+    debounce<F: Function>(func: F, wait?: number, options?: DebounceOptions): Debounced<F>;
     defer(func: Function, ...args?: Array<any>): number;
     delay(func: Function, wait: number, ...args?: Array<any>): number;
     flip(func: Function): Function;
@@ -761,11 +763,11 @@ declare module "lodash" {
     rearg(func: Function, indexes: Array<number>): Function;
     rest(func: Function, start?: number): Function;
     spread(func: Function): Function;
-    throttle(
-      func: Function,
+    throttle<F: Function>(
+      func: F,
       wait?: number,
       options?: ThrottleOptions
-    ): Function;
+    ): Debounced<F>;
     unary(func: Function): Function;
     wrap(value?: any, wrapper?: ?Function): Function;
 
@@ -2308,8 +2310,8 @@ declare module "lodash/fp" {
     curryRight(func: Function): Function;
     curryRightN(arity: number): (func: Function) => Function;
     curryRightN(arity: number, func: Function): Function;
-    debounce(wait: number): <F: Function>(func: F) => F;
-    debounce<F: Function>(wait: number, func: F): F;
+    debounce(wait: number): <F: Function>(func: F) => Debounced<F>;
+    debounce<F: Function>(wait: number, func: F): Debounced<F>;
     defer(func: Function): number;
     delay(wait: number): (func: Function) => number;
     delay(wait: number, func: Function): number;
@@ -2336,8 +2338,8 @@ declare module "lodash/fp" {
     apply(func: Function): Function;
     spreadFrom(start: number): (func: Function) => Function;
     spreadFrom(start: number, func: Function): Function;
-    throttle(wait: number): (func: Function) => Function;
-    throttle(wait: number, func: Function): Function;
+    throttle(wait: number): <F: Function>(func: F) => Debounced<F>;
+    throttle<F: Function>(wait: number, func: F): Debounced<F>;
     unary(func: Function): Function;
     wrap(wrapper: Function): (value: any) => Function;
     wrap(wrapper: Function, value: any): Function;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.55.x-v0.62.x/test_lodash-fp-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.55.x-v0.62.x/test_lodash-fp-v4.x.x.js
@@ -400,3 +400,12 @@ const bc = (b: string) => ({b});
 const cd = (c: {b: string}) => [c.b];
 const pipedResult: string[] = _.pipe(ab, bc, cd)(1);
 const composedResult: string[] = _.compose(cd, bc, ab)(1);
+
+/**
+ * debounce
+ */
+const debounced = _.debounce(100)(() => {});
+debounced.cancel();
+debounced.flush();
+// $ExpectError allows to call unknown method on debounced
+debounced.foobar();

--- a/definitions/npm/lodash_v4.x.x/flow_v0.55.x-v0.62.x/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.55.x-v0.62.x/test_lodash-v4.x.x.js
@@ -454,6 +454,10 @@ memoized = memoize(() => {});
 var debounced: (a: number) => string = debounce((a: number) => "foo");
 // $ExpectError debounce retains type information
 debounced = debounce(() => {});
+debounced.cancel();
+debounced.flush();
+// $ExpectError allows to call unknown method on debounced
+debounced.foobar();
 
 /**
  * _.toPairs / _.toPairsIn

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -156,6 +156,8 @@ declare module "lodash" {
     trailing?: boolean
   };
 
+  declare type Debounced<F> = F & {cancel: () => void, flush: () => void};
+
   declare type NestedArray<T> = Array<Array<T>>;
 
   declare type matchesIterateeShorthand = Object;
@@ -750,7 +752,11 @@ declare module "lodash" {
     curry: Curry;
     curry(func: Function, arity?: number): Function;
     curryRight(func: Function, arity?: number): Function;
-    debounce<F: Function>(func: F, wait?: number, options?: DebounceOptions): F;
+    debounce<F: Function>(
+      func: F,
+      wait?: number,
+      options?: DebounceOptions
+    ): Debounced<F>;
     defer(func: Function, ...args?: Array<any>): TimeoutID;
     delay(func: Function, wait: number, ...args?: Array<any>): TimeoutID;
     flip(func: Function): Function;
@@ -766,11 +772,11 @@ declare module "lodash" {
     rearg(func: Function, indexes: Array<number>): Function;
     rest(func: Function, start?: number): Function;
     spread(func: Function): Function;
-    throttle(
-      func: Function,
+    throttle<F: Function>(
+      func: F,
       wait?: number,
       options?: ThrottleOptions
-    ): Function;
+    ): Debounced<F>;
     unary(func: Function): Function;
     wrap(value?: any, wrapper?: ?Function): Function;
 
@@ -2321,8 +2327,8 @@ declare module "lodash/fp" {
     curryRight(func: Function): Function;
     curryRightN(arity: number): (func: Function) => Function;
     curryRightN(arity: number, func: Function): Function;
-    debounce(wait: number): <F: Function>(func: F) => F;
-    debounce<F: Function>(wait: number, func: F): F;
+    debounce(wait: number): <F: Function>(func: F) => Debounced<F>;
+    debounce<F: Function>(wait: number, func: F): Debounced<F>;
     defer(func: Function): TimeoutID;
     delay(wait: number): (func: Function) => TimeoutID;
     delay(wait: number, func: Function): TimeoutID;
@@ -2349,8 +2355,8 @@ declare module "lodash/fp" {
     apply(func: Function): Function;
     spreadFrom(start: number): (func: Function) => Function;
     spreadFrom(start: number, func: Function): Function;
-    throttle(wait: number): (func: Function) => Function;
-    throttle(wait: number, func: Function): Function;
+    throttle(wait: number): <F: Function>(func: F) => Debounced<F>;
+    throttle<F: Function>(wait: number, func: F): Debounced<F>;
     unary(func: Function): Function;
     wrap(wrapper: Function): (value: any) => Function;
     wrap(wrapper: Function, value: any): Function;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-fp-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-fp-v4.x.x.js
@@ -37,6 +37,7 @@ import noop from 'lodash/fp/noop';
 import pipe from 'lodash/fp/pipe';
 import compose from 'lodash/fp/compose';
 import includes from 'lodash/fp/includes';
+import debounce from 'lodash/fp/debounce';
 
 filter('x', [{x: 1}, {x: 2}]);
 filter('x')([{x: 1}, {x: 2}]);
@@ -445,3 +446,12 @@ const composedResult: string[] = compose(cd, bc, ab)(1);
  * includes
  */
 includes("test")({ a: "test2", b: "test" });
+
+/**
+ * debounce
+ */
+const debounced = debounce(100)(() => {});
+debounced.cancel();
+debounced.flush();
+// $ExpectError allows to call unknown method on debounced
+debounced.foobar();

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -457,6 +457,10 @@ memoized = memoize(() => {});
 var debounced: (a: number) => string = debounce((a: number) => "foo");
 // $ExpectError debounce retains type information
 debounced = debounce(() => {});
+debounced.cancel();
+debounced.flush();
+// $ExpectError allows to call unknown method on debounced
+debounced.foobar();
 
 /**
  * _.toPairs / _.toPairsIn


### PR DESCRIPTION
`cancel` usage is present in example for debounce:
https://lodash.com/docs/4.17.10#debounce

`flush` is provided alongside `cancel`
https://github.com/lodash/lodash/blob/npm/debounce.js#L185

Throttle uses debounce under the hood:
https://github.com/lodash/lodash/blob/npm/throttle.js#L62
