### PR TITLE
[RxJS v6] add some missing defs & fix broken defs

### DIFF
--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -1252,8 +1252,8 @@ declare module "rxjs/operators" {
   };
 }
 
-interface rxjs$Operators$withLatestFrom {
-  <+T, A, B, C, D, E, F, G, H>(
+type rxjs$Operators$withLatestFrom = {
+  <T, A, B, C, D, E, F, G, H>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
     c: rxjs$Observable<C>,
@@ -1264,7 +1264,7 @@ interface rxjs$Operators$withLatestFrom {
     resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
   ): rxjs$Observable<T> => rxjs$Observable<H>;
 
-  <+T, A, B, C, D, E, F, G>(
+  <T, A, B, C, D, E, F, G>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
     c: rxjs$Observable<C>,
@@ -1274,7 +1274,7 @@ interface rxjs$Operators$withLatestFrom {
     resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F) => G
   ): rxjs$Observable<T> => rxjs$Observable<G>;
 
-  <+T, A, B, C, D, E, F>(
+  <T, A, B, C, D, E, F>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
     c: rxjs$Observable<C>,
@@ -1283,7 +1283,7 @@ interface rxjs$Operators$withLatestFrom {
     resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E) => F
   ): rxjs$Observable<T> => rxjs$Observable<F>;
 
-  <+T, A, B, C, D, E>(
+  <T, A, B, C, D, E>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
     c: rxjs$Observable<C>,
@@ -1291,29 +1291,29 @@ interface rxjs$Operators$withLatestFrom {
     resultSelector: (t: T, a: A, b: B, c: C, d: D) => E
   ): rxjs$Observable<T> => rxjs$Observable<E>;
 
-  <+T, A, B, C, D>(
+  <T, A, B, C, D>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
     c: rxjs$Observable<C>,
     resultSelector: (t: T, a: A, b: B, c: C) => D
   ): rxjs$Observable<T> => rxjs$Observable<D>;
 
-  <+T, A, B, C>(
+  <T, A, B, C>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
     resultSelector: (t: T, a: A, b: B) => C
   ): rxjs$Observable<T> => rxjs$Observable<C>;
 
-  <+T, A, B>(
+  <T, A, B>(
     a: rxjs$Observable<A>,
     resultSelector: (t: T, a: A) => B
   ): rxjs$Observable<T> => rxjs$Observable<B>;
 
-  <+T, A>(
+  <T, A>(
     resultSelector: (t: T) => A
   ): rxjs$Observable<T> => rxjs$Observable<A>;
 
-  <+T, A, B, C, D, E, F, G>(
+  <T, A, B, C, D, E, F, G>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
     c: rxjs$Observable<C>,
@@ -1324,7 +1324,7 @@ interface rxjs$Operators$withLatestFrom {
     _: void
   ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D, E, E, F, G]>;
 
-  <+T, A, B, C, D, E, F>(
+  <T, A, B, C, D, E, F>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
     c: rxjs$Observable<C>,
@@ -1334,7 +1334,7 @@ interface rxjs$Operators$withLatestFrom {
     _: void
   ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D, E, F]>;
 
-  <+T, A, B, C, D, E>(
+  <T, A, B, C, D, E>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
     c: rxjs$Observable<C>,
@@ -1343,7 +1343,7 @@ interface rxjs$Operators$withLatestFrom {
     _: void
   ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D, E]>;
 
-  <+T, A, B, C, D>(
+  <T, A, B, C, D>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
     c: rxjs$Observable<C>,
@@ -1351,26 +1351,26 @@ interface rxjs$Operators$withLatestFrom {
     _: void
   ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D]>;
 
-  <+T, A, B, C>(
+  <T, A, B, C>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
     c: rxjs$Observable<C>,
     _: void
   ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C]>;
 
-  <+T, A, B>(
+  <T, A, B>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
     _: void
   ): rxjs$Observable<T> => rxjs$Observable<[T, A, B]>;
 
-  <+T, A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<T> => rxjs$Observable<[T, A]>;
+  <T, A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<T> => rxjs$Observable<[T, A]>;
 
-  <+T, R>(
+  <T, R>(
     ...args: rxjs$Observable<any>[]
   ): rxjs$Observable<T> => rxjs$Observable<any[]>;
 
-  <+T, R>(
+  <T, R>(
     ...args: (rxjs$Observable<any> | (t: T, ...obs: any[]) => R)[]
   ): rxjs$Observable<T> => rxjs$Observable<R>;
 }

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -1633,6 +1633,7 @@ declare module "rxjs" {
       scheduler?: rxjs$SchedulerClass
     ): rxjs$Observable<T>,
     of<+T>(...values: T[]): rxjs$Observable<T>,
+    defer<+T>(factory: () => ?rxjs$ObservableInput<T>): rxjs$Observable<T>,
     empty<+T>(): rxjs$Observable<T>,
     never<+T>(): rxjs$Observable<T>,
     bindNodeCallback<U>(

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -346,116 +346,119 @@ declare module 'rxjs/observable/bindNodeCallback' {
     ): (...args: Array<any>) => rxjs$Observable<T>;
   }
 }
+
+type rxjs$Static$combineLatest = (<A, B>(
+  a: rxjs$Observable<A>,
+  resultSelector: (a: A) => B
+) => rxjs$Observable<B>) &
+(<A, B, C>(
+  a: rxjs$Observable<A>,
+  b: rxjs$Observable<B>,
+  resultSelector: (a: A, b: B) => C
+) => rxjs$Observable<C>) &
+(<A, B, C, D>(
+  a: rxjs$Observable<A>,
+  b: rxjs$Observable<B>,
+  c: rxjs$Observable<C>,
+  resultSelector: (a: A, b: B, c: C) => D
+) => rxjs$Observable<D>) &
+(<A, B, C, D, E>(
+  a: rxjs$Observable<A>,
+  b: rxjs$Observable<B>,
+  c: rxjs$Observable<C>,
+  d: rxjs$Observable<D>,
+  resultSelector: (a: A, b: B, c: C, d: D) => E
+) => rxjs$Observable<E>) &
+(<A, B, C, D, E, F>(
+  a: rxjs$Observable<A>,
+  b: rxjs$Observable<B>,
+  c: rxjs$Observable<C>,
+  d: rxjs$Observable<D>,
+  e: rxjs$Observable<E>,
+  resultSelector: (a: A, b: B, c: C, d: D, e: E) => F
+) => rxjs$Observable<F>) &
+(<A, B, C, D, E, F, G>(
+  a: rxjs$Observable<A>,
+  b: rxjs$Observable<B>,
+  c: rxjs$Observable<C>,
+  d: rxjs$Observable<D>,
+  e: rxjs$Observable<E>,
+  f: rxjs$Observable<F>,
+  resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F) => G
+) => rxjs$Observable<G>) &
+(<A, B, C, D, E, F, G, H>(
+  a: rxjs$Observable<A>,
+  b: rxjs$Observable<B>,
+  c: rxjs$Observable<C>,
+  d: rxjs$Observable<D>,
+  e: rxjs$Observable<E>,
+  f: rxjs$Observable<F>,
+  g: rxjs$Observable<G>,
+  resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
+) => rxjs$Observable<H>) &
+(<A>(a: rxjs$Observable<A>, _: void) => rxjs$Observable<[A]>) &
+(<A, B>(
+  a: rxjs$Observable<A>,
+  b: rxjs$Observable<B>,
+  _: void
+) => rxjs$Observable<[A, B]>) &
+(<A, B, C>(
+  a: rxjs$Observable<A>,
+  b: rxjs$Observable<B>,
+  c: rxjs$Observable<C>,
+  _: void
+) => rxjs$Observable<[A, B, C]>) &
+(<A, B, C, D>(
+  a: rxjs$Observable<A>,
+  b: rxjs$Observable<B>,
+  c: rxjs$Observable<C>,
+  d: rxjs$Observable<D>,
+  _: void
+) => rxjs$Observable<[A, B, C, D]>) &
+(<A, B, C, D, E>(
+  a: rxjs$Observable<A>,
+  b: rxjs$Observable<B>,
+  c: rxjs$Observable<C>,
+  d: rxjs$Observable<D>,
+  e: rxjs$Observable<E>,
+  _: void
+) => rxjs$Observable<[A, B, C, D, E]>) &
+(<A, B, C, D, E, F>(
+  a: rxjs$Observable<A>,
+  b: rxjs$Observable<B>,
+  c: rxjs$Observable<C>,
+  d: rxjs$Observable<D>,
+  e: rxjs$Observable<E>,
+  f: rxjs$Observable<F>,
+  _: void
+) => rxjs$Observable<[A, B, C, D, E, F]>) &
+(<A, B, C, D, E, F, G>(
+  a: rxjs$Observable<A>,
+  b: rxjs$Observable<B>,
+  c: rxjs$Observable<C>,
+  d: rxjs$Observable<D>,
+  e: rxjs$Observable<E>,
+  f: rxjs$Observable<F>,
+  g: rxjs$Observable<G>,
+  _: void
+) => rxjs$Observable<[A, B, C, D, E, F, G]>) &
+(<A, B, C, D, E, F, G, H>(
+  a: rxjs$Observable<A>,
+  b: rxjs$Observable<B>,
+  c: rxjs$Observable<C>,
+  d: rxjs$Observable<D>,
+  e: rxjs$Observable<E>,
+  f: rxjs$Observable<F>,
+  g: rxjs$Observable<G>,
+  h: rxjs$Observable<H>,
+  _: void
+) => rxjs$Observable<[A, B, C, D, E, F, G, H]>);
 declare module 'rxjs/observable/combineLatest' {
   declare module.exports: {
-    combineLatest: (<A, B>(
-      a: rxjs$Observable<A>,
-      resultSelector: (a: A) => B
-    ) => rxjs$Observable<B>) &
-    (<A, B, C>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      resultSelector: (a: A, b: B) => C
-    ) => rxjs$Observable<C>) &
-    (<A, B, C, D>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      resultSelector: (a: A, b: B, c: C) => D
-    ) => rxjs$Observable<D>) &
-    (<A, B, C, D, E>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      resultSelector: (a: A, b: B, c: C, d: D) => E
-    ) => rxjs$Observable<E>) &
-    (<A, B, C, D, E, F>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      resultSelector: (a: A, b: B, c: C, d: D, e: E) => F
-    ) => rxjs$Observable<F>) &
-    (<A, B, C, D, E, F, G>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F) => G
-    ) => rxjs$Observable<G>) &
-    (<A, B, C, D, E, F, G, H>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      g: rxjs$Observable<G>,
-      resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
-    ) => rxjs$Observable<H>) &
-    (<A>(a: rxjs$Observable<A>, _: void) => rxjs$Observable<[A]>) &
-    (<A, B>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      _: void
-    ) => rxjs$Observable<[A, B]>) &
-    (<A, B, C>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      _: void
-    ) => rxjs$Observable<[A, B, C]>) &
-    (<A, B, C, D>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      _: void
-    ) => rxjs$Observable<[A, B, C, D]>) &
-    (<A, B, C, D, E>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      _: void
-    ) => rxjs$Observable<[A, B, C, D, E]>) &
-    (<A, B, C, D, E, F>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      _: void
-    ) => rxjs$Observable<[A, B, C, D, E, F]>) &
-    (<A, B, C, D, E, F, G>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      g: rxjs$Observable<G>,
-      _: void
-    ) => rxjs$Observable<[A, B, C, D, E, F, G]>) &
-    (<A, B, C, D, E, F, G, H>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      g: rxjs$Observable<G>,
-      h: rxjs$Observable<H>,
-      _: void
-    ) => rxjs$Observable<[A, B, C, D, E, F, G, H]>);
+    combineLatest: rxjs$Static$combineLatest;
   }
 }
