### PR TITLE
Make onDismiss optional on react-bootstrap Alert component

### DIFF
--- a/definitions/npm/react-bootstrap_v0.32.x/flow_v0.53.x-/react-bootstrap_v0.32.x.js
+++ b/definitions/npm/react-bootstrap_v0.32.x/flow_v0.53.x-/react-bootstrap_v0.32.x.js
@@ -5,7 +5,7 @@ declare module "react-bootstrap" {
   declare type ElementType = string | ComponentType<*>;
   declare type TriggerType = 'click' | 'hover' | 'focus';
   declare export class Alert extends React$Component<{
-    onDismiss: Function,
+    onDismiss?: Function,
     closeLabel?: string,
     bsStyle?: 'success' | 'warning' | 'danger' | 'info',
     bsClass?: string


### PR DESCRIPTION
According to the [documentation](https://react-bootstrap.github.io/components/alerts/), `onDismiss` is not a required prop on the `Alert` component.

This PR fixes the flow type, and thereby eliminates the flow errors when using `Alert`s without dismiss buttons.

```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/containers/LearnVehicleSelectRobot.js:214:15

Cannot create Alert element because property onDismiss is missing in props [1] but exists in object type [2].

     src/containers/LearnVehicleSelectRobot.js
     211│   renderCompanies = () => {
     212│     const { availableCompanies, energyCompany, errorLoadingCompanies } = this.state
     213│     if (errorLoadingCompanies) {
 [1] 214│       return <Alert bsStyle="danger">Error loading companies</Alert>
     215│     }
     216│     if (availableCompanies.length === 0) {
     217│       return <Alert bsStyle="danger">No companies available</Alert>

     flow-typed/npm/react-bootstrap_v0.32.x.js
 [2]  11│   declare export class Alert extends React$Component<{
      12│     onDismiss: Function,
      13│     closeLabel?: string,
      14│     bsStyle?: 'success' | 'warning' | 'danger' | 'info',
      15│     bsClass?: string,
      16│   }> {}
```