### PR TITLE
Fix commander

### DIFF
--- a/definitions/npm/commander_v2.x.x/flow_v0.28.x-/commander_v2.x.x.js
+++ b/definitions/npm/commander_v2.x.x/flow_v0.28.x-/commander_v2.x.x.js
@@ -243,7 +243,7 @@ declare module "commander" {
      *
      * @api public
      */
-    outputHelp(): void;
+    outputHelp((defaultHelp: string) => string): void;
 
     /**
      * Output help information and exit.

--- a/definitions/npm/commander_v2.x.x/flow_v0.28.x-/commander_v2.x.x.js
+++ b/definitions/npm/commander_v2.x.x/flow_v0.28.x-/commander_v2.x.x.js
@@ -159,8 +159,7 @@ declare module "commander" {
      * @return {Command} for chaining
      * @api public
      */
-    parse(argv: Array<string>): {
-      ...this,
+    parse(argv: Array<string>): this & {
       args: Array<string>,
       rawArgs: Array<string>,
       [string]: any,
@@ -248,7 +247,7 @@ declare module "commander" {
      *
      * @api public
      */
-    outputHelp((defaultHelp: string) => string): void;
+    outputHelp(cb?: ?(defaultHelp: string) => string): void;
 
     /**
      * Output help information and exit.

--- a/definitions/npm/commander_v2.x.x/flow_v0.28.x-/commander_v2.x.x.js
+++ b/definitions/npm/commander_v2.x.x/flow_v0.28.x-/commander_v2.x.x.js
@@ -159,7 +159,12 @@ declare module "commander" {
      * @return {Command} for chaining
      * @api public
      */
-    parse(argv: Array<string>): this;
+    parse(argv: Array<string>): {
+      ...this,
+      args: Array<string>,
+      rawArgs: Array<string>,
+      [string]: any,
+    };
 
     /**
      * Parse options from `argv` returning `argv`

--- a/definitions/npm/commander_v2.x.x/test_commander_v2.x.x.js
+++ b/definitions/npm/commander_v2.x.x/test_commander_v2.x.x.js
@@ -38,5 +38,5 @@ const programName: string = program.name();
 
 const opts: { [key: string]: any } = program.opts();
 
-program.outputHelp();
+program.outputHelp((defaultHelp: string) => `output: ${defaultHelp}`);
 program.help();

--- a/definitions/npm/commander_v2.x.x/test_commander_v2.x.x.js
+++ b/definitions/npm/commander_v2.x.x/test_commander_v2.x.x.js
@@ -2,13 +2,17 @@ import program from 'commander';
 
 new program.Command('support to use class');
 
-program
+const parseResult: {
+  args: Array<string>,
+  rawArgs: Array<string>,
+  foo?: string,
+  bar?: boolean,
+} = program
   .version('1.0.0')
   .arguments('<cmd> [env]')
   .usage('[options] <file ...>')
     .option('-f, --foo', 'Make it foo')
     .option('-b, --bar', 'Make it bar')
-
   .command('foo')
     .alias('f')
     .description('Do that foo thing')
@@ -26,10 +30,10 @@ const commandName: string = program.command('bar');
 // $ExpectError
 program.command('foo').alias().description('bar');
 
-const result = program.parseOptions(process.argv);
-
-const args: Array<string> = result.args;
-const unknown: Array<string> = result.unknown;
+const parseOptionsResult: {
+  args: Array<string>,
+  unknown: Array<string>,
+} = program.parseOptions(process.argv);
 
 const description: string = program.description();
 const alias: string = program.alias();

--- a/definitions/npm/commander_v2.x.x/test_commander_v2.x.x.js
+++ b/definitions/npm/commander_v2.x.x/test_commander_v2.x.x.js
@@ -43,4 +43,6 @@ const programName: string = program.name();
 const opts: { [key: string]: any } = program.opts();
 
 program.outputHelp((defaultHelp: string) => `output: ${defaultHelp}`);
+program.outputHelp();
+program.outputHelp(() => `output`);
 program.help();


### PR DESCRIPTION
- `arguments` in `outputHelp` should be a function
  - [api docs](http://tj.github.io/commander.js/#Command.prototype.outputHelp)
- `command.parse` can return `argv`, `rawArgv` and `options`.
  - [api docs](http://tj.github.io/commander.js/#Command.prototype.parse)