### PR TITLE
@material ui/core  hoc and public imports

### DIFF
--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
@@ -2134,6 +2134,11 @@ declare module "@material-ui/core/styles/withStyles" {
   |};
 
   declare export type WithStyles = {
+    classes: { +[string]: string },
+    innerRef: React$Ref<React$ElementType> | {current: null | React$ElementRef<React$ElementType>}
+  };
+
+  declare type WithStylesHOC = {
     classes: void | { +[string]: string },
     innerRef: void | React$Ref<React$ElementType> | {current: null | React$ElementRef<React$ElementType>}
   };
@@ -2143,20 +2148,25 @@ declare module "@material-ui/core/styles/withStyles" {
     options?: WithStylesOptions,
   ) => <WrappedComponent: React$ComponentType<*>>(
     Component: WrappedComponent
-  ) => React$ComponentType<$Diff<React$ElementConfig<$Supertype<WrappedComponent>>, WithStyles>>;
+  ) => React$ComponentType<$Diff<React$ElementConfig<$Supertype<WrappedComponent>>, WithStylesHOC>>;
 }
 
 declare module "@material-ui/core/styles/withTheme" {
   import type {Theme} from "@material-ui/core/styles/createMuiTheme";
 
   declare export type WithTheme = {
-    theme: void | Theme;
+    theme: Theme,
+    innerRef: React$Ref<React$ElementType> | {current: null | React$ElementRef<React$ElementType>}
+  };
+
+  declare type WithThemeHOC = {
+    theme: void | Theme,
     innerRef: void | React$Ref<React$ElementType> | {current: null | React$ElementRef<React$ElementType>}
-  }
+  };
 
   declare module.exports: () => <Props: {}, WrappedComponent: React$ComponentType<Props>>(
     Component: WrappedComponent
-  ) => React$ComponentType<$Diff<React$ElementConfig<$Supertype<WrappedComponent>>, WithTheme>>;
+  ) => React$ComponentType<$Diff<React$ElementConfig<$Supertype<WrappedComponent>>, WithThemeHOC>>;
 }
 
 declare module "@material-ui/core/styles/zIndex" {

--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
@@ -1,9 +1,11 @@
 declare module "@material-ui/core/AppBar/AppBar" {
+  import type {ComponentType, Node} from "react";
+
   declare type Color = "inherit" | "primary" | "secondary" | "default";
   declare type Position = "fixed" | "absolute" | "sticky" | "static";
 
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  declare module.exports: ComponentType<{
+    children?: Node,
     className?: string,
     classes?: Object,
     color?: Color,
@@ -16,13 +18,15 @@ declare module "@material-ui/core/AppBar" {
 }
 
 declare module "@material-ui/core/Avatar/Avatar" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, Element, ElementType} from "react";
+
+  declare module.exports: ComponentType<{
     alt?: string,
-    children?: string | React$Element<any>,
+    children?: string | Element<any>,
     childrenClassName?: string,
     className?: string,
     classes?: Object,
-    component?: React$ElementType,
+    component?: ElementType,
     imgProps?: Object,
     sizes?: string,
     src?: string,
@@ -35,11 +39,13 @@ declare module "@material-ui/core/Avatar" {
 }
 
 declare module "@material-ui/core/Badge/Badge" {
+  import type {ComponentType, Node} from "react";
+
   declare type Color = "default" | "primary" | "secondary" | "error";
 
-  declare module.exports: React$ComponentType<{
-    badgeContent: React$Node,
-    children: React$Node,
+  declare module.exports: ComponentType<{
+    badgeContent: Node,
+    children: Node,
     className?: string,
     classes?: Object,
     color?: Color
@@ -51,8 +57,10 @@ declare module "@material-ui/core/Badge" {
 }
 
 declare module "@material-ui/core/BottomNavigation/BottomNavigation" {
-  declare module.exports: React$ComponentType<{
-    children: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children: Node,
     className?: string,
     classes?: Object,
     onChange?: Function,
@@ -62,11 +70,13 @@ declare module "@material-ui/core/BottomNavigation/BottomNavigation" {
 }
 
 declare module "@material-ui/core/BottomNavigationAction/BottomNavigationAction" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, Element, Node} from "react";
+
+  declare module.exports: ComponentType<{
     className?: string,
     classes?: Object,
-    icon?: string | React$Element<any>,
-    label?: React$Node,
+    icon?: string | Element<any>,
+    label?: Node,
     onChange?: Function,
     onClick?: Function,
     selected?: boolean,
@@ -88,16 +98,18 @@ declare module "@material-ui/core/BottomNavigationAction" {
 }
 
 declare module "@material-ui/core/Button/Button" {
+  import type {ComponentType, ElementType, Node} from "react";
+
   declare type Color = "default" | "inherit" | "primary" | "secondary";
   declare type Variant = "text" | "flat" | "outlined" | "contained" | "raised" | "fab" | "extendedFab"
   declare type Size = "small" | "medium" | "large"
 
-  declare module.exports: React$ComponentType<{
-    children: React$Node,
+  declare module.exports: ComponentType<{
+    children: Node,
     className?: string,
     classes?: Object,
     color?: Color,
-    component?: React$ElementType,
+    component?: ElementType,
     disabled?: boolean,
     disableFocusRipple?: boolean,
     disableRipple?: boolean,
@@ -114,12 +126,14 @@ declare module "@material-ui/core/Button" {
 }
 
 declare module "@material-ui/core/ButtonBase/ButtonBase" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, ElementType, Node} from "react";
+
+  declare module.exports: ComponentType<{
     centerRipple?: boolean,
-    children?: React$Node,
+    children?: Node,
     className?: string,
     classes?: Object,
-    component?: React$ElementType,
+    component?: ElementType,
     disableRipple?: boolean,
     disabled?: boolean,
     focusRipple?: boolean,
@@ -157,7 +171,9 @@ declare module "@material-ui/core/ButtonBase" {
 }
 
 declare module "@material-ui/core/ButtonBase/Ripple" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<{
     className?: string,
     classes?: Object,
     pulsate?: boolean,
@@ -168,7 +184,9 @@ declare module "@material-ui/core/ButtonBase/Ripple" {
 }
 
 declare module "@material-ui/core/ButtonBase/TouchRipple" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<{
     center?: boolean,
     className?: string,
     classes?: Object
@@ -176,15 +194,19 @@ declare module "@material-ui/core/ButtonBase/TouchRipple" {
 }
 
 declare module "@material-ui/core/Card/Card" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<{
     className?: string,
     raised?: boolean
   }>;
 }
 
 declare module "@material-ui/core/CardActions/CardActions" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     className?: string,
     classes?: Object,
     disableActionSpacing?: boolean
@@ -192,28 +214,34 @@ declare module "@material-ui/core/CardActions/CardActions" {
 }
 
 declare module "@material-ui/core/CardContent/CardContent" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<{
     className?: string,
     classes?: Object
   }>;
 }
 
 declare module "@material-ui/core/CardHeader/CardHeader" {
-  declare module.exports: React$ComponentType<{
-    action?: React$Node,
-    avatar?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    action?: Node,
+    avatar?: Node,
     className?: string,
     classes?: Object,
-    subheader?: React$Node,
-    title?: React$Node
+    subheader?: Node,
+    title?: Node
   }>;
 }
 
 declare module "@material-ui/core/CardMedia/CardMedia" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, ElementType} from "react";
+
+  declare module.exports: ComponentType<{
     className?: string,
     classes?: Object,
-    component?: React$ElementType,
+    component?: ElementType,
     image?: string,
     src?: string,
     style?: Object
@@ -237,17 +265,20 @@ declare module "@material-ui/core/CardMedia" {
 }
 
 declare module "@material-ui/core/Checkbox/Checkbox" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, Node} from "react";
+
+
+  declare module.exports: ComponentType<{
     checked?: boolean | string,
-    checkedIcon?: React$Node,
+    checkedIcon?: Node,
     className?: string,
     classes?: Object,
     defaultChecked?: boolean,
     disableRipple?: boolean,
     disabled?: boolean,
-    icon?: React$Node,
+    icon?: Node,
     indeterminate?: boolean,
-    indeterminateIcon?: React$Node,
+    indeterminateIcon?: Node,
     inputProps?: Object,
     inputRef?: Function,
     name?: string,
@@ -262,14 +293,16 @@ declare module "@material-ui/core/Checkbox" {
 }
 
 declare module "@material-ui/core/Chip/Chip" {
+  import type {ComponentType, Element, Node} from "react";
+
   import typeof Avatar from "@material-ui/core/Avatar/Avatar";
 
-  declare module.exports: React$ComponentType<{
-    avatar?: React$Element<Avatar>,
+  declare module.exports: ComponentType<{
+    avatar?: Element<Avatar>,
     className?: string,
     classes?: Object,
-    deleteIcon?: React$Element<any>,
-    label?: React$Node,
+    deleteIcon?: Element<any>,
+    label?: Node,
     onClick?: Function,
     onDelete?: (event: SyntheticEvent<*>) => void,
     onKeyDown?: Function,
@@ -282,7 +315,9 @@ declare module "@material-ui/core/Chip" {
 }
 
 declare module "@material-ui/core/CssBaseline/CssBaseline" {
-  declare module.exports: React$ComponentType<{ children?: React$Node }>;
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{ children?: Node }>;
 }
 
 declare module "@material-ui/core/CssBaseline" {
@@ -379,14 +414,16 @@ declare module "@material-ui/core/colors/yellow" {
 }
 
 declare module "@material-ui/core/Dialog/Dialog" {
+  import type {ComponentType, Node} from "react";
+
   import type {
     TransitionCallback,
     TransitionDuration
   } from "@material-ui/core/internal/transition";
   declare type MaxWidth = "xs" | "sm" | "md" | false;
 
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  declare module.exports: ComponentType<{
+    children?: Node,
     className?: string,
     classes?: Object,
     fullScreen?: boolean,
@@ -404,38 +441,46 @@ declare module "@material-ui/core/Dialog/Dialog" {
     onExited?: TransitionCallback,
     onExiting?: TransitionCallback,
     open?: boolean,
-    transition?: React$ComponentType<*>,
+    transition?: ComponentType<*>,
     transitionDuration?: TransitionDuration
   }>;
 }
 
 declare module "@material-ui/core/DialogActions/DialogActions" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     className?: string,
     classes?: Object
   }>;
 }
 
 declare module "@material-ui/core/DialogContent/DialogContent" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     className?: string,
     classes?: Object
   }>;
 }
 
 declare module "@material-ui/core/DialogContentText/DialogContentText" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     className?: string,
     classes?: Object
   }>;
 }
 
 declare module "@material-ui/core/DialogTitle/DialogTitle" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     className?: string,
     classes?: Object,
     disableTypography?: boolean
@@ -479,7 +524,7 @@ declare module "@material-ui/core/withMobileDialog" {
 }
 
 declare module "@material-ui/core/withWidth" {
-  import type { Breakpoint } from "@material-ui/core/styles/createBreakpoints";
+  import type {Breakpoint} from "@material-ui/core/styles/createBreakpoints";
   declare export var isWidthUp: (
     matchWidth: Breakpoint,
     currentWidth: Breakpoint
@@ -492,7 +537,9 @@ declare module "@material-ui/core/withWidth" {
 }
 
 declare module "@material-ui/core/Divider/Divider" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<{
     absolute?: boolean,
     className?: string,
     classes?: Object,
@@ -506,17 +553,19 @@ declare module "@material-ui/core/Divider" {
 }
 
 declare module "@material-ui/core/Drawer/Drawer" {
-  import type { TransitionDuration } from "@material-ui/core/internal/transition";
+  import type {ComponentType, Node} from "react";
+
+  import type {TransitionDuration} from "@material-ui/core/internal/transition";
 
   declare type Anchor = "left" | "top" | "right" | "bottom";
   declare type Variant = "permanent" | "persistent" | "temporary";
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     ModalProps?: Object,
     SlideProps?: Object,
     PaperProps?: Object,
     anchor?: Anchor,
-    children: React$Node,
+    children: Node,
     className?: string,
     classes?: Object,
     elevation?: number,
@@ -531,10 +580,12 @@ declare module "@material-ui/core/Drawer" {
 }
 
 declare module "@material-ui/core/SwipeableDrawer/SwipeableDrawer" {
-  import typeof Drawer from "@material-ui/core/Drawer/Drawer"
-  import type { TransitionDuration } from "@material-ui/core/internal/transition";
+  import type {ComponentType} from "react";
 
-  declare module.exports: React$ComponentType<{
+  import typeof Drawer from "@material-ui/core/Drawer/Drawer"
+  import type {TransitionDuration} from "@material-ui/core/internal/transition";
+
+  declare module.exports: ComponentType<{
     disableBackdropTransition: boolean,
     disableDiscovery: boolean,
     disableSwipeToOpen: boolean,
@@ -553,9 +604,11 @@ declare module "@material-ui/core/SwipeableDrawer" {
 }
 
 declare module "@material-ui/core/ExpansionPanel/ExpansionPanel" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
     CollapseProps?: Object,
-    children?: React$Node,
+    children?: Node,
     className?: string,
     classes?: Object,
     defaultExpanded?: boolean,
@@ -566,29 +619,35 @@ declare module "@material-ui/core/ExpansionPanel/ExpansionPanel" {
 }
 
 declare module "@material-ui/core/ExpansionPanelActions/ExpansionPanelActions" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     className?: string,
     classes?: Object
   }>;
 }
 
 declare module "@material-ui/core/ExpansionPanelDetails/ExpansionPanelDetails" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     className?: string,
     classes?: Object
   }>;
 }
 
 declare module "@material-ui/core/ExpansionPanelSummary/ExpansionPanelSummary" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     className?: string,
     classes?: Object,
     disabled?: boolean,
     expanded?: boolean,
-    expandIcon?: React$Node,
+    expandIcon?: Node,
     onChange?: Function,
     onClick?: Function
   }>;
@@ -619,13 +678,15 @@ declare module "@material-ui/core/ExpansionPanelSummary" {
 }
 
 declare module "@material-ui/core/FormControl/FormControl" {
+  import type {ComponentType, ElementType, Node} from "react";
+
   declare type Margin = "none" | "dense" | "normal";
 
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
-    component?: React$ElementType,
+    component?: ElementType,
     disabled?: boolean,
     error?: boolean,
     fullWidth?: boolean,
@@ -637,14 +698,16 @@ declare module "@material-ui/core/FormControl/FormControl" {
 }
 
 declare module "@material-ui/core/FormControlLabel/FormControlLabel" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, Element, Node} from "react";
+
+  declare module.exports: ComponentType<{
     checked?: boolean | string,
     classes?: Object,
     className?: string,
-    control: React$Element<any>,
+    control: Element<any>,
     disabled?: boolean,
     inputRef?: Function,
-    label: React$Node,
+    label: Node,
     name?: string,
     onChange?: Function,
     value?: string
@@ -652,8 +715,10 @@ declare module "@material-ui/core/FormControlLabel/FormControlLabel" {
 }
 
 declare module "@material-ui/core/FormGroup/FormGroup" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
     row?: boolean
@@ -661,8 +726,10 @@ declare module "@material-ui/core/FormGroup/FormGroup" {
 }
 
 declare module "@material-ui/core/FormHelperText/FormHelperText" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
     disabled?: boolean,
@@ -672,11 +739,13 @@ declare module "@material-ui/core/FormHelperText/FormHelperText" {
 }
 
 declare module "@material-ui/core/FormLabel/FormLabel" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, ElementType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
-    component?: React$ElementType,
+    component?: ElementType,
     disabled?: boolean,
     error?: boolean,
     focused?: boolean,
@@ -709,6 +778,8 @@ declare module "@material-ui/core/FormLabel" {
 }
 
 declare module "@material-ui/core/Grid/Grid" {
+  import type {ComponentType, ElementType, Node} from "react";
+
   declare type GridSizes =
     | boolean
     | 1
@@ -746,10 +817,10 @@ declare module "@material-ui/core/Grid/Grid" {
   declare type Spacing = 0 | 8 | 16 | 24 | 32 | 40;
   declare type Wrap = "nowrap" | "wrap" | "wrap-reverse";
   declare type GridProps = {
-    children?: React$Node,
+    children?: Node,
     classes?: Object,
     className?: string,
-    component?: React$ElementType,
+    component?: ElementType,
     container?: boolean,
     item?: boolean,
     alignContent?: AlignContent,
@@ -765,7 +836,7 @@ declare module "@material-ui/core/Grid/Grid" {
     lg?: GridSizes,
     xl?: GridSizes
   }
-  declare module.exports: React$ComponentType<GridProps>;
+  declare module.exports: ComponentType<GridProps>;
 }
 
 declare module "@material-ui/core/Grid" {
@@ -773,42 +844,49 @@ declare module "@material-ui/core/Grid" {
 }
 
 declare module "@material-ui/core/GridList/GridList" {
+  import type {ComponentType, ElementType, Node} from "react";
+
   declare type CellHeight = number | "auto";
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     cellHeight?: CellHeight,
-    children: React$Node,
+    children: Node,
     classes?: Object,
     className?: string,
     cols?: number,
-    component?: React$ElementType,
+    component?: ElementType,
     spacing?: number,
     style?: Object
   }>;
 }
 
 declare module "@material-ui/core/GridListTile/GridListTile" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, ElementType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
     cols?: number,
-    component?: React$ElementType,
+    component?: ElementType,
     rows?: number
   }>;
 }
 
 declare module "@material-ui/core/GridListTileBar/GridListTileBar" {
+  import type {ComponentType, Node} from "react";
+
+
   declare type TitlePosition = "top" | "bottom";
   declare type ActionPosition = "left" | "right";
 
-  declare module.exports: React$ComponentType<{
-    actionIcon?: React$Node,
+  declare module.exports: ComponentType<{
+    actionIcon?: Node,
     actionPosition?: ActionPosition,
     classes?: Object,
     className?: string,
-    subtitle?: React$Node,
-    title: React$Node,
+    subtitle?: Node,
+    title: Node,
     titlePosition?: TitlePosition
   }>;
 }
@@ -829,10 +907,12 @@ declare module "@material-ui/core/GridListTileBar" {
   >;
 }
 declare module "@material-ui/core/Hidden/Hidden" {
-  import type { Breakpoint } from "@material-ui/core/styles/createBreakpoints";
+  import type {ComponentType, Node} from "react";
 
-  declare module.exports: React$ComponentType<{
-    children: React$Node,
+  import type {Breakpoint} from "@material-ui/core/styles/createBreakpoints";
+
+  declare module.exports: ComponentType<{
+    children: Node,
     className?: string,
     only?: Breakpoint | Array<Breakpoint>,
     xsUp?: boolean,
@@ -851,15 +931,19 @@ declare module "@material-ui/core/Hidden/Hidden" {
 }
 
 declare module "@material-ui/core/Hidden/HiddenCss" {
+  import type {ComponentType, ElementProps} from "react";
+
   import typeof Hidden from "@material-ui/core/Hidden/Hidden";
 
-  declare module.exports: React$ComponentType<React$ElementProps<Hidden>>;
+  declare module.exports: ComponentType<ElementProps<Hidden>>;
 }
 
 declare module "@material-ui/core/Hidden/HiddenJs" {
+  import type {ComponentType, ElementProps} from "react";
+
   import typeof Hidden from "@material-ui/core/Hidden/Hidden";
 
-  declare module.exports: React$ComponentType<React$ElementProps<Hidden>>;
+  declare module.exports: ComponentType<ElementProps<Hidden>>;
 }
 
 declare module "@material-ui/core/Hidden" {
@@ -871,6 +955,8 @@ declare module "@material-ui/core/Hidden/types" {
 }
 
 declare module "@material-ui/core/Icon/Icon" {
+  import type {ComponentType, Node} from "react";
+
   declare type Color =
     | "inherit"
     | "accent"
@@ -880,8 +966,8 @@ declare module "@material-ui/core/Icon/Icon" {
     | "error"
     | "primary";
 
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  declare module.exports: ComponentType<{
+    children?: Node,
     className?: string,
     classes?: Object,
     color?: Color
@@ -893,15 +979,17 @@ declare module "@material-ui/core/Icon" {
 }
 
 declare module "@material-ui/core/IconButton/IconButton" {
+  import type {ComponentType, Node} from "react";
+
   declare type Color =
     | "default"
     | "inherit"
     | "primary"
     | "secondary";
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     buttonRef?: Function,
-    children?: React$Node,
+    children?: Node,
     classes?: Object,
     className?: string,
     color?: Color,
@@ -930,7 +1018,9 @@ declare module "@material-ui/core/InputLabel" {
 }
 
 declare module "@material-ui/core/Input/Input" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
     autoComplete?: string,
     autoFocus?: boolean,
     classes?: Object,
@@ -938,11 +1028,11 @@ declare module "@material-ui/core/Input/Input" {
     defaultValue?: string | number,
     disabled?: boolean,
     disableUnderline?: boolean,
-    endAdornment?: React$Node,
+    endAdornment?: Node,
     error?: boolean,
     fullWidth?: boolean,
     id?: string,
-    inputComponent?: string | React$ComponentType<*>,
+    inputComponent?: string | ComponentType<*>,
     inputProps?: Object,
     inputRef?: Function,
     margin?: "dense" | "none",
@@ -959,26 +1049,30 @@ declare module "@material-ui/core/Input/Input" {
     placeholder?: string,
     rows?: string | number,
     rowsMax?: string | number,
-    startAdornment?: React$Node,
+    startAdornment?: Node,
     type?: string,
     value?: string | number | Array<string | number>
   }>;
 }
 
 declare module "@material-ui/core/InputAdornment/InputAdornment" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, ElementType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
-    component?: React$ElementType,
+    component?: ElementType,
     disableTypography?: boolean,
     position: "start" | "end"
   }>;
 }
 
 declare module "@material-ui/core/InputLabel/InputLabel" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
     disableAnimation?: boolean,
@@ -993,9 +1087,11 @@ declare module "@material-ui/core/InputLabel/InputLabel" {
 }
 
 declare module "@material-ui/core/Input/Textarea" {
+  import type {ComponentType} from "react";
+
   declare type Rows = string | number;
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     classes?: Object,
     className?: string,
     defaultValue?: string | number,
@@ -1013,8 +1109,10 @@ declare module "@material-ui/core/internal/dom" {
 }
 
 declare module "@material-ui/core/Portal/Portal" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     open?: boolean
   }>;
 }
@@ -1024,18 +1122,20 @@ declare module "@material-ui/core/Portal" {
 }
 
 declare module "@material-ui/core/internal/SwitchBase" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
     checked?: boolean | string,
-    checkedIcon?: React$Node,
-    children?: React$Node,
+    checkedIcon?: Node,
+    children?: Node,
     classes?: Object,
     className?: string,
     defaultChecked?: boolean,
     disabled?: boolean,
     disableRipple?: boolean,
-    icon?: React$Node,
+    icon?: Node,
     indeterminate?: boolean,
-    indeterminateIcon?: React$Node,
+    indeterminateIcon?: Node,
     inputProps?: Object,
     inputRef?: Function,
     inputType?: string,
@@ -1097,25 +1197,29 @@ declare module "@material-ui/core/ListSubheader" {
 }
 
 declare module "@material-ui/core/List/List" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, ElementType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
-    component?: React$ElementType,
+    component?: ElementType,
     dense?: boolean,
     disablePadding?: boolean,
     rootRef?: Function,
-    subheader?: React$Node
+    subheader?: Node
   }>;
 }
 
 declare module "@material-ui/core/ListItem/ListItem" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, ElementType, Node} from "react";
+
+  declare module.exports: ComponentType<{
     button?: boolean,
-    children?: React$Node,
+    children?: Node,
     classes?: Object,
     className?: string,
-    component?: React$ElementType,
+    component?: ElementType,
     dense?: boolean,
     disabled?: boolean,
     disableGutters?: boolean,
@@ -1124,48 +1228,58 @@ declare module "@material-ui/core/ListItem/ListItem" {
 }
 
 declare module "@material-ui/core/ListItemAvatar/ListItemAvatar" {
-  declare module.exports: React$ComponentType<{
-    children: React$Element<any>,
+  import type {ComponentType, Element} from "react";
+
+  declare module.exports: ComponentType<{
+    children: Element<any>,
     classes?: Object,
     className?: string
   }>;
 }
 
 declare module "@material-ui/core/ListItemIcon/ListItemIcon" {
-  declare module.exports: React$ComponentType<{
-    children: React$Element<any>,
+  import type {ComponentType, Element} from "react";
+
+  declare module.exports: ComponentType<{
+    children: Element<any>,
     classes?: Object,
     className?: string
   }>;
 }
 
 declare module "@material-ui/core/ListItemSecondaryAction/ListItemSecondaryAction" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string
   }>;
 }
 
 declare module "@material-ui/core/ListItemText/ListItemText" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
     classes?: Object,
     className?: string,
     disableTypography?: boolean,
     inset?: boolean,
-    primary?: React$Node,
-    secondary?: React$Node
+    primary?: Node,
+    secondary?: Node
   }>;
 }
 
 declare module "@material-ui/core/ListSubheader/ListSubheader" {
+  import type {ComponentType, ElementType, Node} from "react";
+
   declare type Color = "default" | "primary" | "inherit";
 
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
-    component?: React$ElementType,
+    component?: ElementType,
     color?: Color,
     disableSticky?: boolean,
     inset?: boolean
@@ -1185,16 +1299,18 @@ declare module "@material-ui/core/MenuList" {
 }
 
 declare module "@material-ui/core/Menu/Menu" {
-  import type { TransitionCallback } from "@material-ui/core/internal/transition";
+  import type {ComponentType, Node} from "react";
+
+  import type {TransitionCallback} from "@material-ui/core/internal/transition";
 
   declare type TransitionDuration =
     | number
     | { enter?: number, exit?: number }
     | "auto";
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     anchorEl?: ?HTMLElement,
-    children?: React$Node,
+    children?: Node,
     classes?: Object,
     MenuListProps?: Object,
     onEnter?: TransitionCallback,
@@ -1212,19 +1328,23 @@ declare module "@material-ui/core/Menu/Menu" {
 }
 
 declare module "@material-ui/core/MenuItem/MenuItem" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, ElementType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
-    component?: React$ElementType,
+    component?: ElementType,
     role?: string,
     selected?: boolean
   }>;
 }
 
 declare module "@material-ui/core/MenuList/MenuList" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     className?: string,
     onBlur?: Function,
     onKeyDown?: (event: SyntheticUIEvent<*>, key: string) => void
@@ -1238,15 +1358,17 @@ declare module "@material-ui/core/MobileStepper" {
 }
 
 declare module "@material-ui/core/MobileStepper/MobileStepper" {
+  import type {ComponentType, Element} from "react";
+
   declare type Position = "bottom" | "top" | "static";
   declare type Variant = "text" | "dots" | "progress";
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     activeStep?: number,
-    backButton: React$Element<any>,
+    backButton: Element<any>,
     classes?: Object,
     className?: string,
-    nextButton: React$Element<any>,
+    nextButton: Element<any>,
     position?: Position,
     steps: number,
     variant?: Variant
@@ -1254,8 +1376,10 @@ declare module "@material-ui/core/MobileStepper/MobileStepper" {
 }
 
 declare module "@material-ui/core/Backdrop/Backdrop" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
     invisible?: boolean
@@ -1284,17 +1408,19 @@ declare module "@material-ui/core/Backdrop" {
 }
 
 declare module "@material-ui/core/Modal/Modal" {
+  import type {ComponentType, Element, ElementType,} from "react";
+
   import type {
     TransitionDuration,
     TransitionCallback
   } from "@material-ui/core/internal/transition";
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     BackdropClassName?: string,
-    BackdropComponent?: React$ElementType,
+    BackdropComponent?: ElementType,
     BackdropInvisible?: boolean,
     BackdropTransitionDuration?: TransitionDuration,
-    children?: React$Element<any>,
+    children?: Element<any>,
     classes?: Object,
     className?: string,
     keepMounted?: boolean,
@@ -1326,11 +1452,13 @@ declare module "@material-ui/core/NativeSelect" {
 }
 
 declare module "@material-ui/core/NativeSelect/NativeSelect" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, Element, ElementType, Node} from "react";
+
+  declare module.exports: ComponentType<{
     classes: Object,
-    children?: React$Node,
-    IconComponent?: React$ElementType | Function,
-    input?: React$Element<any>,
+    children?: Node,
+    IconComponent?: ElementType | Function,
+    input?: Element<any>,
     inputProps?: Object,
     onChange?: Function,
     value?: string | number
@@ -1342,11 +1470,13 @@ declare module "@material-ui/core/Paper" {
 }
 
 declare module "@material-ui/core/Paper/Paper" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, ElementType, Node} from "react";
+
+  declare module.exports: ComponentType<{
     classes?: Object,
     className?: string,
-    children?: React$Node,
-    component?: React$ElementType,
+    children?: Node,
+    component?: ElementType,
     elevation?: number,
     square?: boolean
   }>;
@@ -1357,6 +1487,8 @@ declare module "@material-ui/core/Popover" {
 }
 
 declare module "@material-ui/core/Popover/Popover" {
+  import type {ComponentType, Node} from "react";
+
   import type {
     TransitionCallback,
     TransitionClasses
@@ -1372,12 +1504,12 @@ declare module "@material-ui/core/Popover/Popover" {
     vertical: "top" | "center" | "bottom" | number
   };
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     anchorEl?: ?HTMLElement,
     anchorPosition?: Position,
     anchorReference?: "anchorEl" | "anchorPosition",
     anchorOrigin?: Origin,
-    children: React$Node,
+    children: Node,
     classes?: Object,
     elevation?: number,
     getContentAnchorEl?: Function,
@@ -1399,11 +1531,13 @@ declare module "@material-ui/core/Popover/Popover" {
 }
 
 declare module "@material-ui/core/CircularProgress/CircularProgress" {
+  import type {ComponentType} from "react";
+
   declare type Color = "primary" | "secondary" | "inherit";
   declare type Mode = "determinate" | "indeterminate";
   declare type Variant = "determinate" | "indeterminate" | "static";
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     classes?: Object,
     className?: string,
     color?: Color,
@@ -1431,10 +1565,12 @@ declare module "@material-ui/core/LinearProgress" {
 }
 
 declare module "@material-ui/core/LinearProgress/LinearProgress" {
+  import type {ComponentType} from "react";
+
   declare type Color = "primary" | "accent";
   declare type Mode = "determinate" | "indeterminate" | "buffer" | "query";
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     classes?: Object,
     className?: string,
     color?: Color,
@@ -1453,16 +1589,18 @@ declare module "@material-ui/core/RadioGroup" {
 }
 
 declare module "@material-ui/core/Radio/Radio" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
     checked?: boolean | string,
-    checkedIcon?: React$Node,
-    children?: React$Node,
+    checkedIcon?: Node,
+    children?: Node,
     classes?: Object,
     className?: string,
     defaultChecked?: boolean,
     disabled?: boolean,
     disableRipple?: boolean,
-    icon?: React$Node,
+    icon?: Node,
     inputProps?: Object,
     inputRef?: Function,
     name?: string,
@@ -1473,8 +1611,10 @@ declare module "@material-ui/core/Radio/Radio" {
 }
 
 declare module "@material-ui/core/RadioGroup/RadioGroup" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     name?: string,
     onBlur?: Function,
     onChange?: Function,
@@ -1488,12 +1628,14 @@ declare module "@material-ui/core/Select" {
 }
 
 declare module "@material-ui/core/Select/Select" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, Element, Node} from "react";
+
+  declare module.exports: ComponentType<{
     autoWidth?: boolean,
-    children: React$Node,
+    children: Node,
     classes?: Object,
     displayEmpty?: boolean,
-    input?: React$Element<any>,
+    input?: Element<any>,
     inputProps?: Object,
     native?: boolean,
     multiple?: boolean,
@@ -1508,9 +1650,11 @@ declare module "@material-ui/core/Select/Select" {
 }
 
 declare module "@material-ui/core/Select/SelectInput" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, Element, Node} from "react";
+
+  declare module.exports: ComponentType<{
     autoWidth: boolean,
-    children: React$Node,
+    children: Node,
     classes?: Object,
     className?: string,
     disabled?: boolean,
@@ -1520,7 +1664,7 @@ declare module "@material-ui/core/Select/SelectInput" {
     MenuProps?: Object,
     name?: string,
     onBlur?: Function,
-    onChange?: (event: SyntheticUIEvent<*>, child: React$Element<any>) => void,
+    onChange?: (event: SyntheticUIEvent<*>, child: Element<any>) => void,
     onFocus?: Function,
     readOnly?: boolean,
     renderValue?: Function,
@@ -1543,6 +1687,8 @@ declare module "@material-ui/core/SnackbarContent" {
 }
 
 declare module "@material-ui/core/Snackbar/Snackbar" {
+  import type {ComponentType, Element, Node} from "react";
+
   import type {
     TransitionDuration,
     TransitionCallback
@@ -1553,16 +1699,16 @@ declare module "@material-ui/core/Snackbar/Snackbar" {
     vertical?: "top" | "center" | "bottom" | number
   };
 
-  declare module.exports: React$ComponentType<{
-    action?: React$Node,
+  declare module.exports: ComponentType<{
+    action?: Node,
     anchorOrigin?: Origin,
     autoHideDuration?: ?number,
     resumeHideDuration?: number,
-    children?: React$Element<any>,
+    children?: Element<any>,
     classes?: Object,
     className?: string,
     key?: any,
-    message?: React$Node,
+    message?: Node,
     onEnter?: TransitionCallback,
     onEntering?: TransitionCallback,
     onEntered?: TransitionCallback,
@@ -1574,17 +1720,19 @@ declare module "@material-ui/core/Snackbar/Snackbar" {
     onClose?: (event: ?Event, reason: string) => void,
     open: boolean,
     SnackbarContentProps?: Object,
-    transition?: React$ComponentType<*>,
+    transition?: ComponentType<*>,
     transitionDuration?: TransitionDuration
   }>;
 }
 
 declare module "@material-ui/core/SnackbarContent/SnackbarContent" {
-  declare module.exports: React$ComponentType<{
-    action?: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    action?: Node,
     classes?: Object,
     className?: string,
-    message: React$Node
+    message: Node
   }>;
 }
 
@@ -1613,16 +1761,18 @@ declare module "@material-ui/core/Stepper" {
 }
 
 declare module "@material-ui/core/Step/Step" {
-  import type { Orientation } from "@material-ui/core/Stepper/Stepper";
+  import type {ComponentType, Element, Node} from "react";
 
-  declare module.exports: React$ComponentType<{
+  import type {Orientation} from "@material-ui/core/Stepper/Stepper";
+
+  declare module.exports: ComponentType<{
     active?: boolean,
     alternativeLabel?: boolean,
-    children?: React$Node,
+    children?: Node,
     classes?: Object,
     className?: string,
     completed?: boolean,
-    connector?: React$Element<any>,
+    connector?: Element<any>,
     disabled?: boolean,
     index?: number,
     last?: boolean,
@@ -1632,14 +1782,16 @@ declare module "@material-ui/core/Step/Step" {
 }
 
 declare module "@material-ui/core/StepButton/StepButton" {
-  import type { Orientation } from "@material-ui/core/Stepper/Stepper";
+  import type {ComponentType, Element} from "react";
 
-  declare type Icon = React$Element<any> | string | number;
+  import type {Orientation} from "@material-ui/core/Stepper/Stepper";
 
-  declare module.exports: React$ComponentType<{
+  declare type Icon = Element<any> | string | number;
+
+  declare module.exports: ComponentType<{
     active?: boolean,
     alternativeLabel?: boolean,
-    children: React$Element<any>,
+    children: Element<any>,
     classes?: Object,
     className?: string,
     completed?: boolean,
@@ -1652,9 +1804,11 @@ declare module "@material-ui/core/StepButton/StepButton" {
 }
 
 declare module "@material-ui/core/StepConnector/StepConnector" {
-  import type { Orientation } from "@material-ui/core/Stepper/Stepper";
+  import type {ComponentType} from "react";
 
-  declare module.exports: React$ComponentType<{
+  import type {Orientation} from "@material-ui/core/Stepper/Stepper";
+
+  declare module.exports: ComponentType<{
     alternativeLabel?: boolean,
     classes?: Object,
     className?: string,
@@ -1663,13 +1817,15 @@ declare module "@material-ui/core/StepConnector/StepConnector" {
 }
 
 declare module "@material-ui/core/StepContent/StepContent" {
-  import type { TransitionDuration } from "@material-ui/core/Collapse/Collapse";
-  import type { Orientation } from "@material-ui/core/Stepper/Stepper";
+  import type {ComponentType, Node} from "react";
 
-  declare module.exports: React$ComponentType<{
+  import type {TransitionDuration} from "@material-ui/core/Collapse/Collapse";
+  import type {Orientation} from "@material-ui/core/Stepper/Stepper";
+
+  declare module.exports: ComponentType<{
     active?: boolean,
     alternativeLabel?: boolean,
-    children: React$Node,
+    children: Node,
     classes?: Object,
     className?: string,
     completed?: boolean,
@@ -1682,9 +1838,11 @@ declare module "@material-ui/core/StepContent/StepContent" {
 }
 
 declare module "@material-ui/core/StepIcon/StepIcon" {
-  import type { Icon } from "@material-ui/core/StepButton/StepButton";
+  import type {ComponentType} from "react";
 
-  declare module.exports: React$ComponentType<{
+  import type {Icon} from "@material-ui/core/StepButton/StepButton";
+
+  declare module.exports: ComponentType<{
     active?: boolean,
     classes?: Object,
     completed?: boolean,
@@ -1693,13 +1851,15 @@ declare module "@material-ui/core/StepIcon/StepIcon" {
 }
 
 declare module "@material-ui/core/StepLabel/StepLabel" {
-  import type { Orientation } from "@material-ui/core/Stepper/Stepper";
-  import type { Icon } from "@material-ui/core/StepButton/StepButton";
+  import type {ComponentType, Node} from "react";
 
-  declare module.exports: React$ComponentType<{
+  import type {Orientation} from "@material-ui/core/Stepper/Stepper";
+  import type {Icon} from "@material-ui/core/StepButton/StepButton";
+
+  declare module.exports: ComponentType<{
     active?: boolean,
     alternativeLabel?: boolean,
-    children: React$Node,
+    children: Node,
     classes?: Object,
     className?: string,
     completed?: boolean,
@@ -1712,27 +1872,30 @@ declare module "@material-ui/core/StepLabel/StepLabel" {
 }
 
 declare module "@material-ui/core/Stepper/Stepper" {
-  import typeof Step from "@material-ui/core/Step/Step";
+  import type {ComponentType, Element, Node} from "react";
+
   import typeof StepConnector from "@material-ui/core/StepConnector/StepConnector";
 
   declare type Orientation = "horizontal" | "vertical";
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     activeStep?: number,
     alternativeLabel?: boolean,
-    children: React$Node,
+    children: Node,
     classes?: Object,
     className?: string,
-    connector?: React$Element<StepConnector> | React$Node,
+    connector?: Element<StepConnector> | Node,
     nonLinear?: boolean,
     orientation?: Orientation
   }>;
 }
 
 declare module "@material-ui/core/StepIcion/StepPositionIcon" {
-  import type { Icon } from "@material-ui/core/StepButton/StepButton";
+  import type {ComponentType} from "react";
 
-  declare module.exports: React$ComponentType<{
+  import type {Icon} from "@material-ui/core/StepButton/StepButton";
+
+  declare module.exports: ComponentType<{
     active?: boolean,
     classes?: Object,
     className?: string,
@@ -2025,7 +2188,9 @@ declare module "@material-ui/core/styles/jssPreset" {
 }
 
 declare module "@material-ui/core/styles/MuiThemeProvider" {
-  declare module.exports: React$ComponentType<Object>;
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<Object>;
 }
 
 declare module "@material-ui/core/styles/shadows" {
@@ -2108,7 +2273,9 @@ declare module "@material-ui/core/styles/transitions" {
 }
 
 declare module "@material-ui/core/styles/withStyles" {
-  import type { Theme } from "@material-ui/core/styles/createMuiTheme"
+  import type {ComponentType, ElementConfig, ElementRef, ElementType, Ref} from "react";
+
+  import type {Theme} from "@material-ui/core/styles/createMuiTheme"
 
   declare type CSSProperties = any; // import type {StandardProperties as CSSProperties} from "csstype";
 
@@ -2135,38 +2302,40 @@ declare module "@material-ui/core/styles/withStyles" {
 
   declare export type WithStyles = {
     classes: { +[string]: string },
-    innerRef: React$Ref<React$ElementType> | {current: null | React$ElementRef<React$ElementType>}
+    innerRef: Ref<any> | {current: ElementRef<any> | null}
   };
 
   declare type WithStylesHOC = {
     classes: void | { +[string]: string },
-    innerRef: void | React$Ref<React$ElementType> | {current: null | React$ElementRef<React$ElementType>}
+    innerRef: void | (Ref<any> | {current: ElementRef<any>} | null)
   };
 
   declare module.exports: (
     stylesOrCreator: StyleRules | StyleRulesCallback,
     options?: WithStylesOptions,
-  ) => <WrappedComponent: React$ComponentType<*>>(
+  ) => <WrappedComponent: ComponentType<*>>(
     Component: WrappedComponent
-  ) => React$ComponentType<$Diff<React$ElementConfig<$Supertype<WrappedComponent>>, WithStylesHOC>>;
+  ) => ComponentType<$Diff<ElementConfig<$Supertype<WrappedComponent>>, WithStylesHOC>>;
 }
 
 declare module "@material-ui/core/styles/withTheme" {
+  import type {ComponentType, ElementConfig, ElementRef, ElementType, Ref} from "react";
+
   import type {Theme} from "@material-ui/core/styles/createMuiTheme";
 
   declare export type WithTheme = {
     theme: Theme,
-    innerRef: React$Ref<React$ElementType> | {current: null | React$ElementRef<React$ElementType>}
+    innerRef: Ref<any> | {current: ElementRef<any> | null}
   };
 
   declare type WithThemeHOC = {
     theme: void | Theme,
-    innerRef: void | React$Ref<React$ElementType> | {current: null | React$ElementRef<React$ElementType>}
+    innerRef: void | (Ref<any> | {current: ElementRef<any> | null})
   };
 
-  declare module.exports: () => <Props: {}, WrappedComponent: React$ComponentType<Props>>(
+  declare module.exports: () => <Props: {}, WrappedComponent: ComponentType<Props>>(
     Component: WrappedComponent
-  ) => React$ComponentType<$Diff<React$ElementConfig<$Supertype<WrappedComponent>>, WithThemeHOC>>;
+  ) => ComponentType<$Diff<ElementConfig<$Supertype<WrappedComponent>>, WithThemeHOC>>;
 }
 
 declare module "@material-ui/core/styles/zIndex" {
@@ -2204,47 +2373,69 @@ declare module "@material-ui/core/styles" {
 }
 
 declare module "@material-ui/core/svg-icons/ArrowDownward" {
-  declare module.exports: React$ComponentType<Object>;
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<Object>;
 }
 
 declare module "@material-ui/core/svg-icons/ArrowDropDown" {
-  declare module.exports: React$ComponentType<Object>;
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<Object>;
 }
 
 declare module "@material-ui/core/svg-icons/Cancel" {
-  declare module.exports: React$ComponentType<Object>;
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<Object>;
 }
 
 declare module "@material-ui/core/svg-icons/CheckBox" {
-  declare module.exports: React$ComponentType<Object>;
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<Object>;
 }
 
 declare module "@material-ui/core/svg-icons/CheckBoxOutlineBlank" {
-  declare module.exports: React$ComponentType<Object>;
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<Object>;
 }
 
 declare module "@material-ui/core/svg-icons/CheckCircle" {
-  declare module.exports: React$ComponentType<Object>;
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<Object>;
 }
 
 declare module "@material-ui/core/svg-icons/IndeterminateCheckBox" {
-  declare module.exports: React$ComponentType<Object>;
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<Object>;
 }
 
 declare module "@material-ui/core/svg-icons/KeyboardArrowLeft" {
-  declare module.exports: React$ComponentType<Object>;
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<Object>;
 }
 
 declare module "@material-ui/core/svg-icons/KeyboardArrowRight" {
-  declare module.exports: React$ComponentType<Object>;
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<Object>;
 }
 
 declare module "@material-ui/core/svg-icons/RadioButtonChecked" {
-  declare module.exports: React$ComponentType<Object>;
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<Object>;
 }
 
 declare module "@material-ui/core/svg-icons/RadioButtonUnchecked" {
-  declare module.exports: React$ComponentType<Object>;
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<Object>;
 }
 
 declare module "@material-ui/core/SvgIcon" {
@@ -2252,8 +2443,10 @@ declare module "@material-ui/core/SvgIcon" {
 }
 
 declare module "@material-ui/core/SvgIcon/SvgIcon" {
-  declare module.exports: React$ComponentType<{
-    children: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children: Node,
     classes?: Object,
     className?: string,
     titleAccess?: string,
@@ -2266,15 +2459,17 @@ declare module "@material-ui/core/Switch" {
 }
 
 declare module "@material-ui/core/Switch/Switch" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
     checked?: boolean | string,
-    checkedIcon?: React$Node,
+    checkedIcon?: Node,
     classes?: Object,
     className?: string,
     defaultChecked?: boolean,
     disabled?: boolean,
     disableRipple?: boolean,
-    icon?: React$Node,
+    icon?: Node,
     inputProps?: Object,
     inputRef?: Function,
     name?: string,
@@ -2321,55 +2516,67 @@ declare module "@material-ui/core/TableSortLabel" {
 }
 
 declare module "@material-ui/core/Table/Table" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, ElementType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
-    component?: React$ElementType
+    component?: ElementType
   }>;
 }
 
 declare module "@material-ui/core/TableBody/TableBody" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, ElementType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
-    component?: React$ElementType
+    component?: ElementType
   }>;
 }
 
 declare module "@material-ui/core/TableCell/TableCell" {
+  import type {ComponentType, ElementType, Node} from "react";
+
   declare type Padding = "default" | "checkbox" | "dense" | "none";
 
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
-    component?: React$ElementType,
+    component?: ElementType,
     numeric?: boolean,
     padding?: Padding
   }>;
 }
 
 declare module "@material-ui/core/TableFooter/TableFooter" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, ElementType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
-    component?: React$ElementType
+    component?: ElementType
   }>;
 }
 
 declare module "@material-ui/core/TableHead/TableHead" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, ElementType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
-    component?: React$ElementType
+    component?: ElementType
   }>;
 }
 
 declare module "@material-ui/core/TablePagination/TablePagination" {
+  import type {ComponentType, ElementType, Node} from "react";
+
   declare type LabelDisplayedRowsArgs = {
     from: number,
     to: number,
@@ -2380,13 +2587,13 @@ declare module "@material-ui/core/TablePagination/TablePagination" {
     paginationInfo: LabelDisplayedRowsArgs
   ) => Node;
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     classes?: Object,
-    component?: React$ElementType,
+    component?: ElementType,
     colSpan?: number,
     count: number,
     labelDisplayedRows?: LabelDisplayedRows,
-    labelRowsPerPage?: React$Node,
+    labelRowsPerPage?: Node,
     onChangePage: (event: SyntheticInputEvent<*> | null, page: number) => void,
     onChangeRowsPerPage: (event: SyntheticInputEvent<*>) => void,
     page: number,
@@ -2396,22 +2603,26 @@ declare module "@material-ui/core/TablePagination/TablePagination" {
 }
 
 declare module "@material-ui/core/TableRow/TableRow" {
-  declare module.exports: React$ComponentType<{
-    children?: React$Node,
+  import type {ComponentType, ElementType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children?: Node,
     classes?: Object,
     className?: string,
-    component?: React$ElementType,
+    component?: ElementType,
     hover?: boolean,
     selected?: boolean
   }>;
 }
 
 declare module "@material-ui/core/TableSortLabel/TableSortLabel" {
+  import type {ComponentType, Node} from "react";
+
   declare type Direction = "asc" | "desc";
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     active?: boolean,
-    children?: React$Node,
+    children?: Node,
     classes?: Object,
     className?: string,
     direction?: Direction
@@ -2427,14 +2638,16 @@ declare module "@material-ui/core/Tab" {
 }
 
 declare module "@material-ui/core/Tab/Tab" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, Element} from "react";
+
+  declare module.exports: ComponentType<{
     classes?: Object,
     className?: string,
     disabled?: boolean,
     fullWidth?: boolean,
-    icon?: string | React$Element<any>,
-    indicator?: string | React$Element<any>,
-    label?: string | React$Element<any>,
+    icon?: string | Element<any>,
+    indicator?: string | Element<any>,
+    label?: string | Element<any>,
     onChange?: (event: SyntheticEvent<*>, value: any) => void,
     onClick?: (event: SyntheticEvent<*>) => void,
     selected?: boolean,
@@ -2445,12 +2658,14 @@ declare module "@material-ui/core/Tab/Tab" {
 }
 
 declare module "@material-ui/core/Tabs/TabIndicator" {
+  import type {ComponentType} from "react";
+
   declare type IndicatorStyle = {
     left: number,
     width: number
   };
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     classes?: Object,
     className?: string,
     color: "accent" | "primary" | string,
@@ -2459,16 +2674,18 @@ declare module "@material-ui/core/Tabs/TabIndicator" {
 }
 
 declare module "@material-ui/core/Tabs/Tabs" {
-  import type { IndicatorStyle } from "@material-ui/core/Tabs/TabIndicator";
+  import type {ComponentType, Node} from "react";
+
+  import type {IndicatorStyle} from "@material-ui/core/Tabs/TabIndicator";
 
   declare type IndicatorColor = "accent" | "primary" | string;
   declare type ScrollButtons = "auto" | "on" | "off";
   declare type TextColor = "accent" | "primary" | "inherit";
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     buttonClassName?: string,
     centered?: boolean,
-    children?: React$Node,
+    children?: Node,
     classes?: Object,
     className?: string,
     fullWidth?: boolean,
@@ -2477,14 +2694,16 @@ declare module "@material-ui/core/Tabs/Tabs" {
     onChange?: (event: SyntheticEvent<*>, value: any) => void,
     scrollable?: boolean,
     scrollButtons?: ScrollButtons,
-    TabScrollButton?: React$ComponentType<*>,
+    TabScrollButton?: ComponentType<*>,
     textColor?: TextColor,
     value: any
   }>;
 }
 
 declare module "@material-ui/core/Tabs/TabScrollButton" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType} from "react";
+
+  declare module.exports: ComponentType<{
     classes?: Object,
     className?: string,
     direction: "left" | "right",
@@ -2498,23 +2717,25 @@ declare module "@material-ui/core/TextField" {
 }
 
 declare module "@material-ui/core/TextField/TextField" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
     autoComplete?: string,
     autoFocus?: boolean,
-    children?: React$Node,
+    children?: Node,
     className?: string,
     defaultValue?: string,
     disabled?: boolean,
     error?: boolean,
     FormHelperTextProps?: Object,
     fullWidth?: boolean,
-    helperText?: React$Node,
+    helperText?: Node,
     helperTextClassName?: string,
     id?: string,
     InputLabelProps?: Object,
     InputProps?: Object,
     inputRef?: Function,
-    label?: React$Node,
+    label?: Node,
     labelClassName?: string,
     multiline?: boolean,
     name?: string,
@@ -2537,9 +2758,11 @@ declare module "@material-ui/core/Toolbar" {
 }
 
 declare module "@material-ui/core/Toolbar/Toolbar" {
-  declare module.exports: React$ComponentType<{
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
     classes?: Object,
-    children?: React$Node,
+    children?: Node,
     className?: string,
     disableGutters?: boolean
   }>;
@@ -2550,6 +2773,8 @@ declare module "@material-ui/core/Tooltip" {
 }
 
 declare module "@material-ui/core/Tooltip/Tooltip" {
+  import type {ComponentType, Element, Node} from "react";
+
   declare type Placement =
     | "bottom-end"
     | "bottom-start"
@@ -2564,8 +2789,8 @@ declare module "@material-ui/core/Tooltip/Tooltip" {
     | "top-start"
     | "top";
 
-  declare module.exports: React$ComponentType<{
-    children: React$Element<any>,
+  declare module.exports: ComponentType<{
+    children: Element<any>,
     classes?: Object,
     className?: string,
     disableTriggerFocus?: boolean,
@@ -2575,7 +2800,7 @@ declare module "@material-ui/core/Tooltip/Tooltip" {
     onClose?: Function,
     onRequestOpen?: Function,
     open?: boolean,
-    title: React$Node,
+    title: Node,
     enterDelay?: number,
     leaveDelay?: number,
     placement?: Placement,
@@ -2584,19 +2809,21 @@ declare module "@material-ui/core/Tooltip/Tooltip" {
 }
 
 declare module "@material-ui/core/Collapse/Collapse" {
-  import type { TransitionCallback } from "@material-ui/core/internal/transition";
+  import type {ComponentType, ElementType, Node} from "react";
+
+  import type {TransitionCallback} from "@material-ui/core/internal/transition";
 
   declare type TransitionDuration =
     | number
     | { enter?: number, exit?: number }
     | "auto";
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     appear?: boolean,
-    children: React$Node,
+    children: Node,
     classes?: Object,
     className?: String,
-    component?: React$ElementType,
+    component?: ElementType,
     collapsedHeight?: string,
     containerProps?: Object,
     in: boolean,
@@ -2612,14 +2839,16 @@ declare module "@material-ui/core/Collapse/Collapse" {
 }
 
 declare module "@material-ui/core/Fade/Fade" {
+  import type {ComponentType, Element} from "react";
+
   import type {
     TransitionDuration,
     TransitionCallback
   } from "@material-ui/core/internal/transition";
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     appear?: boolean,
-    children: React$Element<any>,
+    children: Element<any>,
     in: boolean,
     onEnter?: TransitionCallback,
     onEntering?: TransitionCallback,
@@ -2630,13 +2859,15 @@ declare module "@material-ui/core/Fade/Fade" {
 }
 
 declare module "@material-ui/core/Zoom/Zoom" {
+  import type {ComponentType, Element} from "react";
+
   import type {
     TransitionDuration,
     TransitionCallback
   } from "@material-ui/core/internal/transition";
 
-  declare module.exports: React$ComponentType<{
-    children: React$Element<any>,
+  declare module.exports: ComponentType<{
+    children: Element<any>,
     in: boolean,
     onEnter?: TransitionCallback,
     onExit?: TransitionCallback,
@@ -2646,6 +2877,8 @@ declare module "@material-ui/core/Zoom/Zoom" {
 }
 
 declare module "@material-ui/core/Grow/Grow" {
+  import type {ComponentType, Element} from "react";
+
   import type {
     TransitionCallback,
     TransitionClasses
@@ -2656,9 +2889,9 @@ declare module "@material-ui/core/Grow/Grow" {
     | { enter?: number, exit?: number }
     | "auto";
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     appear?: boolean,
-    children: React$Element<any>,
+    children: Element<any>,
     in: boolean,
     onEnter?: TransitionCallback,
     onEntering?: TransitionCallback,
@@ -2694,6 +2927,8 @@ declare module "@material-ui/core/Zoom" {
 }
 
 declare module "@material-ui/core/Slide/Slide" {
+  import type {ComponentType, Element} from "react";
+
   import type {
     TransitionDuration,
     TransitionCallback
@@ -2706,8 +2941,8 @@ declare module "@material-ui/core/Slide/Slide" {
     node: HTMLElement | Object
   ): void;
 
-  declare module.exports: React$ComponentType<{
-    children: React$Element<any>,
+  declare module.exports: ComponentType<{
+    children: Element<any>,
     direction: Direction,
     in: boolean,
     onEnter?: TransitionCallback,
@@ -2726,6 +2961,8 @@ declare module "@material-ui/core/Typography" {
 }
 
 declare module "@material-ui/core/Typography/Typography" {
+  import type {ComponentType, ElementType, Node} from "react";
+
   declare type Align = "inherit" | "left" | "center" | "right" | "justify";
   declare type Color =
     | "inherit"
@@ -2747,12 +2984,12 @@ declare module "@material-ui/core/Typography/Typography" {
     | "caption"
     | "button";
 
-  declare module.exports: React$ComponentType<{
+  declare module.exports: ComponentType<{
     align?: Align,
-    children?: React$Node,
+    children?: Node,
     classes?: Object,
     className?: string,
-    component?: React$ElementType,
+    component?: ElementType,
     color?: Color,
     gutterBottom?: boolean,
     headlineMapping?: { [key: Variant]: string },
@@ -2763,8 +3000,10 @@ declare module "@material-ui/core/Typography/Typography" {
 }
 
 declare module "@material-ui/core/utils/addEventListener" {
+  import type {Node} from "react";
+
   declare module.exports: (
-    node: React$Node,
+    node: Node,
     event: string,
     handler: EventHandler,
     capture?: boolean
@@ -2772,8 +3011,10 @@ declare module "@material-ui/core/utils/addEventListener" {
 }
 
 declare module "@material-ui/core/ClickAwayListener/ClickAwayListener" {
-  declare module.exports: React$ComponentType<{
-    children: React$Node,
+  import type {ComponentType, Node} from "react";
+
+  declare module.exports: ComponentType<{
+    children: Node,
     onClickAway: (event: Event) => void
   }>;
 }
@@ -2818,9 +3059,11 @@ declare module "@material-ui/core/utils/manageAriaHidden" {
 }
 
 declare module "@material-ui/core/utils/reactHelpers" {
+  import type {Node} from "react";
+
   declare module.exports: {
     cloneChildrenWithClassName: (
-      children?: React$Node,
+      children?: Node,
       className: string
     ) => any,
     isMuiElement: (element: any, muiNames: Array<string>) => any,
@@ -2833,15 +3076,17 @@ declare module "@material-ui/core/utils/requirePropFactory" {
 }
 
 declare module "@material-ui/core/withWidth/withWidth" {
-  import type { Breakpoint } from "@material-ui/core/styles/createBreakpoints";
+  import type {ComponentType} from "react";
+
+  import type {Breakpoint} from "@material-ui/core/styles/createBreakpoints";
   declare module.exports: (options?: {|
     withTheme?: boolean,
     noSSR?: boolean,
     initialWidth?: Breakpoint,
     resizeInterval?: number
   |}) => <Props: { width: Breakpoint }>(
-    Component: React$ComponentType<Props>
-  ) => React$ComponentType<$Diff<Props, { width: Breakpoint }>>;
+    Component: ComponentType<Props>
+  ) => ComponentType<$Diff<Props, { width: Breakpoint }>>;
 }
 
 declare module "@material-ui/core/colors" {

--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
@@ -2134,8 +2134,8 @@ declare module "@material-ui/core/styles/withStyles" {
   |};
 
   declare export type WithStyles = {
-    classes: { +[string]: string },
-    innerRef: React$Ref<React$ElementType> | {current: null | React$ElementRef<React$ElementType>}
+    classes: void | { +[string]: string },
+    innerRef: void | React$Ref<React$ElementType> | {current: null | React$ElementRef<React$ElementType>}
   };
 
   declare module.exports: (
@@ -2143,20 +2143,20 @@ declare module "@material-ui/core/styles/withStyles" {
     options?: WithStylesOptions,
   ) => <WrappedComponent: React$ComponentType<*>>(
     Component: WrappedComponent
-  ) => React$ComponentType<$Diff<React$ElementConfig<WrappedComponent>, WithStyles>>;
+  ) => React$ComponentType<$Diff<React$ElementConfig<$Supertype<WrappedComponent>>, WithStyles>>;
 }
 
 declare module "@material-ui/core/styles/withTheme" {
   import type {Theme} from "@material-ui/core/styles/createMuiTheme";
 
   declare export type WithTheme = {
-    theme: Theme;
-    innerRef: React$Ref<React$ElementType> | {current: null | React$ElementRef<React$ElementType>}
+    theme: void | Theme;
+    innerRef: void | React$Ref<React$ElementType> | {current: null | React$ElementRef<React$ElementType>}
   }
 
   declare module.exports: () => <Props: {}, WrappedComponent: React$ComponentType<Props>>(
     Component: WrappedComponent
-  ) => React$ComponentType<$Diff<React$ElementConfig<WrappedComponent>, WithTheme>>;
+  ) => React$ComponentType<$Diff<React$ElementConfig<$Supertype<WrappedComponent>>, WithTheme>>;
 }
 
 declare module "@material-ui/core/styles/zIndex" {

--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
@@ -66,12 +66,29 @@ class TestComponentWithTheme extends React.Component<{
   innerRef: string,
 }> {}
 
-const StyledWithThemeTestComponent = withTheme()(withStyles({})(TestComponent));
+const StyledWithThemeTestComponent = withTheme()(withStyles({})(TestComponentWithTheme));
 
 function renderStyledWithThemeTestComponent () {
   return (
     // doesn't require "classes", "theme" or "innerRef"
     <StyledWithThemeTestComponent />
+  )
+}
+
+// withStyles + withTheme - required prop
+class TestComponentWithThemeAndRequiredProp extends React.Component<{
+  classes: {},
+  theme: {},
+  innerRef: string,
+  requiredProp: boolean,
+}> {}
+
+const StyledWithThemeAndRequiredPropTestComponent = withTheme()(withStyles({})(TestComponentWithThemeAndRequiredProp));
+
+function renderStyledWithThemeAndRequiredPropTestComponent () {
+  return (
+    // $ExpectError missing required prop "requiredProp"
+    <StyledWithThemeAndRequiredPropTestComponent />
   )
 }
 

--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
@@ -30,7 +30,7 @@ let typography2 = <Typography variant="headline" />;
 
 // withStyles - required prop
 class TestComponent extends React.Component<{
-  classes: {},
+  classes: *,
   innerRef: string,
   requiredProp: string
 }> {}
@@ -61,8 +61,8 @@ function renderDoubleStyledComponent () {
 
 // withStyles + withTheme
 class TestComponentWithTheme extends React.Component<{
-  classes: {},
-  theme: {},
+  classes: *,
+  theme: *,
   innerRef: string,
 }> {}
 
@@ -77,8 +77,8 @@ function renderStyledWithThemeTestComponent () {
 
 // withStyles + withTheme - required prop
 class TestComponentWithThemeAndRequiredProp extends React.Component<{
-  classes: {},
-  theme: {},
+  classes: *,
+  theme: *,
   innerRef: string,
   requiredProp: boolean,
 }> {}
@@ -94,7 +94,7 @@ function renderStyledWithThemeAndRequiredPropTestComponent () {
 
 // withStyles - default prop
 class TestComponentWithDefaultProps extends React.Component<{
-  classes: {},
+  classes: *,
   innerRef: string,
   value: string,
 }> {

--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
@@ -14,7 +14,11 @@ import CircularProgress from "@material-ui/core/CircularProgress";
 
 import { createMuiTheme } from "@material-ui/core";
 
-import type { Theme } from "@material-ui/core";
+import type {
+  Theme,
+  WithStyles,
+  WithTheme,
+} from "@material-ui/core";
 
 // $ExpectError invalid color value.
 let appBar = <AppBar color="black" />;
@@ -28,13 +32,22 @@ let button2 = <Button disableRipple={3} />;
 let typography1 = <Typography variant="wrong" />;
 let typography2 = <Typography variant="headline" />;
 
+const styles = {
+  root: {
+    color: '#000',
+  },
+}
+
 // withStyles - required prop
 class TestComponent extends React.Component<{
-  classes: *,
-  innerRef: string,
+  ...$Exact<WithStyles>,
   requiredProp: string
-}> {}
-const StyledTestComponent = withStyles({})(TestComponent);
+}> {
+  render() {
+    const root = this.props.classes.root
+  }
+}
+const StyledTestComponent = withStyles(styles)(TestComponent);
 
 function renderStyledTestComponentWithError () {
   return (
@@ -51,7 +64,7 @@ function renderStyledTestComponent () {
 }
 
 // withStyles x2 HOC
-const DoubleStyledComponent = withStyles({})(StyledTestComponent);
+const DoubleStyledComponent = withStyles(styles)(StyledTestComponent);
 function renderDoubleStyledComponent () {
   return (
     // doesn't require the props "classes" or "innerRef", but still requires "requiredProp"
@@ -61,12 +74,11 @@ function renderDoubleStyledComponent () {
 
 // withStyles + withTheme
 class TestComponentWithTheme extends React.Component<{
-  classes: *,
-  theme: *,
-  innerRef: string,
+  ...$Exact<WithStyles>,
+  ...$Exact<WithTheme>,
 }> {}
 
-const StyledWithThemeTestComponent = withTheme()(withStyles({})(TestComponentWithTheme));
+const StyledWithThemeTestComponent = withTheme()(withStyles(styles)(TestComponentWithTheme));
 
 function renderStyledWithThemeTestComponent () {
   return (
@@ -77,13 +89,12 @@ function renderStyledWithThemeTestComponent () {
 
 // withStyles + withTheme - required prop
 class TestComponentWithThemeAndRequiredProp extends React.Component<{
-  classes: *,
-  theme: *,
-  innerRef: string,
+  ...$Exact<WithStyles>,
+  ...$Exact<WithTheme>,
   requiredProp: boolean,
 }> {}
 
-const StyledWithThemeAndRequiredPropTestComponent = withTheme()(withStyles({})(TestComponentWithThemeAndRequiredProp));
+const StyledWithThemeAndRequiredPropTestComponent = withTheme()(withStyles(styles)(TestComponentWithThemeAndRequiredProp));
 
 function renderStyledWithThemeAndRequiredPropTestComponent () {
   return (
@@ -94,8 +105,7 @@ function renderStyledWithThemeAndRequiredPropTestComponent () {
 
 // withStyles - default prop
 class TestComponentWithDefaultProps extends React.Component<{
-  classes: *,
-  innerRef: string,
+  ...$Exact<WithStyles>,
   value: string,
 }> {
   static defaultProps = {
@@ -103,7 +113,7 @@ class TestComponentWithDefaultProps extends React.Component<{
   }
 }
 
-const DefaultPropsStyledComponent = withStyles({})(TestComponentWithDefaultProps);
+const DefaultPropsStyledComponent = withStyles(styles)(TestComponentWithDefaultProps);
 
 function renderTestComponentWithDefaultProps () {
   return (


### PR DESCRIPTION
Re: @material-ui/core:

* Ensured prop validation works correctly when material-ui's HOCs are chained together. 
* Added HOC chaining tests.
* Migrated React type references from `React$` internal types to publicly imported types. 

Real community effort to get this one through, thanks @cesardeazevedo and @jmtoung!

For posterity, the discussion surrounding the HOC prop validation issues and the corresponding solution (implemented in this PR) took place over at https://github.com/Benjamin-Dobell/flow-typed/pull/1