### PR TITLE
Update FormattedMessage in react-intl_v2.x.x.js

### DIFF
--- a/definitions/npm/react-intl_v2.x.x/flow_v0.63.x-/react-intl_v2.x.x.js
+++ b/definitions/npm/react-intl_v2.x.x/flow_v0.63.x-/react-intl_v2.x.x.js
@@ -194,7 +194,9 @@ declare module "react-intl" {
     $npm$ReactIntl$MessageDescriptor & {
       values?: Object,
       tagName?: string,
-      children?: (...formattedMessage: Array<React$Node>) => React$Node
+      children?: 
+        | ((...formattedMessage: Array<React$Node>) => React$Node)
+        | (string => React$Node)
     }
   > {}
   declare class FormattedHTMLMessage extends React$Component<

--- a/definitions/npm/react-intl_v2.x.x/flow_v0.63.x-/test_react-intl_v2.x.x.js
+++ b/definitions/npm/react-intl_v2.x.x/flow_v0.63.x-/test_react-intl_v2.x.x.js
@@ -78,6 +78,12 @@ const msg3:MessageDescriptor = messageDescriptorMap.messagekey3;
   description="Plural example"
   values={{ name: <b>John Doe</b>, numMessages: 1 }}
 />;
+<FormattedMessage
+  id="test_string"
+  defaultMessage="watskeburt"
+>
+	{(msg: string) => <input placeholder={msg} />}
+</FormattedMessage>;
 <FormattedHTMLMessage
   id="test"
   defaultMessage="test message"


### PR DESCRIPTION
`FormattedMessage` can be configured to return strings by using the technique described [here](https://github.com/yahoo/react-intl/issues/999#issuecomment-335799491). This change enables you have the correct Flow type using this technique, as in the following example:

```jsx
<FormattedMessage id="id" defaultMessage="Request pricing">
  {(msg: string) => <a href={`mailto:email@example.com?subject=${msg}`}>{msg}</a>}
</FormattedMessage>
```
