### PR TITLE
[react-test-renderer] Export ReactTestRenderer type

### DIFF
--- a/definitions/npm/react-test-renderer_v16.x.x/flow_v0.47.x-/react-test-renderer_v16.x.x.js
+++ b/definitions/npm/react-test-renderer_v16.x.x/flow_v0.47.x-/react-test-renderer_v16.x.x.js
@@ -38,20 +38,20 @@ type ReactTestInstance = {
   ): ReactTestInstance[]
 };
 
-type ReactTestRenderer = {
-  toJSON(): null | ReactTestRendererJSON,
-  toTree(): null | ReactTestRendererTree,
-  unmount(nextElement?: React$Element<any>): void,
-  update(nextElement: React$Element<any>): void,
-  getInstance(): null | ReactTestInstance,
-  root: ReactTestInstance
-};
-
 type TestRendererOptions = {
   createNodeMock(element: React$Element<any>): any
 };
 
 declare module "react-test-renderer" {
+  declare export type ReactTestRenderer = {
+    toJSON(): null | ReactTestRendererJSON,
+    toTree(): null | ReactTestRendererTree,
+    unmount(nextElement?: React$Element<any>): void,
+    update(nextElement: React$Element<any>): void,
+    getInstance(): null | ReactTestInstance,
+    root: ReactTestInstance
+  };
+
   declare function create(
     nextElement: React$Element<any>,
     options?: TestRendererOptions


### PR DESCRIPTION
This enables importing the ReactTestRenderer type directly.

```js
import type { ReactTestRenderer } from 'react-test-renderer';
```

Useful when building libraries that receive a TestRenderer instance as an argument.