### PR TITLE
[fuzzaldrin-plus_v0.6.0] Removing illegal file 'CONTRIBUTING.md'

### DIFF
--- a/definitions/npm/fuzzaldrin-plus_v0.6.0/CONTRIBUTING.md
+++ b/definitions/npm/fuzzaldrin-plus_v0.6.0/CONTRIBUTING.md
@@ -1,8 +1,0 @@
-# fuzzaldrin-plus
-
-> Sublime text like fuzzy filtering - compatible with atom/fuzzaldrin.
-
-Flow-typed type definitions for fuzzaldrin-plus v0.6.0  
-Project: https://github.com/jeancroy/fuzz-aldrin-plus  
-Author: **Jean Christophe Roy** <https://github.com/jeancroy>  
-Definitions by: **Ronald Rey** <https://github.com/reyronald>  


### PR DESCRIPTION
Inclusion of non-conforming file 'CONTIRBUTING.md' breaks `flow-typed install` with the following message:

> UNCAUGHT ERROR: Error: fuzzaldrin-plus_v0.6.0/CONTRIBUTING.md: Unexpected file name. This directory can only contain test files or a libdef file named `fuzzaldrin-plus_v0.6.0.js`.
>     at validationError (/Users/obidan/Projects/BackpackEMR/igniteremotecare/backpackEMR/node_modules/flow-typed/dist/lib/validationErrors.js:14:11)
>     at /Users/obidan/Projects/BackpackEMR/igniteremotecare/backpackEMR/node_modules/flow-typed/dist/lib/npm/npmLibDefs.js:112:53
>     at Array.forEach (<anonymous>)
>     at extractLibDefsFromNpmPkgDir$ (/Users/obidan/Projects/BackpackEMR/igniteremotecare/backpackEMR/node_modules/flow-typed/dist/lib/npm/npmLibDefs.js:94:23)
>     at tryCatch (/usr/local/lib/node_modules/flow-typed/node_modules/regenerator-runtime/runtime.js:65:40)
>     at Generator.invoke [as _invoke] (/usr/local/lib/node_modules/flow-typed/node_modules/regenerator-runtime/runtime.js:303:22)
>     at Generator.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/flow-typed/node_modules/regenerator-runtime/runtime.js:117:21)
>     at tryCatch (/usr/local/lib/node_modules/flow-typed/node_modules/regenerator-runtime/runtime.js:65:40)
>     at invoke (/usr/local/lib/node_modules/flow-typed/node_modules/regenerator-runtime/runtime.js:155:20)
>     at /usr/local/lib/node_modules/flow-typed/node_modules/regenerator-runtime/runtime.js:165:13
>     at <anonymous>
> 