### PR TITLE
object-assign: use native `Object$Assign` type

### DIFF
--- a/definitions/npm/object-assign_v4.x.x/flow_v0.25.x-/object-assign_v4.x.x.js
+++ b/definitions/npm/object-assign_v4.x.x/flow_v0.25.x-/object-assign_v4.x.x.js
@@ -1,3 +1,3 @@
 declare module "object-assign" {
-  declare module.exports: (target: any, ...sources: Array<any>) => Object;
+  declare module.exports: Object$Assign;
 }

--- a/definitions/npm/object-assign_v4.x.x/test_object-assign_v4.x.x.js
+++ b/definitions/npm/object-assign_v4.x.x/test_object-assign_v4.x.x.js
@@ -1,9 +1,36 @@
 // @flow
 
-import objectAssign from 'object-assign';
+import objectAssign from "object-assign";
 
-const result1: Object = objectAssign({}, null, 2, {}, []);
-const result2: Object = objectAssign(null);
+const extendsExistingFields: { a: number, b: string } = objectAssign(
+  {},
+  { a: 1 },
+  { b: "hi" }
+);
 
 // $ExpectError
-const result3: string = objectAssign();
+const extendsExistingFieldsSoundly: { a: number, b: string } = objectAssign(
+  {},
+  { a: "one" },
+  { b: "hi" }
+);
+
+// $ExpectError
+const resultIsObject: string = objectAssign({});
+
+// TODO(facebook/flow#6856): The following should be valid, but is not,
+// due to a bug in Flow. The same behavior occurs with `Object.assign`.
+// If this is fixed, then this expect-success test case should be
+// reinstated.
+/*
+const sourcesMayHaveVaryingType = objectAssign({}, null, 2, {}, []);
+*/
+
+// TODO(facebook/flow#6857): The following should raise a type error
+// (because it raises a runtime error), but does not, due to a bug in
+// Flow. The same behavior occurs with `Object.assign`. If this is
+// fixed, then this expect-error test case should be reinstated.
+/*
+const nullTargetDisallowed = objectAssign(null);
+const voidTargetDisallowed = objectAssign(undefined);
+*/


### PR DESCRIPTION
Summary:
Resolves #2705. See that issue for rationale and discussion.

Test Plan:
Running `flow-typed run-tests object-assign` passes.

wchargin-branch: object-assign-native