### PR TITLE
react-router-dom: add support for chaining withRouther with other HOCs

### DIFF
--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/react-router-dom_v4.x.x.js
@@ -154,10 +154,10 @@ declare module "react-router-dom" {
     location?: Location
   |}>>
 
-  declare export function withRouter<P: {}, Component: ComponentType<P>>(
-    WrappedComponent: Component
+  declare export function withRouter<WrappedComponent: ComponentType<*>>(
+    Component: WrappedComponent
   ): ComponentType<
-    $Diff<ElementConfig<Component>, ContextRouterVoid>
+    $Diff<ElementConfig<$Supertype<WrappedComponent>>, ContextRouterVoid>
     >;
 
   declare type MatchPathOptions = {

--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/test_react-router-dom.js
@@ -198,6 +198,9 @@ describe("react-router-dom", () => {
         }: Props) => <div />;
         const WrappedComp = withRouter(Comp);
         <WrappedComp s="" />;
+
+        const ChainedHOC = withRouter(WrappedComp);
+        <ChainedHOC s="" />;
       });
 
       it("errors if the component is not passed correct props", () => {
@@ -213,6 +216,12 @@ describe("react-router-dom", () => {
         <WrappedComp />;
         // $ExpectError - wrong type
         <WrappedComp s={1} />;
+
+        const ChainedHOC = withRouter(WrappedComp);
+        // $ExpectError - missing prop "s"
+        <ChainedHOC />;
+        // $ExpectError - wrong type
+        <ChainedHOC s={1} />;
       });
 
       it("errors if trying to access a prop that withRouter does not supply", () => {
@@ -232,6 +241,9 @@ describe("react-router-dom", () => {
         }
         const WrappedComp = withRouter(Comp);
         <WrappedComp s="" />;
+
+        const ChainedHOC = withRouter(WrappedComp);
+        <ChainedHOC s="" />;
       });
 
       it("errors if the component is not passed the correct props", () => {
@@ -245,6 +257,12 @@ describe("react-router-dom", () => {
         <WrappedComp />;
         // $ExpectError - wrong type
         <WrappedComp s={1} />;
+
+        const ChainedHOC = withRouter(WrappedComp);
+        // $ExpectError - missing prop "s"
+        <ChainedHOC />;
+        // $ExpectError - wrong type
+        <ChainedHOC s={1} />;
       });
 
       it("passes if a required prop is handled by defaultProps", () => {
@@ -259,6 +277,10 @@ describe("react-router-dom", () => {
         const WrappedComp = withRouter(Comp);
         <WrappedComp />;
         <WrappedComp s="" />;
+
+        const ChainedHOC = withRouter(WrappedComp);
+        <ChainedHOC />;
+        <ChainedHOC s="" />;
       });
 
       it("errors if a required prop that has a defaultProp is passed the wrong type", () => {
@@ -273,6 +295,10 @@ describe("react-router-dom", () => {
         const WrappedComp = withRouter(Comp);
         // $ExpectError - wrong type
         <WrappedComp s={123} />;
+
+        const ChainedHOC = withRouter(WrappedComp);
+        // $ExpectError - wrong type
+        <ChainedHOC s={123} />;
       });
     });
   });


### PR DESCRIPTION
`withRouter` is getting rid of the types if is chained to another HOC. I ran into this using `withRouter` with material-ui `withStyles`. For example this currently works:
```
const MyComponent = (props: { a: string }) => {}

withRouter(
  withStyles({})(MyComponent)
)

<MyComponent />
```

I used the same solution used in material-ui `withStyles` definitions that allows chaining the HOC functions.