### PR TITLE
[jest] Add inline snapshots definitions

### DIFF
--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
@@ -691,6 +691,9 @@ interface JestExpectType {
    * This ensures that an Object matches the most recent snapshot.
    */
   toMatchSnapshot(name: string): void,
+
+  toMatchInlineSnapshot(snapshot?: string): void,
+  toMatchInlineSnapshot(propertyMatchers?: {[key: string]: JestAsymmetricEqualityType}, snapshot?: string): void,
   /**
    * Use .toThrow to test that a function throws when it is called.
    * If you want to test that a specific error gets thrown, you can provide an
@@ -705,7 +708,8 @@ interface JestExpectType {
    * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
    * matching the most recent snapshot when it is called.
    */
-  toThrowErrorMatchingSnapshot(): void
+  toThrowErrorMatchingSnapshot(): void,
+  toThrowErrorMatchingInlineSnapshot(snapshot?: string): void,
 }
 
 type JestObjectType = {

--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
@@ -25,6 +25,9 @@ const foo: Foo = {
     return Promise.resolve(5);
   }
 };
+
+
+
 foo.doStuff = jest.fn().mockImplementation(str => 10);
 foo.doStuff = jest.fn().mockImplementation(str => parseInt(str, 10));
 foo.doStuff = jest.fn().mockImplementation(str => str.indexOf("a"));
@@ -86,6 +89,23 @@ expect({
 }).toMatchSnapshot({
   foo: expect.any(Number)
 }, "snapshot name");
+expect("foo").toMatchInlineSnapshot();
+expect("foo").toMatchInlineSnapshot(`"foo"`);
+expect({ foo: 1 }).toMatchInlineSnapshot({
+  foo: expect.any(Number)
+});
+expect({ foo: 1 }).toMatchInlineSnapshot(
+  {
+    foo: expect.any(Number),
+  },
+  `
+Object {
+"foo": Any<Number>,
+}
+`,
+);
+// $ExpectError
+expect({ foo: 1 }).toMatchInlineSnapshot([]);
 expect({ foo: "bar" }).toMatchObject({ baz: "qux" });
 expect("foobar").toMatch(/foo/);
 expect("foobar").toMatch("foo");
@@ -196,6 +216,10 @@ expect(() => {
 expect(() => {
   throw err;
 }).toThrowError(err);
+
+expect(() => {}).toThrowErrorMatchingSnapshot();
+expect(() => {}).toThrowErrorMatchingInlineSnapshot();
+expect(() => {}).toThrowErrorMatchingInlineSnapshot("err");
 
 expect(() => {}).toThrow("err");
 expect(() => {}).toThrow(/err/);


### PR DESCRIPTION
Fixes #2658

I took the liberty of updating the definition of jest_v23.x.x.

Technically, jest introduced those in jest v23.3, making those definitions incorrect for jest <v23.3 users.

In my opinion, the tradeoff of having a slightly incorrect libdef is better than the burder of maintaining multiple files for jest versions >=23.3.