### PR TITLE
add read only to the theme

### DIFF
--- a/definitions/npm/styled-components_v3.x.x/flow_v0.75.x-/styled-components_v3.x.x.js
+++ b/definitions/npm/styled-components_v3.x.x/flow_v0.75.x-/styled-components_v3.x.x.js
@@ -108,7 +108,7 @@ type $npm$styledComponents$WithTheme =
   & $npm$styledComponents$WithThemeReactComponentFunctionalUndefinedDefaultProps
 
 // ---- MISC ----
-type $npm$styledComponents$Theme = {[key: string]: mixed};
+type $npm$styledComponents$Theme = $ReadOnly<{[key: string]: mixed}>;
 type $npm$styledComponents$ThemeProviderProps = {
   theme: $npm$styledComponents$Theme | ((outerTheme: $npm$styledComponents$Theme) => void)
 };


### PR DESCRIPTION
as of flow_v0.75, things like: https://flow.org/try/#0C4TwDgpgBA7gFgQ2FAvFA3lA2gawiALgGdgAnASwDsBzAXQIFtyAPCAEwF8AoLgGwmTA4VagViJkaTAjEByAIyyo3LqEjikAZlQYZJCjQA0UAEbEyIlQGMA9pRJQAZgFdKOgBTMC8JAEoUAHzMPLb2yGYawNpSMrIIssZmsiayKi6U7ia+QA
will fail. this happens with styled-components if you try and define a type for your theme e.g.
```
type Theme = {
  primaryColor: string | someHexLiteral
  ...
}
```
adding `$ReadOnly` fixes those errors.