### PR TITLE
Add various RxJS statics

### DIFF
--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -2001,6 +2001,8 @@ declare module "rxjs" {
       resultSelector: (...values: Array<any>) => A
     ): rxjs$Observable<A>;
 
+    race<+T>(other: rxjs$Observable<T>): rxjs$Observable<T> => rxjs$Observable<T>;
+
     zip<A, B>(
       a: rxjs$Observable<A>,
       resultSelector: (a: A) => B

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -1754,6 +1754,114 @@ declare module "rxjs" {
       options: rxjs$EventListenerOptions,
       selector: () => T
     ) => rxjs$Observable<T>);
+
+    combineLatest: (<A, B>(
+      a: rxjs$Observable<A>,
+      resultSelector: (a: A) => B
+    ) => rxjs$Observable<B>) &
+    (<A, B, C>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      resultSelector: (a: A, b: B) => C
+    ) => rxjs$Observable<C>) &
+    (<A, B, C, D>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      resultSelector: (a: A, b: B, c: C) => D
+    ) => rxjs$Observable<D>) &
+    (<A, B, C, D, E>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      resultSelector: (a: A, b: B, c: C, d: D) => E
+    ) => rxjs$Observable<E>) &
+    (<A, B, C, D, E, F>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      resultSelector: (a: A, b: B, c: C, d: D, e: E) => F
+    ) => rxjs$Observable<F>) &
+    (<A, B, C, D, E, F, G>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F) => G
+    ) => rxjs$Observable<G>) &
+    (<A, B, C, D, E, F, G, H>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      g: rxjs$Observable<G>,
+      resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
+    ) => rxjs$Observable<H>) &
+    (<A>(a: rxjs$Observable<A>, _: void) => rxjs$Observable<[A]>) &
+    (<A, B>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      _: void
+    ) => rxjs$Observable<[A, B]>) &
+    (<A, B, C>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      _: void
+    ) => rxjs$Observable<[A, B, C]>) &
+    (<A, B, C, D>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      _: void
+    ) => rxjs$Observable<[A, B, C, D]>) &
+    (<A, B, C, D, E>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      _: void
+    ) => rxjs$Observable<[A, B, C, D, E]>) &
+    (<A, B, C, D, E, F>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      _: void
+    ) => rxjs$Observable<[A, B, C, D, E, F]>) &
+    (<A, B, C, D, E, F, G>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      g: rxjs$Observable<G>,
+      _: void
+    ) => rxjs$Observable<[A, B, C, D, E, F, G]>) &
+    (<A, B, C, D, E, F, G, H>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      g: rxjs$Observable<G>,
+      h: rxjs$Observable<H>,
+      _: void
+    ) => rxjs$Observable<[A, B, C, D, E, F, G, H]>);
+
     Observable: typeof rxjs$Observable,
     Observer: typeof rxjs$Observer,
     ConnectableObservable: typeof rxjs$ConnectableObservable,

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -1862,6 +1862,145 @@ declare module "rxjs" {
       _: void
     ) => rxjs$Observable<[A, B, C, D, E, F, G, H]>);
 
+    forkJoin<A, B>(
+      a: rxjs$Observable<A>,
+      resultSelector: (a: A) => B
+    ): rxjs$Observable<B>;
+
+    forkJoin<A, B, C>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      resultSelector: (a: A, b: B) => C
+    ): rxjs$Observable<C>;
+
+    forkJoin<A, B, C, D>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      resultSelector: (a: A, b: B, c: C) => D
+    ): rxjs$Observable<D>;
+
+    forkJoin<A, B, C, D, E>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      resultSelector: (a: A, b: B, c: C, d: D) => E
+    ): rxjs$Observable<E>;
+
+    forkJoin<A, B, C, D, E, F>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      resultSelector: (a: A, b: B, c: C, d: D, e: E) => F
+    ): rxjs$Observable<F>;
+
+    forkJoin<A, B, C, D, E, F, G>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F) => G
+    ): rxjs$Observable<G>;
+
+    forkJoin<A, B, C, D, E, F, G, H>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      g: rxjs$Observable<G>,
+      resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
+    ): rxjs$Observable<H>;
+
+    forkJoin<A, B>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      _: void
+    ): rxjs$Observable<[A, B]>;
+
+    forkJoin<A, B, C>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      _: void
+    ): rxjs$Observable<[A, B, C]>;
+
+    forkJoin<A, B, C, D>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      _: void
+    ): rxjs$Observable<[A, B, C, D]>;
+
+    forkJoin<A, B, C, D, E>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      _: void
+    ): rxjs$Observable<[A, B, C, D, E]>;
+
+    forkJoin<A, B, C, D, E, F>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      _: void
+    ): rxjs$Observable<[A, B, C, D, E, F]>;
+
+    forkJoin<A, B, C, D, E, F, G>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      g: rxjs$Observable<G>,
+      _: void
+    ): rxjs$Observable<[A, B, C, D, E, F, G]>;
+
+    forkJoin<A, B, C, D, E, F, G, H>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      g: rxjs$Observable<G>,
+      h: rxjs$Observable<H>,
+      _: void
+    ): rxjs$Observable<[A, B, C, D, E, F, G, H]>;
+
+    forkJoin<A>(
+      a: Array<rxjs$Observable<A>>,
+      _: void
+    ): rxjs$Observable<Array<A>>;
+
+    forkJoin<A>(
+      a: Array<rxjs$Observable<any>>,
+      _: void
+    ): rxjs$Observable<A>;
+
+    forkJoin<A, B>(
+      a: Array<rxjs$Observable<A>>,
+      resultSelector: (...values: Array<A>) => B
+    ): rxjs$Observable<B>;
+
+    forkJoin<A>(
+      a: Array<rxjs$Observable<any>>,
+      resultSelector: (...values: Array<any>) => A
+    ): rxjs$Observable<A>;
+
     zip<A, B>(
       a: rxjs$Observable<A>,
       resultSelector: (a: A) => B

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -1862,6 +1862,127 @@ declare module "rxjs" {
       _: void
     ) => rxjs$Observable<[A, B, C, D, E, F, G, H]>);
 
