### PR TITLE
[redux-mock-store] update Store type

### DIFF
--- a/definitions/npm/redux-mock-store_v1.2.x/flow_v0.25.x-/redux-mock-store_v1.2.x.js
+++ b/definitions/npm/redux-mock-store_v1.2.x/flow_v0.25.x-/redux-mock-store_v1.2.x.js
@@ -7,12 +7,14 @@ declare module "redux-mock-store" {
   declare type mockStore = {
     <S, A>(state: S): mockStoreWithoutMiddleware<S, A>
   };
+  declare type DispatchAPI<A> = (action: A) => A;
+  declare type Dispatch<A: { type: $Subtype<string> }> = DispatchAPI<A>;
   declare type mockStoreWithoutMiddleware<S, A> = {
     getState(): S,
     getActions(): Array<A>,
-    dispatch(action: A): A,
+    dispatch: Dispatch<A>,
     clearActions(): void,
-    subscribe(callback: Function): void,
+    subscribe(callback: Function): () => void,
     replaceReducer(nextReducer: Function): void
   };
 


### PR DESCRIPTION
After changes in #2530 it appears that Store type generated by previous definition of redux-mock-store is invalid. This PR makes it compatible again.