### PR TITLE
fix "cannot use function type as a type" error

### DIFF
--- a/definitions/npm/history_v4.x.x/flow_v0.25.x-/history_v4.x.x.js
+++ b/definitions/npm/history_v4.x.x/flow_v0.25.x-/history_v4.x.x.js
@@ -24,8 +24,8 @@ declare module "history/createBrowserHistory" {
     goBack(): void,
     goForward(): void,
     listen: Function,
-    block(message: string): Unblock,
-    block((location: BrowserLocation, action: Action) => string): Unblock,
+    block(message: string): typeof Unblock,
+    block((location: BrowserLocation, action: Action) => string): typeof Unblock,
   }
 
   declare export type BrowserHistory = IBrowserHistory;
@@ -72,8 +72,8 @@ declare module "history/createMemoryHistory" {
     // Memory only
     canGo(n: number): boolean,
     listen: Function,
-    block(message: string): Unblock,
-    block((location: MemoryLocation, action: Action) => string): Unblock,
+    block(message: string): typeof Unblock,
+    block((location: MemoryLocation, action: Action) => string): typeof Unblock,
   }
 
   declare export type MemoryHistory = IMemoryHistory;
@@ -114,8 +114,8 @@ declare module "history/createHashHistory" {
     goBack(): void,
     goForward(): void,
     listen: Function,
-    block(message: string): Unblock,
-    block((location: HashLocation, action: Action) => string): Unblock,
+    block(message: string): typeof Unblock,
+    block((location: HashLocation, action: Action) => string): typeof Unblock,
     push(path: string): void,
   }
 


### PR DESCRIPTION
Flow released v0.82.0 with what seems to be a breaking change:

> Removed the ability to use functions as type annotations. This ability was originally designed to support ES3-style classes, but in practice causes confusion and missed errors. We found that the vast majority of added errors were detecting legitimate bugs, and the remainder could be easily updated to ES6 classes.

https://github.com/facebook/flow/releases/tag/v0.82.0

After upgrading to flow v0.82.0, I started seeing these errors:

```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ flow-typed/npm/history_v4.x.x.js:30:29

Cannot use function type as a type because function type is a value. To get the type of a value use typeof.

     27│     goBack(): void,
     28│     goForward(): void,
     29│     listen: Function,
     30│     block(message: string): Unblock,
     31│     block((location: BrowserLocation, action: Action) => string): Unblock,
     32│   }
     33│


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ flow-typed/npm/history_v4.x.x.js:31:67

Cannot use function type as a type because function type is a value. To get the type of a value use typeof.

     28│     goForward(): void,
     29│     listen: Function,
     30│     block(message: string): Unblock,
     31│     block((location: BrowserLocation, action: Action) => string): Unblock,
     32│   }
     33│
     34│   declare export type BrowserHistory = IBrowserHistory;


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ flow-typed/npm/history_v4.x.x.js:78:29

Cannot use function type as a type because function type is a value. To get the type of a value use typeof.

     75│     // Memory only
     76│     canGo(n: number): boolean,
     77│     listen: Function,
     78│     block(message: string): Unblock,
     79│     block((location: MemoryLocation, action: Action) => string): Unblock,
     80│   }
     81│


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ flow-typed/npm/history_v4.x.x.js:79:66

Cannot use function type as a type because function type is a value. To get the type of a value use typeof.

     76│     canGo(n: number): boolean,
     77│     listen: Function,
     78│     block(message: string): Unblock,
     79│     block((location: MemoryLocation, action: Action) => string): Unblock,
     80│   }
     81│
     82│   declare export type MemoryHistory = IMemoryHistory;


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ flow-typed/npm/history_v4.x.x.js:120:29

Cannot use function type as a type because function type is a value. To get the type of a value use typeof.

     117│     goBack(): void,
     118│     goForward(): void,
     119│     listen: Function,
     120│     block(message: string): Unblock,
     121│     block((location: HashLocation, action: Action) => string): Unblock,
     122│     push(path: string): void,
     123│   }


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ flow-typed/npm/history_v4.x.x.js:121:64

Cannot use function type as a type because function type is a value. To get the type of a value use typeof.

     118│     goForward(): void,
     119│     listen: Function,
     120│     block(message: string): Unblock,
     121│     block((location: HashLocation, action: Action) => string): Unblock,
     122│     push(path: string): void,
     123│   }
     124│

```

I'm not 100% sure if this is the correct fix, flow seems happy with these changes.