### PR TITLE
Add `Card` & `Step` component definitions to `antd`

### DIFF
--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
@@ -23,22 +23,22 @@ declare module 'antd' {
   
   declare export class Grid extends React$Component<{
     className?: string,
-    style?: CSSStyleDeclaration
+    style?: $Shape<CSSStyleDeclaration>,
   }> {}
 
   declare export class Meta extends React$Component<{
     avatar?: React$Node,
     className?: string,
     description?: React$Node,
-    style?: CSSStyleDeclaration
+    style?: $Shape<CSSStyleDeclaration>,
     title?: React$Node,
   }> {}
 
   declare export class Card extends React$Component<{
     actions?: Array<React$Node>,
     activeTabKey?: string,
-    headStyle?: CSSStyleDeclaration,
-    bodyStyle?: CSSStyleDeclaration,
+    headStyle?: $Shape<CSSStyleDeclaration>,
+    bodyStyle?: $Shape<CSSStyleDeclaration>,
     bordered?: boolean,
     cover?: React$Node,
     defaultActiveTabKey?: string,
@@ -238,7 +238,7 @@ declare module 'antd' {
           }
         ) => React$Node),
     size?: 'default' | 'small',
-    status: 'wait' | 'process' | 'finish' | 'error',
+    status?: 'wait' | 'process' | 'finish' | 'error',
   }> {
     static Step: typeof Step;
   }

--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
@@ -21,6 +21,19 @@ declare module 'antd' {
   declare export class Avatar extends React$Component<{}> {}
   declare export class Button extends React$Component<{}> {}
   
+  declare export class Grid extends React$Component<{
+    className?: string,
+    style?: CSSStyleDeclaration
+  }> {}
+
+  declare export class Meta extends React$Component<{
+    avatar?: React$Node,
+    className?: string,
+    description?: React$Node,
+    style?: CSSStyleDeclaration
+    title?: React$Node,
+  }> {}
+
   declare export class Card extends React$Component<{
     actions?: Array<React$Node>,
     activeTabKey?: string,
@@ -36,7 +49,10 @@ declare module 'antd' {
     title?: string | React$Node,
     type?: 'inner',
     onTabChange?: (key: string) => void,
-  }> {}
+  }> {
+    static Grid: typeof Grid;
+    static Meta: typeof Meta;
+  }
 
   declare type CascaderOption = {
     value: string,

--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
@@ -20,6 +20,23 @@ declare module 'antd' {
 
   declare export class Avatar extends React$Component<{}> {}
   declare export class Button extends React$Component<{}> {}
+  
+  declare export class Card extends React$Component<{
+    actions?: Array<React$Node>,
+    activeTabKey?: string,
+    headStyle?: CSSStyleDeclaration,
+    bodyStyle?: CSSStyleDeclaration,
+    bordered?: boolean,
+    cover?: React$Node,
+    defaultActiveTabKey?: string,
+    extra?: string | React$Node,
+    hoverable?: boolean,
+    loading?: boolean,
+    tabList?: Array<{ key: string, tab: React$Node }>,
+    title?: string | React$Node,
+    type?: 'inner',
+    onTabChange?: (key: string) => void,
+  }> {}
 
   declare type CascaderOption = {
     value: string,
@@ -181,6 +198,34 @@ declare module 'antd' {
   }
 
   declare export class Spin extends React$Component<SpinProps> {}
+
+  declare export class Step extends React$Component<{
+    description?: string | React$Node,
+    icon?: string | React$Node,
+    status?: 'wait' | 'process' | 'finish' | 'error',
+    title?: string | React$Node,
+  }> {}
+
+  declare export class Steps extends React$Component<{
+    current?: number,
+    direction?: 'horizontal' | 'vertical',
+    labelPlacement?: 'horizontal' | 'vertical',
+    progressDot?:
+      | boolean
+      | ((
+          iconDot: React$Node,
+          {
+            index: number,
+            status: 'wait' | 'process' | 'finish' | 'error',
+            title: string | React$Node,
+            description: string | React$Node,
+          }
+        ) => React$Node),
+    size?: 'default' | 'small',
+    status: 'wait' | 'process' | 'finish' | 'error',
+  }> {
+    static Step: typeof Step;
+  }
 
   declare export class Table extends React$Component<{}> {}
 

--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/test_antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/test_antd_v3.x.x.js
@@ -4,6 +4,7 @@ import {
   Alert,
   Avatar,
   Button,
+  Card,
   Cascader,
   Checkbox,
   Col,
@@ -24,6 +25,7 @@ import {
   Select,
   Slider,
   Spin,
+  Steps,
   Table,
   Tabs,
   Tag,
@@ -46,6 +48,47 @@ describe('Avatar', () => {
 describe('Button', () => {
   it('is a react component', () => {
     const button = <Button />
+  })
+})
+
+describe('Card', () => {
+  it('is a react component', () => {
+    const card = <Card />
+  })
+
+  it('with content', () => {
+    const card =  (
+      <Card title="Card title" bordered={false} extra={<a href="#">More</a>} style={{ width: 300 }}>
+        <p>Card content</p>
+        <p>Card content</p>
+      </Card>
+    )
+  })
+  
+  it('with Card.Grid', () => {
+    const card = (
+      <Card title="Card Title">
+        <Card.Grid style={{ width: '25%', textAlign: 'center' }}>
+          Content
+        </Card.Grid>
+      </Card>
+    )
+  })
+
+  it('with Card.Meta', () => {
+    const card =  (
+      <Card
+          hoverable
+          style={{ width: 240 }}
+          cover={<img alt="example" src="https://os.alipayobjects.com/rmsportal/QBnOOoLaAfKPirc.png" />}
+        >
+          <Card.Meta
+            avatar={<Avatar src="https://zos.alipayobjects.com/rmsportal/ODTLcjxAfvqbxHnVXCYX.png" />}
+            title="Europe Street beat"
+            description="www.instagram.com"
+          />
+        </Card>
+    )
   })
 })
 
@@ -301,6 +344,22 @@ describe('Slider', () => {
 describe('Spin', () => {
   it('is a react component', () => {
     const spin = <Spin />
+  })
+})
+
+describe('Steps', () => {
+  it('is a react component', () => {
+    const steps = <Steps />
+  })
+
+  it('with Steps.Step', () => {
+    const steps = (
+      <Steps size="small" current={1}>
+        <Steps.Step title="Finished" description="This is a description." />
+        <Steps.Step stats="process" title="In Progress" description="This is a description." />
+        <Steps.Step status="wait" title="Waiting" description="This is a description." />
+      </Steps>
+    )
   })
 })
 


### PR DESCRIPTION
- [Card](https://ant.design/components/card/#Card), [source code 1](https://github.com/ant-design/ant-design/blob/master/components/card/index.tsx)
- [Steps](https://ant.design/components/steps/#Steps), [source code 1](https://github.com/ant-design/ant-design/blob/master/components/steps/index.tsx), [source code 2](https://github.com/react-component/steps/blob/9e62045c58ce7a9edcfd281db912fa11e28ac920/src/Steps.jsx)
- [Step](https://ant.design/components/steps/#Step), [source code](https://github.com/react-component/steps/blob/9e62045c58ce7a9edcfd281db912fa11e28ac920/src/Step.jsx)
