### PR TITLE
[react-redux] add type definition for connectAdvanced

### DIFF
--- a/definitions/npm/react-redux_v5.x.x/flow_v0.63.0-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.63.0-/react-redux_v5.x.x.js
@@ -38,6 +38,7 @@ declare module "react-redux" {
   CP = Props for returned component
   Com = React Component
   ST = Static properties of Com
+  EFO = Extra factory options (used only in connectAdvanced)
   */
 
   declare type MapStateToProps<S: Object, SP: Object, RSP: Object> = (state: S, props: SP) => RSP;
@@ -61,6 +62,50 @@ declare module "react-redux" {
   |};
 
   declare type OmitDispatch<Component> = $Diff<Component, {dispatch?: Dispatch<*>}>;
+
+  declare type ConnectAdvancedOptions = {
+    getDisplayName?: (name: string) => string,
+    methodName?: string,
+    renderCountProp?: string,
+    shouldHandleStateChanges?: boolean,
+    storeKey?: string,
+    withRef?: boolean,
+  };
+
+  declare type SelectorFactoryOptions<Com> = {
+    getDisplayName: (name: string) => string,
+    methodName: string,
+    renderCountProp: ?string,
+    shouldHandleStateChanges: boolean,
+    storeKey: string,
+    withRef: boolean,
+    displayName: string,
+    wrappedComponentName: string,
+    WrappedComponent: Com,
+  };
+
+  declare type SelectorFactory<
+    Com: ComponentType<*>,
+    A,
+    S: Object,
+    OP: Object,
+    EFO: Object,
+    CP: Object
+  > = (dispatch: Dispatch<A>, factoryOptions: SelectorFactoryOptions<Com> & EFO) =>
+      MapStateToProps<S, OP, CP>;
+
+  declare export function connectAdvanced<
+    Com: ComponentType<*>,
+    A,
+    S: Object,
+    OP: Object,
+    CP: Object,
+    EFO: Object,
+    ST: {[_: $Keys<Com>]: any}
+    >(
+    selectorFactory: SelectorFactory<Com, A, S, OP, EFO, CP>,
+    connectAdvancedOptions: ?(ConnectAdvancedOptions & EFO),
+  ): (component: Com) => ComponentType<OP> & $Shape<ST>;
 
   declare export function connect<
     Com: ComponentType<*>,
@@ -208,5 +253,6 @@ declare module "react-redux" {
     Provider: typeof Provider,
     createProvider: typeof createProvider,
     connect: typeof connect,
+    connectAdvanced: typeof connectAdvanced,
   };
 }

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.63.0-/test_connectAdvanced.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.63.0-/test_connectAdvanced.js
@@ -1,0 +1,124 @@
+// @flow
+import React from "react";
+import { connectAdvanced } from "react-redux";
+
+function testConnectAdvanced() {
+  type Props = {fromStateToProps: string, fromInputProps: string};
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.fromInputProps} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = {a: number};
+  type InputProps = {
+    fromInputProps: string
+  };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromInputProps: 'str' + props.fromInputProps,
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const selectorFactory = (dispatch: *, selectorFactoryOptions: *) => {
+    const {
+      getDisplayName,
+      methodName,
+      renderCountProp,
+      shouldHandleStateChanges,
+      storeKey,
+      withRef,
+      displayName,
+      wrappedComponentName,
+    }: {
+      getDisplayName: (name: string) => string,
+      methodName: string,
+      renderCountProp: ?string,
+      shouldHandleStateChanges: boolean,
+      storeKey: string,
+      withRef: boolean,
+      displayName: string,
+      wrappedComponentName: string,
+    } = selectorFactoryOptions;
+    return mapStateToProps;
+  }
+
+  const Connected = connectAdvanced(selectorFactory)(Com);
+  <Connected fromInputProps={'data'}/>;
+  //$ExpectError expects props to match second argument of mapStateToProps
+  <Connected fromInputProps={123}/>;
+  //$ExpectError takes in only React components
+  connectAdvanced(selectorFactory)('');
+}
+
+function testConnectAdvancedWithStatelessFunctionalComponent() {
+  type Props = {fromStateToProps: string, fromInputProps: string};
+  const Com = (props: Props) => <div>{props.fromInputProps} {props.fromStateToProps}</div>;
+
+  type State = {a: number};
+  type InputProps = {
+    fromInputProps: string
+  };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromInputProps: 'str' + props.fromInputProps,
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const selectorFactory = (dispatch: *, selectorFactoryOptions: *) => {
+    return mapStateToProps;
+  }
+
+  const Connected = connectAdvanced(selectorFactory)(Com);
+  <Connected fromInputProps={'data'}/>;
+  //$ExpectError expects props to match second argument of mapStateToProps
+  <Connected fromInputProps={123}/>;
+}
+
+function testConnectAdvancedConnectOptions() {
+  const selectorFactory = () => () => ({});
+  connectAdvanced(selectorFactory, {
+    getDisplayName: (name: string) => name + name,
+    methodName: 'methodName',
+    renderCountProp: 'renderCount',
+    shouldHandleStateChanges: false,
+    storeKey: 'storeKey',
+    withRef: false,
+  });
+
+  //$ExpectError getDisplayName must take a string
+  connectAdvanced(selectorFactory, {getDisplayName: (name: number) => name + name});
+
+  //$ExpectError getDisplayName must return a string
+  connectAdvanced(selectorFactory, {getDisplayName: (name: string) => name.length});
+
+  //$ExpectError methodName must be a string
+  connectAdvanced(selectorFactory, {methodName: 5});
+
+  //$ExpectError renderCountProp must be a string
+  connectAdvanced(selectorFactory, {renderCountProp: 5});
+
+  //$ExpectError shouldHandleStateChanges must be defined if passed in
+  connectAdvanced(selectorFactory, {shouldHandleStateChanges: null});
+
+  //$ExpectError storeKey must be a string
+  connectAdvanced(selectorFactory, {storeKey: 5});
+
+  //$ExpectError withRef must be defined if passed in
+  connectAdvanced(selectorFactory, {withRef: null});
+
+  connectAdvanced(selectorFactory, {otherOption: "other options are allowed"});
+}
+
+function testConnectAdvancedExtraOptions() {
+  const selectorFactory = (dispatch: *, selectorFactoryOptions: *) => {
+    const { otherOption }: {otherOption: string} = selectorFactoryOptions;
+    return () => ({});
+  }
+
+  connectAdvanced(selectorFactory, {otherOption: "other options typecheck too"});
+  //$ExpectError selectorFactory expects otherOption to be a specific type
+  connectAdvanced(selectorFactory, {otherOption: 5});
+}


### PR DESCRIPTION
This adds a type definition for the [`connectAdvanced` function in react-redux](https://github.com/reduxjs/react-redux/blob/master/docs/api.md#connectadvancedselectorfactory-connectoptions). 

This PR addresses https://github.com/flow-typed/flow-typed/issues/2651. This is my first time writing a library definition, so I may be doing silly things :)