### PR TITLE
[papaparse] Fix skipEmptyLines typing

### DIFF
--- a/definitions/npm/papaparse_v4.x.x/flow_v0.39.x-/papaparse_v4.x.x.js
+++ b/definitions/npm/papaparse_v4.x.x/flow_v0.39.x-/papaparse_v4.x.x.js
@@ -31,7 +31,8 @@ declare interface PapaParse$ParseConfig {
     worker?: boolean,
     comments?: boolean,
     download?: boolean,
-    skipEmptyLines?: boolean,
+    // + is required see https://github.com/facebook/flow/issues/3876
+    +skipEmptyLines?: boolean | 'greedy',
     fastMode?: boolean,
     withCredentials?: boolean,
     step?: Function,

--- a/definitions/npm/papaparse_v4.x.x/test_papaparse_v4.x.x.js
+++ b/definitions/npm/papaparse_v4.x.x/test_papaparse_v4.x.x.js
@@ -14,6 +14,17 @@ res.errors[0].code;
   }
 }): PapaParse$ParseResult);
 
+(Papa.parse("3,3,3", {
+  delimiter: ';',
+  comments: false,
+  skipEmptyLines: 'greedy',
+
+  step: function(results, p) {
+    p.abort();
+    results.data.length;
+  }
+}): PapaParse$ParseResult);
+
 // $ExpectError
 (Papa.parse(['data']): PapaParse$ParseResult);
 
@@ -65,8 +76,8 @@ Papa.unparse({
 Papa.unparse({
   fields: ["3"],
   data: ["3"]
-}, { 
-  quotes: true 
+}, {
+  quotes: true
 });
 
 Papa.SCRIPT_PATH;


### PR DESCRIPTION
Papaparse `skipEmptyLines` config option should have `boolean` or string literal `greedy` value, see: https://www.papaparse.com/docs#config.