### PR TITLE
forEach shouldn't require a boolean return

### DIFF
--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
@@ -343,7 +343,7 @@ declare class $npm$firebase$database$DataSnapshot {
   child(path?: string): $npm$firebase$database$DataSnapshot;
   exists(): boolean;
   exportVal(): $npm$firebase$database$Value;
-  forEach(action: ($npm$firebase$database$DataSnapshot) => boolean): boolean;
+  forEach(action: ($npm$firebase$database$DataSnapshot) => ?boolean): boolean;
   getPriority(): $npm$firebase$database$Priority;
   hasChild(path: string): boolean;
   hasChildren(): boolean;


### PR DESCRIPTION
TypeScript defs had the same bug (now fixed): https://github.com/firebase/firebase-js-sdk/issues/555

Documentation to back up optional boolean: https://firebase.google.com/docs/reference/js/firebase.database.DataSnapshot#forEach