### PR TITLE
fix(react-apollo): export DataProxy interface

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -680,7 +680,7 @@ declare module "react-apollo" {
     complete?: boolean
   };
 
-  declare interface DataProxy {
+  declare export interface DataProxy {
     readQuery<QueryType>(
       options: DataProxyReadQueryOptions,
       optimistic?: boolean


### PR DESCRIPTION
So, I have an eslint rule that requires argument type declarations in most places, so my `update` functions (unless a simple lambda expression) need the `cache` argument typed.  But this is currently impossible to do since `react-apollo` doesn't export the `DataProxy` type it uses for this argument.