### PR TITLE
fixes 2723 run runTests test only against latest flow

### DIFF
--- a/cli/src/commands/__tests__/runTests-test.js
+++ b/cli/src/commands/__tests__/runTests-test.js
@@ -10,6 +10,7 @@ describe('run-tests (command)', () => {
       (console: any).log = jest.fn();
       const args = {
         _: ['run-tests', 'regression-1385_v1.x.x'],
+        numberOfFlowVersions: 1,
         path: path.join(__dirname, '__runTests-fixtures__'),
       };
       status = await run(args);


### PR DESCRIPTION
closes https://github.com/flow-typed/flow-typed/issues/2723

It's a bit flaky test, so running the test only against latest flow version should make it much faster and much more reliable