### PR TITLE
Add a Prettier config file

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+---
+singleQuote: true
+trailingComma: "es5"
+parser: "flow"


### PR DESCRIPTION
Hi,

I noticed quite some inconsistencies regarding formatting on the definitions. 
I use Prettier when writing them, but with bare defaults in the doubt.

This is a proposal, just a few config keys. Open to bikeshedding. 

Just a first step, but already useful.

We could go even further and add a script alias, a precommit-hook check, if needed.

@villesau @AndrewSouthpaw @GAntoine 
