### PR TITLE
Add compose export of react-apollo

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -1018,4 +1018,6 @@ declare module "react-apollo" {
     onError?: (error: ApolloError) => mixed,
     context?: { [string]: any }
   }> {}
+
+  declare export var compose: $Compose;
 }

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
@@ -4,6 +4,7 @@ import { it, describe } from "flow-typed-test";
 import {
   ApolloProvider,
   ApolloConsumer,
+  compose,
   Query,
   Mutation,
   Subscription,
@@ -47,6 +48,10 @@ type IQuery = {
 };
 
 const withData: OperationComponent<IQuery> = graphql(query);
+
+// Compose exists and passes type checking
+const noop = (val) => val;
+compose(noop, noop)(true);
 
 it("works with functional component", () => {
   const FunctionalWithData = withData(({ data }) => {


### PR DESCRIPTION
The react-apollo library exports a compose helper which is useful for building applications leveraging react-apollo. This PR adds definitions to the compose methods to avoid flow errors.

https://www.apollographql.com/docs/react/basics/setup#compose

Fixes #2580