### PR TITLE
Make query-string definition more accurate

### DIFF
--- a/definitions/npm/query-string_v6.x.x/flow_v0.32.x-/query-string_v6.x.x.js
+++ b/definitions/npm/query-string_v6.x.x/flow_v0.32.x-/query-string_v6.x.x.js
@@ -11,10 +11,14 @@ declare module 'query-string' {
     sort?: false | <A, B>(A, B) => number,
   |}
 
+  declare type QueryParameters = {
+    [string]: string | Array<string> | null
+  }
+
   declare module.exports: {
     extract(str: string): string,
-    parse(str: string, opts?: ParseOptions): Object,
-    parseUrl(str: string, opts?: ParseOptions): { url: string, query: Object },
-    stringify(obj: Object, opts?: StringifyOptions): string,
+    parse(str: string, opts?: ParseOptions): QueryParameters,
+    parseUrl(str: string, opts?: ParseOptions): { url: string, query: QueryParameters },
+    stringify(obj: QueryParameters, opts?: StringifyOptions): string,
   }
 }

--- a/definitions/npm/query-string_v6.x.x/test_query-string_v6.x.x.js
+++ b/definitions/npm/query-string_v6.x.x/test_query-string_v6.x.x.js
@@ -17,6 +17,11 @@ parse("test", { strict: true });
 // $ExpectError: should be a string
 parse({ test: null });
 
+(parse("foo").foo: null | string | Array<string>);
+
+// $ExpectError: result props cannot be undefined
+(parse("foo").foo: undefined);
+
 stringify({ test: null });
 
 stringify({ test: null }, { strict: true });
@@ -26,7 +31,6 @@ stringify("test");
 
 // $ExpectError: true is not a stringify option
 stringify({ test: null }, { test: true });
-
 
 parseUrl("test");
 

--- a/definitions/npm/query-string_v6.x.x/test_query-string_v6.x.x.js
+++ b/definitions/npm/query-string_v6.x.x/test_query-string_v6.x.x.js
@@ -20,7 +20,7 @@ parse({ test: null });
 (parse("foo").foo: null | string | Array<string>);
 
 // $ExpectError: result props cannot be undefined
-(parse("foo").foo: undefined);
+(parse("foo").foo: void);
 
 stringify({ test: null });
 


### PR DESCRIPTION
Replaced `Object` with better def as per [docs](https://github.com/sindresorhus/query-string)

Tests to show IRL behaviour here:
https://runkit.com/callumlocke/query-string-module-tests
