### PR TITLE
prettier: export individual types

### DIFF
--- a/definitions/npm/prettier_v1.x.x/flow_v0.56.x-/prettier_v1.x.x.js
+++ b/definitions/npm/prettier_v1.x.x/flow_v0.56.x-/prettier_v1.x.x.js
@@ -1,9 +1,9 @@
 declare module "prettier" {
-  declare type AST = Object;
-  declare type Doc = Object;
-  declare type FastPath = Object;
+  declare export type AST = Object;
+  declare export type Doc = Object;
+  declare export type FastPath = Object;
 
-  declare type PrettierParserName =
+  declare export type PrettierParserName =
     | "babylon"
     | "flow"
     | "typescript"
@@ -16,17 +16,17 @@ declare module "prettier" {
     | "markdown"
     | "vue";
 
-  declare type PrettierParser = {
+  declare export type PrettierParser = {
     [name: PrettierParserName]: (text: string, options?: Object) => AST
   };
 
-  declare type CustomParser = (
+  declare export type CustomParser = (
     text: string,
     parsers: PrettierParser,
     options: Options
   ) => AST;
 
-  declare type Options = {|
+  declare export type Options = {|
     printWidth?: number,
     tabWidth?: number,
     useTabs?: boolean,
@@ -46,13 +46,13 @@ declare module "prettier" {
     plugins?: Array<string | Plugin>
   |};
 
-  declare type Plugin = {
+  declare export type Plugin = {
     languages: SupportLanguage,
     parsers: { [parserName: string]: Parser },
     printers: { [astFormat: string]: Printer }
   };
 
-  declare type Parser = {
+  declare export type Parser = {
     parse: (
       text: string,
       parsers: { [parserName: string]: Parser },
@@ -61,7 +61,7 @@ declare module "prettier" {
     astFormat: string
   };
 
-  declare type Printer = {
+  declare export type Printer = {
     print: (
       path: FastPath,
       options: Object,
@@ -75,7 +75,7 @@ declare module "prettier" {
     ) => ?Doc
   };
 
-  declare type CursorOptions = {|
+  declare export type CursorOptions = {|
     cursorOffset: number,
     printWidth?: $PropertyType<Options, "printWidth">,
     tabWidth?: $PropertyType<Options, "tabWidth">,
@@ -94,18 +94,18 @@ declare module "prettier" {
     plugins?: $PropertyType<Options, "plugins">
   |};
 
-  declare type CursorResult = {|
+  declare export type CursorResult = {|
     formatted: string,
     cursorOffset: number
   |};
 
-  declare type ResolveConfigOptions = {|
+  declare export type ResolveConfigOptions = {|
     useCache?: boolean,
     config?: string,
     editorconfig?: boolean
   |};
 
-  declare type SupportLanguage = {
+  declare export type SupportLanguage = {
     name: string,
     since: string,
     parsers: Array<string>,
@@ -121,7 +121,7 @@ declare module "prettier" {
     vscodeLanguageIds: Array<string>
   };
 
-  declare type SupportOption = {|
+  declare export type SupportOption = {|
     since: string,
     type: "int" | "boolean" | "choice" | "path",
     deprecated?: string,
@@ -133,18 +133,18 @@ declare module "prettier" {
     choices?: SupportOptionChoice
   |};
 
-  declare type SupportOptionRedirect = {|
+  declare export type SupportOptionRedirect = {|
     options: string,
     value: SupportOptionValue
   |};
 
-  declare type SupportOptionRange = {|
+  declare export type SupportOptionRange = {|
     start: number,
     end: number,
     step: number
   |};
 
-  declare type SupportOptionChoice = {|
+  declare export type SupportOptionChoice = {|
     value: boolean | string,
     description?: string,
     since?: string,
@@ -152,14 +152,14 @@ declare module "prettier" {
     redirect?: SupportOptionValue
   |};
 
-  declare type SupportOptionValue = number | boolean | string;
+  declare export type SupportOptionValue = number | boolean | string;
 
-  declare type SupportInfo = {|
+  declare export type SupportInfo = {|
     languages: Array<SupportLanguage>,
     options: Array<SupportOption>
   |};
 
-  declare type Prettier = {|
+  declare export type Prettier = {|
     format: (source: string, options?: Options) => string,
     check: (source: string, options?: Options) => boolean,
     formatWithCursor: (source: string, options: CursorOptions) => CursorResult,

--- a/definitions/npm/prettier_v1.x.x/flow_v0.56.x-/test_prettier_v1.x.x.js
+++ b/definitions/npm/prettier_v1.x.x/flow_v0.56.x-/test_prettier_v1.x.x.js
@@ -1,4 +1,4 @@
-import prettier from "prettier";
+import prettier, { type Options } from "prettier";
 
 const code = "let x =  10";
 
@@ -13,6 +13,10 @@ prettier.format(code, { printWidth: 80 });
 // $ExpectError (Options should have proper types)
 prettier.format(code, { parser: "flo" });
 prettier.format(code, { parser: "flow" });
+
+// $ExpectError (Same as above, but with explicit annotation)
+const badOptions: Options = { parser: "flo" };
+const goodOptions: Options = { parser: "flow" };
 
 // $ExpectError (Must pass in some source code)
 prettier.check();


### PR DESCRIPTION
Summary:
It is particularly convenient to be able to import the `Options` type,
but before this commit this was not possible.

Test Plan:
Tests fail before this commit and pass after it.

wchargin-branch: prettier-type-exports