### PR TITLE
[sequelize] Support RegExp on options.retry.match.

### DIFF
--- a/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/sequelize_v4.x.x.js
+++ b/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/sequelize_v4.x.x.js
@@ -5716,9 +5716,9 @@ declare module "sequelize" {
    */
   declare export type RetryOptions = {
     /**
-     * Only retry a query if the error matches one of these strings.
+     * Only retry a query if the error matches one of these strings or Regexes.
      */
-    match?: string[],
+    match?: Array<string | RegExp>,
 
     /**
      * How many times a failing query is automatically retried. Set to 0 to disable retrying on SQL_BUSY error.

--- a/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/test_sequelize.js
+++ b/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/test_sequelize.js
@@ -1351,6 +1351,16 @@ new Sequelize( {
   },
   typeValidation: true
 } );
+new Sequelize( {
+  database: 'db',
+  username: 'user',
+  password: 'pass',
+  retry: {
+    match: [/failed/],
+    max: 3
+  },
+  typeValidation: true
+} );
 
 new Sequelize({
   operatorsAliases: false,


### PR DESCRIPTION
This parameter come from retry-as-promised and it supports both string and RegExp: https://github.com/mickhansen/retry-as-promised/blob/v2.3.2/index.js#L60