+
 declare module 'rxjs/observable/concat' {
   declare module.exports: {
     concat<+T>(...sources: rxjs$Observable<T>[]): rxjs$Observable<T>;
@@ -1594,112 +1597,7 @@ declare module "rxjs" {
       options: rxjs$EventListenerOptions,
       selector: () => T
     ) => rxjs$Observable<T>);
-    combineLatest: (<A, B>(
-      a: rxjs$Observable<A>,
-      resultSelector: (a: A) => B
-    ) => rxjs$Observable<B>) &
-    (<A, B, C>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      resultSelector: (a: A, b: B) => C
-    ) => rxjs$Observable<C>) &
-    (<A, B, C, D>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      resultSelector: (a: A, b: B, c: C) => D
-    ) => rxjs$Observable<D>) &
-    (<A, B, C, D, E>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      resultSelector: (a: A, b: B, c: C, d: D) => E
-    ) => rxjs$Observable<E>) &
-    (<A, B, C, D, E, F>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      resultSelector: (a: A, b: B, c: C, d: D, e: E) => F
-    ) => rxjs$Observable<F>) &
-    (<A, B, C, D, E, F, G>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F) => G
-    ) => rxjs$Observable<G>) &
-    (<A, B, C, D, E, F, G, H>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      g: rxjs$Observable<G>,
-      resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
-    ) => rxjs$Observable<H>) &
-    (<A>(a: rxjs$Observable<A>, _: void) => rxjs$Observable<[A]>) &
-    (<A, B>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      _: void
-    ) => rxjs$Observable<[A, B]>) &
-    (<A, B, C>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      _: void
-    ) => rxjs$Observable<[A, B, C]>) &
-    (<A, B, C, D>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      _: void
-    ) => rxjs$Observable<[A, B, C, D]>) &
-    (<A, B, C, D, E>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      _: void
-    ) => rxjs$Observable<[A, B, C, D, E]>) &
-    (<A, B, C, D, E, F>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      _: void
-    ) => rxjs$Observable<[A, B, C, D, E, F]>) &
-    (<A, B, C, D, E, F, G>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      g: rxjs$Observable<G>,
-      _: void
-    ) => rxjs$Observable<[A, B, C, D, E, F, G]>) &
-    (<A, B, C, D, E, F, G, H>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      g: rxjs$Observable<G>,
-      h: rxjs$Observable<H>,
-      _: void
-    ) => rxjs$Observable<[A, B, C, D, E, F, G, H]>);
+    combineLatest: rxjs$Static$combineLatest,
     Observable: typeof rxjs$Observable,
     Observer: typeof rxjs$Observer,
     ConnectableObservable: typeof rxjs$ConnectableObservable,

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -79,6 +79,36 @@ declare class rxjs$Observable<+T> {
     op5: rxjs$OperatorFunctionLast<D, E>
   ): E;
 
