### PR TITLE
issue-2903 momentjs support empty array and object

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_v0.25.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.25.x-/moment_v2.x.x.js
@@ -129,7 +129,11 @@ declare class moment$Moment {
       | string
       | null
       | void
+      | []
+      | {}
   ): moment$Moment;
+  static (array: []): moment$Moment;
+  static (object: {}): moment$Moment;
   static (string: string, format: string | Array<string>): moment$Moment;
   static (
     string: string,

--- a/definitions/npm/moment_v2.x.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.x.x/test_moment-v2.js
@@ -58,7 +58,7 @@ describe('Parse, moment()', () => {
     seconds: "3",
     milliseconds: "123"
   }); // from 2.11.0
-  // $ExpectError hour is invalid type
+
   moment({ hour: null, minute: 10 });
 
   // https://momentjs.com/docs/#/parsing/array/


### PR DESCRIPTION
issue: https://github.com/flow-typed/flow-typed/issues/2903

Allow momentjs constructed using empty array and object. No additional test cased added as we already have the test case here https://github.com/flow-typed/flow-typed/blob/67180766627b6494c5ed464a9aefb3eeb6b9fb68/definitions/npm/moment_v2.x.x/test_moment-v2.js#L9-L10

Btw i found issue committing the PR with GPG activated and got error error .

```shell
error: gpg failed to sign the data
fatal: failed to write commit object
```

Probably because of the pre-hooks commit rule. So this PR is created using commit file that directly updated from GitHub interface.