### PR TITLE
Add location object support to history_v4.x.x push and replace functions

### DIFF
--- a/definitions/npm/history_v4.x.x/flow_v0.25.x-/history_v4.x.x.js
+++ b/definitions/npm/history_v4.x.x/flow_v0.25.x-/history_v4.x.x.js
@@ -8,24 +8,27 @@ declare module "history/createBrowserHistory" {
     search: string,
     hash: string,
     // Browser and Memory specific
-    state: string,
+    state: {},
     key: string,
   };
 
-  declare export type BrowserHistory = {
+  declare interface IBrowserHistory {
     length: number,
     location: BrowserLocation,
     action: Action,
-    push: (path: string, state?: {}) => void,
-    replace: (path: string, state?: {}) => void,
-    go: (n: number) => void,
-    goBack: () => void,
-    goForward: () => void,
+    push(path: string, state?: {}): void,
+    push(location: $Shape<BrowserLocation>): void,
+    replace(path: string, state?: {}): void,
+    replace(location: $Shape<BrowserLocation>): void,
+    go(n: number): void,
+    goBack(): void,
+    goForward(): void,
     listen: Function,
-    block: (message: string) => Unblock,
-    block: ((location: BrowserLocation, action: Action) => string) => Unblock,
-    push: (path: string) => void,
-  };
+    block(message: string): Unblock,
+    block((location: BrowserLocation, action: Action) => string): Unblock,
+  }
+
+  declare export type BrowserHistory = IBrowserHistory;
 
   declare type HistoryOpts = {
     basename?: string,
@@ -49,28 +52,31 @@ declare module "history/createMemoryHistory" {
     search: string,
     hash: string,
     // Browser and Memory specific
-    state: string,
+    state: {},
     key: string,
   };
 
-  declare export type MemoryHistory = {
+  declare interface IMemoryHistory {
     length: number,
     location: MemoryLocation,
     action: Action,
     index: number,
     entries: Array<string>,
-    push: (path: string, state?: {}) => void,
-    replace: (path: string, state?: {}) => void,
-    go: (n: number) => void,
-    goBack: () => void,
-    goForward: () => void,
+    push(path: string, state?: {}): void,
+    push(location: $Shape<MemoryLocation>): void,
+    replace(path: string, state?: {}): void,
+    replace(location: $Shape<MemoryLocation>): void,
+    go(n: number): void,
+    goBack(): void,
+    goForward(): void,
     // Memory only
-    canGo: (n: number) => boolean,
+    canGo(n: number): boolean,
     listen: Function,
-    block: (message: string) => Unblock,
-    block: ((location: MemoryLocation, action: Action) => string) => Unblock,
-    push: (path: string) => void,
-  };
+    block(message: string): Unblock,
+    block((location: MemoryLocation, action: Action) => string): Unblock,
+  }
+
+  declare export type MemoryHistory = IMemoryHistory;
 
   declare type HistoryOpts = {
     initialEntries?: Array<string>,
@@ -96,20 +102,24 @@ declare module "history/createHashHistory" {
     hash: string,
   };
 
-  declare export type HashHistory = {
+  declare interface IHashHistory {
     length: number,
     location: HashLocation,
     action: Action,
-    push: (path: string, state?: {}) => void,
-    replace: (path: string, state?: {}) => void,
-    go: (n: number) => void,
-    goBack: () => void,
-    goForward: () => void,
+    push(path: string, state?: {}): void,
+    push(location: $Shape<HashLocation>): void,
+    replace(path: string, state?: {}): void,
+    replace(location: $Shape<HashLocation>): void,
+    go(n: number): void,
+    goBack(): void,
+    goForward(): void,
     listen: Function,
-    block: (message: string) => Unblock,
-    block: ((location: HashLocation, action: Action) => string) => Unblock,
-    push: (path: string) => void,
-  };
+    block(message: string): Unblock,
+    block((location: HashLocation, action: Action) => string): Unblock,
+    push(path: string): void,
+  }
+
+  declare export type HashHistory = IHashHistory;
 
   declare type HistoryOpts = {
     basename?: string,

--- a/definitions/npm/history_v4.x.x/flow_v0.25.x-/test_history_v4.x.x.js
+++ b/definitions/npm/history_v4.x.x/flow_v0.25.x-/test_history_v4.x.x.js
@@ -1,51 +1,255 @@
 // @flow
+
+import { describe, it } from 'flow-typed-test';
+
 import createBrowserHistory from 'history/createBrowserHistory';
 import createMemoryHistory from 'history/createMemoryHistory';
 import createHashHistory from 'history/createHashHistory';
 
 // browser history
-{
-  const history = createBrowserHistory({
-    basename: "",
-    forceRefresh: false,
-    keyLength: 6,
-  })
 
-  const pathname: string = history.location.pathname
-  // browser and memory specific
-  const state: string = history.location.state
+describe('browser history', () => {
+  it('should allow to get location fields', () => {
+    const history = createBrowserHistory({
+      basename: "",
+      forceRefresh: false,
+      keyLength: 6,
+    })
 
-  // $ExpectError
-  history.foo
-}
+    const pathname: string = history.location.pathname
+  });
 
-// memory history
-{
-  const history = createMemoryHistory({
-    initialEntries: ["/"],
-    initialIndex: 0,
-    keyLength: 6,
-  })
+  it('should allow to get browser and memory specific location fields', () => {
+    const history = createBrowserHistory({
+      basename: "",
+      forceRefresh: false,
+      keyLength: 6,
+    })
 
-  const pathname: string = history.location.pathname
-  // browser and memory specific
-  const state: string = history.location.state
+    const key: string = history.location.key
+    const state: {} = history.location.state
+  });
 
-  // $ExpectError
-  history.foo
-}
+  it('should not allow to get field which is absent in the history', () => {
+    const history = createBrowserHistory({
+      basename: "",
+      forceRefresh: false,
+      keyLength: 6,
+    })
 
-// hash history
-{
-  const history = createHashHistory({
-    basename: "",
-    hashType: "slash",
-  })
+    // $ExpectError
+    history.foo
+  });
 
-  const pathname: string = history.location.pathname
-  // $ExpectError
-  const state: string = history.location.state
+  describe('#push', () => {
+    it('should allow to use string as first argument', () => {
+      const history = createBrowserHistory({
+        basename: "",
+        forceRefresh: false,
+        keyLength: 6,
+      })
 
-  // $ExpectError
-  history.foo
-}
+      history.push("/")
+    });
+
+    it('should allow to use partial location as first argument', () => {
+      const history = createBrowserHistory({
+        basename: "",
+        forceRefresh: false,
+        keyLength: 6,
+      })
+
+      history.push({
+        pathname: "/",
+        state: { a: 1 },
+      })
+    });
+  });
+
+  describe('#replace', () => {
+    it('should allow to use string as first argument', () => {
+      const history = createBrowserHistory({
+        basename: "",
+        forceRefresh: false,
+        keyLength: 6,
+      })
+
+      history.replace("/")
+    });
+
+    it('should allow to use partial location as first argument', () => {
+      const history = createBrowserHistory({
+        basename: "",
+        forceRefresh: false,
+        keyLength: 6,
+      })
+
+      history.replace({
+        pathname: "/",
+        state: { a: 1 },
+      })
+    });
+  });
+});
+
+describe('memory history', () => {
+  it('should allow to get location fields', () => {
+    const history = createMemoryHistory({
+      initialEntries: ["/"],
+      initialIndex: 0,
+      keyLength: 6,
+    })
+
+    const pathname: string = history.location.pathname
+  });
+
+  it('should allow to get browser and memory specific location fields', () => {
+    const history = createMemoryHistory({
+      initialEntries: ["/"],
+      initialIndex: 0,
+      keyLength: 6,
+    })
+
+    const key: string = history.location.key
+    const state: {} = history.location.state
+  });
+
+  it('should not allow to get field which is absent in the history', () => {
+    const history = createMemoryHistory({
+      initialEntries: ["/"],
+      initialIndex: 0,
+      keyLength: 6,
+    })
+
+    // $ExpectError
+    history.foo
+  });
+
+  describe('#push', () => {
+    it('should allow to use string as first argument', () => {
+      const history = createMemoryHistory({
+        initialEntries: ["/"],
+        initialIndex: 0,
+        keyLength: 6,
+      })
+
+      history.push("/")
+    });
+
+    it('should allow to use partial location as first argument', () => {
+      const history = createMemoryHistory({
+        initialEntries: ["/"],
+        initialIndex: 0,
+        keyLength: 6,
+      })
+
+      history.push({
+        pathname: "/",
+        state: { a: 1 },
+      })
+    });
+  });
+
+  describe('#replace', () => {
+    it('should allow to use string as first argument', () => {
+      const history = createMemoryHistory({
+        initialEntries: ["/"],
+        initialIndex: 0,
+        keyLength: 6,
+      })
+
+      history.replace("/")
+    });
+
+    it('should allow to use partial location as first argument', () => {
+      const history = createMemoryHistory({
+        initialEntries: ["/"],
+        initialIndex: 0,
+        keyLength: 6,
+      })
+
+      history.replace({
+        pathname: "/",
+        state: { a: 1 },
+      })
+    });
+  });
+});
+
+describe('hash history', () => {
+  it('should allow to get location fields', () => {
+    const history = createHashHistory({
+      basename: "",
+      hashType: "slash",
+    })
+
+    const pathname: string = history.location.pathname
+  });
+
+  it('should not allow to get browser and memory specific location fields', () => {
+    const history = createHashHistory({
+      basename: "",
+      hashType: "slash",
+    })
+
+    // $ExpectError
+    const key: string = history.location.key
+    // $ExpectError
+    const state: {} = history.location.state
+  });
+
+  it('should not allow to get field which is absent in the history', () => {
+    const history = createHashHistory({
+      basename: "",
+      hashType: "slash",
+    })
+
+    // $ExpectError
+    history.foo
+  });
+
+
+  describe('#push', () => {
+    it('should allow to use string as first argument', () => {
+      const history = createHashHistory({
+        basename: "",
+        hashType: "slash",
+      })
+
+      history.push("/")
+    });
+
+    it('should allow to use partial location as first argument', () => {
+      const history = createHashHistory({
+        basename: "",
+        hashType: "slash",
+      })
+
+      history.push({
+        search: "?a=1",
+      })
+    });
+  });
+
+  describe('#replace', () => {
+    it('should allow to use string as first argument', () => {
+      const history = createHashHistory({
+        basename: "",
+        hashType: "slash",
+      })
+
+      history.replace("/")
+    });
+
+    it('should allow to use partial location as first argument', () => {
+      const history = createHashHistory({
+        basename: "",
+        hashType: "slash",
+      })
+
+      history.push({
+        search: "?a=1",
+      })
+    });
+  });
+});


### PR DESCRIPTION
Fix #2660 and add more tests

I used interfaces so that I can overload methods.