### PR TITLE
react-apollo: More concise type for QueryRenderProps

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -899,35 +899,52 @@ declare module "react-apollo" {
 
   declare export function cleanupApolloState(apolloState: any): void;
 
-  declare export type QueryRenderProps<
-    TData = any,
-    TVariables = OperationVariables
-  > = {
-    data: TData | {||} | void,
-    loading: boolean,
-    error?: ApolloError,
+  declare export type RenderPropsUtils<TData, TVariables> = {|
     variables: TVariables,
     networkStatus: NetworkStatus,
     refetch: (variables?: TVariables) => Promise<ApolloQueryResult<TData>>,
     fetchMore: ((
       options: FetchMoreOptions<TData, TVariables> &
-        FetchMoreQueryOptions<TVariables>
+        FetchMoreQueryOptions<TVariables>,
     ) => Promise<ApolloQueryResult<TData>>) &
       (<TData2, TVariables2>(
         options: { query: DocumentNode } & FetchMoreQueryOptions<TVariables2> &
-          FetchMoreOptions<TData2, TVariables2>
+          FetchMoreOptions<TData2, TVariables2>,
       ) => Promise<ApolloQueryResult<TData2>>),
     load: () => void,
     startPolling: (interval: number) => void,
     stopPolling: () => void,
     subscribeToMore: (
-      options: SubscribeToMoreOptions<TData, any, any>
+      options: SubscribeToMoreOptions<TData, any, any>,
     ) => () => void,
     updateQuery: (
-      mapFn: (previousResult: TData, options: { variables: TVariables }) => TData
+      mapFn: (
+        previousResult: TData,
+        options: { variables: TVariables },
+      ) => TData,
     ) => mixed,
-    client: ApolloClient<any>
-  };
+    client: ApolloClient<any>,
+  |};
+
+  declare export type QueryRenderProps<
+    TData = any,
+    TVariables = OperationVariables
+  > = {
+      data: TData,
+      loading: false,
+      error?: void,
+      ...RenderPropsUtils<TData, TVariables>
+    } | {
+      data: {||} | void,
+      loading: false,
+      error: ApolloError,
+      ...RenderPropsUtils<TData, TVariables>
+    } | {
+      data: {||} | void,
+      loading: true,
+      error?: void,
+      ...RenderPropsUtils<TData, TVariables>
+    };
 
   declare export type QueryRenderPropFunction<TData, TVariables> = (
     QueryRenderProps<TData, TVariables>

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
@@ -265,13 +265,13 @@ describe("<Query />", () => {
     const vars: Vars = { foo: "bar" };
     const q = (
       <Query variables={vars} query={HERO_QUERY}>
-        {({ data }: QueryRenderProps<Res, Vars>) => {
+        {(result: QueryRenderProps<Res, Vars>) => {
           // $ExpectError Cannot get `data.res`
-          data.res;
-          if (!data) {
+          result.data.res;
+          if (result.loading || result.error) {
             return;
           }
-          const d1: Res | {||} = data;
+          const d1: Res = result.data;
           // $ExpectError Cannot get `data.res` because property `res` is missing in object type
           const s: string = data.res;
           if (d1.res) {

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
@@ -271,13 +271,9 @@ describe("<Query />", () => {
           if (result.loading || result.error) {
             return;
           }
-          const d1: Res = result.data;
-          // $ExpectError Cannot get `data.res` because property `res` is missing in object type
-          const s: string = data.res;
-          if (d1.res) {
-            const d2: Res = d1;
-            const s: string = d1.res;
-          }
+          const { data } = result
+          const d1: Res = data;
+          const s: string = d1.res;
         }}
       </Query>
     );


### PR DESCRIPTION
So flow can infer `data` type from `loading` and `error` states