### PR TITLE
[react-copy-to-clipboard] Add definitions

### DIFF
--- a/definitions/npm/react-copy-to-clipboard_v5.x.x/flow_v0.25.x-/react-copy-to-clipboard_v5.x.x.js
+++ b/definitions/npm/react-copy-to-clipboard_v5.x.x/flow_v0.25.x-/react-copy-to-clipboard_v5.x.x.js
@@ -1,0 +1,17 @@
+// @flow
+
+declare module 'react-copy-to-clipboard' {
+  declare export type CopyToClipboardOptions = {
+    debug: boolean,
+    message: string
+  };
+
+  declare export type CopyToClipboardProps = {
+    text: string,
+    onCopy?: (text: string, result: boolean) => void,
+    options?: CopyToClipboardOptions,
+    children?: React$Node
+  };
+
+  declare export default class CopyToClipboard extends React$Component<CopyToClipboardProps> {}
+}

--- a/definitions/npm/react-copy-to-clipboard_v5.x.x/test_react-copy-to-clipboard_v5.x.x.js
+++ b/definitions/npm/react-copy-to-clipboard_v5.x.x/test_react-copy-to-clipboard_v5.x.x.js
@@ -1,0 +1,28 @@
+// @flow
+
+import React from "react";
+import CopyToClipboard from "react-copy-to-clipboard";
+import { it, describe } from "flow-typed-test";
+
+describe('react-copy-to-clipboard', () => {
+  it('should accept all parameters', () => {
+    <CopyToClipboard
+      text="Lorem ipsum dolor sit amet"
+      options={{ debug: true, message: 'Copy to clipboard: #{key}' }}
+      onCopy={(text: string, result: boolean) => {}}
+    >
+      Copy
+    </CopyToClipboard>
+  });
+
+  it("should not fail without optional parameters", () => {
+    <CopyToClipboard text="Lorem ipsum dolor sit amet">
+      Copy
+    </CopyToClipboard>
+  });
+
+  it("should fail without required parameters", () => {
+    // $ExpectError
+    <CopyToClipboard />;
+  });
+});


### PR DESCRIPTION
Add library definitions for `react-copy-to-clipboard`.

- [https://www.npmjs.com/package/react-copy-to-clipboard](https://www.npmjs.com/package/react-copy-to-clipboard)

- [https://github.com/nkbt/react-copy-to-clipboard](https://github.com/nkbt/react-copy-to-clipboard)