### PR TITLE
prettier: fix type of `resolveConfig.sync`

### DIFF
--- a/definitions/npm/prettier_v1.x.x/flow_v0.56.x-/prettier_v1.x.x.js
+++ b/definitions/npm/prettier_v1.x.x/flow_v0.56.x-/prettier_v1.x.x.js
@@ -165,7 +165,7 @@ declare module "prettier" {
     formatWithCursor: (source: string, options: CursorOptions) => CursorResult,
     resolveConfig: {
       (filePath: string, options?: ResolveConfigOptions): Promise<?Options>,
-      sync(filePath: string, options?: ResolveConfigOptions): Promise<?Options>
+      sync(filePath: string, options?: ResolveConfigOptions): ?Options
     },
     clearConfigCache: () => void,
     getSupportInfo: (version?: string) => SupportInfo

--- a/definitions/npm/prettier_v1.x.x/flow_v0.56.x-/test_prettier_v1.x.x.js
+++ b/definitions/npm/prettier_v1.x.x/flow_v0.56.x-/test_prettier_v1.x.x.js
@@ -38,6 +38,13 @@ prettier.formatWithCursor(code, { cursorOffset: 10 });
 prettier.resolveConfig();
 prettier.resolveConfig("/path");
 
+const asyncConfig = prettier.resolveConfig("/path");
+if (asyncConfig != null) {
+  // $ExpectError (Returns promise)
+  (asyncConfig.printWidth: number);
+}
+(prettier.resolveConfig("/path"): Promise<?{ printWidth?: number }>);
+
 // $ExpectError (Options should have proper types)
 prettier.resolveConfig("/path", { useCache: "true" });
 prettier.resolveConfig("/path", { useCache: true });
@@ -45,6 +52,13 @@ prettier.resolveConfig("/path", { useCache: true });
 // $ExpectError (Must include filePath)
 prettier.resolveConfig.sync();
 prettier.resolveConfig.sync("/path");
+
+const syncConfig = prettier.resolveConfig.sync("/path");
+if (syncConfig != null) {
+  (syncConfig.printWidth: void | number);
+}
+// $ExpectError (Does not return promise)
+(syncConfig: Promise<?{ printWidth?: number }>);
 
 // $ExpectError (Options should have proper types)
 prettier.resolveConfig.sync("/path", { useCache: "true" });


### PR DESCRIPTION
Summary:
As the name suggests, the function does not return a promise.

Test Plan:
Regression tests added; they fail before this change and pass after it.
Also, changing the asynchronous version to _not_ return a promise causes
the new tests to fail.

wchargin-branch: prettier-fix-resolveconfig-sync