### PR TITLE
Fix `pickBy` and `omitBy` method definitions from `lodash` so that they correctly accept objects with `string` and `number` typed ids.

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -679,7 +679,7 @@ export function setup(yargs: Yargs) {
 }
 
 export async function run(argv: Args): Promise<number> {
-  if (!(await fs.exists(BIN_DIR))) {
+  if (!await fs.exists(BIN_DIR)) {
     await fs.mkdir(BIN_DIR);
   }
 

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -1205,7 +1205,7 @@ declare module "lodash" {
     ): Object;
     omit(object?: ?Object, ...props: Array<string>): Object;
     omit(object?: ?Object, props: Array<string>): Object;
-    omitBy<A, T: { [id: string | number]: A }>(
+    omitBy<A, T: { [id: string]: A }|{ [id: number]: A }>(
       object: T,
       predicate?: ?OPredicate<A, T>
     ): Object;
@@ -1215,7 +1215,7 @@ declare module "lodash" {
     ): {};
     pick(object?: ?Object, ...props: Array<string>): Object;
     pick(object?: ?Object, props: Array<string>): Object;
-    pickBy<A, T: { [id: string | number]: A }>(
+    pickBy<A, T: { [id: string]: A }|{ [id: number]: A }>(
       object: T,
       predicate?: ?OPredicate<A, T>
     ): Object;


### PR DESCRIPTION
In response to the next issue #2623 