### PR TITLE
[react-navigation] getCurrentNavigation can be null

### DIFF
--- a/definitions/npm/react-navigation_v2.x.x/flow_v0.60.x-/react-navigation_v2.x.x.js
+++ b/definitions/npm/react-navigation_v2.x.x/flow_v0.60.x-/react-navigation_v2.x.x.js
@@ -535,14 +535,26 @@ declare module 'react-navigation' {
     ) => NavigationEventSubscription,
     getParam: <ParamName>(
       paramName: ParamName,
-      fallback?: $ElementType<$PropertyType<{|
-        ...{| params: {| [ParamName]: void |} |},
-        ...$Exact<S>,
-      |}, 'params'>, ParamName>,
-    ) => $ElementType<$PropertyType<{|
-      ...{| params: {| [ParamName]: void |} |},
-      ...$Exact<S>,
-    |}, 'params'>, ParamName>,
+      fallback?: $ElementType<
+        $PropertyType<
+          {|
+            ...{| params: {| [ParamName]: void |} |},
+            ...$Exact<S>,
+          |},
+          'params'
+        >,
+        ParamName
+      >
+    ) => $ElementType<
+      $PropertyType<
+        {|
+          ...{| params: {| [ParamName]: void |} |},
+          ...$Exact<S>,
+        |},
+        'params'
+      >,
+      ParamName
+    >,
     dangerouslyGetParent: () => NavigationScreenProp<*>,
     isFocused: () => boolean,
     // Shared action creators that exist for all routers
@@ -1213,6 +1225,6 @@ declare module 'react-navigation' {
     dispatch: NavigationDispatch,
     actionSubscribers: Set<NavigationEventCallback>,
     getScreenProps: () => {},
-    getCurrentNavigation: () => NavigationScreenProp<State>
+    getCurrentNavigation: () => ?NavigationScreenProp<State>
   ): NavigationScreenProp<State>;
 }


### PR DESCRIPTION
React Navigation allows this to return a null value, and in fact this is required for proper functioning of `react-navigation-redux-helpers`.

(The change to `getParam`'s `fallback` parameter is just automatic Prettier formatting. Not sure how the last commit skipped it.)

Corresponding React Navigation PR: https://github.com/react-navigation/react-navigation/pull/5173