+  pipe<A, B, C, D, E, F>(
+    op1: rxjs$OperatorFunction<T, A>,
+    op2: rxjs$OperatorFunction<A, B>,
+    op3: rxjs$OperatorFunction<B, C>,
+    op4: rxjs$OperatorFunction<C, D>,
+    op5: rxjs$OperatorFunction<D, E>,
+    op6: rxjs$OperatorFunctionLast<E, F>
+  ): F;
+
+  pipe<A, B, C, D, E, F, G>(
+    op1: rxjs$OperatorFunction<T, A>,
+    op2: rxjs$OperatorFunction<A, B>,
+    op3: rxjs$OperatorFunction<B, C>,
+    op4: rxjs$OperatorFunction<C, D>,
+    op5: rxjs$OperatorFunction<D, E>,
+    op6: rxjs$OperatorFunction<E, F>,
+    op7: rxjs$OperatorFunctionLast<F, G>
+  ): G;
+
+  pipe<A, B, C, D, E, F, G>(
+    op1: rxjs$OperatorFunction<T, A>,
+    op2: rxjs$OperatorFunction<A, B>,
+    op3: rxjs$OperatorFunction<B, C>,
+    op4: rxjs$OperatorFunction<C, D>,
+    op5: rxjs$OperatorFunction<D, E>,
+    op6: rxjs$OperatorFunction<E, F>,
+    op7: rxjs$OperatorFunction<F, G>,
+    ...operations: rxjs$OperatorFunctionLast<any, any>[]
+  ): any;
+
   toArray(): rxjs$Observable<T[]>;
 
   toPromise(): Promise<T>;

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -1190,224 +1190,6 @@ declare module "rxjs/operators" {
 
     toArray<+T>(): rxjs$Observable<T> => rxjs$Observable<T[]>;
 
-    combineLatest<+T, A, B, C, D, E, F, G, H>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      g: rxjs$Observable<G>,
-      resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
-    ): rxjs$Observable<T> => rxjs$Observable<H>;
-
-    combineLatest<+T, A, B, C, D, E, F, G>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F) => G
-    ): rxjs$Observable<T> => rxjs$Observable<G>;
-
-    combineLatest<+T, A, B, C, D, E, F>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E) => F
-    ): rxjs$Observable<T> => rxjs$Observable<F>;
-
-    combineLatest<+T, A, B, C, D, E>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      resultSelector: (t: T, a: A, b: B, c: C, d: D) => E
-    ): rxjs$Observable<T> => rxjs$Observable<E>;
-
-    combineLatest<+T, A, B, C, D>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      resultSelector: (t: T, a: A, b: B, c: C) => D
-    ): rxjs$Observable<T> => rxjs$Observable<D>;
-
-    combineLatest<+T, A, B, C>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      resultSelector: (t: T, a: A, b: B) => C
-    ): rxjs$Observable<T> => rxjs$Observable<C>;
-
-    combineLatest<+T, A, B>(
-      a: rxjs$Observable<A>,
-      resultSelector: (t: T, a: A) => B
-    ): rxjs$Observable<T> => rxjs$Observable<B>;
-
-    combineLatest<+T, A, B, C, D, E, F, G>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      g: rxjs$Observable<G>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D, E, E, F, G]>;
-
-    combineLatest<+T, A, B, C, D, E, F>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D, E, F]>;
-
-    combineLatest<+T, A, B, C, D, E>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D, E]>;
-
-    combineLatest<+T, A, B, C, D>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D]>;
-
-    combineLatest<+T, A, B, C>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C]>;
-
-    combineLatest<+T, A, B>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B]>;
-
-    combineLatest<+T, A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<T> => rxjs$Observable<[T, A]>;
-
-    zip<+T, A, B, C, D, E, F, G, H>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      g: rxjs$Observable<G>,
-      resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
-    ): rxjs$Observable<T> => rxjs$Observable<H>;
-
-    zip<+T, A, B, C, D, E, F, G>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F) => G
-    ): rxjs$Observable<T> => rxjs$Observable<G>;
-
-    zip<+T, A, B, C, D, E, F>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E) => F
-    ): rxjs$Observable<T> => rxjs$Observable<F>;
-
-    zip<+T, A, B, C, D, E>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      resultSelector: (t: T, a: A, b: B, c: C, d: D) => E
-    ): rxjs$Observable<T> => rxjs$Observable<E>;
-
-    zip<+T, A, B, C, D>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      resultSelector: (t: T, a: A, b: B, c: C) => D
-    ): rxjs$Observable<T> => rxjs$Observable<D>;
-
-    zip<+T, A, B, C>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      resultSelector: (t: T, a: A, b: B) => C
-    ): rxjs$Observable<T> => rxjs$Observable<C>;
-
-    zip<+T, A, B>(
-      a: rxjs$Observable<A>,
-      resultSelector: (t: T, a: A) => B
-    ): rxjs$Observable<T> => rxjs$Observable<B>;
-
-    zip<+T, A, B, C, D, E, F, G>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      g: rxjs$Observable<G>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D, E, E, F, G]>;
-
-    zip<+T, A, B, C, D, E, F>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D, E, F]>;
-
-    zip<+T, A, B, C, D, E>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D, E]>;
-
-    zip<+T, A, B, C, D>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D]>;
-
-    zip<+T, A, B, C>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C]>;
-
-    zip<+T, A, B>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B]>;
-
-    zip<+T, A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<T> => rxjs$Observable<[T, A]>;
-
     window<+T>(
       windowBoundaries: rxjs$Observable<any>
     ): rxjs$Observable<T> => rxjs$Observable<rxjs$Observable<T>>;
