### PR TITLE
fix[react-apollo]: mutate() options should be optional

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -981,7 +981,7 @@ declare module "react-apollo" {
   declare export type MutationFunction<
     TData = any,
     TVariables = OperationVariables
-  > = (options: {
+  > = (options?: {
     variables?: TVariables,
     optimisticResponse?: Object,
     refetchQueries?: RefetchQueryDescription | RefetchQueriesProviderFn,

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
@@ -509,6 +509,20 @@ class UpdateHeroMutationComp extends Mutation<
 > {}
 
 describe("<Mutation />", () => {
+  it("mutate() args are optional", () => {
+    type Vars = {| foo: string |};
+    type Res = {| res: string |};
+    const vars: Vars = { foo: "bar" };
+    const q = (
+      <Mutation variables={vars} mutation={HERO_QUERY}>
+        {mutate => {
+          mutate();
+        }}
+      </Mutation>
+    );
+  });
+
+
   it("works", () => {
     type Vars = {| foo: string |};
     type Res = {| res: string |};


### PR DESCRIPTION
As described in title `mutate()` execution should be valid without any options specified e.g. https://www.apollographql.com/docs/react/essentials/mutations.html#render-prop