### PR TITLE
[apollo-client] Export ApolloClientOptions

### DIFF
--- a/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
+++ b/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
@@ -415,7 +415,7 @@ declare module "apollo-client" {
     +mutate?: MutationBaseOptions<>;
   }
 
-  declare type ApolloClientOptions<TCacheShape> = {
+  declare export type ApolloClientOptions<TCacheShape> = {
     link: ApolloLink,
     cache: ApolloCache<TCacheShape>,
     ssrMode?: boolean,


### PR DESCRIPTION
Adds `export` for `ApolloClientOptions`.