### PR TITLE
[react-navigation] - Fix error "ParamName [1] is incompatible with string [2]."

### DIFF
--- a/definitions/npm/react-navigation_v2.x.x/flow_v0.60.x-/react-navigation_v2.x.x.js
+++ b/definitions/npm/react-navigation_v2.x.x/flow_v0.60.x-/react-navigation_v2.x.x.js
@@ -533,7 +533,7 @@ declare module 'react-navigation' {
       eventName: string,
       callback: NavigationEventCallback
     ) => NavigationEventSubscription,
-    getParam: <ParamName>(
+    getParam: <ParamName: string>(
       paramName: ParamName,
       fallback?: $ElementType<
         $PropertyType<


### PR DESCRIPTION
`ParamName` should be a string to be compatible with the type `NavigationParams` where key is a string:

```js
declare export type NavigationParams = {
    [key: string]: mixed,
  };
```

Flow error:

```js
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ flow-typed/npm/react-navigation_v2.x.x.js:539:16

ParamName [1] is incompatible with string [2].

 [2]  72│     [key: string]: mixed,
        :
     536│       eventName: string,
     537│       callback: NavigationEventCallback
     538│     ) => NavigationEventSubscription,
 [1] 539│     getParam: <ParamName>(
     540│       paramName: ParamName,
     541│       fallback?: $ElementType<
     542│         $PropertyType<
```