### PR TITLE
Improve type definitions for next.js and next-routes Router events

### DIFF
--- a/definitions/npm/next-routes_v1.x.x/flow_v0.47.x-/next-routes_v1.x.x.js
+++ b/definitions/npm/next-routes_v1.x.x/flow_v0.47.x-/next-routes_v1.x.x.js
@@ -40,11 +40,28 @@ declare module 'next-routes' {
     [key: string]: any
   };
 
+  declare export interface RouterEvents {
+    on(event: "routeChangeStart", cb: RouteCallback): RouterEvents,
+    on(event: "routeChangeComplete", cb: RouteCallback): RouterEvents,
+    on(event: "routeChangeError", cb: RouteErrorCallback): RouterEvents,
+    on(event: "beforeHistoryChange", cb: RouteCallback): RouterEvents,
+    on(event: "hashChangeStart", cb: RouteCallback): RouterEvents,
+    on(event: "hashChangeComplete", cb: RouteCallback): RouterEvents,
+
+    off(event: "routeChangeStart", cb: RouteCallback): RouterEvents,
+    off(event: "routeChangeComplete", cb: RouteCallback): RouterEvents,
+    off(event: "routeChangeError", cb: RouteErrorCallback): RouterEvents,
+    off(event: "beforeHistoryChange", cb: RouteCallback): RouterEvents,
+    off(event: "hashChangeStart", cb: RouteCallback): RouterEvents,
+    off(event: "hashChangeComplete", cb: RouteCallback): RouterEvents
+  }
+
   declare export type NextRouter = {
     +route: string,
     +pathname: string,
     +asPath: string,
     +query: Object,
+    events: RouterEvents,
     onRouteChangeStart: ?RouteCallback,
     onRouteChangeComplete: ?RouteCallback,
     onRouteChangeError: ?RouteErrorCallback,
@@ -59,7 +76,23 @@ declare module 'next-routes' {
       url: string,
       as: ?string,
       options?: EventChangeOptions
-    ): Promise<boolean>
+    ): Promise<boolean>,
+    prefetch(url: string): Promise<*>,
+    pushRoute(
+      route: string,
+      params?: { [name: string]: string },
+      options?: any
+    ): Promise<boolean>,
+    replaceRoute(
+      route: string,
+      params?: { [name: string]: string },
+      options?: any
+    ): Promise<boolean>,
+    prefetchRoute(
+      route: string,
+      params?: { [name: string]: string },
+      options?: any
+    ): Promise<*>,
   };
 
   declare type RoutesOpt = {
@@ -80,21 +113,6 @@ declare module 'next-routes' {
     add(pattern: string, page: string): Routes;
     add(name: string, pattern: string, page: string): Routes;
     getRequestHandler(app: Object, customHandler?: (any) => any): Function;
-    pushRoute(
-      route: string,
-      params?: { [name: string]: string },
-      options?: any
-    ): void;
-    replaceRoute(
-      route: string,
-      params?: { [name: string]: string },
-      options?: any
-    ): void;
-    prefetchRoute(
-      route: string,
-      params?: { [name: string]: string },
-      options?: any
-    ): void;
   }
 
   declare module.exports: (opt?: RoutesOpt) => Routes;

--- a/definitions/npm/next-routes_v1.x.x/test_next-routes.js
+++ b/definitions/npm/next-routes_v1.x.x/test_next-routes.js
@@ -2,16 +2,18 @@
 
 import RoutesBuiler, { type Routes } from 'next-routes';
 
-const Router: Routes = RoutesBuiler();
+const routes: Routes = RoutesBuiler();
 
 // $ExpectError
-Router.add();
+routes.add();
 
-const routerV2: Routes = Router.add('about')
-.add('blog', '/blog/:slug')
-.add('user', '/user/:id', 'profile')
-.add('/:noname/:lang(en|es)/:wow+', 'complex')
-.add({name: 'beta', pattern: '/v3', page: 'v3'});
+const routesV2: Routes = routes.add('about')
+  .add('blog', '/blog/:slug')
+  .add('user', '/user/:id', 'profile')
+  .add('/:noname/:lang(en|es)/:wow+', 'complex')
+  .add({name: 'beta', pattern: '/v3', page: 'v3'});
+
+const Router = routes.Router;
 
 Router.pushRoute('blog', {slug: 'hello-world'});
 Router.pushRoute('/blog/hello-world');
@@ -36,3 +38,16 @@ Router.replaceRoute();
 
 // $ExpectError
 Router.prefetchRoute();
+
+// $ExpectError
+Router.events.on('unknown', (url: string) => {});
+// $ExpectError
+Router.events.off('unknown', (url: string) => {});
+
+Router.events.on('routeChangeStart', (url: string) => {});
+Router.events.off('routeChangeStart', (url: string) => {});
+
+Router.events
+  .on("routeChangeStart", (url: string) => {})
+  .on("routeChangeComplete", (url: string) => {})
+  .on("routeChangeError", () => {});

--- a/definitions/npm/next_v7.x.x/flow_v0.53.x-/next_v7.x.x.js
+++ b/definitions/npm/next_v7.x.x/flow_v0.53.x-/next_v7.x.x.js
@@ -56,9 +56,9 @@ declare module "next" {
   declare export type Page<T, S> = {
     ...React$Component<T, S>,
     getInitialProps: (ctx: Context) => Promise<*>
-  }
+  };
 
-  declare export default (opts: Options) => NextApp
+  declare export default (opts: Options) => NextApp;
 }
 
 declare module "next/head" {
@@ -91,7 +91,7 @@ declare module "next/link" {
     passHref?: boolean
   };
 
-  declare export default Class<React$Component<Props>>
+  declare export default Class<React$Component<Props>>;
 }
 
 declare module "next/router" {
@@ -102,9 +102,20 @@ declare module "next/router" {
     url: string
   ) => void;
 
-  declare export type EventEmitter = {
-    on: (event: string, cb: RouteCallback | RouteErrorCallback) => EventEmitter,
-    off: (event: string, cb: RouteCallback | RouteErrorCallback) => EventEmitter
+  declare export interface RouterEvents {
+    on(event: "routeChangeStart", cb: RouteCallback): RouterEvents,
+    on(event: "routeChangeComplete", cb: RouteCallback): RouterEvents,
+    on(event: "routeChangeError", cb: RouteErrorCallback): RouterEvents,
+    on(event: "beforeHistoryChange", cb: RouteCallback): RouterEvents,
+    on(event: "hashChangeStart", cb: RouteCallback): RouterEvents,
+    on(event: "hashChangeComplete", cb: RouteCallback): RouterEvents,
+
+    off(event: "routeChangeStart", cb: RouteCallback): RouterEvents,
+    off(event: "routeChangeComplete", cb: RouteCallback): RouterEvents,
+    off(event: "routeChangeError", cb: RouteErrorCallback): RouterEvents,
+    off(event: "beforeHistoryChange", cb: RouteCallback): RouterEvents,
+    off(event: "hashChangeStart", cb: RouteCallback): RouterEvents,
+    off(event: "hashChangeComplete", cb: RouteCallback): RouterEvents
   }
 
   declare export type EventChangeOptions = {
@@ -116,14 +127,14 @@ declare module "next/router" {
     url: string,
     as: ?string,
     options: EventChangeOptions
-  }) => boolean
+  }) => boolean;
 
   declare export type Router = {
     +route: string,
     +pathname: string,
     +asPath: string,
     +query: Object,
-    events: EventEmitter,
+    events: RouterEvents,
     push(
       url: string,
       as: ?string,
@@ -142,7 +153,7 @@ declare module "next/router" {
     Component: React$ComponentType<T & { router: Router }>
   ): Class<React$Component<T>>;
 
-  declare export default Router
+  declare export default Router;
 }
 
 declare module "next/document" {
@@ -154,12 +165,12 @@ declare module "next/document" {
   declare export default Class<React$Component<any, any>> & {
     getInitialProps: (ctx: Context) => Promise<*>,
     renderPage(cb: Function): void
-  }
+  };
 }
 
 declare module "next/app" {
   import type { Context, Page } from "next";
-  import type { Router } from "next/router"
+  import type { Router } from "next/router";
 
   declare export var Container: Class<React$Component<any, any>>;
 
@@ -167,33 +178,38 @@ declare module "next/app" {
     Component: Page<any, any>,
     router: Router,
     ctx: Context
-  }
+  };
 
   declare export default Class<React$Component<any, any>> & {
     getInitialProps: (appInitialProps: AppInitialProps) => Promise<*>
-  }
+  };
 }
 
 declare module "next/dynamic" {
-
-  declare type ImportedComponent = Promise<null|React$ElementType>
-  declare type ComponentMapping = {[componentName: string]: ImportedComponent}
+  declare type ImportedComponent = Promise<null | React$ElementType>;
+  declare type ComponentMapping = {
+    [componentName: string]: ImportedComponent
+  };
 
   declare type NextDynamicOptions = {
-    loader?: ComponentMapping | () => ImportedComponent,
+    loader?: ComponentMapping | (() => ImportedComponent),
     loading?: React$ElementType,
     timeout?: number,
     delay?: number,
     ssr?: boolean,
-    render?: (props: any, loaded: {[componentName: string]: React$ElementType}) => React$ElementType,
+    render?: (
+      props: any,
+      loaded: { [componentName: string]: React$ElementType }
+    ) => React$ElementType,
     modules?: () => ComponentMapping,
     loadableGenerated?: {
       webpack?: any,
       modules?: any
     }
-  }
+  };
 
   declare export default function dynamic(
     dynamicOptions: any,
-    options: ?NextDynamicOptions): Object
+    options: ?NextDynamicOptions
+  ): Object;
 }

--- a/definitions/npm/next_v7.x.x/test_next_v7.x.x.js
+++ b/definitions/npm/next_v7.x.x/test_next_v7.x.x.js
@@ -62,6 +62,11 @@ app.setAssetPrefix('');
 // $ExpectError
 Router.onRouteChangeStart = {};
 
+// $ExpectError
+Router.events.on('unknown', (url: string) => {});
+// $ExpectError
+Router.events.off('unknown', (url: string) => {});
+
 Router.events.on('routeChangeStart', (url: string) => {});
 Router.events.off('routeChangeStart', (url: string) => {});
 


### PR DESCRIPTION
[next.js](https://github.com/zeit/next.js) now uses a property on `Router` called `events` to manage callbacks.

I've updated the definitions in `next.js` and `next-routes` accordingly.

`events` now uses overloads too, so you can be sure that you have a valid event name! 🎉 