### PR TITLE
Use imported react types instead of flow internal react types

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -1,4 +1,5 @@
 declare module "react-apollo" {
+  import type { ComponentType, Element, Node } from 'react';
   /**
    * Copied types from Apollo Client libdef
    * Please update apollo-client libdef as well if updating these types
@@ -713,11 +714,11 @@ declare module "react-apollo" {
 
   declare export interface ApolloProviderProps<TCache> {
     client: any; // ApolloClient<TCache>;
-    children: React$Node;
+    children: Node;
   }
 
   declare export interface ApolloConsumerProps {
-    children: (client: ApolloClient<any>) => React$Node;
+    children: (client: ApolloClient<any>) => Node;
   }
 
   declare export class ApolloConsumer extends React$Component<
@@ -840,8 +841,8 @@ declare module "react-apollo" {
     TMergedProps: Object = ChildProps<TOwnProps, TResult, TVariables>
   > {
     (
-      component: React$ComponentType<TMergedProps>
-    ): React$ComponentType<TOwnProps>;
+      component: ComponentType<TMergedProps>
+    ): ComponentType<TOwnProps>;
   }
 
   declare export function graphql<TResult, TProps, TVariables, TChildProps>(
@@ -854,9 +855,9 @@ declare module "react-apollo" {
   };
 
   declare export function withApollo<TProps>(
-    component: React$ComponentType<{ client: ApolloClient<any> } & TProps>,
+    component: ComponentType<{ client: ApolloClient<any> } & TProps>,
     operationOptions?: WithApolloOptions
-  ): React$ComponentType<TProps>;
+  ): ComponentType<TProps>;
 
   declare export interface IDocumentDefinition {
     type: DocumentType;
@@ -872,28 +873,28 @@ declare module "react-apollo" {
 
   declare export interface QueryResult {
     query: Promise<ApolloQueryResult<mixed>>;
-    element: React$Element<*>;
+    element: Element<*>;
     context: Context;
   }
 
   declare export function walkTree(
-    element: React$Node,
+    element: Node,
     context: Context,
     visitor: (
-      element: React$Node,
+      element: Node,
       instance: any,
       context: Context
     ) => boolean | void
   ): void;
 
   declare export function getDataFromTree(
-    rootElement: React$Element<*>,
+    rootElement: Element<*>,
     rootContext?: any,
     fetchRoot?: boolean
   ): Promise<void>;
 
   declare export function renderToStringWithData(
-    component: React$Element<*>
+    component: Element<*>
   ): Promise<string>;
 
   declare export function cleanupApolloState(apolloState: any): void;
@@ -930,7 +931,7 @@ declare module "react-apollo" {
 
   declare export type QueryRenderPropFunction<TData, TVariables> = (
     QueryRenderProps<TData, TVariables>
-  ) => React$Node;
+  ) => Node;
 
   declare export class Query<TData, TVariables> extends React$Component<{
     query: DocumentNode,
@@ -954,7 +955,7 @@ declare module "react-apollo" {
 
   declare export type SubscriptionRenderPropFunction<TData, TVariables> = (
     result: SubscriptionResult<TData, TVariables>
-  ) => React$Node
+  ) => Node
 
   declare type SubscriptionProps<
     TData,
@@ -998,7 +999,7 @@ declare module "react-apollo" {
   declare export type MutationRenderPropFunction<TData, TVariables> = (
     mutate: MutationFunction<TData, TVariables>,
     result: MutationResult<TData>
-  ) => React$Node;
+  ) => Node;
 
   declare export class Mutation<
     TData,

--- a/definitions/npm/react-color_v2.x.x/flow_v0.56.x-/react-color_v2.x.x.js
+++ b/definitions/npm/react-color_v2.x.x/flow_v0.56.x-/react-color_v2.x.x.js
@@ -1,4 +1,5 @@
 declare module "react-color" {
+  import type { ComponentType, Component } from 'react';
   declare export type HexColor = string;
 
   declare export type HSLColor = {|
@@ -45,7 +46,7 @@ declare module "react-color" {
     height?: string,
     direction?: "horizontal" | "vertical",
     renderers?: Object,
-    pointer?: React$ComponentType<any>
+    pointer?: ComponentType<any>
   |};
 
   declare export type BlockPickerProps = {|
@@ -90,7 +91,7 @@ declare module "react-color" {
     width?: string,
     height?: string,
     direction?: "horizontal" | "vertical",
-    pointer?: React$ComponentType<any>
+    pointer?: ComponentType<any>
   |};
 
   declare export type MaterialPickerProps = {|
@@ -115,7 +116,7 @@ declare module "react-color" {
 
   declare export type SliderPickerProps = {|
     ...ColorPickerProps,
-    pointer?: React$ComponentType<any>
+    pointer?: ComponentType<any>
   |};
 
   declare export type SwatchesPickerProps = {|
@@ -148,26 +149,27 @@ declare module "react-color" {
     source: string
   };
 
-  declare export class AlphaPicker extends React$Component<AlphaPickerProps> {}
-  declare export class BlockPicker extends React$Component<BlockPickerProps> {}
-  declare export class ChromePicker extends React$Component<ChromePickerProps> {}
-  declare export class CirclePicker extends React$Component<CirclePickerProps> {}
-  declare export class CompactPicker extends React$Component<CompactPickerProps> {}
-  declare export class GithubPicker extends React$Component<GithubPickerProps> {}
-  declare export class HuePicker extends React$Component<HuePickerProps> {}
-  declare export class MaterialPicker extends React$Component<MaterialPickerProps> {}
-  declare export class PhotoshopPicker extends React$Component<PhotoshopPickerProps> {}
-  declare export class SketchPicker extends React$Component<SketchPickerProps> {}
-  declare export class SliderPicker extends React$Component<SliderPickerProps> {}
-  declare export class SwatchesPicker extends React$Component<SwatchesPickerProps> {}
-  declare export class TwitterPicker extends React$Component<TwitterPickerProps> {}
+  declare export var AlphaPicker: Class<Component<AlphaPickerProps>>;
+  declare export var BlockPicker: Class<Component<BlockPickerProps>>;
+  declare export var ChromePicker: Class<Component<ChromePickerProps>>;
+  declare export var CirclePicker: Class<Component<CirclePickerProps>>;
+  declare export var CompactPicker: Class<Component<CompactPickerProps>>;
+  declare export var GithubPicker: Class<Component<GithubPickerProps>>;
+  declare export var HuePicker: Class<Component<HuePickerProps>>;
+  declare export var MaterialPicker: Class<Component<MaterialPickerProps>>;
+  declare export var PhotoshopPicker: Class<Component<PhotoshopPickerProps>>;
+  declare export var SketchPicker: Class<Component<SketchPickerProps>>;
+  declare export var SliderPicker: Class<Component<SliderPickerProps>>;
+  declare export var SwatchesPicker: Class<Component<SwatchesPickerProps>>;
+  declare export var TwitterPicker: Class<Component<TwitterPickerProps>>;
 
   declare export function CustomPicker<Props: {}>(
-    Component: React$ComponentType<InjectedColorProps & $Supertype<Props>>
-  ): React$ComponentType<Props>;
+    Component: ComponentType<InjectedColorProps & $Supertype<Props>>
+  ): ComponentType<Props>;
 }
 
 declare module "react-color/lib/components/common" {
+  import type { ComponentType, Component } from 'react';
   import type {
     HexColor,
     RGBColor,
@@ -185,7 +187,7 @@ declare module "react-color/lib/components/common" {
 
   declare export type AlphaProps = {|
     ...PartialColorResult,
-    pointer?: React$ComponentType<any>,
+    pointer?: ComponentType<any>,
     onChange?: ColorChangeHandler
   |};
 
@@ -202,14 +204,14 @@ declare module "react-color/lib/components/common" {
 
   declare export type HueProps = {|
     ...PartialColorResult,
-    pointer?: React$ComponentType<any>,
+    pointer?: ComponentType<any>,
     onChange?: ColorChangeHandler,
     direction?: "horizontal" | "vertical"
   |};
 
   declare export type SaturationProps = {|
     ...PartialColorResult,
-    pointer?: React$ComponentType<any>,
+    pointer?: ComponentType<any>,
     onChange?: ColorChangeHandler
   |};
 
@@ -219,9 +221,9 @@ declare module "react-color/lib/components/common" {
     grey?: string
   |};
 
-  declare export class Alpha extends React$Component<AlphaProps> {}
-  declare export class EditableInput extends React$Component<EditableInputProps> {}
-  declare export class Hue extends React$Component<HueProps> {}
-  declare export class Saturation extends React$Component<SaturationProps> {}
-  declare export class Checkboard extends React$Component<CheckboardProps> {}
+  declare export var Alpha: Class<Component<AlphaProps>>;
+  declare export var EditableInput: Class<Component<EditableInputProps>>;
+  declare export var Hue: Class<Component<HueProps>>;
+  declare export var Saturation: Class<Component<SaturationProps>>;
+  declare export var Checkboard: Class<Component<CheckboardProps>>;
 }

--- a/definitions/npm/react-navigation_v1.x.x/flow_v0.60.x-/react-navigation_v1.x.x.js
+++ b/definitions/npm/react-navigation_v1.x.x/flow_v0.60.x-/react-navigation_v1.x.x.js
@@ -1,6 +1,5 @@
-// @flow
-
 declare module 'react-navigation' {
+  import type { ComponentType, Node, ElementType, Ref, Element } from 'react'
   /**
    * First, a bunch of things we would love to import but instead must
    * reconstruct (mostly copy-pasted).
@@ -275,14 +274,14 @@ declare module 'react-navigation' {
     Route: NavigationRoute,
     Options: {},
     Props: {}
-  > = React$ComponentType<NavigationNavigatorProps<Options, Route> & Props> &
+  > = ComponentType<NavigationNavigatorProps<Options, Route> & Props> &
     ({} | { navigationOptions: NavigationScreenConfig<Options> });
 
   declare export type NavigationNavigator<
     State: NavigationState,
     Options: {},
     Props: {}
-  > = React$ComponentType<NavigationNavigatorProps<Options, State> & Props> & {
+  > = ComponentType<NavigationNavigatorProps<Options, State> & Props> & {
     router: NavigationRouter<State, Options>,
     navigationOptions?: ?NavigationScreenConfig<Options>,
   };
@@ -334,22 +333,22 @@ declare module 'react-navigation' {
    */
 
   declare export type NavigationStackScreenOptions = NavigationScreenOptions & {
-    header?: ?(React$Node | (HeaderProps => React$Node)),
+    header?: ?(Node | (HeaderProps => Node)),
     headerTransparent?: boolean,
-    headerTitle?: string | React$Node | React$ElementType,
+    headerTitle?: string | Node | ElementType,
     headerTitleStyle?: AnimatedTextStyleProp,
     headerTitleAllowFontScaling?: boolean,
     headerTintColor?: string,
-    headerLeft?: React$Node | React$ElementType,
+    headerLeft?: Node | ElementType,
     headerBackTitle?: string,
     headerBackImage?: ImageSource,
     headerTruncatedBackTitle?: string,
     headerBackTitleStyle?: TextStyleProp,
     headerPressColorAndroid?: string,
-    headerRight?: React$Node,
+    headerRight?: Node,
     headerStyle?: ViewStyleProp,
     headerForceInset?: HeaderForceInset,
-    headerBackground?: React$Node | React$ElementType,
+    headerBackground?: Node | ElementType,
     gesturesEnabled?: boolean,
     gestureResponseDistance?: { vertical?: number, horizontal?: number },
     gestureDirection?: 'default' | 'inverted',
@@ -417,12 +416,12 @@ declare module 'react-navigation' {
   declare export type NavigationTabScreenOptions = {|
     ...$Exact<NavigationScreenOptions>,
     tabBarIcon?:
-      | React$Node
-      | ((options: { tintColor: ?string, focused: boolean }) => ?React$Node),
+      | Node
+      | ((options: { tintColor: ?string, focused: boolean }) => ?Node),
     tabBarLabel?:
       | string
-      | React$Node
-      | ((options: { tintColor: ?string, focused: boolean }) => ?React$Node),
+      | Node
+      | ((options: { tintColor: ?string, focused: boolean }) => ?Node),
     tabBarVisible?: boolean,
     tabBarTestIDProps?: { testID?: string, accessibilityLabel?: string },
     tabBarOnPress?: (
@@ -438,11 +437,11 @@ declare module 'react-navigation' {
   declare export type NavigationDrawerScreenOptions = {|
     ...$Exact<NavigationScreenOptions>,
     drawerIcon?:
-      | React$Node
-      | ((options: { tintColor: ?string, focused: boolean }) => ?React$Node),
+      | Node
+      | ((options: { tintColor: ?string, focused: boolean }) => ?Node),
     drawerLabel?:
-      | React$Node
-      | ((options: { tintColor: ?string, focused: boolean }) => ?React$Node),
+      | Node
+      | ((options: { tintColor: ?string, focused: boolean }) => ?Node),
     drawerLockMode?: 'unlocked' | 'locked-closed' | 'locked-open',
   |};
 
@@ -547,7 +546,7 @@ declare module 'react-navigation' {
     State: NavigationState,
     Options: {},
     Props: {}
-  > = React$ComponentType<NavigationContainerProps<State, Options> & Props> & {
+  > = ComponentType<NavigationContainerProps<State, Options> & Props> & {
     router: NavigationRouter<State, Options>,
     navigationOptions?: ?NavigationScreenConfig<Options>,
   };
@@ -656,7 +655,7 @@ declare module 'react-navigation' {
     lastState: NavigationState
   ) => void;
 
-  declare export type NavigationSceneRenderer = () => React$Node;
+  declare export type NavigationSceneRenderer = () => Node;
 
   declare export type NavigationStyleInterpolator = (
     props: NavigationSceneRendererProps
@@ -781,7 +780,7 @@ declare module 'react-navigation' {
     S: NavigationState,
     O: {}
   > = (
-    NavigationView: React$ComponentType<_RouterProp<S, O> & NavigationViewProps>
+    NavigationView: ComponentType<_RouterProp<S, O> & NavigationViewProps>
   ) => NavigationNavigator<S, O, NavigationViewProps>;
   declare export function createNavigator<
     S: NavigationState,
@@ -800,7 +799,7 @@ declare module 'react-navigation' {
   ): NavigationContainer<*, *, *>;
 
   declare type _TabViewConfig = {|
-    tabBarComponent?: React$ElementType,
+    tabBarComponent?: ElementType,
     tabBarPosition?: 'top' | 'bottom',
     tabBarOptions?: {},
     swipeEnabled?: boolean,
@@ -837,7 +836,7 @@ declare module 'react-navigation' {
     drawerOpenRoute?: string,
     drawerCloseRoute?: string,
     drawerToggleRoute?: string,
-    contentComponent?: React$ElementType,
+    contentComponent?: ElementType,
     contentOptions?: {},
     style?: ViewStyleProp,
     useNativeAnimations?: boolean,
@@ -875,9 +874,9 @@ declare module 'react-navigation' {
     render: (
       transitionProps: NavigationTransitionProps,
       prevTransitionProps: ?NavigationTransitionProps
-    ) => React$Node,
+    ) => Node,
   };
-  declare export var Transitioner: React$ComponentType<_TransitionerProps>;
+  declare export var Transitioner: ComponentType<_TransitionerProps>;
 
   declare type _CardStackTransitionerProps = {
     headerMode: HeaderMode,
@@ -891,14 +890,14 @@ declare module 'react-navigation' {
      */
     transitionConfig?: () => TransitionConfig,
   } & NavigationNavigatorProps<NavigationStackScreenOptions, NavigationState>;
-  declare export var CardStackTransitioner: React$ComponentType<
+  declare export var CardStackTransitioner: ComponentType<
     _CardStackTransitionerProps
   >;
 
   declare type _CardStackProps = {
     screenProps?: {},
     headerMode: HeaderMode,
-    headerComponent?: React$ElementType,
+    headerComponent?: ElementType,
     mode: 'card' | 'modal',
     router: NavigationRouter<NavigationState, NavigationStackScreenOptions>,
     cardStyle?: ViewStyleProp,
@@ -917,16 +916,16 @@ declare module 'react-navigation' {
     scene: NavigationScene,
     index: number,
   };
-  declare export var CardStack: React$ComponentType<_CardStackProps>;
+  declare export var CardStack: ComponentType<_CardStackProps>;
 
   declare type _CardProps = {
     ...$Exact<NavigationSceneRendererProps>,
-    children: React$Node,
-    onComponentRef: React$Ref<*>,
+    children: Node,
+    onComponentRef: Ref<*>,
     pointerEvents: string,
     style: any,
   };
-  declare export var Card: React$ComponentType<_CardProps>;
+  declare export var Card: ComponentType<_CardProps>;
 
   declare type _SafeAreaViewForceInsetValue = 'always' | 'never' | number;
   declare type _SafeAreaViewProps = {
@@ -938,21 +937,21 @@ declare module 'react-navigation' {
       vertical?: _SafeAreaViewForceInsetValue,
       horizontal?: _SafeAreaViewForceInsetValue,
     },
-    children?: React$Node,
+    children?: Node,
     style?: AnimatedViewStyleProp,
   };
-  declare export var SafeAreaView: React$ComponentType<_SafeAreaViewProps>;
+  declare export var SafeAreaView: ComponentType<_SafeAreaViewProps>;
 
-  declare export var Header: React$ComponentType<HeaderProps> & {
+  declare export var Header: ComponentType<HeaderProps> & {
     HEIGHT: number,
   };
 
   declare type _HeaderTitleProps = {
-    children: React$Node,
+    children: Node,
     selectionColor?: string | number,
     style?: AnimatedTextStyleProp,
   };
-  declare export var HeaderTitle: React$ComponentType<_HeaderTitleProps>;
+  declare export var HeaderTitle: ComponentType<_HeaderTitleProps>;
 
   declare type _HeaderBackButtonProps = {
     onPress?: () => void,
@@ -963,7 +962,7 @@ declare module 'react-navigation' {
     truncatedTitle?: ?string,
     width?: ?number,
   };
-  declare export var HeaderBackButton: React$ComponentType<
+  declare export var HeaderBackButton: ComponentType<
     _HeaderBackButtonProps
   >;
 
@@ -974,7 +973,7 @@ declare module 'react-navigation' {
     drawerOpenRoute: string,
     drawerCloseRoute: string,
     drawerToggleRoute: string,
-    contentComponent: React$ElementType,
+    contentComponent: ElementType,
     contentOptions?: {},
     style?: ViewStyleProp,
     useNativeAnimations: boolean,
@@ -983,7 +982,7 @@ declare module 'react-navigation' {
     navigation: NavigationScreenProp<NavigationState>,
     router: NavigationRouter<NavigationState, NavigationDrawerScreenOptions>,
   };
-  declare export var DrawerView: React$ComponentType<_DrawerViewProps>;
+  declare export var DrawerView: ComponentType<_DrawerViewProps>;
 
   declare type _DrawerScene = {
     route: NavigationRoute,
@@ -1003,8 +1002,8 @@ declare module 'react-navigation' {
     activeBackgroundColor?: string,
     inactiveTintColor?: string,
     inactiveBackgroundColor?: string,
-    getLabel: (scene: _DrawerScene) => ?(React$Node | string),
-    renderIcon: (scene: _DrawerScene) => ?React$Node,
+    getLabel: (scene: _DrawerScene) => ?(Node | string),
+    renderIcon: (scene: _DrawerScene) => ?Node,
     onItemPress: (info: _DrawerItem) => void,
     itemsContainerForceInset?: Object,
     itemsContainerStyle?: ViewStyleProp,
@@ -1015,10 +1014,10 @@ declare module 'react-navigation' {
     iconContainerStyle?: ViewStyleProp,
     drawerPosition: 'left' | 'right',
   };
-  declare export var DrawerItems: React$ComponentType<_DrawerItemsProps>;
+  declare export var DrawerItems: ComponentType<_DrawerItemsProps>;
 
   declare type _TabViewProps = {
-    tabBarComponent?: React$ElementType,
+    tabBarComponent?: ElementType,
     tabBarPosition?: 'top' | 'bottom',
     tabBarOptions?: {},
     swipeEnabled?: boolean,
@@ -1032,7 +1031,7 @@ declare module 'react-navigation' {
     navigation: NavigationScreenProp<NavigationState>,
     router: NavigationRouter<NavigationState, NavigationTabScreenOptions>,
   };
-  declare export var TabView: React$ComponentType<_TabViewProps>;
+  declare export var TabView: ComponentType<_TabViewProps>;
 
   declare type _TabBarTopProps = {
     activeTintColor: string,
@@ -1045,7 +1044,7 @@ declare module 'react-navigation' {
     tabBarPosition: string,
     navigation: NavigationScreenProp<NavigationState>,
     jumpToIndex: (index: number) => void,
-    getLabel: (scene: TabScene) => ?(React$Node | string),
+    getLabel: (scene: TabScene) => ?(Node | string),
     getOnPress: (
       previousScene: NavigationRoute,
       scene: TabScene
@@ -1054,11 +1053,11 @@ declare module 'react-navigation' {
       scene: TabScene,
       jumpToIndex: (index: number) => void,
     }) => void,
-    renderIcon: (scene: TabScene) => React$Element<*>,
+    renderIcon: (scene: TabScene) => Element<*>,
     labelStyle?: TextStyleProp,
     iconStyle?: ViewStyleProp,
   };
-  declare export var TabBarTop: React$ComponentType<_TabBarTopProps>;
+  declare export var TabBarTop: ComponentType<_TabBarTopProps>;
 
   declare type _TabBarBottomProps = {
     activeTintColor: string,
@@ -1072,7 +1071,7 @@ declare module 'react-navigation' {
     position: AnimatedValue,
     navigation: NavigationScreenProp<NavigationState>,
     jumpToIndex: (index: number) => void,
-    getLabel: (scene: TabScene) => ?(React$Node | string),
+    getLabel: (scene: TabScene) => ?(Node | string),
     getOnPress: (
       previousScene: NavigationRoute,
       scene: TabScene
@@ -1082,18 +1081,18 @@ declare module 'react-navigation' {
       jumpToIndex: (index: number) => void,
     }) => void,
     getTestIDProps: (scene: TabScene) => (scene: TabScene) => any,
-    renderIcon: (scene: TabScene) => React$Node,
+    renderIcon: (scene: TabScene) => Node,
     style?: ViewStyleProp,
     animateStyle?: ViewStyleProp,
     labelStyle?: TextStyleProp,
     tabStyle?: ViewStyleProp,
     showIcon?: boolean,
   };
-  declare export var TabBarBottom: React$ComponentType<_TabBarBottomProps>;
+  declare export var TabBarBottom: ComponentType<_TabBarBottomProps>;
 
   declare export function withNavigation<Props: {}>(
-    Component: React$ComponentType<Props>
-  ): React$ComponentType<
+    Component: ComponentType<Props>
+  ): ComponentType<
     $Diff<
       Props,
       {
@@ -1102,6 +1101,6 @@ declare module 'react-navigation' {
     >
   >;
   declare export function withNavigationFocus<Props: {}>(
-    Component: React$ComponentType<Props>
-  ): React$ComponentType<$Diff<Props, { isFocused: boolean | void }>>;
+    Component: ComponentType<Props>
+  ): ComponentType<$Diff<Props, { isFocused: boolean | void }>>;
 }

--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/react-router-dom_v4.x.x.js
@@ -1,29 +1,29 @@
 declare module "react-router-dom" {
-  import type { ComponentType, ElementConfig, Node } from 'react';
+  import type { ComponentType, ElementConfig, Node, Component } from 'react';
 
-  declare export class BrowserRouter extends React$Component<{|
+  declare export var BrowserRouter: Class<Component<{|
     basename?: string,
     forceRefresh?: boolean,
     getUserConfirmation?: GetUserConfirmation,
     keyLength?: number,
     children?: Node
-  |}> {}
+  |}>>
 
-  declare export class HashRouter extends React$Component<{|
+  declare export var HashRouter: Class<Component<{|
     basename?: string,
     getUserConfirmation?: GetUserConfirmation,
     hashType?: "slash" | "noslash" | "hashbang",
     children?: Node
-  |}> {}
+  |}>>
 
-  declare export class Link extends React$Component<{
+  declare export var Link: Class<Component<{
     className?: string,
     to: string | LocationShape,
     replace?: boolean,
     children?: Node
-  }> {}
+  }>>
 
-  declare export class NavLink extends React$Component<{
+  declare export var NavLink: Class<Component<{
     to: string | LocationShape,
     activeClassName?: string,
     className?: string,
@@ -33,7 +33,7 @@ declare module "react-router-dom" {
     children?: Node,
     exact?: boolean,
     strict?: boolean
-  }> {}
+  }>>
 
   // NOTE: Below are duplicated from react-router. If updating these, please
   // update the react-router and react-router-native types as well.
@@ -105,40 +105,40 @@ declare module "react-router-dom" {
     url?: string
   };
 
-  declare export class StaticRouter extends React$Component<{|
+  declare export var StaticRouter: Class<Component<{|
     basename?: string,
     location?: string | Location,
     context: StaticRouterContext,
     children?: Node
-  |}> {}
+  |}>>
 
-  declare export class MemoryRouter extends React$Component<{|
+  declare export var MemoryRouter: Class<Component<{|
     initialEntries?: Array<LocationShape | string>,
     initialIndex?: number,
     getUserConfirmation?: GetUserConfirmation,
     keyLength?: number,
     children?: Node
-  |}> {}
+  |}>>
 
-  declare export class Router extends React$Component<{|
+  declare export var Router: Class<Component<{|
     history: RouterHistory,
     children?: Node
-  |}> {}
+  |}>>
 
-  declare export class Prompt extends React$Component<{|
+  declare export var Prompt: Class<Component<{|
     message: string | ((location: Location) => string | boolean),
     when?: boolean
-  |}> {}
+  |}>>
 
-  declare export class Redirect extends React$Component<{|
+  declare export var Redirect: Class<Component<{|
     to: string | LocationShape,
     push?: boolean,
     from?: string,
     exact?: boolean,
     strict?: boolean
-  |}> {}
+  |}>>
 
-  declare export class Route extends React$Component<{|
+  declare export var Route: Class<Component<{|
     component?: ComponentType<*>,
     render?: (router: ContextRouter) => Node,
     children?: ComponentType<ContextRouter> | Node,
@@ -147,12 +147,12 @@ declare module "react-router-dom" {
     strict?: boolean,
     location?: LocationShape,
     sensitive?: boolean
-  |}> {}
+  |}>>
 
-  declare export class Switch extends React$Component<{|
+  declare export var Switch: Class<Component<{|
     children?: Node,
     location?: Location
-  |}> {}
+  |}>>
 
   declare export function withRouter<P: {}, Component: ComponentType<P>>(
     WrappedComponent: Component

--- a/definitions/npm/rsuite_v3.x.x/flow_v0.53.x-/rsuite_v3.x.x.js
+++ b/definitions/npm/rsuite_v3.x.x/flow_v0.53.x-/rsuite_v3.x.x.js
@@ -1,5 +1,5 @@
 declare module "rsuite" {
-
+  import type { ElementType, Element, Node, ElementRef } from 'react';
   declare type moment$Moment = Object;
   declare type Size = "lg" | "md" | "sm" | "xs";
   declare type Types = "success" | "warning" | "error" | "info";
@@ -62,7 +62,7 @@ declare module "rsuite" {
   declare type PickerProps = {
     className?: string,
     classPrefix?: string,
-    toggleComponentClass?: React$ElementType,
+    toggleComponentClass?: ElementType,
     style?: Object,
     container?: HTMLElement | (() => HTMLElement),
     containerPadding?: number,
@@ -73,7 +73,7 @@ declare module "rsuite" {
     block?: boolean,
     disabled?: boolean,
     placeholder?: string,
-    renderMenu?: (itemLabel: React$Node, item: Object) => React$Node,
+    renderMenu?: (itemLabel: Node, item: Object) => Node,
     onOpen?: () => void,
     onClose?: () => void
   } & AnimationCallbackProps;
@@ -84,7 +84,7 @@ declare module "rsuite" {
         appearance?: PickerAppearanceType,
         childrenKey?: string,
         data: Array<any>,
-        renderExtraFooter?: () => React$Node,
+        renderExtraFooter?: () => Node,
         value?: any,
         defaultValue?: any,
         onChange?: (value: any, event: SyntheticEvent<*>) => void,
@@ -93,8 +93,8 @@ declare module "rsuite" {
           activePaths: Array<any>,
           event: SyntheticEvent<*>
         ) => void,
-        renderValue?: (activePaths?: Array<any>) => React$Node,
-        renderMenuItem?: (itemLabel: React$Node, item: Object) => React$Node,
+        renderValue?: (activePaths?: Array<any>) => Node,
+        renderMenuItem?: (itemLabel: Node, item: Object) => Node,
         menuWidth?: number,
         menuHeight?: number,
         disabledItemValues?: Array<any>
@@ -126,11 +126,11 @@ declare module "rsuite" {
         renderValue?: (
           values: Array<any>,
           checkItems: Array<any>,
-          placeholder: string | React$Node
-        ) => React$Node,
-        renderTreeNode?: (nodeData: Object) => React$Node,
-        renderTreeIcon?: (nodeData: Object) => React$Node,
-        renderExtraFooter?: () => React$Node
+          placeholder: string | Node
+        ) => Node,
+        renderTreeNode?: (nodeData: Object) => Node,
+        renderTreeIcon?: (nodeData: Object) => Node,
+        renderExtraFooter?: () => Node
       }
   > {}
 
@@ -160,11 +160,11 @@ declare module "rsuite" {
         ) => void,
         renderValue?: (
           activeNode: Object,
-          placeholder: string | React$Node
-        ) => React$Node,
-        renderTreeNode?: (nodeData: Object) => React$Node,
-        renderTreeIcon?: (nodeData: Object) => React$Node,
-        renderExtraFooter?: () => React$Node
+          placeholder: string | Node
+        ) => Node,
+        renderTreeNode?: (nodeData: Object) => Node,
+        renderTreeIcon?: (nodeData: Object) => Node,
+        renderExtraFooter?: () => Node
       }
   > {}
 
@@ -186,8 +186,8 @@ declare module "rsuite" {
       layer: number,
       event: SyntheticEvent<*>
     ) => void,
-    renderTreeNode?: (nodeData: Object) => React$Node,
-    renderTreeIcon?: (nodeData: Object) => React$Node
+    renderTreeNode?: (nodeData: Object) => Node,
+    renderTreeIcon?: (nodeData: Object) => Node
   }> {}
 
   declare export class CheckTree extends React$Component<{
@@ -208,8 +208,8 @@ declare module "rsuite" {
       layer: number,
       event: SyntheticEvent<*>
     ) => void,
-    renderTreeNode?: (nodeData: Object) => React$Node,
-    renderTreeIcon?: (nodeData: Object) => React$Node
+    renderTreeNode?: (nodeData: Object) => Node,
+    renderTreeIcon?: (nodeData: Object) => Node
   }> {}
 
   declare export class CheckPicker extends React$Component<
@@ -221,10 +221,10 @@ declare module "rsuite" {
         maxHeight?: number,
         value?: Array<any>,
         defaultValue?: Array<any>,
-        renderMenuItem?: (itemLabel: React$Node, item: Object) => React$Node,
-        renderMenuGroup?: (title: React$Node, item: Object) => React$Node,
-        renderValue?: (value: Array<any>, items: Array<any>) => React$Node,
-        renderExtraFooter?: () => React$Node,
+        renderMenuItem?: (itemLabel: Node, item: Object) => Node,
+        renderMenuGroup?: (title: Node, item: Object) => Node,
+        renderValue?: (value: Array<any>, items: Array<any>) => Node,
+        renderExtraFooter?: () => Node,
         onChange?: (value: Array<any>, event: SyntheticEvent<*>) => void,
         onSelect?: (value: any, item: Object, event: SyntheticEvent<*>) => void,
         onGroupTitleClick?: (event: SyntheticEvent<*>) => void,
@@ -302,10 +302,10 @@ declare module "rsuite" {
         maxHeight?: number,
         value?: any,
         defaultValue?: any,
-        renderMenuItem?: (itemLabel: React$Node, item: Object) => React$Node,
-        renderMenuGroup?: (title: React$Node, item: Object) => React$Node,
-        renderValue?: (value: any, item: Object) => React$Node,
-        renderExtraFooter?: () => React$Node,
+        renderMenuItem?: (itemLabel: Node, item: Object) => Node,
+        renderMenuGroup?: (title: Node, item: Object) => Node,
+        renderValue?: (value: any, item: Object) => Node,
+        renderExtraFooter?: () => Node,
         onChange?: (value: any, event: SyntheticEvent<*>) => void,
         onSelect?: (value: any, item: Object, event: SyntheticEvent<*>) => void,
         onGroupTitleClick?: (event: SyntheticEvent<*>) => void,
@@ -325,10 +325,10 @@ declare module "rsuite" {
         maxHeight?: number,
         value?: Array<any>,
         defaultValue?: Array<any>,
-        renderMenuItem?: (itemLabel: React$Node, item: Object) => React$Node,
-        renderMenuGroup?: (title: React$Node, item: Object) => React$Node,
-        renderValue?: (value: Array<any>, item: Object) => React$Node,
-        renderExtraFooter?: () => React$Node,
+        renderMenuItem?: (itemLabel: Node, item: Object) => Node,
+        renderMenuGroup?: (title: Node, item: Object) => Node,
+        renderValue?: (value: Array<any>, item: Object) => Node,
+        renderExtraFooter?: () => Node,
         onChange?: (value: Array<any>, event: SyntheticEvent<*>) => void,
         onSelect?: (
           value: Array<any>,
@@ -352,10 +352,10 @@ declare module "rsuite" {
         maxHeight?: number,
         value?: any,
         defaultValue?: any,
-        renderMenuItem?: (itemLabel: React$Node, item: Object) => React$Node,
-        renderMenuGroup?: (title: React$Node, item: Object) => React$Node,
-        renderValue?: (value: any, item: Object) => React$Node,
-        renderExtraFooter?: () => React$Node,
+        renderMenuItem?: (itemLabel: Node, item: Object) => Node,
+        renderMenuGroup?: (title: Node, item: Object) => Node,
+        renderValue?: (value: any, item: Object) => Node,
+        renderExtraFooter?: () => Node,
         onChange?: (value: any, event: SyntheticEvent<*>) => void,
         onSelect?: (value: any, item: Object, event: SyntheticEvent<*>) => void,
         onGroupTitleClick?: (event: SyntheticEvent<*>) => void,
@@ -382,7 +382,7 @@ declare module "rsuite" {
     onKeyDown?: (event: SyntheticEvent<*>) => void,
     onOpen?: () => void,
     onClose?: () => void,
-    renderItem?: (itemValue: string) => React$Node,
+    renderItem?: (itemValue: string) => Node,
     style?: Object,
     open?: boolean,
     selectOnEnter?: boolean
@@ -393,16 +393,16 @@ declare module "rsuite" {
     className?: string,
     style?: Object,
     href?: string,
-    title?: React$ElementType,
+    title?: ElementType,
     target?: string,
     classPrefix?: string,
-    componentClass?: React$ElementType
+    componentClass?: ElementType
   }> {}
 
   declare export class Breadcrumb extends React$Component<{
-    separator?: React$Node,
-    componentClass?: React$ElementType,
-    children?: React$Node,
+    separator?: Node,
+    componentClass?: ElementType,
+    children?: Node,
     className?: string,
     classPrefix?: string
   }> {
@@ -412,14 +412,14 @@ declare module "rsuite" {
   declare export class Button extends React$Component<{
     appearance?: "default" | "primary" | "link" | "subtle" | "ghost",
     classPrefix?: string,
-    componentClass?: React$ElementType,
+    componentClass?: ElementType,
     className?: string,
     active?: boolean,
     block?: boolean,
     href?: string,
     loading?: boolean,
     disabled?: boolean,
-    children?: React$Node
+    children?: Node
   }> {}
 
   declare export class ButtonGroup extends React$Component<{
@@ -428,7 +428,7 @@ declare module "rsuite" {
     justified?: boolean,
     block?: boolean,
     classPrefix?: string,
-    children?: React$Element<typeof Button>
+    children?: Element<typeof Button>
   }> {}
 
   declare export class ButtonToolbar extends React$Component<{
@@ -450,9 +450,9 @@ declare module "rsuite" {
       event: SyntheticInputEvent<HTMLInputElement>
     ) => void,
     onClick?: (event: SyntheticEvent<*>) => void,
-    inputRef?: React$ElementRef<*>,
+    inputRef?: ElementRef<*>,
     value?: any,
-    children?: React$Node,
+    children?: Node,
     classPrefix?: string,
     tabIndex?: number
   }> {}
@@ -493,7 +493,7 @@ declare module "rsuite" {
     smHidden?: boolean,
     mdHidden?: boolean,
     lgHidden?: boolean,
-    componentClass?: React$ElementType
+    componentClass?: ElementType
   }> {}
 
   declare export class Container extends React$Component<{
@@ -517,8 +517,8 @@ declare module "rsuite" {
     className?: string,
     vertical?: boolean,
     classPrefix?: string,
-    children?: React$Node,
-    componentClass?: React$ElementType
+    children?: Node,
+    componentClass?: ElementType
   }> {}
 
   declare export class Drawer extends React$Component<{
@@ -526,7 +526,7 @@ declare module "rsuite" {
     placement?: "top" | "right" | "bottom" | "left",
     show?: boolean,
     full?: boolean,
-    children?: React$Node,
+    children?: Node,
     className?: string
   }> {
     static Body: Class<ModalBody>;
@@ -541,9 +541,9 @@ declare module "rsuite" {
     classPrefix?: string,
     trigger?: DropdownTriggerType | Array<DropdownTriggerType>,
     placement?: PlacementEightPoints,
-    title?: React$Node,
+    title?: Node,
     disabled?: boolean,
-    icon?: React$Element<typeof Icon>,
+    icon?: Element<typeof Icon>,
     onClose?: () => void,
     onOpen?: () => void,
     onToggle?: (open?: boolean) => void,
@@ -555,12 +555,12 @@ declare module "rsuite" {
     menuStyle?: Object,
     className?: string,
     toggleClassName?: string,
-    renderTitle?: (children?: React$Node) => React$Node,
+    renderTitle?: (children?: Node) => Node,
     tabIndex?: number,
     open?: boolean,
     eventKey?: any,
-    componentClass?: React$ElementType,
-    toggleComponentClass?: React$ElementType,
+    componentClass?: ElementType,
+    toggleComponentClass?: ElementType,
     noCaret?: boolean
   }> {
     static Item: Class<DropdownMenuItem>;
@@ -570,11 +570,11 @@ declare module "rsuite" {
   declare export class DropdownMenu extends React$Component<{
     activeKey?: any,
     className?: string,
-    icon?: React$Element<typeof Icon>,
+    icon?: Element<typeof Icon>,
     classPrefix?: string,
     pullLeft?: boolean,
     onSelect?: Function,
-    title?: React$Node,
+    title?: Node,
     open?: boolean,
     trigger?: TriggerType | Array<TriggerType>,
     eventKey?: any,
@@ -587,12 +587,12 @@ declare module "rsuite" {
   declare export class DropdownMenuItem extends React$Component<{
     activeKey?: any,
     className?: string,
-    children?: React$Node,
-    icon?: React$Element<typeof Icon>,
+    children?: Node,
+    icon?: Element<typeof Icon>,
     classPrefix?: string,
     pullLeft?: boolean,
     onSelect?: Function,
-    title?: React$Node,
+    title?: Node,
     open?: boolean,
     trigger?: TriggerType | Array<TriggerType>,
     eventKey?: any,
@@ -604,19 +604,19 @@ declare module "rsuite" {
 
   declare export class DorpdownToggle extends React$Component<{
     className?: string,
-    children?: React$Node,
-    icon?: React$Element<typeof Icon>,
-    renderTitle?: (children?: React$Node) => React$Node,
+    children?: Node,
+    icon?: Element<typeof Icon>,
+    renderTitle?: (children?: Node) => Node,
     classPrefix?: string,
     noCaret?: boolean,
-    componentClass?: React$ElementType
+    componentClass?: ElementType
   }> {}
 
   declare export class ErrorMessage extends React$Component<{
     htmlFor?: string,
     show?: boolean,
     classPrefix?: string,
-    children?: React$Node,
+    children?: Node,
     className?: string,
     placement?: PlacementEightPoints
   }> {}
@@ -662,7 +662,7 @@ declare module "rsuite" {
     icon: string | SVGIcon,
     className?: string,
     classPrefix?: string,
-    componentClass?: React$ElementType,
+    componentClass?: ElementType,
     size?: "lg" | "2x" | "3x" | "4x" | "5x",
     flip?: "horizontal" | "vertical",
     stack?: "1x" | "2x",
@@ -675,17 +675,17 @@ declare module "rsuite" {
 
   declare export class IntlProvider extends React$Component<{
     locale?: Object,
-    children?: React$Node
+    children?: Node
   }> {}
 
   declare export class FormControl extends React$Component<{
     name: string,
     checkTrigger?: "change" | "blur" | "none",
-    accepter?: React$ElementType,
+    accepter?: ElementType,
     onChange?: (value: any, event: SyntheticEvent<*>) => void,
     onBlur?: (event: SyntheticEvent<*>) => void,
     classPrefix?: string,
-    errorMessage?: React$Node,
+    errorMessage?: Node,
     errorPlacement?: PlacementEightPoints
   }> {}
 
@@ -701,7 +701,7 @@ declare module "rsuite" {
     className?: string,
     fluid?: boolean,
     classPrefix?: string,
-    componentClass?: React$ElementType
+    componentClass?: ElementType
   }> {}
 
   declare export class Header extends React$Component<{
@@ -718,23 +718,23 @@ declare module "rsuite" {
 
   declare export class IconButton extends React$Component<{
     className?: string,
-    icon?: React$Element<typeof Icon>,
+    icon?: Element<typeof Icon>,
     classPrefix?: string,
     circle?: boolean,
-    children?: React$Node,
+    children?: Node,
     placement?: "left" | "right"
   }> {}
 
   declare export class Input extends React$Component<{
     type?: string,
-    componentClass?: React$ElementType,
+    componentClass?: ElementType,
     id?: string,
     classPrefix?: string,
     className?: string,
     disabled?: boolean,
     value?: string | number,
     defaultValue?: string | number,
-    inputRef?: React$ElementRef<*>,
+    inputRef?: ElementRef<*>,
     onChange?: (
       value: any,
       event: SyntheticInputEvent<HTMLInputElement>
@@ -774,8 +774,8 @@ declare module "rsuite" {
     step?: number,
     value?: number | string,
     defaultValue?: number | string,
-    prefix?: React$Node,
-    postfix?: React$Node,
+    prefix?: Node,
+    postfix?: Node,
     disabled?: boolean,
     size?: "lg" | "md" | "sm" | "xs",
     onWheel?: (event?: SyntheticEvent<*>) => void,
@@ -790,7 +790,7 @@ declare module "rsuite" {
     backdrop?: boolean,
     inverse?: boolean,
     vertical?: boolean,
-    content?: React$Node,
+    content?: Node,
     speed?: "normal" | "fast" | "slow"
   }> {}
 
@@ -800,8 +800,8 @@ declare module "rsuite" {
     onClose?: () => void,
     closable?: boolean,
     closeLabel?: string,
-    title?: React$Node,
-    description?: React$Node,
+    title?: Node,
+    description?: Node,
     showIcon?: boolean,
     full?: boolean,
     classPrefix?: string
@@ -810,7 +810,7 @@ declare module "rsuite" {
   declare export class Modal extends React$Component<{
     classPrefix?: string,
     size?: Size,
-    container?: React$ElementType | Function,
+    container?: ElementType | Function,
     onRendered?: Function,
     className?: string,
     dialogClassName?: string,
@@ -822,7 +822,7 @@ declare module "rsuite" {
     full?: boolean,
     backdrop?: boolean | "static",
     keyboard?: boolean,
-    transition?: React$ElementType,
+    transition?: ElementType,
     dialogTransitionTimeout?: number,
     backdropTransitionTimeout?: number,
     autoFocus?: boolean,
@@ -830,7 +830,7 @@ declare module "rsuite" {
     overflow?: boolean,
     drawer?: boolean,
     animation?: boolean,
-    dialogComponentClass?: React$ElementType,
+    dialogComponentClass?: ElementType,
     onEscapeKeyUp?: Function,
     onBackdropClick?: Function,
     onShow?: Function,
@@ -902,19 +902,19 @@ declare module "rsuite" {
     panel?: boolean,
     onClick?: (event: SyntheticEvent<*>) => void,
     style?: Object,
-    icon?: React$Element<typeof Icon>,
+    icon?: Element<typeof Icon>,
     onSelect?: (eventKey: any, event: SyntheticEvent<*>) => void,
     eventKey?: any,
     tabIndex?: number,
     hasTooltip?: boolean,
-    componentClass?: React$ElementType
+    componentClass?: ElementType
   }> {}
 
   declare export class Navbar extends React$Component<{
     classPrefix?: string,
     className?: string,
     appearance?: "default" | "inverse" | "subtle",
-    componentClass?: React$ElementType,
+    componentClass?: ElementType,
     hasChildContext?: boolean
   }> {
     static Body: Class<NavbarBody>;
@@ -924,7 +924,7 @@ declare module "rsuite" {
   declare export class NavbarBody extends React$Component<{
     classPrefix?: string,
     className?: string,
-    children?: React$Node
+    children?: Node
   }> {}
 
   declare export class NavbarHeader extends React$Component<{
@@ -937,13 +937,13 @@ declare module "rsuite" {
     pages?: number,
     maxButtons?: number,
     boundaryLinks?: boolean,
-    ellipsis?: boolean | React$Node,
-    first?: boolean | React$Node,
-    last?: boolean | React$Node,
-    prev?: boolean | React$Node,
-    next?: boolean | React$Node,
+    ellipsis?: boolean | Node,
+    first?: boolean | Node,
+    last?: boolean | Node,
+    prev?: boolean | Node,
+    next?: boolean | Node,
     onSelect?: (event: SyntheticEvent<*>) => void,
-    buttonComponentClass?: React$ElementType | string,
+    buttonComponentClass?: ElementType | string,
     className?: string,
     classPrefix?: string
   }> {}
@@ -960,7 +960,7 @@ declare module "rsuite" {
     headerRole?: string,
     panelRole?: string,
     classPrefix?: string,
-    children?: React$Node,
+    children?: Node,
     onSelect?: (eventKey: any, event: SyntheticEvent<*>) => void,
     onEnter?: Function,
     onEntering?: Function,
@@ -977,7 +977,7 @@ declare module "rsuite" {
     bordered?: boolean,
     defaultActiveKey?: any,
     className?: string,
-    children?: React$Node,
+    children?: Node,
     classPrefix?: string,
     onSelect?: (eventKey: any, event: SyntheticEvent<*>) => void
   }> {}
@@ -985,8 +985,8 @@ declare module "rsuite" {
   declare export class Popover extends React$Component<{
     placement?: PlacementFourSides | Placement,
     classPrefix?: string,
-    children?: React$Node,
-    title?: React$Node,
+    children?: Node,
+    title?: Node,
     visible?: boolean,
     className?: string,
     full?: boolean,
@@ -1029,8 +1029,8 @@ declare module "rsuite" {
     disabled?: boolean,
     checked?: boolean,
     defaultChecked?: boolean,
-    inputRef?: React$ElementRef<any>,
-    children?: React$Node,
+    inputRef?: ElementRef<any>,
+    children?: Node,
     className?: string,
     classPrefix?: string,
     value?: any,
@@ -1050,7 +1050,7 @@ declare module "rsuite" {
     defaultValue?: any,
     className?: string,
     classPrefix?: string,
-    children?: React$Node,
+    children?: Node,
     onChange?: (
       value: any,
       event: SyntheticInputEvent<HTMLInputElement>
@@ -1062,8 +1062,8 @@ declare module "rsuite" {
     classPrefix?: string,
     gutter?: number,
     style?: Object,
-    componentClass?: React$ElementType,
-    children?: React$Node
+    componentClass?: ElementType,
+    children?: Node
   }> {}
 
   declare export class SafeAnchor extends React$Component<{
@@ -1073,7 +1073,7 @@ declare module "rsuite" {
     role?: string,
     style?: Object,
     tabIndex?: number | string,
-    componentClass?: React$ElementType
+    componentClass?: ElementType
   }> {}
 
   declare export class Sidebar extends React$Component<{
@@ -1093,7 +1093,7 @@ declare module "rsuite" {
     onOpenChange?: (openKeys: Array<any>, event: SyntheticEvent<*>) => void,
     activeKey?: any,
     onSelect?: (eventKey: Array<any>, event: SyntheticEvent<*>) => void,
-    componentClass?: React$ElementType
+    componentClass?: ElementType
   }> {
     static Header: Class<SidenavHeader>;
     static Body: Class<SidenavBody>;
@@ -1124,7 +1124,7 @@ declare module "rsuite" {
     className?: string,
     classPrefix?: string,
     handleClassName?: string,
-    handleTitle?: React$Node,
+    handleTitle?: Node,
     barClassName?: string,
     hanldeStyle?: Object,
     disabled?: boolean,
@@ -1133,7 +1133,7 @@ declare module "rsuite" {
     progress?: boolean,
     vertical?: boolean,
     onChange?: (value: number) => void,
-    renderMark?: (mark: number) => React$Node
+    renderMark?: (mark: number) => Node
   }> {}
 
   declare export class StepItem extends React$Component<{
@@ -1141,10 +1141,10 @@ declare module "rsuite" {
     classPrefix?: string,
     itemWidth?: number | string,
     status?: "finish" | "wait" | "process" | "error",
-    icon?: React$Element<typeof Icon>,
+    icon?: Element<typeof Icon>,
     stepNumber?: number,
-    description?: React$Node,
-    title?: React$Node
+    description?: Node,
+    title?: Node
   }> {}
 
   declare export class Steps extends React$Component<{
@@ -1183,7 +1183,7 @@ declare module "rsuite" {
     firstColumn?: boolean,
     lastColumn?: boolean,
     hasChildren?: boolean,
-    children?: React$Node,
+    children?: Node,
     rowKey?: string | number,
     rowIndex?: number,
     rowData?: Object,
@@ -1195,10 +1195,10 @@ declare module "rsuite" {
       event?: SyntheticEvent<*>
     ) => void,
     renderTreeToggle?: (
-      expandButton: React$Node,
+      expandButton: Node,
       rowData?: Object
-    ) => React$Node,
-    renderCell?: (contentChildren: React$Node) => React$Node,
+    ) => Node,
+    renderCell?: (contentChildren: Node) => Node,
     wordWrap?: boolean,
     removed?: boolean
   }> {}
@@ -1210,7 +1210,7 @@ declare module "rsuite" {
     className?: string,
     classPrefix?: string,
     headerHeight?: number,
-    children?: React$Node,
+    children?: Node,
     index?: number,
     sortColumn?: string,
     sortType?: "desc" | "asc",
@@ -1238,12 +1238,12 @@ declare module "rsuite" {
   }> {}
 
   declare export class TablePagination extends React$Component<{
-    lengthMenu?: Array<{ value: number, label: React$Node }>,
+    lengthMenu?: Array<{ value: number, label: Node }>,
     showLengthMenu?: boolean,
     showInfo?: boolean,
     total: number,
     displayLength?: number,
-    renderLengthMenu?: (picker: React$Node) => React$Node,
+    renderLengthMenu?: (picker: Node) => Node,
     renderTotal?: Function,
     onChangePage?: Function,
     onChangeLength?: Function,
@@ -1272,10 +1272,10 @@ declare module "rsuite" {
     defaultExpandedRowKeys?: Array<string | number>,
     expandedRowKeys?: Array<string | number>,
     renderTreeToggle?: (
-      expandButton: React$Node,
+      expandButton: Node,
       rowData: Object
-    ) => React$Node,
-    renderRowExpanded?: (rowDate?: Object) => React$Node,
+    ) => Node,
+    renderRowExpanded?: (rowDate?: Object) => Node,
     rowExpandedHeight?: number,
     style?: Object,
     sortColumn?: string,
@@ -1295,7 +1295,7 @@ declare module "rsuite" {
     onExpandChange?: (expanded: boolean, rowData: Object) => void,
     onTouchStart?: (event: SyntheticTouchEvent<*>) => void, // for tests
     onTouchMove?: (event: SyntheticTouchEvent<*>) => void, // for tests
-    bodyRef?: React$ElementRef<*>,
+    bodyRef?: ElementRef<*>,
     loadAnimation?: boolean,
     showHeader?: boolean
   }> {
@@ -1309,27 +1309,27 @@ declare module "rsuite" {
     closable?: boolean,
     classPrefix?: string,
     onClose?: (event: SyntheticEvent<*>) => void,
-    children?: React$Node,
+    children?: Node,
     className?: string,
-    componentClass?: React$ElementType
+    componentClass?: ElementType
   }> {}
 
   declare export class Timeline extends React$Component<{
     className?: string,
     classPrefix?: string,
-    children?: React$Node,
-    componentClass?: React$ElementType
+    children?: Node,
+    componentClass?: ElementType
   }> {
     static Item: Class<TimelineItem>;
   }
 
   declare export class TimelineItem extends React$Component<{
     last?: boolean,
-    dot?: React$Node,
+    dot?: Node,
     className?: string,
-    children?: React$Node,
+    children?: Node,
     classPrefix?: string,
-    componentClass?: React$ElementType
+    componentClass?: ElementType
   }> {}
 
   declare export class Toggle extends React$Component<{
@@ -1337,8 +1337,8 @@ declare module "rsuite" {
     checked?: boolean,
     defaultChecked?: boolean,
     onChange?: (checked: boolean, event: SyntheticEvent<*>) => void,
-    checkedChildren?: React$Node,
-    unCheckedChildren?: React$Node,
+    checkedChildren?: Node,
+    unCheckedChildren?: Node,
     classPrefix?: string,
     className?: string
   }> {}
@@ -1350,7 +1350,7 @@ declare module "rsuite" {
     visible?: boolean,
     classPrefix?: string,
     className?: string,
-    children?: React$Node,
+    children?: Node,
     onMouseLeave?: (event: SyntheticEvent<*>) => void,
     onMouseEnter?: (event: SyntheticEvent<*>) => void
   }> {}
@@ -1368,7 +1368,7 @@ declare module "rsuite" {
     action: string,
     accept?: string,
     autoUpload?: boolean,
-    children?: React$Element<any>,
+    children?: Element<any>,
     className?: string,
     classPrefix?: string,
     defaultFileList?: Array<FileType>,
@@ -1408,7 +1408,7 @@ declare module "rsuite" {
     ) => void,
     onRemove?: (file: FileType) => void,
     maxPreviewFileSize?: number,
-    toggleComponentClass?: React$ElementType
+    toggleComponentClass?: ElementType
   }> {}
 
   declare export class Whisper extends React$Component<{
@@ -1419,22 +1419,22 @@ declare module "rsuite" {
     show?: boolean,
     rootClose?: boolean,
     onHide?: Function,
-    transition?: React$ElementType,
+    transition?: ElementType,
     onEnter?: Function,
     onEntering?: Function,
     onEntered?: Function,
     onExit?: Function,
     onExiting?: Function,
     onExited?: Function,
-    animation?: React$ElementType | boolean,
+    animation?: ElementType | boolean,
     trigger?: WhisperTriggerType | Array<WhisperTriggerType>,
     delay?: number,
     delayShow?: number,
     delayHide?: number,
     defaultOpen?: boolean,
     open?: boolean,
-    speaker: React$Element<any>,
-    children: React$Node,
+    speaker: Element<any>,
+    children: Node,
     onMouseOver?: (event: SyntheticEvent<*>) => void,
     onMouseOut?: (event: SyntheticEvent<*>) => void,
     onClick?: (event: SyntheticEvent<*>) => void,
@@ -1449,8 +1449,8 @@ declare module "rsuite" {
   };
 
   declare type NotificationConfig = {
-    title: React$Node,
-    description: React$ElementType,
+    title: Node,
+    description: ElementType,
     duration?: number,
     placement?: string,
     top?: number,
@@ -1482,7 +1482,7 @@ declare module "rsuite" {
   };
 
   declare export class Transition extends React$Component<{
-    children?: React$Node,
+    children?: Node,
     className?: string,
     in?: boolean,
     unmountOnExit?: boolean,
@@ -1533,7 +1533,7 @@ declare module "rsuite" {
   declare export class Portal extends React$Component<{
     container?: HTMLElement | (() => HTMLElement),
     onRendered?: Function,
-    children?: React$Node
+    children?: Node
   }> {}
 
   declare export var Animation: {


### PR DESCRIPTION
There's been some inconsistencies between React$ -types and imported react types. I'd prefer to use imported types when ever possible. an example case where importing fixed weird compatibility error: https://github.com/flow-typed/flow-typed/pull/2629

This does not tackle even half of the occurrences so more similar PRs might follow. Would be nice to gain some consistency so that it's easier for people to figure out how react types should look like.