### PR TITLE
fix order of generic types in MergeWithKey

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-v0.81.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-v0.81.x/ramda_v0.x.x.js
@@ -653,8 +653,11 @@ declare module ramda {
   declare function chain<A, B>(f: (x: A) => B[], xs: A[]): B[]
   declare function chain<A, B>(f: (x: A) => B[]): (xs: A[]) => B[]
 
-  declare function concat<V, T: Array<V> | string>(x: T, y: T): T;
-  declare function concat<V, T: Array<V> | string>(x: T): (y: T) => T;
+  declare function concat<V, T: Array<V>>(x: T, y: T): T;
+  declare function concat<V, T: Array<V>>(x: T): (y: T) => T;
+
+  declare function concat(x: string, y: string): string;
+  declare function concat(x: string): (y: string) => string;
 
   declare function contains<E, T: Array<E> | string>(x: E, xs: T): boolean;
   declare function contains<E, T: Array<E> | string>(

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-v0.81.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-v0.81.x/ramda_v0.x.x.js
@@ -1501,21 +1501,21 @@ declare module ramda {
 
   declare type MergeWithKey = (<
     S: string,
+    T,
     A: { [k: string]: T },
-    B: { [k: string]: T },
-    T
+    B: { [k: string]: T }
   >(
     fn: (s: S, a: T, b: T) => T,
     a: A,
     b: B
   ) => A & B) &
-    (<S: string, A: { [k: string]: T }, B: { [k: string]: T }, T>(
+    (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
       fn: (s: S, a: T, b: T) => T,
     ) => (a: A, b: B) => A & B) &
-    (<S: string, A: { [k: string]: T }, B: { [k: string]: T }, T>(
+    (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
       fn: (s: S, a: T, b: T) => T,
     ) => (a: A) => (b: B) => A & B) &
-    (<S: string, A: { [k: string]: T }, B: { [k: string]: T }, T>(
+    (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
       fn: (s: S, a: T, b: T) => T,
       a: A,
     ) => (b: B) => A & B);

--- a/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
@@ -577,8 +577,11 @@ declare module ramda {
   declare function chain<A, B>(f: (x: A) => B[], xs: A[]): B[]
   declare function chain<A, B>(f: (x: A) => B[]): (xs: A[]) => B[]
 
-  declare function concat<V, T: Array<V> | string>(x: T, y: T): T;
-  declare function concat<V, T: Array<V> | string>(x: T): (y: T) => T;
+  declare function concat<V, T: Array<V>>(x: T, y: T): T;
+  declare function concat<V, T: Array<V>>(x: T): (y: T) => T;
+
+  declare function concat(x: string, y: string): string;
+  declare function concat(x: string): (y: string) => string;
 
   declare function contains<E, T: Array<E> | string>(x: E, xs: T): boolean;
   declare function contains<E, T: Array<E> | string>(
@@ -1425,21 +1428,21 @@ declare module ramda {
 
   declare type MergeWithKey = (<
     S: string,
-    A: { [k: string]: mixed },
-    B: { [k: string]: mixed },
-    T
+    T,
+    A: { [k: string]: T },
+    B: { [k: string]: T }
   >(
     fn: (s: S, a: T, b: T) => T,
     a: A,
     b: B
   ) => A & B) &
-    (<S: string, A: { [k: string]: mixed }, B: { [k: string]: mixed }, T>(
+    (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
       fn: (s: S, a: T, b: T) => T,
     ) => (a: A, b: B) => A & B) &
-    (<S: string, A: { [k: string]: mixed }, B: { [k: string]: mixed }, T>(
+      (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
       fn: (s: S, a: T, b: T) => T,
     ) => (a: A) => (b: B) => A & B) &
-    (<S: string, A: { [k: string]: mixed }, B: { [k: string]: mixed }, T>(
+      (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
       fn: (s: S, a: T, b: T) => T,
       a: A,
     ) => (b: B) => A & B);


### PR DESCRIPTION
Flow (at least 0.82+) is producing the following errors on current typing, unless this fix is applied:

```

Error --------------------------------------------------------------------------- flow-typed/npm/ramda_v0.x.x.js:1431:23

Cannot use function type as a type because function type is a value. To get the type of a value use `typeof`.

   1431|     A: { [k: string]: T },
                               ^


Error --------------------------------------------------------------------------- flow-typed/npm/ramda_v0.x.x.js:1432:23

Cannot use function type as a type because function type is a value. To get the type of a value use `typeof`.

   1432|     B: { [k: string]: T },
                               ^


Error --------------------------------------------------------------------------- flow-typed/npm/ramda_v0.x.x.js:1439:36

Cannot use function type as a type because function type is a value. To get the type of a value use `typeof`.

   1439|     (<S: string, A: { [k: string]: T }, B: { [k: string]: T }, T>(
                                            ^


Error --------------------------------------------------------------------------- flow-typed/npm/ramda_v0.x.x.js:1439:59

Cannot use function type as a type because function type is a value. To get the type of a value use `typeof`.

   1439|     (<S: string, A: { [k: string]: T }, B: { [k: string]: T }, T>(
                                                                   ^


Error --------------------------------------------------------------------------- flow-typed/npm/ramda_v0.x.x.js:1442:36

Cannot use function type as a type because function type is a value. To get the type of a value use `typeof`.

   1442|     (<S: string, A: { [k: string]: T }, B: { [k: string]: T }, T>(
                                            ^


Error --------------------------------------------------------------------------- flow-typed/npm/ramda_v0.x.x.js:1442:59

Cannot use function type as a type because function type is a value. To get the type of a value use `typeof`.

   1442|     (<S: string, A: { [k: string]: T }, B: { [k: string]: T }, T>(
                                                                   ^


Error --------------------------------------------------------------------------- flow-typed/npm/ramda_v0.x.x.js:1445:36

Cannot use function type as a type because function type is a value. To get the type of a value use `typeof`.

   1445|     (<S: string, A: { [k: string]: T }, B: { [k: string]: T }, T>(
                                            ^


Error --------------------------------------------------------------------------- flow-typed/npm/ramda_v0.x.x.js:1445:59

Cannot use function type as a type because function type is a value. To get the type of a value use `typeof`.

   1445|     (<S: string, A: { [k: string]: T }, B: { [k: string]: T }, T>(
                                                                  
```