@@ -1423,118 +1205,145 @@ declare module "rxjs/operators" {
       closingSelector: () => rxjs$Observable<any>
     ): rxjs$Observable<T> => rxjs$Observable<rxjs$Observable<T>>;
 
-    withLatestFrom<+T, A, B, C, D, E, F, G, H>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      g: rxjs$Observable<G>,
-      resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
-    ): rxjs$Observable<T> => rxjs$Observable<H>;
+    withLatestFrom: rxjs$Operators$withLatestFrom;
 
-    withLatestFrom<+T, A, B, C, D, E, F, G>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F) => G
-    ): rxjs$Observable<T> => rxjs$Observable<G>;
+    // deprecated in favor of static zip
+    // see: https://rxjs-dev.firebaseapp.com/api/operators/zip
+    zip: rxjs$Operators$zip;
 
-    withLatestFrom<+T, A, B, C, D, E, F>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E) => F
-    ): rxjs$Observable<T> => rxjs$Observable<F>;
-
-    withLatestFrom<+T, A, B, C, D, E>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      resultSelector: (t: T, a: A, b: B, c: C, d: D) => E
-    ): rxjs$Observable<T> => rxjs$Observable<E>;
-
-    withLatestFrom<+T, A, B, C, D>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      resultSelector: (t: T, a: A, b: B, c: C) => D
-    ): rxjs$Observable<T> => rxjs$Observable<D>;
-
-    withLatestFrom<+T, A, B, C>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      resultSelector: (t: T, a: A, b: B) => C
-    ): rxjs$Observable<T> => rxjs$Observable<C>;
-
-    withLatestFrom<+T, A, B>(
-      a: rxjs$Observable<A>,
-      resultSelector: (t: T, a: A) => B
-    ): rxjs$Observable<T> => rxjs$Observable<B>;
-
-    withLatestFrom<+T, A, B, C, D, E, F, G>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      g: rxjs$Observable<G>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D, E, E, F, G]>;
-
-    withLatestFrom<+T, A, B, C, D, E, F>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      f: rxjs$Observable<F>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D, E, F]>;
-
-    withLatestFrom<+T, A, B, C, D, E>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      e: rxjs$Observable<E>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D, E]>;
-
-    withLatestFrom<+T, A, B, C, D>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      d: rxjs$Observable<D>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D]>;
-
-    withLatestFrom<+T, A, B, C>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      c: rxjs$Observable<C>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C]>;
-
-    withLatestFrom<+T, A, B>(
-      a: rxjs$Observable<A>,
-      b: rxjs$Observable<B>,
-      _: void
-    ): rxjs$Observable<T> => rxjs$Observable<[T, A, B]>;
-
-    withLatestFrom<+T, A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<T> => rxjs$Observable<[T, A]>;
+    // deprecated in favor of static combineLatest
+    // see: https://rxjs-dev.firebaseapp.com/api/operators/combineLatest
+    combineLatest: rxjs$Operators$combineLatest;
 
     refCount<T>(): rxjs$ConnectableObservable<T> => rxjs$Observable<T>;
   };
 }
