### PR TITLE
Expose static class definitions for Bluebird Errors

### DIFF
--- a/definitions/npm/bluebird_v3.x.x/flow_v0.70.x-/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.70.x-/bluebird_v3.x.x.js
@@ -51,11 +51,11 @@ declare type $Promisable<T> = Promise<T> | T;
 declare class Bluebird$Disposable<R> {}
 
 declare class Bluebird$Promise<+R> extends Promise<R> {
-  static RangeError = Class<Bluebird$RangeError>;
-  static CancellationErrors = Class<Bluebird$CancellationErrors>;
-  static TimeoutError = Class<Bluebird$TimeoutError>;
-  static RejectionError = Class<Bluebird$RejectionError>;
-  static OperationalError = Class<Bluebird$OperationalError>;
+  static RangeError: Class<Bluebird$RangeError>;
+  static CancellationErrors: Class<Bluebird$CancellationErrors>;
+  static TimeoutError: Class<Bluebird$TimeoutError>;
+  static RejectionError: Class<Bluebird$RejectionError>;
+  static OperationalError: Class<Bluebird$OperationalError>;
   
   static Defer: Class<Bluebird$Defer>;
   static PromiseInspection: Class<Bluebird$PromiseInspection<*>>;

--- a/definitions/npm/bluebird_v3.x.x/flow_v0.70.x-/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.70.x-/bluebird_v3.x.x.js
@@ -51,6 +51,12 @@ declare type $Promisable<T> = Promise<T> | T;
 declare class Bluebird$Disposable<R> {}
 
 declare class Bluebird$Promise<+R> extends Promise<R> {
+  static RangeError = Class<Bluebird$RangeError>;
+  static CancellationErrors = Class<Bluebird$CancellationErrors>;
+  static TimeoutError = Class<Bluebird$TimeoutError>;
+  static RejectionError = Class<Bluebird$RejectionError>;
+  static OperationalError = Class<Bluebird$OperationalError>;
+  
   static Defer: Class<Bluebird$Defer>;
   static PromiseInspection: Class<Bluebird$PromiseInspection<*>>;
 


### PR DESCRIPTION
I came across this while trying to filter a Bluebird.catch and wasn't sure how to import an internal class def.

Turns out it's much easier / more intuitive to just expose the internal class defs in bluebird for error subtypes.

As an example:
```
Bluebird
  .delay(1000) // Normally an error-prone, slow task
  .timeout(0)
  .catch(Bluebird.TimeoutError, e => ...)
```

Is a common use case to handle timeouts explicitly, but trying to access `Bluebird.TimeoutError` currently throws `Cannot get Bluebird.TimeoutError because property TimeoutError is missing in statics of Bluebird$Promise [1].`