### PR TITLE
Try to fix CI issues by reducing worker count

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -127,13 +127,7 @@ async function getOrderedFlowBinVersions(
 
     const flowBins = apiPayload.data
       .filter(rel => {
-        if (rel.tag_name === 'v0.84.0') {
-          printSkipMessage(
-            rel.tag_name,
-            'https://github.com/facebook/flow/issues/7108',
-          );
-          return false;
-        } else if (rel.tag_name === 'v0.67.0') {
+        if (rel.tag_name === 'v0.67.0') {
           printSkipMessage(
             rel.tag_name,
             'https://github.com/facebook/flow/issues/5922',

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -305,6 +305,8 @@ async function writeFlowConfig(repoDirPath, testDirPath, libDefPath) {
     '[options]',
     'suppress_comment=\\\\(.\\\\|\\n\\\\)*\\\\$ExpectError',
     'include_warnings=true',
+    'sharedmemory.dep_table_pow=19',
+    'sharedmemory.hash_table_pow=21',
     '',
 
     // Be sure to ignore stuff in the node_modules directory of the flow-typed

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -305,8 +305,6 @@ async function writeFlowConfig(repoDirPath, testDirPath, libDefPath) {
     '[options]',
     'suppress_comment=\\\\(.\\\\|\\n\\\\)*\\\\$ExpectError',
     'include_warnings=true',
-    'sharedmemory.dep_table_pow=19',
-    'sharedmemory.hash_table_pow=21',
     'server.max_workers=1',
     '',
 

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -305,7 +305,7 @@ async function writeFlowConfig(repoDirPath, testDirPath, libDefPath) {
     '[options]',
     'suppress_comment=\\\\(.\\\\|\\n\\\\)*\\\\$ExpectError',
     'include_warnings=true',
-    'server.max_workers=1',
+    'server.max_workers=0',
     '',
 
     // Be sure to ignore stuff in the node_modules directory of the flow-typed

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -307,6 +307,7 @@ async function writeFlowConfig(repoDirPath, testDirPath, libDefPath) {
     'include_warnings=true',
     'sharedmemory.dep_table_pow=19',
     'sharedmemory.hash_table_pow=21',
+    'server.max_workers=1',
     '',
 
     // Be sure to ignore stuff in the node_modules directory of the flow-typed


### PR DESCRIPTION
This should increase the hash table size from 8 megabytes to 32 megabytes and dir table size from 2 megabytes to 8 megabytes for libdef tests. Let's see if this fixes our CI issues.

See
https://flow.org/en/docs/config/options/#toc-sharedmemory-dep-table-pow-unsigned-integer
https://flow.org/en/docs/config/options/#toc-sharedmemory-hash-table-pow-unsigned-integer

E: Ended up reducing worker count so that there is only one flow instance per version. This not only fixes the CI issues but should also speed up tests in most of the cases.