### PR TITLE
fix(lodash): Support number as keys in pickBy and omitBy.

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -1205,7 +1205,7 @@ declare module "lodash" {
     ): Object;
     omit(object?: ?Object, ...props: Array<string>): Object;
     omit(object?: ?Object, props: Array<string>): Object;
-    omitBy<A, T: { [id: string]: A }>(
+    omitBy<A, T: { [id: string | number]: A }>(
       object: T,
       predicate?: ?OPredicate<A, T>
     ): Object;
@@ -1215,7 +1215,7 @@ declare module "lodash" {
     ): {};
     pick(object?: ?Object, ...props: Array<string>): Object;
     pick(object?: ?Object, props: Array<string>): Object;
-    pickBy<A, T: { [id: string]: A }>(
+    pickBy<A, T: { [id: string | number]: A }>(
       object: T,
       predicate?: ?OPredicate<A, T>
     ): Object;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -235,7 +235,7 @@ declare module "lodash" {
       fromIndex?: ?number
     ): number;
     findIndex<T>(
-      array: void | null,
+      array: void | null,
       predicate?: ?Predicate<T>,
       fromIndex?: ?number
     ): -1;
@@ -257,7 +257,7 @@ declare module "lodash" {
     fromPairs<A, B>(pairs?: ?Array<[A, B]>): { [key: A]: B };
     head<T>(array: ?$ReadOnlyArray<T>): T;
     indexOf<T>(array: Array<T>, value: T, fromIndex?: number): number;
-    indexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
+    indexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
     initial<T>(array: ?Array<T>): Array<T>;
     intersection<T>(...arrays?: Array<Array<T>>): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
@@ -301,62 +301,62 @@ declare module "lodash" {
       comparator?: ?Comparator<T>
     ): Array<T>;
     join<T>(array: Array<T>, separator?: ?string): string;
-    join<T>(array: void | null, separator?: ?string): '';
+    join<T>(array: void | null, separator?: ?string): '';
     last<T>(array: ?$ReadOnlyArray<T>): T;
     lastIndexOf<T>(array: Array<T>, value?: ?T, fromIndex?: ?number): number;
-    lastIndexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
+    lastIndexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
     nth<T>(array: T[], n?: ?number): T;
-    nth(array: void | null, n?: ?number): void;
+    nth(array: void | null, n?: ?number): void;
     pull<T>(array: Array<T>, ...values?: Array<?T>): Array<T>;
-    pull<T: void | null>(array: T, ...values?: Array<?any>): T;
+    pull<T: void | null>(array: T, ...values?: Array<?any>): T;
     pullAll<T>(array: Array<T>, values?: ?Array<T>): Array<T>;
-    pullAll<T: void | null>(array: T, values?: ?Array<any>): T;
+    pullAll<T: void | null>(array: T, values?: ?Array<any>): T;
     pullAllBy<T>(
       array: Array<T>,
       values?: ?Array<T>,
       iteratee?: ?ValueOnlyIteratee<T>
     ): Array<T>;
-    pullAllBy<T: void | null>(
+    pullAllBy<T: void | null>(
       array: T,
       values?: ?Array<any>,
       iteratee?: ?ValueOnlyIteratee<any>
     ): T;
     pullAllWith<T>(array: T[], values?: ?T[], comparator?: ?Function): T[];
-    pullAllWith<T: void | null>(array: T, values?: ?Array<any>, comparator?: ?Function): T;
+    pullAllWith<T: void | null>(array: T, values?: ?Array<any>, comparator?: ?Function): T;
     pullAt<T>(array?: ?Array<T>, ...indexed?: Array<?number>): Array<T>;
     pullAt<T>(array?: ?Array<T>, indexed?: ?Array<number>): Array<T>;
     remove<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
     reverse<T>(array: Array<T>): Array<T>;
-    reverse<T: void | null>(array: T): T;
+    reverse<T: void | null>(array: T): T;
     slice<T>(array?: ?$ReadOnlyArray<T>, start?: ?number, end?: ?number): Array<T>;
     sortedIndex<T>(array: Array<T>, value: T): number;
-    sortedIndex<T>(array: void | null, value: ?T): 0;
+    sortedIndex<T>(array: void | null, value: ?T): 0;
     sortedIndexBy<T>(
       array: Array<T>,
       value?: ?T,
       iteratee?: ?ValueOnlyIteratee<T>
     ): number;
     sortedIndexBy<T>(
-      array: void | null,
+      array: void | null,
       value?: ?T,
       iteratee?: ?ValueOnlyIteratee<T>
     ): 0;
     sortedIndexOf<T>(array: Array<T>, value: T): number;
-    sortedIndexOf<T>(array: void | null, value?: ?T): -1;
+    sortedIndexOf<T>(array: void | null, value?: ?T): -1;
     sortedLastIndex<T>(array: Array<T>, value: T): number;
-    sortedLastIndex<T>(array: void | null, value?: ?T): 0;
+    sortedLastIndex<T>(array: void | null, value?: ?T): 0;
     sortedLastIndexBy<T>(
       array: Array<T>,
       value: T,
       iteratee?: ValueOnlyIteratee<T>
     ): number;
     sortedLastIndexBy<T>(
-      array: void | null,
+      array: void | null,
       value?: ?T,
       iteratee?: ?ValueOnlyIteratee<T>
     ): 0;
     sortedLastIndexOf<T>(array: Array<T>, value: T): number;
-    sortedLastIndexOf<T>(array: void | null, value?: ?T): -1;
+    sortedLastIndexOf<T>(array: void | null, value?: ?T): -1;
     sortedUniq<T>(array?: ?Array<T>): Array<T>;
     sortedUniqBy<T>(array?: ?Array<T>, iteratee?: ?(value: T) => mixed): Array<T>;
     tail<T>(array?: ?Array<T>): Array<T>;
@@ -464,9 +464,9 @@ declare module "lodash" {
     ): Array<[A, B, C, D, E]>;
 
     zipObject<K, V>(props: Array<K>, values?: ?Array<V>): { [key: K]: V };
-    zipObject<K, V>(props: void | null, values?: ?Array<V>): {};
+    zipObject<K, V>(props: void | null, values?: ?Array<V>): {};
     zipObjectDeep(props: any[], values?: ?any): Object;
-    zipObjectDeep(props: void | null, values?: ?any): {};
+    zipObjectDeep(props: void | null, values?: ?any): {};
 
     zipWith<A>(a1?: ?Array<A>): Array<[A]>;
     zipWith<T, A>(a1: Array<A>, iteratee: (A) => T): Array<T>;
@@ -506,15 +506,15 @@ declare module "lodash" {
 
     // Collection
     countBy<T>(array: Array<T>, iteratee?: ?ValueOnlyIteratee<T>): Object;
-    countBy<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>): {};
+    countBy<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>): {};
     countBy<T: Object>(object: T, iteratee?: ?ValueOnlyIteratee<T>): Object;
     // alias of _.forEach
     each<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
-    each<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    each<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
     each<T: Object>(object: T, iteratee?: ?OIteratee<T>): T;
     // alias of _.forEachRight
     eachRight<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
-    eachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    eachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
     eachRight<T: Object>(object: T, iteratee?: OIteratee<T>): T;
     every<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): boolean;
     every<T: Object>(object: T, iteratee?: OIteratee<T>): boolean;
@@ -529,7 +529,7 @@ declare module "lodash" {
       fromIndex?: ?number
     ): T | void;
     find<T>(
-      array: void | null,
+      array: void | null,
       predicate?: ?Predicate<T>,
       fromIndex?: ?number
     ): void;
@@ -574,17 +574,17 @@ declare module "lodash" {
       depth?: number
     ): Array<U>;
     forEach<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
-    forEach<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    forEach<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
     forEach<T: Object>(object: T, iteratee?: ?OIteratee<T>): T;
     forEachRight<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
-    forEachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    forEachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
     forEachRight<T: Object>(object: T, iteratee?: ?OIteratee<T>): T;
     groupBy<V, T>(
       array: $ReadOnlyArray<T>,
       iteratee?: ?ValueOnlyIteratee<T>
     ): { [key: V]: Array<T> };
     groupBy(
-      array: void | null,
+      array: void | null,
       iteratee?: ?ValueOnlyIteratee<any>
     ): {};
     groupBy<V, A, T: { [id: string]: A }>(
@@ -592,7 +592,7 @@ declare module "lodash" {
       iteratee?: ValueOnlyIteratee<A>
     ): { [key: V]: Array<A> };
     includes<T>(array: $ReadOnlyArray<T>, value: T, fromIndex?: ?number): boolean;
-    includes<T>(array: void | null, value?: ?T, fromIndex?: ?number): false;
+    includes<T>(array: void | null, value?: ?T, fromIndex?: ?number): false;
     includes<T: Object>(object: T, value: any, fromIndex?: number): boolean;
     includes(str: string, value: string, fromIndex?: number): boolean;
     invokeMap<T>(
@@ -610,7 +610,7 @@ declare module "lodash" {
       iteratee?: ?ValueOnlyIteratee<T>
     ): { [key: V]: ?T };
     keyBy(
-      array: void | null,
+      array: void | null,
       iteratee?: ?ValueOnlyIteratee<*>
     ): {};
     keyBy<V, A, I, T: { [id: I]: A }>(
@@ -664,7 +664,7 @@ declare module "lodash" {
       accumulator?: U
     ): U;
     reduce<T, U>(
-      array: void | null,
+      array: void | null,
       iteratee?: ?(
         accumulator: U,
         value: T,
@@ -672,14 +672,14 @@ declare module "lodash" {
         array: ?Array<T>
       ) => U,
       accumulator?: ?U
-    ): void | null;
+    ): void | null;
     reduce<T: Object, U>(
       object: T,
       iteratee?: (accumulator: U, value: any, key: string, object: T) => U,
       accumulator?: U
     ): U;
     reduceRight<T, U>(
-      array: void | null,
+      array: void | null,
       iteratee?: ?(
         accumulator: U,
         value: T,
@@ -687,7 +687,7 @@ declare module "lodash" {
         array: ?Array<T>
       ) => U,
       accumulator?: ?U
-    ): void | null;
+    ): void | null;
     reduceRight<T, U>(
       array: Array<T>,
       iteratee?: ?(
@@ -716,7 +716,7 @@ declare module "lodash" {
     shuffle<V, T: Object>(object: T): Array<V>;
     size(collection: $ReadOnlyArray<any> | Object | string): number;
     some<T>(array: ?$ReadOnlyArray<T>, predicate?: Predicate<T>): boolean;
-    some<T>(array: void | null, predicate?: ?Predicate<T>): false;
+    some<T>(array: void | null, predicate?: ?Predicate<T>): false;
     some<A, T: { [id: string]: A }>(
       object?: ?T,
       predicate?: OPredicate<A, T>
@@ -793,15 +793,15 @@ declare module "lodash" {
     eq(value: any, other: any): boolean;
     gt(value: any, other: any): boolean;
     gte(value: any, other: any): boolean;
-    isArguments(value: void | null): false;
+    isArguments(value: void | null): false;
     isArguments(value: any): boolean;
     isArray(value: Array<any>): true;
     isArray(value: any): false;
     isArrayBuffer(value: ArrayBuffer): true;
     isArrayBuffer(value: any): false;
-    isArrayLike(value: Array<any> | string | {length: number}): true;
+    isArrayLike(value: Array<any> | string | {length: number}): true;
     isArrayLike(value: any): false;
-    isArrayLikeObject(value: {length: number} | Array<any>): true;
+    isArrayLikeObject(value: {length: number} | Array<any>): true;
     isArrayLikeObject(value: any): false;
     isBoolean(value: boolean): true;
     isBoolean(value: any): false;
@@ -811,7 +811,7 @@ declare module "lodash" {
     isDate(value: any): false;
     isElement(value: Element): true;
     isElement(value: any): false;
-    isEmpty(value: void | null | '' | {} | [] | number | boolean): true;
+    isEmpty(value: void | null | '' | {} | [] | number | boolean): true;
     isEmpty(value: any): boolean;
     isEqual(value: any, other: any): boolean;
     isEqualWith<T, U>(
@@ -834,7 +834,7 @@ declare module "lodash" {
     isFunction(value: any): false;
     isInteger(value: number): boolean;
     isInteger(value: any): false;
-    isLength(value: void | null): false;
+    isLength(value: void | null): false;
     isLength(value: any): boolean;
     isMap(value: Map<any, any>): true;
     isMap(value: any): false;
@@ -852,9 +852,9 @@ declare module "lodash" {
     ): boolean;
     isNaN(value: number): boolean;
     isNaN(value: any): false;
-    isNative(value: number | string | void | null | Object): false;
+    isNative(value: number | string | void | null | Object): false;
     isNative(value: any): boolean;
-    isNil(value: void | null): true;
+    isNil(value: void | null): true;
     isNil(value: any): false;
     isNull(value: null): true;
     isNull(value: any): false;
@@ -862,7 +862,7 @@ declare module "lodash" {
     isNumber(value: any): false;
     isObject(value: Object): true;
     isObject(value: any): false;
-    isObjectLike(value: void | null): false;
+    isObjectLike(value: void | null): false;
     isObjectLike(value: any): boolean;
     isPlainObject(value: Object): true;
     isPlainObject(value: any): false;
@@ -887,18 +887,18 @@ declare module "lodash" {
     lt(value: any, other: any): boolean;
     lte(value: any, other: any): boolean;
     toArray(value: any): Array<any>;
-    toFinite(value: void | null): 0;
+    toFinite(value: void | null): 0;
     toFinite(value: any): number;
-    toInteger(value: void | null): 0;
+    toInteger(value: void | null): 0;
     toInteger(value: any): number;
-    toLength(value: void | null): 0;
+    toLength(value: void | null): 0;
     toLength(value: any): number;
-    toNumber(value: void | null): 0;
+    toNumber(value: void | null): 0;
     toNumber(value: any): number;
     toPlainObject(value: any): Object;
-    toSafeInteger(value: void | null): 0;
+    toSafeInteger(value: void | null): 0;
     toSafeInteger(value: any): number;
-    toString(value: void | null): '';
+    toString(value: void | null): '';
     toString(value: any): string;
 
     // Math
@@ -1036,7 +1036,7 @@ declare module "lodash" {
     at(object?: ?Object, ...paths: Array<string>): Array<any>;
     at(object?: ?Object, paths: Array<string>): Array<any>;
     create<T>(prototype: T, properties: Object): $Supertype<T>;
-    create(prototype: any, properties: void | null): {};
+    create(prototype: any, properties: void | null): {};
     defaults(object?: ?Object, ...sources?: Array<?Object>): Object;
     defaultsDeep(object?: ?Object, ...sources?: Array<?Object>): Object;
     // alias for _.toPairs
@@ -1104,7 +1104,7 @@ declare module "lodash" {
       predicate?: ?OPredicate<A, T>
     ): string | void;
     findKey<A, T: { [id: string]: A }>(
-      object: void | null,
+      object: void | null,
       predicate?: ?OPredicate<A, T>
     ): void;
     findLastKey<A, T: { [id: string]: A }>(
@@ -1112,17 +1112,17 @@ declare module "lodash" {
       predicate?: ?OPredicate<A, T>
     ): string | void;
     findLastKey<A, T: { [id: string]: A }>(
-      object: void | null,
+      object: void | null,
       predicate?: ?OPredicate<A, T>
     ): void;
     forIn(object: Object, iteratee?: ?OIteratee<*>): Object;
-    forIn(object: void | null, iteratee?: ?OIteratee<*>): null;
+    forIn(object: void | null, iteratee?: ?OIteratee<*>): null;
     forInRight(object: Object, iteratee?: ?OIteratee<*>): Object;
-    forInRight(object: void | null, iteratee?: ?OIteratee<*>): null;
+    forInRight(object: void | null, iteratee?: ?OIteratee<*>): null;
     forOwn(object: Object, iteratee?: ?OIteratee<*>): Object;
-    forOwn(object: void | null, iteratee?: ?OIteratee<*>): null;
+    forOwn(object: void | null, iteratee?: ?OIteratee<*>): null;
     forOwnRight(object: Object, iteratee?: ?OIteratee<*>): Object;
-    forOwnRight(object: void | null, iteratee?: ?OIteratee<*>): null;
+    forOwnRight(object: void | null, iteratee?: ?OIteratee<*>): null;
     functions(object?: ?Object): Array<string>;
     functionsIn(object?: ?Object): Array<string>;
     get(
@@ -1131,15 +1131,15 @@ declare module "lodash" {
       defaultValue?: any
     ): any;
     has(object: Object, path: Array<string> | string): boolean;
-    has(object: Object, path: void | null): false;
+    has(object: Object, path: void | null): false;
     has(object: void | null, path?: ?Array<string> | ?string): false;
     hasIn(object: Object, path: Array<string> | string): boolean;
-    hasIn(object: Object, path: void | null): false;
+    hasIn(object: Object, path: void | null): false;
     hasIn(object: void | null, path?: ?Array<string> | ?string): false;
     invert(object: Object, multiVal?: ?boolean): Object;
-    invert(object: void | null, multiVal?: ?boolean): {};
+    invert(object: void | null, multiVal?: ?boolean): {};
     invertBy(object: Object, iteratee?: ?Function): Object;
-    invertBy(object: void | null, iteratee?: ?Function): {};
+    invertBy(object: void | null, iteratee?: ?Function): {};
     invoke(
       object?: ?Object,
       path?: ?Array<string> | string,
@@ -1149,9 +1149,9 @@ declare module "lodash" {
     keys(object?: ?Object): Array<string>;
     keysIn(object?: ?Object): Array<string>;
     mapKeys(object: Object, iteratee?: ?OIteratee<*>): Object;
-    mapKeys(object: void | null, iteratee?: ?OIteratee<*>): {};
+    mapKeys(object: void | null, iteratee?: ?OIteratee<*>): {};
     mapValues(object: Object, iteratee?: ?OIteratee<*>): Object;
-    mapValues(object: void | null, iteratee?: ?OIteratee<*>): {};
+    mapValues(object: void | null, iteratee?: ?OIteratee<*>): {};
     merge(object?: ?Object, ...sources?: Array<?Object>): Object;
     mergeWith(): {};
     mergeWith<T: Object, A: Object>(
@@ -1229,7 +1229,7 @@ declare module "lodash" {
       defaultValue?: any
     ): any;
     set(object: Object, path?: ?Array<string> | string, value: any): Object;
-    set<T: void | null>(
+    set<T: void | null>(
       object: T,
       path?: ?Array<string> | string,
       value?: ?any): T;
@@ -1239,7 +1239,7 @@ declare module "lodash" {
       value: any,
       customizer?: (nsValue: any, key: string, nsObject: T) => any
     ): Object;
-    setWith<T: void | null>(
+    setWith<T: void | null>(
       object: T,
       path?: ?Array<string> | string,
       value?: ?any,
@@ -1253,14 +1253,14 @@ declare module "lodash" {
       accumulator?: any
     ): any;
     transform(
-      collection: void | null,
+      collection: void | null,
       iteratee?: ?OIteratee<*>,
       accumulator?: ?any
     ): {};
     unset(object: Object, path?: ?Array<string> | ?string): boolean;
-    unset(object: void | null, path?: ?Array<string> | ?string): true;
+    unset(object: void | null, path?: ?Array<string> | ?string): true;
     update(object: Object, path: string[] | string, updater: Function): Object;
-    update<T: void | null>(
+    update<T: void | null>(
       object: T,
       path?: ?string[] | ?string,
       updater?: ?Function): T;
@@ -1270,7 +1270,7 @@ declare module "lodash" {
       updater?: ?Function,
       customizer?: ?Function
     ): Object;
-    updateWith<T: void | null>(
+    updateWith<T: void | null>(
       object: T,
       path?: ?string[] | ?string,
       updater?: ?Function,
@@ -1289,75 +1289,75 @@ declare module "lodash" {
 
     // String
     camelCase(string: string): string;
-    camelCase(string: void | null): '';
+    camelCase(string: void | null): '';
     capitalize(string: string): string;
-    capitalize(string: void | null): '';
+    capitalize(string: void | null): '';
     deburr(string: string): string;
-    deburr(string: void | null): '';
+    deburr(string: void | null): '';
     endsWith(string: string, target?: string, position?: ?number): boolean;
-    endsWith(string: void | null, target?: ?string, position?: ?number): false;
+    endsWith(string: void | null, target?: ?string, position?: ?number): false;
     escape(string: string): string;
-    escape(string: void | null): '';
+    escape(string: void | null): '';
     escapeRegExp(string: string): string;
-    escapeRegExp(string: void | null): '';
+    escapeRegExp(string: void | null): '';
     kebabCase(string: string): string;
-    kebabCase(string: void | null): '';
+    kebabCase(string: void | null): '';
     lowerCase(string: string): string;
-    lowerCase(string: void | null): '';
+    lowerCase(string: void | null): '';
     lowerFirst(string: string): string;
-    lowerFirst(string: void | null): '';
+    lowerFirst(string: void | null): '';
     pad(string?: ?string, length?: ?number, chars?: ?string): string;
     padEnd(string?: ?string, length?: ?number, chars?: ?string): string;
     padStart(string?: ?string, length?: ?number, chars?: ?string): string;
     parseInt(string: string, radix?: ?number): number;
     repeat(string: string, n?: ?number): string;
-    repeat(string: void | null, n?: ?number): '';
+    repeat(string: void | null, n?: ?number): '';
     replace(
       string: string,
       pattern: RegExp | string,
       replacement: ((string: string) => string) | string
     ): string;
     replace(
-      string: void | null,
+      string: void | null,
       pattern?: ?RegExp | ?string,
       replacement: ?((string: string) => string) | ?string
     ): '';
     snakeCase(string: string): string;
-    snakeCase(string: void | null): '';
+    snakeCase(string: void | null): '';
     split(
       string?: ?string,
       separator?: ?RegExp | ?string,
       limit?: ?number
     ): Array<string>;
     startCase(string: string): string;
-    startCase(string: void | null): '';
+    startCase(string: void | null): '';
     startsWith(string: string, target?: string, position?: number): boolean;
-    startsWith(string: void | null, target?: ?string, position?: ?number): false;
+    startsWith(string: void | null, target?: ?string, position?: ?number): false;
     template(string?: ?string, options?: ?TemplateSettings): Function;
     toLower(string: string): string;
-    toLower(string: void | null): '';
+    toLower(string: void | null): '';
     toUpper(string: string): string;
-    toUpper(string: void | null): '';
+    toUpper(string: void | null): '';
     trim(string: string, chars?: string): string;
-    trim(string: void | null, chars?: ?string): '';
+    trim(string: void | null, chars?: ?string): '';
     trimEnd(string: string, chars?: ?string): string;
-    trimEnd(string: void | null, chars?: ?string): '';
+    trimEnd(string: void | null, chars?: ?string): '';
     trimStart(string: string, chars?: ?string): string;
-    trimStart(string: void | null, chars?: ?string): '';
+    trimStart(string: void | null, chars?: ?string): '';
     truncate(string: string, options?: TruncateOptions): string;
-    truncate(string: void | null, options?: ?TruncateOptions): '';
+    truncate(string: void | null, options?: ?TruncateOptions): '';
     unescape(string: string): string;
-    unescape(string: void | null): '';
+    unescape(string: void | null): '';
     upperCase(string: string): string;
-    upperCase(string: void | null): '';
+    upperCase(string: void | null): '';
     upperFirst(string: string): string;
-    upperFirst(string: void | null): '';
+    upperFirst(string: void | null): '';
     words(string?: ?string, pattern?: ?RegExp | ?string): Array<string>;
 
     // Util
     attempt(func: Function, ...args: Array<any>): any;
     bindAll(object: Object, methodNames?: ?Array<string>): Object;
-    bindAll<T: void | null>(object: T, methodNames?: ?Array<string>): T;
+    bindAll<T: void | null>(object: T, methodNames?: ?Array<string>): T;
     bindAll(object: Object, ...methodNames: Array<string>): Object;
     cond(pairs?: ?NestedArray<Function>): Function;
     conforms(source?: ?Object): Function;
@@ -1404,7 +1404,7 @@ declare module "lodash" {
     stubObject(): {};
     stubString(): "";
     stubTrue(): true;
-    times(n?: ?number, ...rest?: Array<void | null>): Array<number>;
+    times(n?: ?number, ...rest?: Array<void | null>): Array<number>;
     times<T>(n: number, iteratee: (i: number) => T): Array<T>;
     toPath(value: any): Array<string>;
     uniqueId(prefix?: ?string): string;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -235,7 +235,7 @@ declare module "lodash" {
       fromIndex?: ?number
     ): number;
     findIndex<T>(
-      array: void | null,
+      array: void | null,
       predicate?: ?Predicate<T>,
       fromIndex?: ?number
     ): -1;
@@ -257,7 +257,7 @@ declare module "lodash" {
     fromPairs<A, B>(pairs?: ?Array<[A, B]>): { [key: A]: B };
     head<T>(array: ?$ReadOnlyArray<T>): T;
     indexOf<T>(array: Array<T>, value: T, fromIndex?: number): number;
-    indexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
+    indexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
     initial<T>(array: ?Array<T>): Array<T>;
     intersection<T>(...arrays?: Array<Array<T>>): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
@@ -301,62 +301,62 @@ declare module "lodash" {
       comparator?: ?Comparator<T>
     ): Array<T>;
     join<T>(array: Array<T>, separator?: ?string): string;
-    join<T>(array: void | null, separator?: ?string): '';
+    join<T>(array: void | null, separator?: ?string): '';
     last<T>(array: ?$ReadOnlyArray<T>): T;
     lastIndexOf<T>(array: Array<T>, value?: ?T, fromIndex?: ?number): number;
-    lastIndexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
+    lastIndexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
     nth<T>(array: T[], n?: ?number): T;
-    nth(array: void | null, n?: ?number): void;
+    nth(array: void | null, n?: ?number): void;
     pull<T>(array: Array<T>, ...values?: Array<?T>): Array<T>;
-    pull<T: void | null>(array: T, ...values?: Array<?any>): T;
+    pull<T: void | null>(array: T, ...values?: Array<?any>): T;
     pullAll<T>(array: Array<T>, values?: ?Array<T>): Array<T>;
-    pullAll<T: void | null>(array: T, values?: ?Array<any>): T;
+    pullAll<T: void | null>(array: T, values?: ?Array<any>): T;
     pullAllBy<T>(
       array: Array<T>,
       values?: ?Array<T>,
       iteratee?: ?ValueOnlyIteratee<T>
     ): Array<T>;
-    pullAllBy<T: void | null>(
+    pullAllBy<T: void | null>(
       array: T,
       values?: ?Array<any>,
       iteratee?: ?ValueOnlyIteratee<any>
     ): T;
     pullAllWith<T>(array: T[], values?: ?T[], comparator?: ?Function): T[];
-    pullAllWith<T: void | null>(array: T, values?: ?Array<any>, comparator?: ?Function): T;
+    pullAllWith<T: void | null>(array: T, values?: ?Array<any>, comparator?: ?Function): T;
     pullAt<T>(array?: ?Array<T>, ...indexed?: Array<?number>): Array<T>;
     pullAt<T>(array?: ?Array<T>, indexed?: ?Array<number>): Array<T>;
     remove<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
     reverse<T>(array: Array<T>): Array<T>;
-    reverse<T: void | null>(array: T): T;
+    reverse<T: void | null>(array: T): T;
     slice<T>(array?: ?$ReadOnlyArray<T>, start?: ?number, end?: ?number): Array<T>;
     sortedIndex<T>(array: Array<T>, value: T): number;
-    sortedIndex<T>(array: void | null, value: ?T): 0;
+    sortedIndex<T>(array: void | null, value: ?T): 0;
     sortedIndexBy<T>(
       array: Array<T>,
       value?: ?T,
       iteratee?: ?ValueOnlyIteratee<T>
     ): number;
     sortedIndexBy<T>(
-      array: void | null,
+      array: void | null,
       value?: ?T,
       iteratee?: ?ValueOnlyIteratee<T>
     ): 0;
     sortedIndexOf<T>(array: Array<T>, value: T): number;
-    sortedIndexOf<T>(array: void | null, value?: ?T): -1;
+    sortedIndexOf<T>(array: void | null, value?: ?T): -1;
     sortedLastIndex<T>(array: Array<T>, value: T): number;
-    sortedLastIndex<T>(array: void | null, value?: ?T): 0;
+    sortedLastIndex<T>(array: void | null, value?: ?T): 0;
     sortedLastIndexBy<T>(
       array: Array<T>,
       value: T,
       iteratee?: ValueOnlyIteratee<T>
     ): number;
     sortedLastIndexBy<T>(
-      array: void | null,
+      array: void | null,
       value?: ?T,
       iteratee?: ?ValueOnlyIteratee<T>
     ): 0;
     sortedLastIndexOf<T>(array: Array<T>, value: T): number;
-    sortedLastIndexOf<T>(array: void | null, value?: ?T): -1;
+    sortedLastIndexOf<T>(array: void | null, value?: ?T): -1;
     sortedUniq<T>(array?: ?Array<T>): Array<T>;
     sortedUniqBy<T>(array?: ?Array<T>, iteratee?: ?(value: T) => mixed): Array<T>;
     tail<T>(array?: ?Array<T>): Array<T>;
@@ -464,9 +464,9 @@ declare module "lodash" {
     ): Array<[A, B, C, D, E]>;
 
     zipObject<K, V>(props: Array<K>, values?: ?Array<V>): { [key: K]: V };
-    zipObject<K, V>(props: void | null, values?: ?Array<V>): {};
+    zipObject<K, V>(props: void | null, values?: ?Array<V>): {};
     zipObjectDeep(props: any[], values?: ?any): Object;
-    zipObjectDeep(props: void | null, values?: ?any): {};
+    zipObjectDeep(props: void | null, values?: ?any): {};
 
     zipWith<A>(a1?: ?Array<A>): Array<[A]>;
     zipWith<T, A>(a1: Array<A>, iteratee: (A) => T): Array<T>;
@@ -506,15 +506,15 @@ declare module "lodash" {
 
     // Collection
     countBy<T>(array: Array<T>, iteratee?: ?ValueOnlyIteratee<T>): Object;
-    countBy<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>): {};
+    countBy<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>): {};
     countBy<T: Object>(object: T, iteratee?: ?ValueOnlyIteratee<T>): Object;
     // alias of _.forEach
     each<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
-    each<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    each<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
     each<T: Object>(object: T, iteratee?: ?OIteratee<T>): T;
     // alias of _.forEachRight
     eachRight<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
-    eachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    eachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
     eachRight<T: Object>(object: T, iteratee?: OIteratee<T>): T;
     every<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): boolean;
     every<T: Object>(object: T, iteratee?: OIteratee<T>): boolean;
@@ -529,7 +529,7 @@ declare module "lodash" {
       fromIndex?: ?number
     ): T | void;
     find<T>(
-      array: void | null,
+      array: void | null,
       predicate?: ?Predicate<T>,
       fromIndex?: ?number
     ): void;
@@ -574,17 +574,17 @@ declare module "lodash" {
       depth?: number
     ): Array<U>;
     forEach<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
-    forEach<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    forEach<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
     forEach<T: Object>(object: T, iteratee?: ?OIteratee<T>): T;
     forEachRight<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
-    forEachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    forEachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
     forEachRight<T: Object>(object: T, iteratee?: ?OIteratee<T>): T;
     groupBy<V, T>(
       array: $ReadOnlyArray<T>,
       iteratee?: ?ValueOnlyIteratee<T>
     ): { [key: V]: Array<T> };
     groupBy(
-      array: void | null,
+      array: void | null,
       iteratee?: ?ValueOnlyIteratee<any>
     ): {};
     groupBy<V, A, T: { [id: string]: A }>(
@@ -592,7 +592,7 @@ declare module "lodash" {
       iteratee?: ValueOnlyIteratee<A>
     ): { [key: V]: Array<A> };
     includes<T>(array: $ReadOnlyArray<T>, value: T, fromIndex?: ?number): boolean;
-    includes<T>(array: void | null, value?: ?T, fromIndex?: ?number): false;
+    includes<T>(array: void | null, value?: ?T, fromIndex?: ?number): false;
     includes<T: Object>(object: T, value: any, fromIndex?: number): boolean;
     includes(str: string, value: string, fromIndex?: number): boolean;
     invokeMap<T>(
@@ -610,7 +610,7 @@ declare module "lodash" {
       iteratee?: ?ValueOnlyIteratee<T>
     ): { [key: V]: ?T };
     keyBy(
-      array: void | null,
+      array: void | null,
       iteratee?: ?ValueOnlyIteratee<*>
     ): {};
     keyBy<V, A, I, T: { [id: I]: A }>(
@@ -664,7 +664,7 @@ declare module "lodash" {
       accumulator?: U
     ): U;
     reduce<T, U>(
-      array: void | null,
+      array: void | null,
       iteratee?: ?(
         accumulator: U,
         value: T,
@@ -672,14 +672,14 @@ declare module "lodash" {
         array: ?Array<T>
       ) => U,
       accumulator?: ?U
-    ): void | null;
+    ): void | null;
     reduce<T: Object, U>(
       object: T,
       iteratee?: (accumulator: U, value: any, key: string, object: T) => U,
       accumulator?: U
     ): U;
     reduceRight<T, U>(
-      array: void | null,
+      array: void | null,
       iteratee?: ?(
         accumulator: U,
         value: T,
@@ -687,7 +687,7 @@ declare module "lodash" {
         array: ?Array<T>
       ) => U,
       accumulator?: ?U
-    ): void | null;
+    ): void | null;
     reduceRight<T, U>(
       array: Array<T>,
       iteratee?: ?(
@@ -716,7 +716,7 @@ declare module "lodash" {
     shuffle<V, T: Object>(object: T): Array<V>;
     size(collection: $ReadOnlyArray<any> | Object | string): number;
     some<T>(array: ?$ReadOnlyArray<T>, predicate?: Predicate<T>): boolean;
-    some<T>(array: void | null, predicate?: ?Predicate<T>): false;
+    some<T>(array: void | null, predicate?: ?Predicate<T>): false;
     some<A, T: { [id: string]: A }>(
       object?: ?T,
       predicate?: OPredicate<A, T>
@@ -793,15 +793,15 @@ declare module "lodash" {
     eq(value: any, other: any): boolean;
     gt(value: any, other: any): boolean;
     gte(value: any, other: any): boolean;
-    isArguments(value: void | null): false;
+    isArguments(value: void | null): false;
     isArguments(value: any): boolean;
     isArray(value: Array<any>): true;
     isArray(value: any): false;
     isArrayBuffer(value: ArrayBuffer): true;
     isArrayBuffer(value: any): false;
-    isArrayLike(value: Array<any> | string | {length: number}): true;
+    isArrayLike(value: Array<any> | string | {length: number}): true;
     isArrayLike(value: any): false;
-    isArrayLikeObject(value: {length: number} | Array<any>): true;
+    isArrayLikeObject(value: {length: number} | Array<any>): true;
     isArrayLikeObject(value: any): false;
     isBoolean(value: boolean): true;
     isBoolean(value: any): false;
@@ -811,7 +811,7 @@ declare module "lodash" {
     isDate(value: any): false;
     isElement(value: Element): true;
     isElement(value: any): false;
-    isEmpty(value: void | null | '' | {} | [] | number | boolean): true;
+    isEmpty(value: void | null | '' | {} | [] | number | boolean): true;
     isEmpty(value: any): boolean;
     isEqual(value: any, other: any): boolean;
     isEqualWith<T, U>(
@@ -834,7 +834,7 @@ declare module "lodash" {
     isFunction(value: any): false;
     isInteger(value: number): boolean;
     isInteger(value: any): false;
-    isLength(value: void | null): false;
+    isLength(value: void | null): false;
     isLength(value: any): boolean;
     isMap(value: Map<any, any>): true;
     isMap(value: any): false;
@@ -852,9 +852,9 @@ declare module "lodash" {
     ): boolean;
     isNaN(value: number): boolean;
     isNaN(value: any): false;
-    isNative(value: number | string | void | null | Object): false;
+    isNative(value: number | string | void | null | Object): false;
     isNative(value: any): boolean;
-    isNil(value: void | null): true;
+    isNil(value: void | null): true;
     isNil(value: any): false;
     isNull(value: null): true;
     isNull(value: any): false;
@@ -862,7 +862,7 @@ declare module "lodash" {
     isNumber(value: any): false;
     isObject(value: Object): true;
     isObject(value: any): false;
-    isObjectLike(value: void | null): false;
+    isObjectLike(value: void | null): false;
     isObjectLike(value: any): boolean;
     isPlainObject(value: Object): true;
     isPlainObject(value: any): false;
@@ -887,18 +887,18 @@ declare module "lodash" {
     lt(value: any, other: any): boolean;
     lte(value: any, other: any): boolean;
     toArray(value: any): Array<any>;
-    toFinite(value: void | null): 0;
+    toFinite(value: void | null): 0;
     toFinite(value: any): number;
-    toInteger(value: void | null): 0;
+    toInteger(value: void | null): 0;
     toInteger(value: any): number;
-    toLength(value: void | null): 0;
+    toLength(value: void | null): 0;
     toLength(value: any): number;
-    toNumber(value: void | null): 0;
+    toNumber(value: void | null): 0;
     toNumber(value: any): number;
     toPlainObject(value: any): Object;
-    toSafeInteger(value: void | null): 0;
+    toSafeInteger(value: void | null): 0;
     toSafeInteger(value: any): number;
-    toString(value: void | null): '';
+    toString(value: void | null): '';
     toString(value: any): string;
 
     // Math
@@ -1036,7 +1036,7 @@ declare module "lodash" {
     at(object?: ?Object, ...paths: Array<string>): Array<any>;
     at(object?: ?Object, paths: Array<string>): Array<any>;
     create<T>(prototype: T, properties: Object): $Supertype<T>;
-    create(prototype: any, properties: void | null): {};
+    create(prototype: any, properties: void | null): {};
     defaults(object?: ?Object, ...sources?: Array<?Object>): Object;
     defaultsDeep(object?: ?Object, ...sources?: Array<?Object>): Object;
     // alias for _.toPairs
@@ -1104,7 +1104,7 @@ declare module "lodash" {
       predicate?: ?OPredicate<A, T>
     ): string | void;
     findKey<A, T: { [id: string]: A }>(
-      object: void | null,
+      object: void | null,
       predicate?: ?OPredicate<A, T>
     ): void;
     findLastKey<A, T: { [id: string]: A }>(
@@ -1112,17 +1112,17 @@ declare module "lodash" {
       predicate?: ?OPredicate<A, T>
     ): string | void;
     findLastKey<A, T: { [id: string]: A }>(
-      object: void | null,
+      object: void | null,
       predicate?: ?OPredicate<A, T>
     ): void;
     forIn(object: Object, iteratee?: ?OIteratee<*>): Object;
-    forIn(object: void | null, iteratee?: ?OIteratee<*>): null;
+    forIn(object: void | null, iteratee?: ?OIteratee<*>): null;
     forInRight(object: Object, iteratee?: ?OIteratee<*>): Object;
-    forInRight(object: void | null, iteratee?: ?OIteratee<*>): null;
+    forInRight(object: void | null, iteratee?: ?OIteratee<*>): null;
     forOwn(object: Object, iteratee?: ?OIteratee<*>): Object;
-    forOwn(object: void | null, iteratee?: ?OIteratee<*>): null;
+    forOwn(object: void | null, iteratee?: ?OIteratee<*>): null;
     forOwnRight(object: Object, iteratee?: ?OIteratee<*>): Object;
-    forOwnRight(object: void | null, iteratee?: ?OIteratee<*>): null;
+    forOwnRight(object: void | null, iteratee?: ?OIteratee<*>): null;
     functions(object?: ?Object): Array<string>;
     functionsIn(object?: ?Object): Array<string>;
     get(
@@ -1131,15 +1131,15 @@ declare module "lodash" {
       defaultValue?: any
     ): any;
     has(object: Object, path: Array<string> | string): boolean;
-    has(object: Object, path: void | null): false;
+    has(object: Object, path: void | null): false;
     has(object: void | null, path?: ?Array<string> | ?string): false;
     hasIn(object: Object, path: Array<string> | string): boolean;
-    hasIn(object: Object, path: void | null): false;
+    hasIn(object: Object, path: void | null): false;
     hasIn(object: void | null, path?: ?Array<string> | ?string): false;
     invert(object: Object, multiVal?: ?boolean): Object;
-    invert(object: void | null, multiVal?: ?boolean): {};
+    invert(object: void | null, multiVal?: ?boolean): {};
     invertBy(object: Object, iteratee?: ?Function): Object;
-    invertBy(object: void | null, iteratee?: ?Function): {};
+    invertBy(object: void | null, iteratee?: ?Function): {};
     invoke(
       object?: ?Object,
       path?: ?Array<string> | string,
@@ -1149,9 +1149,9 @@ declare module "lodash" {
     keys(object?: ?Object): Array<string>;
     keysIn(object?: ?Object): Array<string>;
     mapKeys(object: Object, iteratee?: ?OIteratee<*>): Object;
-    mapKeys(object: void | null, iteratee?: ?OIteratee<*>): {};
+    mapKeys(object: void | null, iteratee?: ?OIteratee<*>): {};
     mapValues(object: Object, iteratee?: ?OIteratee<*>): Object;
-    mapValues(object: void | null, iteratee?: ?OIteratee<*>): {};
+    mapValues(object: void | null, iteratee?: ?OIteratee<*>): {};
     merge(object?: ?Object, ...sources?: Array<?Object>): Object;
     mergeWith(): {};
     mergeWith<T: Object, A: Object>(
@@ -1229,7 +1229,7 @@ declare module "lodash" {
       defaultValue?: any
     ): any;
     set(object: Object, path?: ?Array<string> | string, value: any): Object;
-    set<T: void | null>(
+    set<T: void | null>(
       object: T,
       path?: ?Array<string> | string,
       value?: ?any): T;
@@ -1239,7 +1239,7 @@ declare module "lodash" {
       value: any,
       customizer?: (nsValue: any, key: string, nsObject: T) => any
     ): Object;
-    setWith<T: void | null>(
+    setWith<T: void | null>(
       object: T,
       path?: ?Array<string> | string,
       value?: ?any,
@@ -1253,14 +1253,14 @@ declare module "lodash" {
       accumulator?: any
     ): any;
     transform(
-      collection: void | null,
+      collection: void | null,
       iteratee?: ?OIteratee<*>,
       accumulator?: ?any
     ): {};
     unset(object: Object, path?: ?Array<string> | ?string): boolean;
-    unset(object: void | null, path?: ?Array<string> | ?string): true;
+    unset(object: void | null, path?: ?Array<string> | ?string): true;
     update(object: Object, path: string[] | string, updater: Function): Object;
-    update<T: void | null>(
+    update<T: void | null>(
       object: T,
       path?: ?string[] | ?string,
       updater?: ?Function): T;
@@ -1270,7 +1270,7 @@ declare module "lodash" {
       updater?: ?Function,
       customizer?: ?Function
     ): Object;
-    updateWith<T: void | null>(
+    updateWith<T: void | null>(
       object: T,
       path?: ?string[] | ?string,
       updater?: ?Function,
@@ -1289,75 +1289,75 @@ declare module "lodash" {
 
     // String
     camelCase(string: string): string;
-    camelCase(string: void | null): '';
+    camelCase(string: void | null): '';
     capitalize(string: string): string;
-    capitalize(string: void | null): '';
+    capitalize(string: void | null): '';
     deburr(string: string): string;
-    deburr(string: void | null): '';
+    deburr(string: void | null): '';
     endsWith(string: string, target?: string, position?: ?number): boolean;
-    endsWith(string: void | null, target?: ?string, position?: ?number): false;
+    endsWith(string: void | null, target?: ?string, position?: ?number): false;
     escape(string: string): string;
-    escape(string: void | null): '';
+    escape(string: void | null): '';
     escapeRegExp(string: string): string;
-    escapeRegExp(string: void | null): '';
+    escapeRegExp(string: void | null): '';
     kebabCase(string: string): string;
-    kebabCase(string: void | null): '';
+    kebabCase(string: void | null): '';
     lowerCase(string: string): string;
-    lowerCase(string: void | null): '';
+    lowerCase(string: void | null): '';
     lowerFirst(string: string): string;
-    lowerFirst(string: void | null): '';
+    lowerFirst(string: void | null): '';
     pad(string?: ?string, length?: ?number, chars?: ?string): string;
     padEnd(string?: ?string, length?: ?number, chars?: ?string): string;
     padStart(string?: ?string, length?: ?number, chars?: ?string): string;
     parseInt(string: string, radix?: ?number): number;
     repeat(string: string, n?: ?number): string;
-    repeat(string: void | null, n?: ?number): '';
+    repeat(string: void | null, n?: ?number): '';
     replace(
       string: string,
       pattern: RegExp | string,
       replacement: ((string: string) => string) | string
     ): string;
     replace(
-      string: void | null,
+      string: void | null,
       pattern?: ?RegExp | ?string,
       replacement: ?((string: string) => string) | ?string
     ): '';
     snakeCase(string: string): string;
-    snakeCase(string: void | null): '';
+    snakeCase(string: void | null): '';
     split(
       string?: ?string,
       separator?: ?RegExp | ?string,
       limit?: ?number
     ): Array<string>;
     startCase(string: string): string;
-    startCase(string: void | null): '';
+    startCase(string: void | null): '';
     startsWith(string: string, target?: string, position?: number): boolean;
-    startsWith(string: void | null, target?: ?string, position?: ?number): false;
+    startsWith(string: void | null, target?: ?string, position?: ?number): false;
     template(string?: ?string, options?: ?TemplateSettings): Function;
     toLower(string: string): string;
-    toLower(string: void | null): '';
+    toLower(string: void | null): '';
     toUpper(string: string): string;
-    toUpper(string: void | null): '';
+    toUpper(string: void | null): '';
     trim(string: string, chars?: string): string;
-    trim(string: void | null, chars?: ?string): '';
+    trim(string: void | null, chars?: ?string): '';
     trimEnd(string: string, chars?: ?string): string;
-    trimEnd(string: void | null, chars?: ?string): '';
+    trimEnd(string: void | null, chars?: ?string): '';
     trimStart(string: string, chars?: ?string): string;
-    trimStart(string: void | null, chars?: ?string): '';
+    trimStart(string: void | null, chars?: ?string): '';
     truncate(string: string, options?: TruncateOptions): string;
-    truncate(string: void | null, options?: ?TruncateOptions): '';
+    truncate(string: void | null, options?: ?TruncateOptions): '';
     unescape(string: string): string;
-    unescape(string: void | null): '';
+    unescape(string: void | null): '';
     upperCase(string: string): string;
-    upperCase(string: void | null): '';
+    upperCase(string: void | null): '';
     upperFirst(string: string): string;
-    upperFirst(string: void | null): '';
+    upperFirst(string: void | null): '';
     words(string?: ?string, pattern?: ?RegExp | ?string): Array<string>;
 
     // Util
     attempt(func: Function, ...args: Array<any>): any;
     bindAll(object: Object, methodNames?: ?Array<string>): Object;
-    bindAll<T: void | null>(object: T, methodNames?: ?Array<string>): T;
+    bindAll<T: void | null>(object: T, methodNames?: ?Array<string>): T;
     bindAll(object: Object, ...methodNames: Array<string>): Object;
     cond(pairs?: ?NestedArray<Function>): Function;
     conforms(source?: ?Object): Function;
@@ -1404,7 +1404,7 @@ declare module "lodash" {
     stubObject(): {};
     stubString(): "";
     stubTrue(): true;
-    times(n?: ?number, ...rest?: Array<void | null>): Array<number>;
+    times(n?: ?number, ...rest?: Array<void | null>): Array<number>;
     times<T>(n: number, iteratee: (i: number) => T): Array<T>;
     toPath(value: any): Array<string>;
     uniqueId(prefix?: ?string): string;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -479,4 +479,4 @@ pairs = toPairsIn({ a: 12, b: 100 });
 (omitBy({a: 2, b: 3, c: 4}, num => num % 2): {[prop: string]: number});
 (omitBy(null, num => num % 2): {});
 (omitBy(undefined, num => num % 2): {});
-(pickBy({[1]: 1, [2]: 2}, num => num === 2): {[prop: number]: number});
+(omitBy({[1]: 1, [2]: 2}, num => num === 2): {[prop: number]: number});

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -471,6 +471,7 @@ pairs = toPairsIn({ a: 12, b: 100 });
 (pickBy({a: 2, b: 3, c: 4}, num => num % 2): {[prop: string]: number});
 (pickBy(null, num => num % 2): {});
 (pickBy(undefined, num => num % 2): {});
+(pickBy({[1]: 1, [2]: 2}, num => num === 2): {[prop: number]: number});
 
 /**
  * _.omitBy
@@ -478,3 +479,4 @@ pairs = toPairsIn({ a: 12, b: 100 });
 (omitBy({a: 2, b: 3, c: 4}, num => num % 2): {[prop: string]: number});
 (omitBy(null, num => num % 2): {});
 (omitBy(undefined, num => num % 2): {});
+(pickBy({[1]: 1, [2]: 2}, num => num === 2): {[prop: number]: number});


### PR DESCRIPTION
Until now, `pickBy` and `omitBy` did not support numbers as valid object keys.