### PR TITLE
[metrics] Fix Meter#mark()

### DIFF
--- a/definitions/npm/metrics_v0.1.x/flow_v0.25.x-/metrics_v0.1.x.js
+++ b/definitions/npm/metrics_v0.1.x/flow_v0.25.x-/metrics_v0.1.x.js
@@ -24,7 +24,7 @@ declare module 'metrics' {
   declare class Meter {
     type: 'meter';
 
-    mark(n: number): void;
+    mark(n?: number): void;
     rates(): Rates;
     fifteenMinuteRate(): number;
     fiveMinuteRate(): number;

--- a/definitions/npm/metrics_v0.1.x/test_metrics_v0.1.x.js
+++ b/definitions/npm/metrics_v0.1.x/test_metrics_v0.1.x.js
@@ -10,6 +10,7 @@ import {
 import type { Metric } from 'metrics';
 
 const meter: Meter = new Meter();
+meter.mark();
 meter.mark(3);
 // $ExpectError wrong argument type
 meter.mark('hello');


### PR DESCRIPTION
Making the argument of `Meter#mark()` optional.

Source: https://github.com/mikejihbe/metrics/blob/v0.1.17/metrics/meter.js#L16