### PR TITLE
[react-test-renderer] Fix component instance type

### DIFF
--- a/definitions/npm/react-test-renderer_v16.x.x/flow_v0.47.x-/react-test-renderer_v16.x.x.js
+++ b/definitions/npm/react-test-renderer_v16.x.x/flow_v0.47.x-/react-test-renderer_v16.x.x.js
@@ -1,6 +1,8 @@
 // Type definitions for react-test-renderer 16.x.x
 // Ported from: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-test-renderer
 
+type ReactComponentInstance = React$Component<any>;
+
 type ReactTestRendererJSON = {
   type: string,
   props: { [propName: string]: any },
@@ -9,12 +11,12 @@ type ReactTestRendererJSON = {
 
 type ReactTestRendererTree = ReactTestRendererJSON & {
   nodeType: "component" | "host",
-  instance: any,
+  instance: ?ReactComponentInstance,
   rendered: null | ReactTestRendererTree
 };
 
 type ReactTestInstance = {
-  instance: any,
+  instance: ?ReactComponentInstance,
   type: string,
   props: { [propName: string]: any },
   parent: null | ReactTestInstance,
@@ -48,7 +50,7 @@ declare module "react-test-renderer" {
     toTree(): null | ReactTestRendererTree,
     unmount(nextElement?: React$Element<any>): void,
     update(nextElement: React$Element<any>): void,
-    getInstance(): null | ReactTestInstance,
+    getInstance(): ?ReactComponentInstance,
     root: ReactTestInstance
   };
 


### PR DESCRIPTION
From the [Test Renderer docs](https://reactjs.org/docs/test-renderer.html):

![image](https://user-images.githubusercontent.com/250750/45247757-b7d87680-b312-11e8-838f-ee4759a126e7.png)
