### PR TITLE
Add Observable.race static function

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
@@ -308,6 +308,8 @@ declare class rxjs$Observable<+T> {
 
   static of(...values: T[]): rxjs$Observable<T>;
 
+  static race(...sources: rxjs$Observable<T>[]): rxjs$Observable<T>;
+
   static throw(error: any): rxjs$Observable<any>;
 
   audit(

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -324,6 +324,8 @@ declare class rxjs$Observable<+T> {
 
   static of(...values: T[]): rxjs$Observable<T>;
 
+  static race(...sources: rxjs$Observable<T>[]): rxjs$Observable<T>;
+
   static range(
     start?: number,
     count?: number,

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -37,6 +37,11 @@ strings.elementAt(1, 5);
 // $ExpectError -- need the typecast or the error appears at the declaration site
 numbers.merge((strings: Observable<string>));
 
+(Observable.race(
+  Observable.timer(0, 100),
+  Observable.timer(0, 200)
+): Observable<number>);
+
 numbers.let(_numbers => strings);
 numbers.letBind(_numbers => strings);
 // $ExpectError -- need to return an observable


### PR DESCRIPTION
This adds type definitions for the [Observable.race](https://github.com/ReactiveX/rxjs/blob/stable/src/observable/race.ts#L11) static function + a simple test. Observable.race takes in multiple observables and returns an observable that mirrors the first observable to emit a value.