### PR TITLE
Make ShortIdModule private

### DIFF
--- a/definitions/npm/shortid_v2.2.x/flow_v0.25.x-/shortid_v2.2.x.js
+++ b/definitions/npm/shortid_v2.2.x/flow_v0.25.x-/shortid_v2.2.x.js
@@ -1,13 +1,12 @@
-type ShortIdModule = {
-  (): string,
-  generate(): string,
-  seed(seed: number): ShortIdModule,
-  worker(workerId: number): ShortIdModule,
-  characters(characters: string): string,
-  decode(id: string): { version: number, worker: number },
-  isValid(id: mixed): boolean,
-};
-
 declare module 'shortid' {
+  declare type ShortIdModule = {|
+    (): string,
+    generate(): string,
+    seed(seed: number): ShortIdModule,
+    worker(workerId: number): ShortIdModule,
+    characters(characters: string): string,
+    decode(id: string): { version: number, worker: number },
+    isValid(id: mixed): boolean,
+  |};
   declare module.exports: ShortIdModule;
 };


### PR DESCRIPTION
ShortIdModule is not needed in global scope. It can also be exact type.