### PR TITLE
fix commander: can use `commander.Command`

### DIFF
--- a/definitions/npm/commander_v2.x.x/flow_v0.28.x-/commander_v2.x.x.js
+++ b/definitions/npm/commander_v2.x.x/flow_v0.28.x-/commander_v2.x.x.js
@@ -272,7 +272,7 @@ declare module "commander" {
   }
 
   declare module.exports: Command & {
-    Command: Command,
-    Option: Option
+    Command: (name?: string) => Command;
+    Options: (flags: string, description?: string) => Option;
   };
 }

--- a/definitions/npm/commander_v2.x.x/test_commander_v2.x.x.js
+++ b/definitions/npm/commander_v2.x.x/test_commander_v2.x.x.js
@@ -1,5 +1,7 @@
 import program from 'commander';
 
+new program.Command('support to use class');
+
 program
   .version('1.0.0')
   .arguments('<cmd> [env]')


### PR DESCRIPTION
I want to use `Commander.Command`, but I got this error: 

```js
Cannot call commander.Command because Command [1] is not a function.

     packages/configs/src/bin/core/cliOptions.js
       8│
       9│ import { version } from '../../../package.json';
      10│
      11│ const program = new commander.Command('name')
      12│   .version(version, '-v, --version')
      13│   .arguments('[arguments...]')
      14│   .usage(chalk`{green [arguments...]} {gray [options]}`)

     flow-typed/npm/commander_v2.x.x.js
 [1] 278│     Command: Command,
```

This `PR` is used to fix this error.