### PR TITLE
Add typeof to material-ui handleEvent

### DIFF
--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
@@ -163,7 +163,7 @@ declare module "@material-ui/core/ButtonBase/createRippleHandler" {
     eventName: string,
     action: string,
     cb: ?Function
-  ) => handleEvent;
+  ) => typeof handleEvent;
 }
 
 declare module "@material-ui/core/ButtonBase" {

--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/test_core_v1.x.x.js
@@ -45,6 +45,7 @@ class TestComponent extends React.Component<{
 }> {
   render() {
     const root = this.props.classes.root
+    return null;
   }
 }
 const StyledTestComponent = withStyles(styles)(TestComponent);


### PR DESCRIPTION
Without this fix, the following error occurs in flow 0.83:

![image](https://user-images.githubusercontent.com/122602/46836793-cbd72400-cd67-11e8-9be8-991037a1c822.png)
