### PR TITLE
Add support for jest async matchers

### DIFF
--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
@@ -116,7 +116,9 @@ type JestMatcherResult = {
   pass: boolean
 };
 
-type JestMatcher = (actual: any, expected: any) => JestMatcherResult;
+type JestMatcher = (actual: any, expected: any) =>
+  | JestMatcherResult
+  | Promise<JestMatcherResult>;
 
 type JestPromiseType = {
   /**

--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
@@ -208,6 +208,15 @@ expect.extend({
   }
 });
 
+expect.extend({
+  blah(actual, expected) {
+    return Promise.resolve({
+      message: () => "blah fail",
+      pass: false
+    });
+  }
+});
+
 const err = new Error("err");
 expect(() => {
   throw err;


### PR DESCRIPTION
Since v23 of jest, it is possible to add async matchers to jest via the `extend` api. Implementing PR is https://github.com/facebook/jest/pull/5919

Documentation: https://github.com/facebook/jest/blob/master/docs/ExpectAPI.md#async-matchers

This PR modifies the type definitions for v23 to accept a Promise returning a `JestMatcherResult` as return value of any `JestMatcher` function