### PR TITLE
feat: ramda keys works with Maybe as input

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
@@ -1365,7 +1365,7 @@ declare module ramda {
   declare function invert(o: Object): { [k: string]: Array<string> };
   declare function invertObj(o: Object): { [k: string]: string };
 
-  declare function keys(o: Object): Array<string>;
+  declare function keys(o: ?Object): Array<string>;
 
   declare type Lens = <T, V>(x: T) => V;
 

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
@@ -159,6 +159,7 @@ const inverted: { [k: string]: Array<string> } = _.invert(
 const inverted1: { [k: string]: string } = _.invertObj(raceResultsByFirstName);
 
 const ks: Array<string> = _.keys(raceResultsByFirstName);
+const ksMaybe: Array<string> = _.keys(null)
 const ksi: Array<string> = _.keysIn(square);
 
 const xs = { x: 1, y: 2, z: 3 };


### PR DESCRIPTION
The function `keys` works with `?Object` (aka `Maybe Object`). 

This MR allows for correct Flow types when using `keys` with other functions that return `Maybe` types (such as `path`).