+
+interface rxjs$Operators$withLatestFrom {
+  <+T, A, B, C, D, E, F, G, H>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    g: rxjs$Observable<G>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
+  ): rxjs$Observable<T> => rxjs$Observable<H>;
+
+  <+T, A, B, C, D, E, F, G>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F) => G
+  ): rxjs$Observable<T> => rxjs$Observable<G>;
+
+  <+T, A, B, C, D, E, F>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E) => F
+  ): rxjs$Observable<T> => rxjs$Observable<F>;
+
+  <+T, A, B, C, D, E>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D) => E
+  ): rxjs$Observable<T> => rxjs$Observable<E>;
+
+  <+T, A, B, C, D>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    resultSelector: (t: T, a: A, b: B, c: C) => D
+  ): rxjs$Observable<T> => rxjs$Observable<D>;
+
+  <+T, A, B, C>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    resultSelector: (t: T, a: A, b: B) => C
+  ): rxjs$Observable<T> => rxjs$Observable<C>;
+
+  <+T, A, B>(
+    a: rxjs$Observable<A>,
+    resultSelector: (t: T, a: A) => B
+  ): rxjs$Observable<T> => rxjs$Observable<B>;
+
+  <+T, A>(
+    resultSelector: (t: T) => A
+  ): rxjs$Observable<T> => rxjs$Observable<A>;
+
+  <+T, A, B, C, D, E, F, G>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    g: rxjs$Observable<G>,
+    _: void
+  ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D, E, E, F, G]>;
+
+  <+T, A, B, C, D, E, F>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    _: void
+  ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D, E, F]>;
+
+  <+T, A, B, C, D, E>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    _: void
+  ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D, E]>;
+
+  <+T, A, B, C, D>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    _: void
+  ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C, D]>;
+
+  <+T, A, B, C>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    _: void
+  ): rxjs$Observable<T> => rxjs$Observable<[T, A, B, C]>;
+
+  <+T, A, B>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    _: void
+  ): rxjs$Observable<T> => rxjs$Observable<[T, A, B]>;
+
+  <+T, A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<T> => rxjs$Observable<[T, A]>;
+
+  <+T, R>(
+    ...args: rxjs$Observable<any>[]
+  ): rxjs$Observable<T> => rxjs$Observable<any[]>;
+
+  <+T, R>(
+    ...args: (rxjs$Observable<any> | (t: T, ...obs: any[]) => R)[]
+  ): rxjs$Observable<T> => rxjs$Observable<R>;
+}
+
+type rxjs$Operators$zip = rxjs$Operators$withLatestFrom;
+type rxjs$Operators$combineLatest = rxjs$Operators$withLatestFrom;
 
 declare class rxjs$GroupedObservable<K, V> extends rxjs$Observable<V> {
   key: K;

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -1594,6 +1594,112 @@ declare module "rxjs" {
       options: rxjs$EventListenerOptions,
       selector: () => T
     ) => rxjs$Observable<T>);
