### PR TITLE
Next.js 7.x.x router push and replace not correct type

### DIFF
--- a/definitions/npm/next_v7.x.x/flow_v0.53.x-/next_v7.x.x.js
+++ b/definitions/npm/next_v7.x.x/flow_v0.53.x-/next_v7.x.x.js
@@ -65,21 +65,21 @@ declare module "next/head" {
   declare module.exports: Class<React$Component<any, any>>;
 }
 
-declare module "next/link" {
-  declare export type URLObject = {
-    +href?: string,
-    +protocol?: string,
-    +slashes?: boolean,
-    +auth?: string,
-    +hostname?: string,
-    +port?: string | number,
-    +host?: string,
-    +pathname?: string,
-    +search?: string,
-    +query?: Object,
-    +hash?: string
-  };
+declare type URLObject = {
+  +href?: string,
+  +protocol?: string,
+  +slashes?: boolean,
+  +auth?: string,
+  +hostname?: string,
+  +port?: string | number,
+  +host?: string,
+  +pathname?: string,
+  +search?: string,
+  +query?: Object,
+  +hash?: string
+};
 
+declare module "next/link" {
   declare export type Props = {
     prefetch?: boolean,
     shallow?: boolean,
@@ -136,13 +136,13 @@ declare module "next/router" {
     +query: Object,
     events: RouterEvents,
     push(
-      url: string,
-      as: ?string,
+      url: string | URLObject,
+      as: ?(string | URLObject),
       options?: EventChangeOptions
     ): Promise<boolean>,
     replace(
-      url: string,
-      as: ?string,
+      url: string | URLObject,
+      as: ?(string | URLObject),
       options?: EventChangeOptions
     ): Promise<boolean>,
     prefetch(url: string): Promise<*>,

--- a/definitions/npm/next_v7.x.x/test_next_v7.x.x.js
+++ b/definitions/npm/next_v7.x.x/test_next_v7.x.x.js
@@ -79,7 +79,6 @@ Router.events.on('routeChangeError', (err: RouteError, url: string) => {
   }
 });
 
-// $ExpectError
 Router.push({});
 
 Router.push("/about");


### PR DESCRIPTION
`Router` components `push` and `replace` have URL as a string, but it can be either string or URL object. The same one as `Link` is using.

`push` and `replace` are using property `change` which accept object or string. [Source code](https://github.com/zeit/next.js/blob/canary/packages/next-server/lib/router/router.js#L146)

`Link` is using `formatUrls` which has the same logic - [Surce code](https://github.com/zeit/next.js/blob/canary/packages/next-server/lib/link.js#L47)