### PR TITLE
[material-ui]: support createMuiTheme() without any options

### DIFF
--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
@@ -2015,7 +2015,7 @@ declare module "@material-ui/core/styles/createMuiTheme" {
     zIndex: ZIndex
   };
 
-  declare module.exports: (options: ThemeOptions) => Theme;
+  declare module.exports: (options?: ThemeOptions) => Theme;
 }
 
 declare module "@material-ui/core/styles/createPalette" {

--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
@@ -249,3 +249,8 @@ const createMuiCustomThemeInvalidNestedOptions = () => (
     },
   })
 )
+
+// createMuiTheme test without any options
+const createMuiCustomThemeWithoutAnyOptions = () => (
+  createMuiTheme()
+)


### PR DESCRIPTION
`createMuiTheme()` without any options provided should not show an error message. Here is an example from official docs: https://material-ui.com/customization/overrides/#theme-nesting