### PR TITLE
[formik] Fixed typo in `withFormik` HOC definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ cli/package-lock.json
 # Editors
 .vscode
 .idea
+*.iml

--- a/definitions/npm/formik_v0.11.x/flow_v0.59.x-/formik_v0.11.x.js
+++ b/definitions/npm/formik_v0.11.x/flow_v0.59.x-/formik_v0.11.x.js
@@ -277,7 +277,7 @@ declare module "formik" {
   declare export function withFormik<
     Props,
     Values,
-  >(WithFormikConfig<React$ComponentType<Props>, Values>): (
+  >(WithFormikConfig<Props, Values>): (
     Component: React$ComponentType<Props>
   ) => React$ComponentType<$Diff<Props, $ObjMap<FormikProps<Values>, TypeOrVoid>>>;
 }


### PR DESCRIPTION
This pull request fixes a typo in `withFormik` HOC definition.

### Expected
`WithFormikConfig` type and `withFormik` function are polymorphic and expect `Props` and `Values` as type parameters. 
It is expected that `withFormik<Props, Values>` receives argument of type `WithFormikConfig<Props, Values>`.

### Problem
`withFormik<Props, Values>` expects argument of type `WithFormikConfig<`**`React$ComponentType<Props>`**`, Values>`.

### Suggested fix
First type parameter of `withFormik` HOC `React$ComponentType<Props>` needs to be replaced with `Props`.