### PR TITLE
lodash allow any type for object keys

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -519,7 +519,7 @@ declare module "lodash" {
     every<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): boolean;
     every<T: Object>(object: T, iteratee?: OIteratee<T>): boolean;
     filter<T>(array?: ?$ReadOnlyArray<T>, predicate?: ?Predicate<T>): Array<T>;
-    filter<A, T: { [id: string]: A }>(
+    filter<A, T: { [id: any]: A }>(
       object: T,
       predicate?: OPredicate<A, T>
     ): Array<A>;
@@ -533,7 +533,7 @@ declare module "lodash" {
       predicate?: ?Predicate<T>,
       fromIndex?: ?number
     ): void;
-    find<V, A, T: { [id: string]: A }>(
+    find<V, A, T: { [id: any]: A }>(
       object: T,
       predicate?: OPredicate<A, T>,
       fromIndex?: number
@@ -543,7 +543,7 @@ declare module "lodash" {
       predicate?: ?Predicate<T>,
       fromIndex?: ?number
     ): T | void;
-    findLast<V, A, T: { [id: string]: A }>(
+    findLast<V, A, T: { [id: any]: A }>(
       object: T,
       predicate?: ?OPredicate<A, T>
     ): V;
@@ -587,7 +587,7 @@ declare module "lodash" {
       array: void | null,
       iteratee?: ?ValueOnlyIteratee<any>
     ): {};
-    groupBy<V, A, T: { [id: string]: A }>(
+    groupBy<V, A, T: { [id: any]: A }>(
       object: T,
       iteratee?: ValueOnlyIteratee<A>
     ): { [key: V]: Array<A> };
@@ -649,7 +649,7 @@ declare module "lodash" {
       array?: ?Array<T>,
       predicate?: ?Predicate<T>
     ): [Array<T>, Array<T>];
-    partition<V, A, T: { [id: string]: A }>(
+    partition<V, A, T: { [id: any]: A }>(
       object: T,
       predicate?: OPredicate<A, T>
     ): [Array<V>, Array<V>];
@@ -704,7 +704,7 @@ declare module "lodash" {
       accumulator?: ?U
     ): U;
     reject<T>(array: ?$ReadOnlyArray<T>, predicate?: Predicate<T>): Array<T>;
-    reject<V: Object, A, T: { [id: string]: A }>(
+    reject<V: Object, A, T: { [id: any]: A }>(
       object?: ?T,
       predicate?: ?OPredicate<A, T>
     ): Array<V>;
@@ -717,7 +717,7 @@ declare module "lodash" {
     size(collection: $ReadOnlyArray<any> | Object | string): number;
     some<T>(array: ?$ReadOnlyArray<T>, predicate?: Predicate<T>): boolean;
     some<T>(array: void | null, predicate?: ?Predicate<T>): false;
-    some<A, T: { [id: string]: A }>(
+    some<A, T: { [id: any]: A }>(
       object?: ?T,
       predicate?: OPredicate<A, T>
     ): boolean;
@@ -1099,19 +1099,19 @@ declare module "lodash" {
         source: A | B | C | D
       ) => any | void
     ): Object;
-    findKey<A, T: { [id: string]: A }>(
+    findKey<A, T: { [id: any]: A }>(
       object: T,
       predicate?: ?OPredicate<A, T>
     ): string | void;
-    findKey<A, T: { [id: string]: A }>(
+    findKey<A, T: { [id: any]: A }>(
       object: void | null,
       predicate?: ?OPredicate<A, T>
     ): void;
-    findLastKey<A, T: { [id: string]: A }>(
+    findLastKey<A, T: { [id: any]: A }>(
       object: T,
       predicate?: ?OPredicate<A, T>
     ): string | void;
-    findLastKey<A, T: { [id: string]: A }>(
+    findLastKey<A, T: { [id: any]: A }>(
       object: void | null,
       predicate?: ?OPredicate<A, T>
     ): void;
@@ -1205,7 +1205,7 @@ declare module "lodash" {
     ): Object;
     omit(object?: ?Object, ...props: Array<string>): Object;
     omit(object?: ?Object, props: Array<string>): Object;
-    omitBy<A, T: { [id: string]: A }|{ [id: number]: A }>(
+    omitBy<A, T: { [id: any]: A }|{ [id: number]: A }>(
       object: T,
       predicate?: ?OPredicate<A, T>
     ): Object;
@@ -1215,7 +1215,7 @@ declare module "lodash" {
     ): {};
     pick(object?: ?Object, ...props: Array<string>): Object;
     pick(object?: ?Object, props: Array<string>): Object;
-    pickBy<A, T: { [id: string]: A }|{ [id: number]: A }>(
+    pickBy<A, T: { [id: any]: A }|{ [id: number]: A }>(
       object: T,
       predicate?: ?OPredicate<A, T>
     ): Object;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -58,8 +58,15 @@ countBy(["one", "two", "three"], "length");
 /**
  * _.difference
  */
-difference((["a", "b"]: $ReadOnlyArray<string>), (["b"]: $ReadOnlyArray<string>));
-difference((["a", "b"]: $ReadOnlyArray<string>), (["b"]: $ReadOnlyArray<string>), (["a"]: $ReadOnlyArray<string>));
+difference(
+  (["a", "b"]: $ReadOnlyArray<string>),
+  (["b"]: $ReadOnlyArray<string>)
+);
+difference(
+  (["a", "b"]: $ReadOnlyArray<string>),
+  (["b"]: $ReadOnlyArray<string>),
+  (["a"]: $ReadOnlyArray<string>)
+);
 
 /**
  * _.differenceBy
@@ -92,6 +99,10 @@ find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.x == 3);
 find({ x: 1, y: 2 }, (a: number, b: string) => a);
 find({ x: 1, y: 2 }, { x: 3 });
 find((["a", "b"]: $ReadOnlyArray<string>), "c");
+// opaque types are allowed as keys of objects
+opaque type O = string;
+const v: { [O]: number } = { x: 1, y: 2 };
+find(v, { x: 3 });
 
 // $ExpectError undefined. This type is incompatible with object type.
 var result: Object = find(users, "active");
@@ -170,8 +181,8 @@ get([{ a: "foo" }, { b: "bar" }, { c: "baz" }], "2");
 get([[1, 2], [3, 4], [5, 6], [7, 8]], "3");
 
 // Nil - it is safe to perform on nil root values, just like nil values along the "get" path
-get(null, 'thing');
-get(undefined, 'data');
+get(null, "thing");
+get(undefined, "data");
 
 /**
  * _.keyBy
@@ -468,15 +479,15 @@ pairs = toPairsIn({ a: 12, b: 100 });
 /**
  * _.pickBy
  */
-(pickBy({a: 2, b: 3, c: 4}, num => num % 2): {[prop: string]: number});
+(pickBy({ a: 2, b: 3, c: 4 }, num => num % 2): { [prop: string]: number });
 (pickBy(null, num => num % 2): {});
 (pickBy(undefined, num => num % 2): {});
-(pickBy({[1]: 1, [2]: 2}, num => num === 2): {[prop: number]: number});
+(pickBy({ [1]: 1, [2]: 2 }, num => num === 2): { [prop: number]: number });
 
 /**
  * _.omitBy
  */
-(omitBy({a: 2, b: 3, c: 4}, num => num % 2): {[prop: string]: number});
+(omitBy({ a: 2, b: 3, c: 4 }, num => num % 2): { [prop: string]: number });
 (omitBy(null, num => num % 2): {});
 (omitBy(undefined, num => num % 2): {});
-(omitBy({[1]: 1, [2]: 2}, num => num === 2): {[prop: number]: number});
+(omitBy({ [1]: 1, [2]: 2 }, num => num === 2): { [prop: number]: number });


### PR DESCRIPTION
this commit changes `[id: string]` to `[id: any]` for many
lodash methods. This is needed because keys can be more than just
strings in JavaScript itself and then in Flow, keys can be opaque
types which before this commit would throw errors.

fixes #1330 

A union of some sort allowing `string | number | Symbol | opaque ...` would be ideal here but I don't know of a way to allow opaque types based on the underlying type?