### PR TITLE
Add missing definition for rxjsv6

### DIFF
--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -1734,6 +1734,7 @@ declare module "rxjs" {
       source2: rxjs$Observable<V>
     ) => rxjs$Observable<T | U | V>) &
       (<+T>(...sources: rxjs$Observable<T>[]) => rxjs$Observable<T>),
+    fromPromise<+T>(promise: Promise<T>): rxjs$Observable<T>,
     fromEvent: (<+T>(
       element: any,
       eventName: string,


### PR DESCRIPTION
Adds missing definition for **fromPromise** `import { fromPromise } from 'rxjs';`