### PR TITLE
Update ramda_v0.x.x.js

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
@@ -1307,17 +1307,17 @@ declare module ramda {
   ): { [k: string]: T } & S;
 
   declare function assocPath<T, S>(
-    key: Array<string>,
+    key: Array<string | number>,
     ...args: Array<void>
   ): ((val: T) => (src: S) => { [k: string]: T }) &
     ((val: T) => (src: S) => { [k: string]: T } & S);
   declare function assocPath<T, S>(
-    key: Array<string>,
+    key: Array<string | number>,
     val: T,
     ...args: Array<void>
   ): (src: S) => { [k: string]: T } & S;
   declare function assocPath<T, S>(
-    key: Array<string>,
+    key: Array<string | number>,
     val: T,
     src: S
   ): { [k: string]: T } & S;


### PR DESCRIPTION
Updated method `assocPath` parameter `key`, because this parameter should also support number type
```
const state = {
  controllers: [
    { tracks: [] },
    { tracks: [ 'song1' ] }
  ]
}

const index = 1
const data = ['newSongs1']

R.assocPath(
  ['controllers', index, 'tracks'],
  data,
  state
)
```