### PR TITLE
Add in type definitions for describe.each, test.each and test.only.each for jest

### DIFF
--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
@@ -911,7 +911,19 @@ declare var describe: {
   /**
    * Skip running this describe block
    */
-  skip(name: JestTestName, fn: () => void): void
+  skip(name: JestTestName, fn: () => void): void,
+
+  /**
+   * each runs this test against array of argument arrays per each run
+   *
+   * @param {table} table of Test
+   */
+  each(
+    table: Array<Array<mixed> | mixed>
+  ): (
+    name: JestTestName,
+    fn?: (...args: Array<any>) => ?Promise<mixed>
+  ) => void,
 };
 
 /** An individual test unit */
@@ -934,7 +946,7 @@ declare var it: {
    * @param {table} table of Test
    */
   each(
-    table: Array<Array<mixed>>
+    table: Array<Array<mixed> | mixed>
   ): (
     name: JestTestName,
     fn?: (...args: Array<any>) => ?Promise<mixed>
@@ -952,7 +964,7 @@ declare var it: {
     timeout?: number
   ): {
     each(
-      table: Array<Array<mixed>>
+      table: Array<Array<mixed> | mixed>
     ): (
       name: JestTestName,
       fn?: (...args: Array<any>) => ?Promise<mixed>
@@ -981,7 +993,18 @@ declare var it: {
     name: JestTestName,
     fn?: (done: () => void) => ?Promise<mixed>,
     timeout?: number
-  ): void
+  ): void,
+  /**
+   * each runs this test against array of argument arrays per each run
+   *
+   * @param {table} table of Test
+   */
+  each(
+    table: Array<Array<mixed> | mixed>
+  ): (
+    name: JestTestName,
+    fn?: (...args: Array<any>) => ?Promise<mixed>
+  ) => void,
 };
 declare function fit(
   name: JestTestName,

--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
@@ -130,6 +130,8 @@ describe(aFunction, () => {});
 describe.only("name", () => {});
 describe.only(AClass, () => {});
 describe.only(aFunction, () => {});
+describe.each([['arg1', 2, true], ['arg2', 3, false]])("test", () => expect("foo").toMatchSnapshot());
+describe.each(['arg1', 2, true])("test", () => expect("foo").toMatchSnapshot());
 
 describe.skip("name", () => {});
 describe.skip(AClass, () => {});
@@ -139,7 +141,9 @@ test("test", () => expect("foo").toMatchSnapshot());
 test(AClass, () => expect("foo").toMatchSnapshot());
 test(aFunction, () => expect("foo").toMatchSnapshot());
 test.each([['arg1', 2, true], ['arg2', 3, false]])("test", () => expect("foo").toMatchSnapshot());
+test.each(['arg1', 2, true])("test", () => expect("foo").toMatchSnapshot());
 test.only.each([['arg1', 2, true], ['arg2', 3, false]])("test", () => expect("foo").toMatchSnapshot());
+test.only.each(['arg1', 2, true])("test", () => expect("foo").toMatchSnapshot());
 test.only("test", () => expect("foo").toMatchSnapshot());
 test.skip("test", () => expect("foo").toMatchSnapshot());
 


### PR DESCRIPTION
I've added in type definitions for `describe.each, test.each and test.only.each`in the jest repository. This PR is to share the changes from that repo to this one so that both are inline and anyone else using flow will get the benefits. That [PR](https://github.com/facebook/jest/pull/6931#) was merged in already. 