+    combineLatest: (<A, B>(
+      a: rxjs$Observable<A>,
+      resultSelector: (a: A) => B
+    ) => rxjs$Observable<B>) &
+    (<A, B, C>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      resultSelector: (a: A, b: B) => C
+    ) => rxjs$Observable<C>) &
+    (<A, B, C, D>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      resultSelector: (a: A, b: B, c: C) => D
+    ) => rxjs$Observable<D>) &
+    (<A, B, C, D, E>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      resultSelector: (a: A, b: B, c: C, d: D) => E
+    ) => rxjs$Observable<E>) &
+    (<A, B, C, D, E, F>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      resultSelector: (a: A, b: B, c: C, d: D, e: E) => F
+    ) => rxjs$Observable<F>) &
+    (<A, B, C, D, E, F, G>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F) => G
+    ) => rxjs$Observable<G>) &
+    (<A, B, C, D, E, F, G, H>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      g: rxjs$Observable<G>,
+      resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
+    ) => rxjs$Observable<H>) &
+    (<A>(a: rxjs$Observable<A>, _: void) => rxjs$Observable<[A]>) &
+    (<A, B>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      _: void
+    ) => rxjs$Observable<[A, B]>) &
+    (<A, B, C>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      _: void
+    ) => rxjs$Observable<[A, B, C]>) &
+    (<A, B, C, D>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      _: void
+    ) => rxjs$Observable<[A, B, C, D]>) &
+    (<A, B, C, D, E>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      _: void
+    ) => rxjs$Observable<[A, B, C, D, E]>) &
+    (<A, B, C, D, E, F>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      _: void
+    ) => rxjs$Observable<[A, B, C, D, E, F]>) &
+    (<A, B, C, D, E, F, G>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      g: rxjs$Observable<G>,
+      _: void
+    ) => rxjs$Observable<[A, B, C, D, E, F, G]>) &
+    (<A, B, C, D, E, F, G, H>(
+      a: rxjs$Observable<A>,
+      b: rxjs$Observable<B>,
+      c: rxjs$Observable<C>,
+      d: rxjs$Observable<D>,
+      e: rxjs$Observable<E>,
+      f: rxjs$Observable<F>,
+      g: rxjs$Observable<G>,
+      h: rxjs$Observable<H>,
+      _: void
+    ) => rxjs$Observable<[A, B, C, D, E, F, G, H]>);
     Observable: typeof rxjs$Observable,
     Observer: typeof rxjs$Observer,
     ConnectableObservable: typeof rxjs$ConnectableObservable,

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
@@ -36,6 +36,9 @@ import {
   exhaustMap,
   bufferWhen,
   bufferToggle,
+  withLatestFrom,
+  zip as zipOp,
+  combineLatest as combineLatestOp,
 } from 'rxjs/operators'
 
 const numbers = of(1);
