### PR TITLE
[lodash 4.x] 'keyBy': do not return map of maybe types

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.28.x-v0.37.x/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.28.x-v0.37.x/lodash_v4.x.x.js
@@ -373,7 +373,7 @@ declare module "lodash" {
       path: ((value: any) => Array<string> | string) | Array<string> | string,
       ...args?: Array<any>
     ): Array<any>;
-    keyBy<T, V>(array: ?Array<T>, iteratee?: Iteratee2<T, V>): { [key: V]: ?T };
+    keyBy<T, V>(array: ?Array<T>, iteratee?: Iteratee2<T, V>): { [key: V]: T };
     keyBy<V, T: Object>(object: T, iteratee?: OIteratee<T>): Object;
     map<T, U>(array: ?Array<T>, iteratee?: MapIterator<T, U>): Array<U>;
     map<V, T: Object, U>(

--- a/definitions/npm/lodash_v4.x.x/flow_v0.38.x-v0.46.x/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.38.x-v0.46.x/lodash_v4.x.x.js
@@ -392,11 +392,11 @@ declare module "lodash" {
     keyBy<T, V>(
       array: ?Array<T>,
       iteratee?: ValueOnlyIteratee<T>
-    ): { [key: V]: ?T };
+    ): { [key: V]: T };
     keyBy<V, A, T: { [id: string]: A }>(
       object: T,
       iteratee?: ValueOnlyIteratee<A>
-    ): { [key: V]: ?A };
+    ): { [key: V]: A };
     map<T, U>(array: ?Array<T>, iteratee?: MapIterator<T, U>): Array<U>;
     map<V, T: Object, U>(
       object: ?T,

--- a/definitions/npm/lodash_v4.x.x/flow_v0.47.x-v0.54.x/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.47.x-v0.54.x/lodash_v4.x.x.js
@@ -605,11 +605,11 @@ declare module "lodash" {
     keyBy<T, V>(
       array: ?Array<T>,
       iteratee?: ValueOnlyIteratee<T>
-    ): { [key: V]: ?T };
+    ): { [key: V]: T };
     keyBy<V, A, I, T: { [id: I]: A }>(
       object: T,
       iteratee?: ValueOnlyIteratee<A>
-    ): { [key: V]: ?A };
+    ): { [key: V]: A };
     map<T, U>(array: ?Array<T>, iteratee?: MapIterator<T, U>): Array<U>;
     map<V, T: Object, U>(
       object: ?T,

--- a/definitions/npm/lodash_v4.x.x/flow_v0.47.x-v0.54.x/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.47.x-v0.54.x/test_lodash-v4.x.x.js
@@ -170,7 +170,7 @@ var keyByTest_map: KeyByTest$ByNumber<KeyByTest$Record> = {
   [keyByTest_array[2].id]: keyByTest_array[2],
 }
 
-var keyByTest_map2: KeyByTest$ByNumberMaybe<?KeyByTest$Record> = keyBy(keyByTest_map, 'id')
+var keyByTest_map2: KeyByTest$ByNumberMaybe<KeyByTest$Record> = keyBy(keyByTest_map, 'id')
 
 
 /**

--- a/definitions/npm/lodash_v4.x.x/flow_v0.55.x-v0.62.x/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.55.x-v0.62.x/lodash_v4.x.x.js
@@ -612,7 +612,7 @@ declare module "lodash" {
     keyBy<T, V>(
       array: Array<T>,
       iteratee?: ?ValueOnlyIteratee<T>
-    ): { [key: V]: ?T };
+    ): { [key: V]: T };
     keyBy(
       array: void | null,
       iteratee?: ?ValueOnlyIteratee<*>
@@ -620,7 +620,7 @@ declare module "lodash" {
     keyBy<V, A, I, T: { [id: I]: A }>(
       object: T,
       iteratee?: ?ValueOnlyIteratee<A>
-    ): { [key: V]: ?A };
+    ): { [key: V]: A };
     map<T, U>(array?: ?Array<T>, iteratee?: ?MapIterator<T, U>): Array<U>;
     map<T, U>(
       array: ?$ReadOnlyArray<T>,

--- a/definitions/npm/lodash_v4.x.x/flow_v0.55.x-v0.62.x/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.55.x-v0.62.x/test_lodash-v4.x.x.js
@@ -176,7 +176,7 @@ var keyByTest_map: KeyByTest$ByNumber<KeyByTest$Record> = {
   [keyByTest_array[2].id]: keyByTest_array[2]
 };
 
-var keyByTest_map2: KeyByTest$ByNumberMaybe<?KeyByTest$Record> = keyBy(
+var keyByTest_map2: KeyByTest$ByNumberMaybe<KeyByTest$Record> = keyBy(
   keyByTest_map,
   "id"
 );

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -608,7 +608,7 @@ declare module "lodash" {
     keyBy<T, V>(
       array: $ReadOnlyArray<T>,
       iteratee?: ?ValueOnlyIteratee<T>
-    ): { [key: V]: ?T };
+    ): { [key: V]: T };
     keyBy(
       array: void | null,
       iteratee?: ?ValueOnlyIteratee<*>
@@ -616,7 +616,7 @@ declare module "lodash" {
     keyBy<V, A, I, T: { [id: I]: A }>(
       object: T,
       iteratee?: ?ValueOnlyIteratee<A>
-    ): { [key: V]: ?A };
+    ): { [key: V]: A };
     map<T, U>(array?: ?Array<T>, iteratee?: ?MapIterator<T, U>): Array<U>;
     map<T, U>(
       array: ?$ReadOnlyArray<T>,

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -196,7 +196,7 @@ var keyByTest_map: KeyByTest$ByNumber<KeyByTest$Record> = {
   [keyByTest_array[2].id]: keyByTest_array[2]
 };
 
-var keyByTest_map2: KeyByTest$ByNumberMaybe<?KeyByTest$Record> = keyBy(
+var keyByTest_map2: KeyByTest$ByNumberMaybe<KeyByTest$Record> = keyBy(
   keyByTest_map,
   "id"
 );


### PR DESCRIPTION
As stated in #924 and in comment in #681, current type definition of lodash `keyBy` is invalid. `fp` version is already valid.

Resolve  #924