### PR TITLE
element-ready: Create libdefs

### DIFF
--- a/definitions/npm/element-ready_v3.x.x/flow_v0.25.x-/element-ready_v3.x.x.js
+++ b/definitions/npm/element-ready_v3.x.x/flow_v0.25.x-/element-ready_v3.x.x.js
@@ -1,0 +1,11 @@
+declare module 'element-ready' {
+  declare export type Options = {|
+      target?: Document | DocumentFragment | Element,
+  |}
+
+  // TODO: Replace `Promise<HTMLElement>` with PCancelable
+  declare export default function elementReady(
+      selector: string,
+      options?: ?Options
+  ): Promise<HTMLElement>
+}

--- a/definitions/npm/element-ready_v3.x.x/flow_v0.25.x-/test_element-ready.js
+++ b/definitions/npm/element-ready_v3.x.x/flow_v0.25.x-/test_element-ready.js
@@ -1,0 +1,43 @@
+// @flow
+
+import elementReady, {type Options} from 'element-ready';
+
+elementReady('#unicorn');
+elementReady('#unicorn', null);
+elementReady('#unicorn', {});
+elementReady('#unicorn', {target: document});
+elementReady('#unicorn', {target: document.createElement('div')});
+elementReady('#unicorn', {target: document.createDocumentFragment()});
+
+(async (): Promise<void> => {
+	const element: HTMLElement = await elementReady('#unicorn');
+	if (element instanceof HTMLInputElement) {
+		element.checked = true;
+	}
+})();
+
+({target: document}: Options);
+
+// $ExpectError
+elementReady(1);
+// $ExpectError
+elementReady(true);
+// $ExpectError
+elementReady({});
+// $ExpectError
+elementReady('#unicorn', {target: null});
+// $ExpectError
+elementReady('#unicorn', {target: 1});
+// $ExpectError
+elementReady('#unicorn', {target: {}});
+// $ExpectError
+elementReady('#unicorn', {unknownProperty: ''});
+
+// $ExpectError
+({target: null}: Options);
+// $ExpectError
+({target: 1}: Options);
+// $ExpectError
+({target: {}}: Options);
+// $ExpectError
+({unknownProperty: ''}: Options);


### PR DESCRIPTION
Create library definitions for the [`element-ready`](http://npm.im/element-ready) package by @sindresorhus ([see source code here](https://github.com/sindresorhus/element-ready/blob/master/index.js))

The return type of the exported function is actually a `PCancelable` from [`p-cancelable`](http://npm.im/p-cancelable), but since there are no libdefs for that package yet I typed it with a Promise and added the TODO comment. I will submit another PR for those libdefs later and then come back to resolve it. If the maintainer's don't mind, this can be merged as it is now.

Reference: https://github.com/sindresorhus/element-ready/pull/14