+    zip<A, B>(
+      a: rxjs$Observable<A>,
+      resultSelector: (a: A) => B
+    ): rxjs$Observable<B>;
+
+    zip<A, B, C>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      resultSelector: (a: A, b: B) => C
+    ): rxjs$Observable<C>;
+
+    zip<A, B, C, D>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      resultSelector: (a: A, b: B, c: C) => D
+    ): rxjs$Observable<D>;
+
+    zip<A, B, C, D, E>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      resultSelector: (a: A, b: B, c: C, d: D) => E
+    ): rxjs$Observable<E>;
+
+    zip<A, B, C, D, E, F>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      resultSelector: (a: A, b: B, c: C, d: D, e: E) => F
+    ): rxjs$Observable<F>;
+
+    zip<A, B, C, D, E, F, G>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F) => G
+    ): rxjs$Observable<G>;
+
+    zip<A, B, C, D, E, F, G, H>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      g: rxjs$Observable<G>,
+      resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
+    ): rxjs$Observable<H>;
+
+    zip<A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<[A]>;
+
+    zip<A, B>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      _: void
+    ): rxjs$Observable<[A, B]>;
+
+    zip<A, B, C>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      _: void
+    ): rxjs$Observable<[A, B, C]>;
+
+    zip<A, B, C, D>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      _: void
+    ): rxjs$Observable<[A, B, C, D]>;
+
+    zip<A, B, C, D, E>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      _: void
+    ): rxjs$Observable<[A, B, C, D, E]>;
+
+    zip<A, B, C, D, E, F>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      _: void
+    ): rxjs$Observable<[A, B, C, D, E, F]>;
+
+    zip<A, B, C, D, E, F, G>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      g: rxjs$Observable<G>,
+      _: void
+    ): rxjs$Observable<[A, B, C, D, E, F, G]>;
+
+    zip<A, B, C, D, E, F, G, H>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      g: rxjs$Observable<G>,
+      h: rxjs$Observable<H>,
+      _: void
+    ): rxjs$Observable<[A, B, C, D, E, F, G, H]>;
+
     Observable: typeof rxjs$Observable,
     Observer: typeof rxjs$Observer,
     ConnectableObservable: typeof rxjs$ConnectableObservable,

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
@@ -13,6 +13,7 @@ import {
   range,
   merge,
   combineLatest,
+  zip,
   fromEvent,
   AnonymousSubject,
   Observer,

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
@@ -14,6 +14,7 @@ import {
   merge,
   combineLatest,
   forkJoin,
+  race,
   zip,
   fromEvent,
   AnonymousSubject,

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
@@ -13,6 +13,7 @@ import {
   range,
   merge,
   combineLatest,
+  forkJoin,
   zip,
   fromEvent,
   AnonymousSubject,

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
@@ -12,6 +12,7 @@ import {
   empty,
   range,
   merge,
+  combineLatest,
   fromEvent,
   AnonymousSubject,
   Observer,


### PR DESCRIPTION
The non-static versions of these have been deprecated. See:

- [`combineLatest`](https://rxjs-dev.firebaseapp.com/api/operators/combineLatest)
- [`zip`](https://rxjs-dev.firebaseapp.com/api/operators/zip)
- [`forkJoin`](https://rxjs-dev.firebaseapp.com/api/operators/forkJoin)
- [`race`](https://rxjs-dev.firebaseapp.com/api/operators/race)