### PR TITLE
[RxJS v6] fix wrong import path for TestScheduler

### DIFF
--- a/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.34.x-/rxjs_v6.x.x.js
@@ -1821,7 +1821,7 @@ declare module "rxjs/Subscription" {
   };
 }
 
-declare module "rxjs/testing/TestScheduler" {
+declare module "rxjs/testing" {
   declare module.exports: {
     TestScheduler: typeof rxjs$SchedulerClass
   };


### PR DESCRIPTION
Fix only the import path. Deep import of `TestScheduler` does not work.

https://github.com/ReactiveX/rxjs/blob/master/src/testing/index.ts