### PR TITLE
Properly deal with injected props in withStyles function of material-ui

### DIFF
--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
@@ -1844,15 +1844,20 @@ declare module "@material-ui/core/styles/withStyles" {
     generateClassName?: Function
   };
 
+  declare export type InjectedProps = {
+    classes: void | { +[string]: string },
+    innerRef: void | React$Ref<React$ElementType>
+  }
+
   declare module.exports: (
     stylesOrCreator: Object,
     options?: Options
-  ) => <Props: {}>(
-    Component: React$ComponentType<Props>
-  ) => React$ComponentType<$Diff<Props, {
-    classes?: Object,
-    innerRef?: React$Ref<React$ElementType>
-  }>>;
+  ) => <
+    Props: {},
+    WrappedComponent: React$ComponentType<Props>
+    >(
+    Component: WrappedComponent
+  ) => React$ComponentType<$Diff<React$ElementConfig<WrappedComponent>, InjectedProps>>;
 }
 
 declare module "@material-ui/core/styles/withTheme" {

--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
@@ -20,34 +20,39 @@ let button1 = <Button>Click me!</Button>;
 let button2 = <Button disableRipple={3} />;
 
 // $ExpectError invalid variant
-let typography1 = <Typography variant="wrong" />
-let typography2 = <Typography variant="headline" />
+let typography1 = <Typography variant="wrong" />;
+let typography2 = <Typography variant="headline" />;
 
-// withStyles - remove prop "classes" from Props
+// withStyles
 class TestComponent extends React.Component<{
   classes: {},
   requiredProp: string
-}> {}
-const CustomTestComponent = withStyles({})(TestComponent)
+}> {
+  static defaultProps = {
+    value: 'value'
+  }
+}
+const CustomTestComponent = withStyles({})(TestComponent);
 
 function renderTestComponentWithError () {
   return (
-    // $ExpectError is missing required prop
+    // $ExpectError is missing 'requiredProp'
     <CustomTestComponent />
   )
 }
 
 function renderTestComponent () {
   return (
-    // doesn't require the prop classes
+    // doesn't require the prop 'classes' nor default prop 'value'
     <CustomTestComponent requiredProp='test' />
   )
 }
 
-const DoubleStyledComponent = withStyles({})(CustomTestComponent)
+const DoubleStyledComponent = withStyles({})(CustomTestComponent);
+
 function renderDoubleStyledComponent () {
   return (
-    // doesn't require the prop classes
+    // doesn't require the prop 'classes' nor default prop 'value'
     <DoubleStyledComponent requiredProp='test' />
   )
 }


### PR DESCRIPTION
In this commit we fix an issue with how the higher-order component `withStyles` dealt with default props and properly deal with HOCs per the documentation on injecting props with a higher-order component (`https://flow.org/en/docs/react/hoc/`).