### PR TITLE
[react-loadable] Add retry prop

### DIFF
--- a/definitions/npm/react-loadable_v5.x.x/flow_v0.56.0-/react-loadable_v5.x.x.js
+++ b/definitions/npm/react-loadable_v5.x.x/flow_v0.56.0-/react-loadable_v5.x.x.js
@@ -3,6 +3,7 @@ declare module 'react-loadable' {
     isLoading: boolean,
     pastDelay: boolean,
     timedOut: boolean,
+    retry: () => void,
     error: ?Error
   };
 


### PR DESCRIPTION
Introduced in v5.4, the `retry` prop is a `() => void` function that retries loading the module. 

https://github.com/jamiebuilds/react-loadable/pull/82