### PR TITLE
lodash 'last' must return maybe - empty arrays return undefined

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -302,7 +302,7 @@ declare module "lodash" {
     ): Array<T>;
     join<T>(array: Array<T>, separator?: ?string): string;
     join<T>(array: void | null, separator?: ?string): '';
-    last<T>(array: ?$ReadOnlyArray<T>): T;
+    last<T>(array: ?$ReadOnlyArray<T>): ?T;
     lastIndexOf<T>(array: Array<T>, value?: ?T, fromIndex?: ?number): number;
     lastIndexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
     nth<T>(array: T[], n?: ?number): T;
@@ -1770,7 +1770,7 @@ declare module "lodash/fp" {
     ): Array<T>;
     join<T>(separator: string): (array: Array<T>) => string;
     join<T>(separator: string, array: Array<T>): string;
-    last<T>(array: Array<T>): T;
+    last<T>(array: Array<T>): ?T;
     lastIndexOf<T>(value: T): (array: Array<T>) => number;
     lastIndexOf<T>(value: T, array: Array<T>): number;
     lastIndexOfFrom<T>(

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -21,6 +21,7 @@ import intersectionBy from "lodash/intersectionBy";
 import isEqual from "lodash/isEqual";
 import isString from "lodash/isString";
 import keyBy from "lodash/keyBy";
+import last from "lodash/last";
 import map from "lodash/map";
 import memoize from "lodash/memoize";
 import noop from "lodash/noop";
@@ -480,3 +481,15 @@ pairs = toPairsIn({ a: 12, b: 100 });
 (omitBy(null, num => num % 2): {});
 (omitBy(undefined, num => num % 2): {});
 (omitBy({[1]: 1, [2]: 2}, num => num === 2): {[prop: number]: number});
+
+/**
+ * _.last
+ */
+
+(last([1]): ?number);
+(last(['test']): ?string);
+type Item = { a: boolean };
+var items: Array<Item> = [{ a: true }, { a: false }];
+(last(items): ?Item);
+var items: Array<Item> = [];
+(last(items): ?Item);


### PR DESCRIPTION
Currently, calling `_.last` returns `T`, where the argument is `Array<T>`. The return in that case will actually be `void` - the [lodash source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L7609) explicitly makes that the case.

Previously false negative:

```js
const arr: Array<number> = [];
const res = _.last(arr);
(res: number); // passes
```