@@ -189,3 +192,39 @@ of(true).pipe(map(function(x){
   (x: boolean);
   return this.v;
 }, { v: 123 }));
+
+(of(1).pipe(withLatestFrom(of('a'), of(true))): rxjs$Observable<[number, string, boolean]>);
+(of(1).pipe(withLatestFrom(of('a'), of(true), (a, b, c) => ({ a, b, c }))): rxjs$Observable<{ a: number, b: string, c: boolean }>);
+of(1).pipe(
+  withLatestFrom(
+    of('a'),
+    of(true),
+    of(1),
+    of('a'),
+    of(true),
+    of(1),
+    of('a'),
+    of(true)
+  ),
+  map(x => (x: Array<any>))
+);
+of(1).pipe(
+  withLatestFrom(
+    of('a'),
+    of(true),
+    of(1),
+    of('a'),
+    of(true),
+    of(1),
+    of('a'),
+    of(true),
+    (...values) => values.length
+  ),
+  map(x => (x: number))
+);
+
+(of(1).pipe(zipOp(of('a'), of(true))): rxjs$Observable<[number, string, boolean]>);
+(of(1).pipe(zipOp(of('a'), of(true), (a, b, c) => ({ a, b, c }))): rxjs$Observable<{ a: number, b: string, c: boolean }>);
+
+(of(1).pipe(combineLatestOp(of('a'), of(true))): rxjs$Observable<[number, string, boolean]>);
+(of(1).pipe(combineLatestOp(of('a'), of(true), (a, b, c) => ({ a, b, c }))): rxjs$Observable<{ a: number, b: string, c: boolean }>);

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
@@ -21,6 +21,7 @@ import {
   Subscriber
 } from "rxjs";
 import {
+  map,
   distinct,
   startWith,
   repeat,
@@ -174,3 +175,17 @@ buffered.subscribe(x => console.log(x));
 (defer(() => Promise.resolve(1)): rxjs$Observable<number>);
 (defer(() => of(1)): rxjs$Observable<number>);
 (defer(() => null): rxjs$Observable<empty>);
+
+(of(1).pipe(
+  map(x => (x: number).toString(10)),
+  map(x => (x: string) === '1'),
+  map(x => ({ v: (x: boolean) })),
+  map(x => (x: { v: boolean }))
+): rxjs$Observable<{ v: boolean }>);
+
+(of(true).pipe(map((x, i) => (i: number))): rxjs$Observable<number>);
+
+of(true).pipe(map(function(x){
+  (x: boolean);
+  return this.v;
+}, { v: 123 }));

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
@@ -14,6 +14,7 @@ import {
   range,
   merge,
   fromEvent,
+  combineLatest,
   AnonymousSubject,
   Observer,
   Scheduler,
@@ -244,3 +245,6 @@ of(1).pipe(
   identity,
   identity,
 );
+
+(combineLatest(of(1), of(2), of(3)): rxjs$Observable<[number, number, number]>);
+(combineLatest(of(1), of(2), of(3), (a, b, c) => ({ a, b, c })): rxjs$Observable<{ a: number, b: number, c: number }>);

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
@@ -228,3 +228,19 @@ of(1).pipe(
 
 (of(1).pipe(combineLatestOp(of('a'), of(true))): rxjs$Observable<[number, string, boolean]>);
 (of(1).pipe(combineLatestOp(of('a'), of(true), (a, b, c) => ({ a, b, c }))): rxjs$Observable<{ a: number, b: string, c: boolean }>);
+
+// must accept unlimited argument
+declare function identity<T>(x: T): T;
+of(1).pipe(
+  identity,
+  identity,
+  identity,
+  identity,
+  identity,
+  identity,
+  identity,
+  identity,
+  identity,
+  identity,
+  identity,
+);

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/test_rxjs.js
@@ -6,6 +6,7 @@ import {
   concat,
   of,
   from,
+  defer,
   timer,
   interval,
   never,
@@ -169,3 +170,7 @@ var buffered = clicks.pipe(bufferWhen(() =>
 // $ExpectError
 click.pipe(bufferWhen(() => true));
 buffered.subscribe(x => console.log(x));
+
+(defer(() => Promise.resolve(1)): rxjs$Observable<number>);
+(defer(() => of(1)): rxjs$Observable<number>);
+(defer(() => null): rxjs$Observable<empty>);


### PR DESCRIPTION
# targets
## static
- [defer](https://rxjs-dev.firebaseapp.com/api/index/function/defer) (add)
- [combineLatest](https://rxjs-dev.firebaseapp.com/api/index/function/combineLatest) (add, rel. #2616)
- [pipe](https://rxjs-dev.firebaseapp.com/api/index/function/pipe) (improvement: allow to accept unlimited arguments)

## operators
- [withLatestFrom](https://rxjs-dev.firebaseapp.com/api/operators/withLatestFrom) (fix)
- [zip](https://rxjs-dev.firebaseapp.com/api/operators/zip) (fix)
- [combineLatest](https://rxjs-dev.firebaseapp.com/api/operators/combineLatest) (fix)
  - These operators are broken in case of multiple arguments, and now fixed in this PR
- [map](https://rxjs-dev.firebaseapp.com/api/operators/map) (add test)