### PR TITLE
[recompose] fix branch() type signature

### DIFF
--- a/definitions/npm/recompose_v0.x.x/flow_v0.47.x-v0.52.x/recompose_v0.x.x.js
+++ b/definitions/npm/recompose_v0.x.x/flow_v0.47.x-v0.52.x/recompose_v0.x.x.js
@@ -231,7 +231,7 @@ declare module "recompose" {
    * We make an assumtion that left and right have the same type if exists
    */
   declare export function branch<Base, Enhanced>(
-    testFn: (props: Enhanced) => boolean,
+    testFn: (props: Base) => boolean,
     // not a HOC because of inference problems, this works but HOC<Base, Enhanced> is not
     left: (Component<Base>) => Component<Enhanced>,
     // I never use right part and it can be a problem with inference as should be same type as left

--- a/definitions/npm/recompose_v0.x.x/flow_v0.53.x-v0.54.x/recompose_v0.x.x.js
+++ b/definitions/npm/recompose_v0.x.x/flow_v0.53.x-v0.54.x/recompose_v0.x.x.js
@@ -225,7 +225,7 @@ declare module "recompose" {
    * We make an assumtion that left and right have the same type if exists
    */
   declare export function branch<Base, Enhanced>(
-    testFn: (props: Enhanced) => boolean,
+    testFn: (props: Base) => boolean,
     // not a HOC because of inference problems, this works but HOC<Base, Enhanced> is not
     left: (Component<Base>) => Component<Enhanced>,
     // I never use right part and it can be a problem with inference as should be same type as left

--- a/definitions/npm/recompose_v0.x.x/flow_v0.55.x-v0.56.x/recompose_v0.x.x.js
+++ b/definitions/npm/recompose_v0.x.x/flow_v0.55.x-v0.56.x/recompose_v0.x.x.js
@@ -167,7 +167,7 @@ declare module "recompose" {
    * We make an assumtion that left and right have the same type if exists
    */
   declare export function branch<Base, Enhanced>(
-    testFn: (props: Enhanced) => boolean,
+    testFn: (props: Base) => boolean,
     // not a HOC because of inference problems, this works but HOC<Base, Enhanced> is not
     left: (Component<Base>) => Component<Enhanced>,
     // I never use right part and it can be a problem with inference as should be same type as left

--- a/definitions/npm/recompose_v0.x.x/flow_v0.57.x-/recompose_v0.x.x.js
+++ b/definitions/npm/recompose_v0.x.x/flow_v0.57.x-/recompose_v0.x.x.js
@@ -167,7 +167,7 @@ declare module "recompose" {
    * We make an assumtion that left and right have the same type if exists
    */
   declare export function branch<Base, Enhanced>(
-    testFn: (props: Enhanced) => boolean,
+    testFn: (props: Base) => boolean,
     // not a HOC because of inference problems, this works but HOC<Base, Enhanced> is not
     left: (Component<Base>) => Component<Enhanced>,
     // I never use right part and it can be a problem with inference as should be same type as left


### PR DESCRIPTION
Recompose's `branch()` function's first argument is a function that takes the original props of the component and returns a boolean. The current flow-typed definition defines it as a function that takes the enhanced props instead. This is incorrect.

- [`branch()` Docs](https://github.com/acdlite/recompose/blob/master/docs/API.md#branch)
- [`branch()` Implementation](https://github.com/acdlite/recompose/blob/master/src/packages/recompose/branch.js#L10-L11)