### PR TITLE
[react-loadable] Make type application of ReactLoadable.Map more precisely

### DIFF
--- a/definitions/npm/react-loadable_v5.x.x/flow_v0.56.0-/react-loadable_v5.x.x.js
+++ b/definitions/npm/react-loadable_v5.x.x/flow_v0.56.0-/react-loadable_v5.x.x.js
@@ -1,3 +1,5 @@
+declare type $Await<T, P: Promise<T>> = T;
+
 declare module 'react-loadable' {
   declare type LoadingProps = {
     isLoading: boolean,
@@ -28,7 +30,7 @@ declare module 'react-loadable' {
 
   declare type Options<TProps, TModule> = OptionsWithoutRender<TProps> | OptionsWithRender<TProps, TModule>;
 
-  declare type MapOptions<TProps, TModules: { [key: string]: * }> = {
+  declare type MapOptions<TProps, TModules: { +[key: string]: * }> = {
     ...CommonOptions,
     loader: {
       [key: $Keys<TModules>]: () => Promise<*>
@@ -43,6 +45,15 @@ declare module 'react-loadable' {
   declare type CaptureProps = {
     report(moduleName: string): void
   };
+  
+  /**
+  * A type level function of
+  * <T>({ [string]: () => Promise<T> }) -> ({ [string]: T })
+  * It would be helpful to applicate type arguments into ReactLoadable.Map like below.
+  * 
+  * ReactLoadable.Map<Props, typeof { A: () => import("a") }>({...});
+  */
+  declare type MapModules<L> = $ObjMap<L, <P>(P) => $Await<*, $Call<P>>>;
 
   declare module.exports: {
     <TProps, TModule>(opts: Options<TProps, TModule>): Class<LoadableComponent<TProps>>,

--- a/definitions/npm/react-loadable_v5.x.x/flow_v0.56.0-/react-loadable_v5.x.x.js
+++ b/definitions/npm/react-loadable_v5.x.x/flow_v0.56.0-/react-loadable_v5.x.x.js
@@ -47,11 +47,11 @@ declare module 'react-loadable' {
   };
   
   /**
-  * A type level function of
+  * A type level function like
   * <T>({ [string]: () => Promise<T> }) -> ({ [string]: T })
-  * It would be helpful to applicate type arguments into ReactLoadable.Map like below.
+  * It would be helpful to apply type arguments to Loadable.Map<> like below.
   * 
-  * ReactLoadable.Map<Props, typeof { A: () => import("a") }>({...});
+  * Loadable.Map<Props, typeof { A: () => import("a") }>({...});
   */
   declare type MapModules<L> = $ObjMap<L, <P>(P) => $Await<*, $Call<P>>>;
 

--- a/definitions/npm/react-loadable_v5.x.x/flow_v0.56.0-/test_react-loadable_v5.x.x.js
+++ b/definitions/npm/react-loadable_v5.x.x/flow_v0.56.0-/test_react-loadable_v5.x.x.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import Loadable from 'react-loadable';
+import Loadable, { type MapModules } from 'react-loadable';
 import { describe, it } from 'flow-typed-test';
 
 type Props = { a: string };
@@ -163,6 +163,27 @@ it('Loadable.Map() should work', () => {
       b: () => Promise.resolve(1)
     },
     render: (loaded: { Cmp: { foo: React$ComponentType<{ a: string, b: number }> }, b: number }, props: { a: string }) => <loaded.Cmp.foo a={props.a} b={loaded.b} />
+  });
+
+  <LoadableMap a="foo" />
+});
+
+it('Loadable.Map() can infer type of modules', () => {
+  class Component extends React.Component<{ a: string, b: number }> {}
+  const loader = {
+    Cmp: () => Promise.resolve({ foo: Component }),
+    b: () => Promise.resolve(1)
+  };
+
+  const LoadableMap = Loadable.Map<*, MapModules<typeof loader>>({
+    loading: () => null,
+    loader,
+    render: (loaded, props) => {
+      // $ExpectError
+      (loaded: empty);
+      (loaded: { Cmp: { foo: React$ComponentType<{ a: string, b: number }> }, b: number });
+      return <loaded.Cmp.foo a={props.a} b={loaded.b} />;
+    }
   });
 
   <LoadableMap a="foo" />


### PR DESCRIPTION
## Why

When a programmer uses [Loadable.Map](https://github.com/jamiebuilds/react-loadable#loading-multiple-resources), he faces a situation where a loaded module hasn't any type-restriction.
(Actually, it may evaluate as `empty`)

Then, the programmer applies its own type arguments into `Loadable.Map` like below.

```js
Loadable.Map<Props, { a: () => Promise<string>, b: () => Promise<number> }>({...})
```

But this application causes type error with a message like `Cannot instantiate `MapOptions` because number [1] is incompatible with string [2] in property `b` of type argument `Loadable.Map`.`.

This causes from a restriction of type argument named `TModules`.
It defined as `MapOptions<TProps, TModules: { [key: string]: * }>`,
When type arguments applied to TModules, It seems Flow may infer resctriction of TModules like `{[string]: () => Promise<string> & () => Promise<number>}`, of course actual value like this can't exist anyay.

Therefore, it would be better to relax restriction of TModules to a type of properties as covariant.
It makes Flow can infer TModules more pragmatically.

FYI: A situation described above can reproduce more simply as below.

```js
type T<S: {[string]: * }> = S;
declare var t: T<{a: string, b: number}>;

(t.a); // Cause error
```

[Try code](https://flow.org/try/#0C4TwDgpgBAKgPAZQFxQN4G0DOwBOBLAOwHMBdFAKigF8A+KAXigQG4AoAEwgGMAbAQxzQAbgKjAU8VHxTZ8xADRQARigIBXALZKIOWm1YAKYADo+ASmZA).