### PR TITLE
[normalizr] Use $ReadOnlyArray

### DIFF
--- a/definitions/npm/normalizr_v3.x.x/flow_v0.25.x-/normalizr_v3.x.x.js
+++ b/definitions/npm/normalizr_v3.x.x/flow_v0.25.x-/normalizr_v3.x.x.js
@@ -66,7 +66,7 @@ declare module 'normalizr' {
     entities: Collections,
   |}
 
-  declare export function normalize<Result, Collections>(raw: Array<mixed> | Object, schema: Schema): NormalizeResult<Result, Collections>;
+  declare export function normalize<Result, Collections>(raw: $ReadOnlyArray<mixed> | Object, schema: Schema): NormalizeResult<Result, Collections>;
   declare export function denormalize(
     input: mixed,
     schema: Schema,


### PR DESCRIPTION
I believe normalizr does not mutate the input values, so it should be safe to use  `$ReadOnlyArray` here.

Disclaimer: I am a flow typing newbie, so please review carefully :-)