### PR TITLE
[element-resize-detector] Add definitions

### DIFF
--- a/definitions/npm/element-resize-detector_v1.x.x/flow_v0.25.x-/element-resize-detector_v1.x.x.js
+++ b/definitions/npm/element-resize-detector_v1.x.x/flow_v0.25.x-/element-resize-detector_v1.x.x.js
@@ -1,0 +1,14 @@
+declare module "element-resize-detector" {
+  declare type  ErdOptions = {
+    strategy?: 'scroll' | 'object';
+  }
+
+  declare type Erd = {
+    listenTo(element: HTMLElement, callback: (elem: HTMLElement) => void): void;
+    removeListener(element: HTMLElement, callback: (elem: HTMLElement) => void): void;
+    removeAllListeners(element: HTMLElement): void;
+    uninstall(element: HTMLElement): void;
+  }
+
+  declare module.exports: (options?: ErdOptions) => Erd
+}

--- a/definitions/npm/element-resize-detector_v1.x.x/test_element-resize-detector_v1.x.x.js
+++ b/definitions/npm/element-resize-detector_v1.x.x/test_element-resize-detector_v1.x.x.js
@@ -1,15 +1,62 @@
+// @flow
+
 import elementResizeDetectorMaker from 'element-resize-detector';
+import { it, describe } from "flow-typed-test";
 
-const erd = elementResizeDetectorMaker({
-  strategy: "scroll"
+describe('element-resize-detector', () => {
+  const element: HTMLElement = document.createElement('div');
+  const elementResizeHandler = (el: HTMLElement) => { el.offsetWidth };
+  const erd = elementResizeDetectorMaker({
+    strategy: "scroll"
+  });
+
+  describe('method listenTo', () => {
+    it("should be able to attach a listener to an element", () => {
+      erd.listenTo(element, elementResizeHandler);
+    });
+
+    it("should fail without required arguments", () => {
+      // $ExpectError
+      erd.listenTo(element);
+
+      // $ExpectError
+      erd.listenTo();
+    });
+  });
+
+  describe('method removeListener', () => {
+    it("should be able to remove a listener from an element", () => {
+      erd.removeListener(element, elementResizeHandler);
+    });
+
+    it("should fail without required arguments", () => {
+      // $ExpectError
+      erd.removeListener(element);
+
+      // $ExpectError
+      erd.removeListener();
+    });
+  });
+
+  describe('method removeAllListeners', () => {
+    it("should be able to remove all listeners from an element", () => {
+      erd.removeAllListeners(element);
+    });
+
+    it("should fail without required arguments", () => {
+      // $ExpectError
+      erd.removeAllListeners();
+    });
+  });
+
+  describe('method uninstall', () => {
+    it("should completely remove detector from element", () => {
+      erd.uninstall(element);
+    });
+
+    it("should fail without required arguments", () => {
+      // $ExpectError
+      erd.uninstall();
+    });
+  });
 });
-
-const element: HTMLElement = document.createElement('div');
-
-erd.listenTo(element, (testElement) => {});
-
-erd.removeListener(element, (testElement) => {});
-
-erd.removeAllListeners(element);
-
-erd.uninstall(element);

--- a/definitions/npm/element-resize-detector_v1.x.x/test_element-resize-detector_v1.x.x.js
+++ b/definitions/npm/element-resize-detector_v1.x.x/test_element-resize-detector_v1.x.x.js
@@ -1,0 +1,15 @@
+import elementResizeDetectorMaker from 'element-resize-detector';
+
+const erd = elementResizeDetectorMaker({
+  strategy: "scroll"
+});
+
+const element: HTMLElement = document.createElement('div');
+
+erd.listenTo(element, (testElement) => {});
+
+erd.removeListener(element, (testElement) => {});
+
+erd.removeAllListeners(element);
+
+erd.uninstall(element);


### PR DESCRIPTION
Add library definitions for `element-resize-detector`.

- [https://www.npmjs.com/package/element-resize-detector](https://www.npmjs.com/package/element-resize-detector)
- [https://github.com/wnr/element-resize-detector](https://github.com/wnr/element-resize-detector)