### PR TITLE
Add some missing functions to fs-extra

### DIFF
--- a/definitions/npm/fs-extra_v7.x.x/flow_all/fs-extra_v7.x.x.js
+++ b/definitions/npm/fs-extra_v7.x.x/flow_all/fs-extra_v7.x.x.js
@@ -1,5 +1,5 @@
 declare module "fs-extra" {
-  import type { Stats } from "fs";
+  import type { Stats, ReadStream, WriteStream } from "fs";
 
   declare export type SymlinkType = "dir" | "file";
   declare export type FsSymlinkType = "dir" | "file" | "junction";
@@ -112,6 +112,8 @@ declare module "fs-extra" {
     callback: (err: Error) => void
   ): void;
   declare export function createFileSync(file: string): void;
+  declare export function createReadStream(path: string, options?: Object): ReadStream;
+  declare export function createWriteStream(path: string, options?: Object): WriteStream;
 
   declare export function ensureDir(path: string): Promise<void>;
   declare export function ensureDir(
@@ -119,6 +121,9 @@ declare module "fs-extra" {
     callback: (err: Error) => void
   ): void;
   declare export function ensureDirSync(path: string): void;
+
+  declare export function exists(path: string): Promise<boolean>;
+  declare export function exists(path: string, callback?: (exists: boolean) => void): void;
 
   declare export function mkdirs(dir: string): Promise<void>;
   declare export function mkdirs(
@@ -612,6 +617,8 @@ declare module "fs-extra" {
     callback: (err: ErrnoError, stats: Stats) => any
   ): void;
   declare export function stat(path: string | Buffer): Promise<Stats>;
+
+  declare export function statSync(path: string): Stats;
 
   declare export function symlink(
     srcpath: string | Buffer,

--- a/definitions/npm/fs-extra_v7.x.x/test_fs-extra_v7.x.x.js
+++ b/definitions/npm/fs-extra_v7.x.x/test_fs-extra_v7.x.x.js
@@ -194,7 +194,7 @@ describe("The `ensureDirSync` function", () => {
 });
 
 describe("The `exists` function", () => {
-  it("take in string and options object", () => {
+  it("take in string", () => {
     (fs.exists('str'): Promise<boolean>);
     // $ExpectError number not allowed
     fs.exists(123);

--- a/definitions/npm/fs-extra_v7.x.x/test_fs-extra_v7.x.x.js
+++ b/definitions/npm/fs-extra_v7.x.x/test_fs-extra_v7.x.x.js
@@ -199,7 +199,7 @@ describe("The `exists` function", () => {
     // $ExpectError number not allowed
     fs.exists(123);
 
-    fs.exists(123, (exists) => {(exists: boolean)})
+    fs.exists('str', (exists) => {(exists: boolean)})
   });
 });
 

--- a/definitions/npm/fs-extra_v7.x.x/test_fs-extra_v7.x.x.js
+++ b/definitions/npm/fs-extra_v7.x.x/test_fs-extra_v7.x.x.js
@@ -160,6 +160,26 @@ describe("The `ensureDir` function", () => {
   });
 });
 
+describe("The `createReadStream` function", () => {
+  it("take in string and options object", () => {
+    fs.createReadStream('str', {});
+    // $ExpectError number not allowed
+    fs.createReadStream(123, {});
+    // $ExpectError options should be object
+    fs.createReadStream('str', 123);
+  });
+});
+
+describe("The `createWriteStream` function", () => {
+  it("take in string and options object", () => {
+    fs.createWriteStream('str', {});
+    // $ExpectError number not allowed
+    fs.createWriteStream(123, {});
+    // $ExpectError options should be object
+    fs.createWriteStream('str', 123);
+  });
+});
+
 describe("The `ensureDirSync` function", () => {
   it("should validate on proper usage", () => {
     fs.ensureDirSync(path);
@@ -170,6 +190,16 @@ describe("The `ensureDirSync` function", () => {
     fs.ensureDirSync();
     // $ExpectError
     fs.ensureDirSync(path).then(() => {});
+  });
+});
+
+describe("The `exists` function", () => {
+  it("take in string and options object", () => {
+    (fs.exists('str'): Promise<boolean>);
+    // $ExpectError number not allowed
+    fs.exists(123);
+
+    fs.exists(123, (exists) => {(exists: boolean)})
   });
 });
 


### PR DESCRIPTION
fs-extra has all the fs functions. I added some of which our CLI relies on. copied from here: https://github.com/facebook/flow/blob/master/lib/node.js

see: https://github.com/jprichardson/node-fs-extra