### PR TITLE
cache .flow-typed folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,5 @@ script: ./travis.sh
 cache:
   directories:
   - cli/.flow-bins-cache
+  - $HOME/.flow-typed
   - $HOME/.cache/yarn


### PR DESCRIPTION
This should speedup tests as we have a spec that tries to fetch the repo. So instead of cloning the whole repo we can just rebase it -> less data moved -> hopefully faster and more reliable tests 

So from:
```
 PASS  src/lib/npm/__tests__/npmLibDefs-test.js (14.414s)
  ● Console
    console.log src/lib/cacheRepoUtils.js:93
      • flow-typed cache not found, fetching from GitHub...
```
to:
```
 PASS  src/lib/npm/__tests__/npmLibDefs-test.js (11.944s)
  ● Console
    console.log src/lib/cacheRepoUtils.js:108
      • rebasing flow-typed cache...
```