### PR TITLE
Accepting a type T as options to support custom rendered options

### DIFF
--- a/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/react-select_v1.x.x.js
+++ b/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/react-select_v1.x.x.js
@@ -1,13 +1,6 @@
 declare module 'react-select' {
-  declare type SelectOption = {
-    value: string | number,
-    label: string,
-    clearableValue?: boolean,
-  };
-
-  declare type Option = {
-    [key: string]: any,
-  };
+  declare type OptionType = Object
+  declare type OptionsType = OptionType[]
 
   declare type Props = {
     // html id(s) of element(s) that should be used to describe this input (for assistive tech)
@@ -51,16 +44,16 @@ declare module 'react-select' {
     // whether escape clears the value when the menu is closed
     escapeClearsValue?: boolean,
     // method to filter a single option (option, filterString)
-    filterOption?: (option: Option, filterString: string) => boolean,
+    filterOption?: (option: OptionType, filterString: string) => boolean,
     // boolean to enable default filtering or function to filter the options array ([options], filterString, [values])
     filterOptions?:
       | boolean
       | ((
-          options: Array<Option>,
+          options: OptionsType,
           filterValue: string,
           excludeOptions: Array<{}>,
           props: {}
-        ) => Array<{}>),
+        ) => OptionsType),
     // whether to strip diacritics when filtering
     ignoreAccents?: boolean,
     // whether to perform case-insensitive filtering
@@ -127,12 +120,12 @@ declare module 'react-select' {
     optionComponent?: React$ComponentType<{}>,
     // optionRenderer: function (option) {}
     optionRenderer?: (
-      option: Option,
+      option: OptionType,
       idx: number,
       inputValue: any
     ) => React$Node,
     // array of options
-    options?: Array<SelectOption>,
+    options?: OptionsType,
     // number of entries to page when using page up/down keys
     pageSize?: number,
     // field placeholder, displayed when there's no value
@@ -160,7 +153,7 @@ declare module 'react-select' {
     // path of the label value in option objects
     valueKey?: string,
     // valueRenderer: function (option) {}
-    valueRenderer?: (option: Option, idx?: number) => React$Node,
+    valueRenderer?: (option: OptionType, idx?: number) => React$Node,
     // optional style to apply to the component wrapper
     wrapperStyle?: {},
   };

--- a/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/test_react-select_v1.x.x.js
+++ b/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/test_react-select_v1.x.x.js
@@ -19,7 +19,42 @@ let options = [
 let ValueComponent = (props: {}) => <span />;
 let ValueRenderer = (option: { label: string }) => option.label;
 
-describe('The `Select` component', () => {
+type ParentType = {
+  type: "parent",
+  disabled: true,
+  commonData: string
+}
+
+type ChildType = {
+  type: "child",
+  disabled: false,
+  commonData: string,
+  childData: string,
+}
+
+type OptionType = ParentType | ChildType
+
+let customOptions: OptionType[] =[
+  {
+    type: "parent",
+    disabled: true,
+    commonData: "data"
+  },
+  {
+    type: "child",
+    disabled: false,
+    commonData: "data",
+    childData: "child data 1"
+  },
+  {
+    type: "child",
+    disabled: false,
+    commonData: "data",
+    childData: "child data 2"
+  }
+];
+
+  describe('The `Select` component', () => {
   it('should validate on proper props usage', () => {
     <Select
       addLabelText="Add label, plz"
@@ -101,4 +136,50 @@ describe('The `Select` component', () => {
     // $ExpectError addLabelText cannot be number
     <Select addLabelText={123} />;
   });
+
+  it('should handle custom options', () => {
+    let customOptionRenderer = (o: OptionType) => <span/>;
+    let customFilterOption = (options: OptionType[], filterValue: string) => options;
+    <Select
+      name="name"
+      autoFocus
+      placeholder="Enter data"
+      valueKey="id"
+      labelKey="data"
+      options={customOptions}
+      value=""
+      optionRenderer={customOptionRenderer}
+      filterOptions={customFilterOption}
+    />
+  })
+
+  it('should error when optionRenderer option param type is not the same as options element type', () => {
+    let invalidRenderer = (o: string) => <span/>;
+    // $ExpectError
+    <Select
+      name="name"
+      autoFocus
+      placeholder="Enter data"
+      valueKey="id"
+      labelKey="data"
+      options={customOptions}
+      value=""
+      optionRenderer={invalidRenderer}
+    />
+  })
+
+  it('should error when filterOptions options param type is not an array of options element type', () => {
+    let invalidFilterOptions = (o: string) => <span/>;
+    // $ExpectError
+    <Select
+      name="name"
+      autoFocus
+      placeholder="Enter data"
+      valueKey="id"
+      labelKey="data"
+      options={customOptions}
+      value=""
+      filterOptions={invalidFilterOptions}
+    />
+  })
 });


### PR DESCRIPTION
Accept any type as options in react-select.
The types added in 
https://github.com/flow-typed/flow-typed/pull/2817
break the implementations where a custom optionRenderer and filterOptions are passed