### PR TITLE
Add missing 'delete' method in react-native-simple-store

### DIFF
--- a/definitions/npm/react-native-simple-store_v1.x.x/flow_v0.25.x-/react-native-simple-store_v1.x.x.js
+++ b/definitions/npm/react-native-simple-store_v1.x.x/flow_v0.25.x-/react-native-simple-store_v1.x.x.js
@@ -2,9 +2,14 @@ declare module 'react-native-simple-store' {
   declare type Key = string | Array<Array<any>>;
   declare type Value = string | boolean | Object | Array<any>;
 
-  declare function get(key: Key): Promise<?any>;
-  declare function save(key: Key, value: Value): Promise<?any>;
-  declare function update(key: string, value: Value): Promise<?any>;
-  declare function keys(): Promise<?any>;
-  declare function push(key: string, value: Value): Promise<?any>;
+  declare type SimpleStore = {
+    get: (key: Key)=> Promise<any>,
+    save: (key: Key, value: Value)=> Promise<any>,
+    update: (key: string, value: Value)=> Promise<any>,
+    keys: ()=> Promise<any>,
+    push: (key: string, value: Value)=> Promise<any>,
+    delete: (key: string | string[])=> Promise<any>,
+  }
+
+  declare module.exports: SimpleStore;
 }

--- a/definitions/npm/react-native-simple-store_v1.x.x/flow_v0.25.x-/test_react-native-simple-store.js
+++ b/definitions/npm/react-native-simple-store_v1.x.x/flow_v0.25.x-/test_react-native-simple-store.js
@@ -20,3 +20,8 @@ store.update('hasItem');
 store.push('items', '1');
 // $ExpectError
 store.push('items');
+
+store.keys();
+
+store.delete("foo");
+store.delete(["foo", "bar"]);


### PR DESCRIPTION
ctx https://github.com/flow-typed/flow-typed/pull/2786


switched to another synthax because `declare function delete` would not pass eslint