### PR TITLE
feat: update ramda dissocPath to work with generic type

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
@@ -1326,20 +1326,19 @@ declare module ramda {
   declare function dissoc<T>(
     key: string,
     ...args: Array<void>
-  ): (src: { [k: string]: T }) => { [k: string]: T };
+  ): (src: T) => T;
   declare function dissoc<T>(
     key: string,
-    src: { [k: string]: T }
-  ): { [k: string]: T };
+    src: T
+  ): T;
 
   declare function dissocPath<T>(
-    key: Array<string>,
-    ...args: Array<void>
-  ): (src: { [k: string]: T }) => { [k: string]: T };
+    key: Array<string>
+  ): (src: T) => T;
   declare function dissocPath<T>(
     key: Array<string>,
-    src: { [k: string]: T }
-  ): { [k: string]: T };
+    src: T
+  ): T;
 
   declare function evolve<A: Object>(NestedObject<Function>, A): A;
   declare function evolve<A: Object>(NestedObject<Function>): A => A;


### PR DESCRIPTION
the previous definition assumed that all the values would be the same type, which will not work for any other type