### PR TITLE
fix(moment): allow maybe string types in moment instantiation

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_v0.25.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.25.x-/moment_v2.x.x.js
@@ -118,23 +118,23 @@ declare class moment$MomentDuration {
 }
 declare class moment$Moment {
   static ISO_8601: string;
-  static (): moment$Moment;
+  static (string?: ?string): moment$Moment;
   static (
     initDate: moment$MomentOptions | number | Date | Array<number> | moment$Moment | string
   ): moment$Moment;
-  static (string: string, format: string | Array<string>): moment$Moment;
+  static (string: ?string, format: string | Array<string>): moment$Moment;
   static (
-    string: string,
+    string: ?string,
     format: string | Array<string>,
     strict: boolean
   ): moment$Moment;
   static (
-    string: string,
+    string: ?string,
     format: string | Array<string>,
     locale: string
   ): moment$Moment;
   static (
-    string: string,
+    string: ?string,
     format: string | Array<string>,
     locale: string,
     strict: boolean

--- a/definitions/npm/moment_v2.x.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.x.x/test_moment-v2.js
@@ -9,6 +9,12 @@ describe('Parse, moment()', () => {
   moment([]);
   moment({});
 
+  const maybeString: ?string = '2015-01-01'
+  moment(maybeString)
+
+  const voidString: string | void = '2015-01-01'
+  moment(voidString)
+
   moment('2015-01-01');
   moment("12-25-1995", "MM-DD-YYYY");
   moment('It is 2012-05-25', 'YYYY-MM-DD', true);


### PR DESCRIPTION
Moment allows for an empty constructor, which was accounted for. But the types did not account for passing a variable that may have an undefined/null value.