### PR TITLE
[React-Apollo] Mark `data` as optional in OptionProps

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -804,7 +804,7 @@ declare module "react-apollo" {
 
   declare export interface OptionProps<TProps, TResult, TVariables> {
     ownProps: TProps;
-    data: GraphqlData<TResult, TVariables>;
+    data?: GraphqlData<TResult, TVariables>;
     mutate: MutationFunc<TResult, TVariables>;
   }
 


### PR DESCRIPTION
OptionProps takes properties and functions that are used in places like the `graphql` higher-order-component. One of its properties is `data` which is marked as required, but is in fact optional when querying [as seen here](https://github.com/apollographql/react-apollo/blob/master/src/query-hoc.tsx#L88).

This PR updates OptionProps' structure to denote `data` as optional.

![thing](https://user-images.githubusercontent.com/5721314/45547996-9bf53900-b81a-11e8-8d4d-487971ea19ba.gif)
