### PR TITLE
[luxon] fix zone options

### DIFF
--- a/definitions/npm/luxon_v1.x.x/flow_v0.32.0-/luxon_v1.x.x.js
+++ b/definitions/npm/luxon_v1.x.x/flow_v0.32.0-/luxon_v1.x.x.js
@@ -285,7 +285,8 @@ declare module "luxon" {
   |};
 
   declare type SetZoneOptions = {|
-    keepCalendarTime?: ?boolean
+    keepCalendarTime?: ?boolean, // Support deprecated name for keepLocalTime
+    keepLocalTime?: ?boolean,
   |};
 
   declare type DateTimeFieldsOptions = {|

--- a/definitions/npm/luxon_v1.x.x/test_luxon.js
+++ b/definitions/npm/luxon_v1.x.x/test_luxon.js
@@ -490,6 +490,8 @@ if (date.equals(new Date())) {
 (date.setLocale("de-DE"): DateTime);
 
 (date.setZone("America/Detroit"): DateTime);
+(date.setZone("America/Detroit", {keepCalendarTime: true}): DateTime); // Support deprecated name for keepLocalTime
+(date.setZone("America/Detroit", {keepLocalTime: true}): DateTime);
 (date.setZone(new CustomZone()): DateTime);
 
 (date.toBSON(): Date);
@@ -580,7 +582,8 @@ date.toObject({ includeConfig: false }).numberingSystem;
 
 (date.toUTC(): DateTime);
 (date.toUTC(32): DateTime);
-(date.toUTC(32, { keepCalendarTime: true }): DateTime);
+(date.toUTC(32, { keepCalendarTime: true }): DateTime); // Support deprecated name for keepLocalTime
+(date.toUTC(32, { keepLocalTime: true }): DateTime);
 
 (date.until(DateTime.utc()): Duration);
 


### PR DESCRIPTION
`keepCalendarTime` is depreciated in `DateTime.setZone` and `DateTime.toUtc` and will be replaced by `keepLocalTime`.
- Docs: https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#instance-method-setZone
- https://github.com/moment/luxon/blob/master/src/datetime.js#L1144
- https://github.com/moment/luxon/blob/master/src/datetime.js#L1121

`keepCalendarTime` is still supported by `luxon`:
- https://github.com/moment/luxon/blob/master/src/datetime.js#L1152

Changes:
- Add tests to cover deprecated `keepCalendarTime` and new `keepLocalTime`
- Update SetZoneOptions to support both fields