### PR TITLE
Revert "[recompose] fix branch() type signature"

### DIFF
--- a/definitions/npm/recompose_v0.x.x/flow_v0.47.x-v0.52.x/recompose_v0.x.x.js
+++ b/definitions/npm/recompose_v0.x.x/flow_v0.47.x-v0.52.x/recompose_v0.x.x.js
@@ -231,7 +231,7 @@ declare module "recompose" {
    * We make an assumtion that left and right have the same type if exists
    */
   declare export function branch<Base, Enhanced>(
-    testFn: (props: Base) => boolean,
+    testFn: (props: Enhanced) => boolean,
     // not a HOC because of inference problems, this works but HOC<Base, Enhanced> is not
     left: (Component<Base>) => Component<Enhanced>,
     // I never use right part and it can be a problem with inference as should be same type as left

--- a/definitions/npm/recompose_v0.x.x/flow_v0.53.x-v0.54.x/recompose_v0.x.x.js
+++ b/definitions/npm/recompose_v0.x.x/flow_v0.53.x-v0.54.x/recompose_v0.x.x.js
@@ -225,7 +225,7 @@ declare module "recompose" {
    * We make an assumtion that left and right have the same type if exists
    */
   declare export function branch<Base, Enhanced>(
-    testFn: (props: Base) => boolean,
+    testFn: (props: Enhanced) => boolean,
     // not a HOC because of inference problems, this works but HOC<Base, Enhanced> is not
     left: (Component<Base>) => Component<Enhanced>,
     // I never use right part and it can be a problem with inference as should be same type as left

--- a/definitions/npm/recompose_v0.x.x/flow_v0.55.x-v0.56.x/recompose_v0.x.x.js
+++ b/definitions/npm/recompose_v0.x.x/flow_v0.55.x-v0.56.x/recompose_v0.x.x.js
@@ -167,7 +167,7 @@ declare module "recompose" {
    * We make an assumtion that left and right have the same type if exists
    */
   declare export function branch<Base, Enhanced>(
-    testFn: (props: Base) => boolean,
+    testFn: (props: Enhanced) => boolean,
     // not a HOC because of inference problems, this works but HOC<Base, Enhanced> is not
     left: (Component<Base>) => Component<Enhanced>,
     // I never use right part and it can be a problem with inference as should be same type as left

--- a/definitions/npm/recompose_v0.x.x/flow_v0.57.x-/recompose_v0.x.x.js
+++ b/definitions/npm/recompose_v0.x.x/flow_v0.57.x-/recompose_v0.x.x.js
@@ -167,7 +167,7 @@ declare module "recompose" {
    * We make an assumtion that left and right have the same type if exists
    */
   declare export function branch<Base, Enhanced>(
-    testFn: (props: Base) => boolean,
+    testFn: (props: Enhanced) => boolean,
     // not a HOC because of inference problems, this works but HOC<Base, Enhanced> is not
     left: (Component<Base>) => Component<Enhanced>,
     // I never use right part and it can be a problem with inference as should be same type as left


### PR DESCRIPTION
Reverts flow-typed/flow-typed#2684

I misunderstood the generic types used in Recompose's type definitions when writing #2684. This reverts that change, since it was correct in the first place.