### PR TITLE
Add $ReadOnlyArray to Relay's Variable union type

### DIFF
--- a/definitions/npm/react-relay_v1.x.x/flow_v0.47.x-/react-relay_v1.x.x.js
+++ b/definitions/npm/react-relay_v1.x.x/flow_v0.47.x-/react-relay_v1.x.x.js
@@ -349,7 +349,7 @@ declare module "react-relay" {
     connectionConfig: ConnectionConfig
   ): TBase;
 
-  declare type Variable = string | null | boolean | number | Variables | void | Array<Variable>;
+  declare type Variable = string | null | boolean | number | Variables | void | Array<Variable> | $ReadOnlyArray<Variable>;
   declare export type Variables = ?{ [string]: Variable };
   declare export type DataID = string;
 


### PR DESCRIPTION
This allows types generated by relay-compiler to be used with this libdef.