### PR TITLE
Enable to export Component as named-export

### DIFF
--- a/definitions/npm/react-copy-to-clipboard_v5.x.x/flow_v0.25.x-/react-copy-to-clipboard_v5.x.x.js
+++ b/definitions/npm/react-copy-to-clipboard_v5.x.x/flow_v0.25.x-/react-copy-to-clipboard_v5.x.x.js
@@ -13,5 +13,6 @@ declare module 'react-copy-to-clipboard' {
     children?: React$Node
   };
 
+  declare export class CopyToClipboard extends React$Component<CopyToClipboardProps> {}
   declare export default class CopyToClipboard extends React$Component<CopyToClipboardProps> {}
 }

--- a/definitions/npm/react-copy-to-clipboard_v5.x.x/test_react-copy-to-clipboard_v5.x.x.js
+++ b/definitions/npm/react-copy-to-clipboard_v5.x.x/test_react-copy-to-clipboard_v5.x.x.js
@@ -1,28 +1,53 @@
 // @flow
 
 import React from "react";
-import CopyToClipboard from "react-copy-to-clipboard";
+import CopyToClipboard, {CopyToClipboard as NamedCopyToClipboard} from "react-copy-to-clipboard";
 import { it, describe } from "flow-typed-test";
 
 describe('react-copy-to-clipboard', () => {
-  it('should accept all parameters', () => {
-    <CopyToClipboard
-      text="Lorem ipsum dolor sit amet"
-      options={{ debug: true, message: 'Copy to clipboard: #{key}' }}
-      onCopy={(text: string, result: boolean) => {}}
-    >
-      Copy
-    </CopyToClipboard>
+  describe('default', () => {
+    it('should accept all parameters', () => {
+      <CopyToClipboard
+        text="Lorem ipsum dolor sit amet"
+        options={{ debug: true, message: 'Copy to clipboard: #{key}' }}
+        onCopy={(text: string, result: boolean) => {}}
+      >
+        Copy
+      </CopyToClipboard>
+    });
+  
+    it("should not fail without optional parameters", () => {
+      <CopyToClipboard text="Lorem ipsum dolor sit amet">
+        Copy
+      </CopyToClipboard>
+    });
+  
+    it("should fail without required parameters", () => {
+      // $ExpectError
+      <CopyToClipboard />;
+    });
   });
 
-  it("should not fail without optional parameters", () => {
-    <CopyToClipboard text="Lorem ipsum dolor sit amet">
-      Copy
-    </CopyToClipboard>
-  });
-
-  it("should fail without required parameters", () => {
-    // $ExpectError
-    <CopyToClipboard />;
+  describe('named export', () => {
+    it('should accept all parameters', () => {
+      <NamedCopyToClipboard
+        text="Lorem ipsum dolor sit amet"
+        options={{ debug: true, message: 'Copy to clipboard: #{key}' }}
+        onCopy={(text: string, result: boolean) => {}}
+      >
+        Copy
+      </NamedCopyToClipboard>
+    });
+  
+    it("should not fail without optional parameters", () => {
+      <NamedCopyToClipboard text="Lorem ipsum dolor sit amet">
+        Copy
+      </NamedCopyToClipboard>
+    });
+  
+    it("should fail without required parameters", () => {
+      // $ExpectError
+      <NamedCopyToClipboard />;
+    });
   });
 });


### PR DESCRIPTION
It seems OK to treat `react-copy-to-clipboard` as it publishes own component as named-export
https://github.com/nkbt/react-copy-to-clipboard/blob/master/src/index.js
