### PR TITLE
Make Archive.url optional in OpenTok typings

### DIFF
--- a/definitions/npm/opentok_v2.6.x/flow_v0.61.x-/opentok_v2.6.x.js
+++ b/definitions/npm/opentok_v2.6.x/flow_v0.61.x-/opentok_v2.6.x.js
@@ -67,7 +67,7 @@ declare module 'opentok' {
     hasAudio: boolean;
     hasVideo: boolean;
     outputMode: ArchiveOutputMode;
-    url: string;
+    url: ?string;
     delete(callback: (?Error) => any): void;
     stop(callback: (?Error, ?Archive) => any): void;
   }


### PR DESCRIPTION
Based on the docs the `url` field can be null:

>url  | String | The download URL of the available MP4 file. This is only set for an archive with the status set to "available"; **for other archives, (including archives with the status "uploaded") this property is set to null**. The download URL is obfuscated, and the file is only available from the URL for 10 minutes. To generate a new URL, call the OpenTok.getArchive() or OpenTok.listArchives() method.

Reference: https://tokbox.com/developer/sdks/node/reference/Archive.html