### PR TITLE
[react-apollo] Extract QueryComponentProps

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -933,7 +933,7 @@ declare module "react-apollo" {
     QueryRenderProps<TData, TVariables>
   ) => Node;
 
-  declare export class Query<TData, TVariables> extends React$Component<{
+  declare export type QueryComponentProps<TData, TVariables> = {
     query: DocumentNode,
     children: QueryRenderPropFunction<TData, TVariables>,
     variables?: TVariables,
@@ -945,7 +945,9 @@ declare module "react-apollo" {
     displayName?: string,
     delay?: boolean,
     context?: { [string]: any }
-  }> {}
+  };
+
+  declare export class Query<TData, TVariables> extends React$Component<QueryComponentProps<TData, TVariables>> {}
 
   declare export type SubscriptionResult<TData, TVariables = OperationVariables> = {
     loading: boolean,


### PR DESCRIPTION
As a user of `react-apollo`, it's a common use case to want to create your own higher-order `Query` component to specify default options, additional behaviours, etc.

In order to type that higher order component, we need to export the Props type of the `react-apollo` `Query` component, so that a consumer of the library can use it to define their HoC props type by extending it.

This commit extracts and exports a generic `QueryComponentProps<TData, TVariables>` type. It has no functional changes.