### PR TITLE
Updates Jest 23's toMatchSnapshot to allow 'any' for propertyMatchers.

### DIFF
--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
@@ -701,14 +701,14 @@ interface JestExpectType {
   /**
    * This ensures that an Object matches the most recent snapshot.
    */
-  toMatchSnapshot(propertyMatchers?: {[key: string]: JestAsymmetricEqualityType}, name?: string): void,
+  toMatchSnapshot(propertyMatchers?: any, name?: string): void,
   /**
    * This ensures that an Object matches the most recent snapshot.
    */
   toMatchSnapshot(name: string): void,
 
   toMatchInlineSnapshot(snapshot?: string): void,
-  toMatchInlineSnapshot(propertyMatchers?: {[key: string]: JestAsymmetricEqualityType}, snapshot?: string): void,
+  toMatchInlineSnapshot(propertyMatchers?: any, snapshot?: string): void,
   /**
    * Use .toThrow to test that a function throws when it is called.
    * If you want to test that a specific error gets thrown, you can provide an

--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
@@ -109,7 +109,7 @@ Object {
 }
 `,
 );
-// $ExpectError
+
 expect({ foo: 1 }).toMatchInlineSnapshot([]);
 expect({ foo: "bar" }).toMatchObject({ baz: "qux" });
 expect("foobar").toMatch(/foo/);


### PR DESCRIPTION
Based on feedback here: https://github.com/facebook/metro/pull/266#discussion_r220581436

This now matches the flow annotations in the Jest source code: https://github.com/facebook/jest/blob/bab6399a89a069273c38cb624236d19be0c98adf/packages/jest-snapshot/src/index.js#L55