### PR TITLE
add mock.results type

### DIFF
--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
@@ -14,7 +14,12 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
      * An array that contains all the object instances that have been
      * instantiated from this mock function.
      */
-    instances: Array<TReturn>
+    instances: Array<TReturn>,
+    /**
+     * An array that contains all the object results that have been
+     * returned by this mock function call
+     */
+    results: Array<{ isThrow: boolean, value: TReturn }>
   },
   /**
    * Resets all information stored in the mockFn.mock.calls and

--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
@@ -75,6 +75,11 @@ mockedDoStuff.mock.instances[0] > 5;
 // $ExpectError function `doesntExist` not found in number.
 mockedDoStuff.mock.instances[0].indexOf("a");
 
+expect(mockedDoStuff.mock.results[0].isThrow).toBe(false);
+expect(mockedDoStuff.mock.results[0].value).toBe(10);
+// $ExpectError
+mockedDoStuff.mock.results[0].foo;
+
 expect(1).toEqual(1);
 expect(true).toBe(true);
 expect(5).toBeGreaterThan(3);


### PR DESCRIPTION
`instances` and `calls` were typed, but `results` were not.

see documentation here: https://jestjs.io/docs/en/mock-function-api#mockfnmockresults