### PR TITLE
Add zipkin defs

### DIFF
--- a/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/test_model.js
+++ b/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/test_model.js
@@ -1,0 +1,6 @@
+// @flow
+
+import { model } from 'zipkin'
+
+const e1: model.Endpoint = new model.Endpoint({ serviceName: 'test1' })
+const isEmpty: boolean = e1.isEmpty()

--- a/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/test_model.js
+++ b/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/test_model.js
@@ -1,6 +1,13 @@
 // @flow
 
+import { describe, it } from 'flow-typed-test'
 import { model } from 'zipkin'
 
-const e1: model.Endpoint = new model.Endpoint({ serviceName: 'test1' })
-const isEmpty: boolean = e1.isEmpty()
+describe('Endpoint', () => {
+    describe('isEmpty', () => {
+        it('should return boolean', () => {
+            const e1: model.Endpoint = new model.Endpoint({ serviceName: 'test1' })
+            const isEmpty: boolean = e1.isEmpty()
+        })
+    })
+})

--- a/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/test_option.js
+++ b/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/test_option.js
@@ -1,54 +1,138 @@
 // @flow
 
+import { describe, it } from 'flow-typed-test'
 import { type $Option, option } from 'zipkin'
 
-const o1: $Option<number> = option.None
-const o2: $Option<number> = new option.Some(1)
+describe('Option', () => {
+    it('constructors should construct Option', () => {
+        const o1: $Option<number> = option.None
+        const o2: $Option<number> = new option.Some(1)
+    })
 
-const t1: 'None' = option.None.type 
-const t2: 'Some' = (new option.Some(1)).type
-const t3: 'None' | 'Some' = o1.type
-const t4: 'None' | 'Some' = o2.type
+    it('should have expected .type', () => {
+        const o1: $Option<number> = option.None
+        const o2: $Option<number> = new option.Some(1)
 
-const p1: false = option.None.present
-const p2: true = (new option.Some(1)).present
-const p3: boolean = o1.present
-const p4: boolean = o2.present
+        const t1: 'None' = option.None.type
+        const t2: 'Some' = (new option.Some(1)).type
+        const t3: 'None' | 'Some' = o1.type
+        const t4: 'None' | 'Some' = o2.type
+    })
 
-const o3: $Option<string> = o1.map(x => x.toFixed(2))
-const o4: $Option<string> = o2.map(x => x.toFixed(2))
+    it('should have expected .present', () => {
+        const o1: $Option<number> = option.None
+        const o2: $Option<number> = new option.Some(1)
 
-const v1: void = o1.ifPresent(x => x)
-const v2: void = o2.ifPresent(x => x)
+        const p1: false = option.None.present
+        const p2: true = (new option.Some(1)).present
+        const p3: boolean = o1.present
+        const p4: boolean = o2.present
+    })
 
-const o5: $Option<string> = o1.flatMap(x => option.None)
-const o6: $Option<string> = o1.flatMap(x => new option.Some(x.toFixed(2)))
-const o7: $Option<string> = o2.flatMap(x => option.None)
-const o8: $Option<string> = o2.flatMap(x => new option.Some(x.toFixed(2)))
+    describe('map', () => {
+        it('should return expected type', () => {
+            const f = (x: number): string => x.toFixed(2)
 
-const v3: number = o1.getOrElse(2)
-const v4: number = o1.getOrElse(() => 2)
-const v5: number = o2.getOrElse(2)
-const v6: number = o2.getOrElse(() => 2)
+            const o1: $Option<number> = option.None
+            const o2: $Option<number> = new option.Some(1)
 
-const b1: boolean = o1.equals(o2)
-const b2: boolean = option.None.equals(o2) 
-const b3: boolean = new option.Some(3).equals(o2) 
+            const o3: $Option<string> = o1.map(f)
+            const o4: $Option<string> = o2.map(f)
+        })
+    })
 
-const s1: string = option.None.toString()
-const s2: string = new option.Some(4).toString()
+    describe('ifPresent', () => {
+        it('should provide value, and return void', () => {
+            const f = (x: number): number => x
 
-const b4: boolean = option.isOptional(1)
-const b5: boolean = option.isOptional(option.None)
-const b6: boolean = option.isOptional(new option.Some(1))
+            const o1: $Option<number> = option.None
+            const o2: $Option<number> = new option.Some(1)
 
-option.verifyIsOptional(1)
-option.verifyIsOptional(option.None)
-option.verifyIsOptional(new option.Some(1))
-option.verifyIsNotOptional(1)
-option.verifyIsNotOptional(option.None)
-option.verifyIsNotOptional(new option.Some(1))
+            const v1: void = o1.ifPresent(f)
+            const v2: void = o2.ifPresent(f)
+       })
+    })
 
-const n1: $Option<number> = option.fromNullable(1) 
-const n2: $Option<number> = option.fromNullable(null) 
-const n3: $Option<number> = option.fromNullable(undefined) 
+    describe('flatMap', () => {
+        it('should flatten', () => {
+            const f = (x: number): $Option<string> => option.None
+            const g = (x: number): $Option<string> => new option.Some(x.toFixed(2))
+
+            const o1: $Option<number> = option.None
+            const o2: $Option<number> = new option.Some(1)
+
+            const o5: $Option<string> = o1.flatMap(f)
+            const o6: $Option<string> = o1.flatMap(g)
+            const o7: $Option<string> = o2.flatMap(f)
+            const o8: $Option<string> = o2.flatMap(g)
+        })
+    })
+
+    describe('getOrElse', () => {
+        it('should return value type', () => {
+            const o1: $Option<number> = option.None
+            const o2: $Option<number> = new option.Some(1)
+
+            const v3: number = o1.getOrElse(2)
+            const v4: number = o1.getOrElse(() => 2)
+            const v5: number = o2.getOrElse(2)
+            const v6: number = o2.getOrElse(() => 2)
+        })
+    })
+
+    describe('equals', () => {
+        it('should return boolean', () => {
+            const o1: $Option<number> = option.None
+            const o2: $Option<number> = new option.Some(1)
+
+            const b1: boolean = o1.equals(o2)
+            const b2: boolean = option.None.equals(o2)
+            const b3: boolean = new option.Some(3).equals(o2)
+        })
+    })
+
+    describe('toString', () => {
+        it('should return string', () => {
+            const o1: $Option<number> = option.None
+            const o2: $Option<number> = new option.Some(1)
+
+            const s1: string = option.None.toString()
+            const s2: string = new option.Some(4).toString()
+        })
+    })
+
+    describe('isOptional', () => {
+        it('should return boolean', () => {
+            const o1: $Option<number> = option.None
+            const o2: $Option<number> = new option.Some(1)
+
+            const b4: boolean = option.isOptional(1)
+            const b5: boolean = option.isOptional(option.None)
+            const b6: boolean = option.isOptional(new option.Some(1))
+        })
+    })
+})
+
+describe('verifyIsOptional', () => {
+    it('should accept Option and non-Option and return void', () => {
+        const v1: void = option.verifyIsOptional(1)
+        const v2: void = option.verifyIsOptional(option.None)
+        const v3: void = option.verifyIsOptional(new option.Some(1))
+   })
+})
+
+describe('verifyIsNotOptional', () => {
+    it('should accept Option and non-Option and return void', () => {
+        const v1: void = option.verifyIsNotOptional(1)
+        const v2: void = option.verifyIsNotOptional(option.None)
+        const v3: void = option.verifyIsNotOptional(new option.Some(1))
+    })
+})
+
+describe('fromNullable', () => {
+    it('should return expected Option type', () => {
+        const n1: $Option<number> = option.fromNullable(1)
+        const n2: $Option<number> = option.fromNullable(null)
+        const n3: $Option<number> = option.fromNullable(undefined)
+    })
+})

--- a/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/test_option.js
+++ b/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/test_option.js
@@ -1,0 +1,54 @@
+// @flow
+
+import { type $Option, option } from 'zipkin'
+
+const o1: $Option<number> = option.None
+const o2: $Option<number> = new option.Some(1)
+
+const t1: 'None' = option.None.type 
+const t2: 'Some' = (new option.Some(1)).type
+const t3: 'None' | 'Some' = o1.type
+const t4: 'None' | 'Some' = o2.type
+
+const p1: false = option.None.present
+const p2: true = (new option.Some(1)).present
+const p3: boolean = o1.present
+const p4: boolean = o2.present
+
+const o3: $Option<string> = o1.map(x => x.toFixed(2))
+const o4: $Option<string> = o2.map(x => x.toFixed(2))
+
+const v1: void = o1.ifPresent(x => x)
+const v2: void = o2.ifPresent(x => x)
+
+const o5: $Option<string> = o1.flatMap(x => option.None)
+const o6: $Option<string> = o1.flatMap(x => new option.Some(x.toFixed(2)))
+const o7: $Option<string> = o2.flatMap(x => option.None)
+const o8: $Option<string> = o2.flatMap(x => new option.Some(x.toFixed(2)))
+
+const v3: number = o1.getOrElse(2)
+const v4: number = o1.getOrElse(() => 2)
+const v5: number = o2.getOrElse(2)
+const v6: number = o2.getOrElse(() => 2)
+
+const b1: boolean = o1.equals(o2)
+const b2: boolean = option.None.equals(o2) 
+const b3: boolean = new option.Some(3).equals(o2) 
+
+const s1: string = option.None.toString()
+const s2: string = new option.Some(4).toString()
+
+const b4: boolean = option.isOptional(1)
+const b5: boolean = option.isOptional(option.None)
+const b6: boolean = option.isOptional(new option.Some(1))
+
+option.verifyIsOptional(1)
+option.verifyIsOptional(option.None)
+option.verifyIsOptional(new option.Some(1))
+option.verifyIsNotOptional(1)
+option.verifyIsNotOptional(option.None)
+option.verifyIsNotOptional(new option.Some(1))
+
+const n1: $Option<number> = option.fromNullable(1) 
+const n2: $Option<number> = option.fromNullable(null) 
+const n3: $Option<number> = option.fromNullable(undefined) 

--- a/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/test_recorder.js
+++ b/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/test_recorder.js
@@ -1,0 +1,24 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test'
+import { TraceId, Tracer, model, sampler, type Context, ExplicitContext, BatchRecorder } from 'zipkin'
+
+describe('BatchRecorder', () => {
+    it('should accept Logger', () => {
+        const ctxImpl: Context<TraceId> = new ExplicitContext() 
+        
+        const logger = {
+            logSpan(s: model.Span): void {}
+        }
+
+        const recorder = new BatchRecorder({ logger })
+
+        const tracer2: Tracer = new Tracer({
+            ctxImpl,
+            recorder,
+            sampler: new sampler.Sampler((traceId: TraceId) => true),
+            traceId128Bit: false,
+            localServiceName: 'test2'
+        })
+    })
+})

--- a/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/test_tracer.js
+++ b/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/test_tracer.js
@@ -1,27 +1,19 @@
 // @flow
 
-import { TraceId, Tracer, model, sampler, type Context, ExplicitContext, BatchRecorder, ConsoleRecorder } from 'zipkin'
+import { describe, it } from 'flow-typed-test'
+import { TraceId, Tracer, sampler, type Context, ExplicitContext, ConsoleRecorder } from 'zipkin'
 
-// Example ported from https://github.com/openzipkin/zipkin-js/blob/master/packages/zipkin/README.md 
-const ctxImpl: Context<TraceId> = new ExplicitContext() 
+describe('Tracer', () => {
+    it('should accept proper argument types', () => {
+        // Example ported from https://github.com/openzipkin/zipkin-js/blob/master/packages/zipkin/README.md
+        const ctxImpl: Context<TraceId> = new ExplicitContext()
 
-const tracer1: Tracer = new Tracer({
-  ctxImpl,
-  recorder: new ConsoleRecorder(),
-  sampler: new sampler.CountingSampler(0.01),
-  traceId128Bit: true,
-  localServiceName: 'test1'
-});
-
-const logger = {
-    logSpan(s: model.Span): void {}
-}
-
-const recorder = new BatchRecorder({ logger })
-
-const tracer2: Tracer = new Tracer({
-    ctxImpl,
-    recorder,
-    sampler: new sampler.Sampler((traceId: TraceId) => true),
-    localServiceName: 'test2'
+        const tracer1: Tracer = new Tracer({
+            ctxImpl,
+            recorder: new ConsoleRecorder(),
+            sampler: new sampler.CountingSampler(0.01),
+            traceId128Bit: true,
+            localServiceName: 'test1'
+        })
+    })
 })

--- a/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/test_tracer.js
+++ b/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/test_tracer.js
@@ -1,0 +1,27 @@
+// @flow
+
+import { TraceId, Tracer, model, sampler, type Context, ExplicitContext, BatchRecorder, ConsoleRecorder } from 'zipkin'
+
+// Example ported from https://github.com/openzipkin/zipkin-js/blob/master/packages/zipkin/README.md 
+const ctxImpl: Context<TraceId> = new ExplicitContext() 
+
+const tracer1: Tracer = new Tracer({
+  ctxImpl,
+  recorder: new ConsoleRecorder(),
+  sampler: new sampler.CountingSampler(0.01),
+  traceId128Bit: true,
+  localServiceName: 'test1'
+});
+
+const logger = {
+    logSpan(s: model.Span): void {}
+}
+
+const recorder = new BatchRecorder({ logger })
+
+const tracer2: Tracer = new Tracer({
+    ctxImpl,
+    recorder,
+    sampler: new sampler.Sampler((traceId: TraceId) => true),
+    localServiceName: 'test2'
+})

--- a/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/zipkin_v0.14.x.js
+++ b/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/zipkin_v0.14.x.js
@@ -115,7 +115,7 @@ declare module 'zipkin' {
         setIpv4(ipv4: string): void;
         setPort(port: number): void;
 
-        isEmpty(): void;
+        isEmpty(): boolean;
     }
 
     declare interface model$Annotation {

--- a/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/zipkin_v0.14.x.js
+++ b/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/zipkin_v0.14.x.js
@@ -14,7 +14,7 @@ declare module 'zipkin' {
         letContext<V>(ctx: T, callback: () => V): V;
     }
 
-    declare interface $Sampler {
+    declare export interface $Sampler {
         shouldSample(traceId: TraceId): option$Option<boolean>;
     }
 
@@ -348,9 +348,8 @@ declare module 'zipkin' {
         ServerAddr: Class<Annotation$ServerAddr>,
         LocalAddr: Class<Annotation$LocalAddr>,
         BinaryAnnotation: Class<Annotation$BinaryAnnotation>,
-   }
+    }
 
-    declare export type Sampler = $Sampler
     declare export var sampler: {
         Sampler: Class<sampler$Sampler>,
         CountingSampler: Class<sampler$CountingSampler>,

--- a/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/zipkin_v0.14.x.js
+++ b/definitions/npm/zipkin_v0.14.x/flow_v0.72.x-/zipkin_v0.14.x.js
@@ -1,0 +1,382 @@
+// These are heavily derived from the official zipkin
+// Typescript defs: https://github.com/openzipkin/zipkin-js/blob/master/packages/zipkin/index.d.ts
+// with various tweaks for handling the nested structure of
+// the zipkin exports.
+
+// See notes in various places below for specific oddities,
+// warnings, etc.
+
+declare module 'zipkin' {
+    declare export interface Context<T> {
+        setContext(ctx: T): void;
+        getContext(): T;
+        scoped<V>(callback: () => V): V;
+        letContext<V>(ctx: T, callback: () => V): V;
+    }
+
+    declare interface $Sampler {
+        shouldSample(traceId: TraceId): option$Option<boolean>;
+    }
+
+    declare class sampler$Sampler implements $Sampler {
+        constructor(evaluator: (traceId: TraceId) => boolean): this;
+        shouldSample(traceId: TraceId): option$Option<boolean>;
+    }
+
+    declare class sampler$CountingSampler implements $Sampler {
+        constructor(sampleRate?: number): this;
+        shouldSample(traceId: TraceId): option$Option<boolean>;
+    }
+
+    declare export class Tracer {
+        constructor({ ctxImpl: Context<TraceId>, recorder: Recorder, sampler?: $Sampler, traceId128Bit?: boolean, localServiceName?: string, localEndpoint?: model$Endpoint }): this;
+        id: TraceId;
+
+        scoped<V>(callback: () => V): V;
+        local<V>(name: string, callback: () => V): V;
+        createRootId(isSampled?: option$Option<boolean>, isDebug?: boolean): TraceId;
+        createChildId(): TraceId;
+        letId<V>(traceId: TraceId, callback: () => V): V;
+        setId(traceId: TraceId): void;
+        recordAnnotation(annotation: $Annotation): void;
+        recordMessage(message: string): void;
+        recordServiceName(serviceName: string): void;
+        recordRpc(name: string): void;
+        recordClientAddr(inetAddress: InetAddress): void;
+        recordServerAddr(inetAddress: InetAddress): void;
+        recordLocalAddr(inetAddress: InetAddress): void;
+        recordBinary(key: string, value: boolean | string | number): void;
+        writeIdToConsole(message: any): void;
+    }
+
+    declare export class TraceId {
+        +traceId: string;
+        +parentId: string;
+        +spanId: string;
+        +sampled: option$Option<boolean>;
+        +flags: number;
+
+        isDebug(): boolean;
+
+        constructor(args?: {
+            traceId?: option$Option<string>,
+            parentId?: option$Option<string>,
+            spanId?: string,
+            sampled?: option$Option<boolean>,
+            flags?: number
+        }): this;
+
+        toString(): string;
+    }
+
+    // Restructured to (imho) better capture the intent of
+    // zipkin's option type.  There are also some specific
+    // adjustments/fixes:
+    // - ifPresent returns void. The intended usage, from looking at
+    //   how it's used in the zipkin code base, seems to be side-effects.
+    // - Fixed flatMap signature. The TS signature is identical to map,
+    //   and thus isn't the common definition of flatMap.
+    // - getOrElse returns T. The TS defs introduce an extra V type
+    //   parameter and then throw it away, which seemed odd for any
+    //   case where V != T.
+    declare interface option$OptionMethods<T> {
+        map<V>(fn: (value: T) => V): option$Option<V>;
+        ifPresent<V>(fn: (value: T) => V): void;
+        flatMap<V>(fn: (value: T) => option$Option<V>): option$Option<V>;
+        getOrElse(fnOrValue: (() => T) | T): T;
+        equals(other: option$Option<T>): boolean;
+        toString(): string;
+    }
+
+    declare interface option$None<T> extends option$OptionMethods<T> {
+        type: 'None';
+        present: false;
+    }
+
+    declare class option$Some<T> implements option$OptionMethods<T> {
+        constructor(value: T): this;
+        type: 'Some'; 
+        present: true;
+
+        map<V>(fn: (value: T) => V): option$Option<V>;
+        ifPresent<V>(fn: (value: T) => V): void;
+        flatMap<V>(fn: (value: T) => option$Option<V>): option$Option<V>;
+        getOrElse(fnOrValue: (() => T) | T): T;
+        equals(other: option$Option<T>): boolean;
+        toString(): string;
+    }
+
+    declare type option$Option<T> = option$None<T> | option$Some<T>
+
+    declare class model$Endpoint {
+        constructor({ serviceName?: string, ipv4?: string, port?: number }): this;
+
+        setServiceName(serviceName: string): void;
+        setIpv4(ipv4: string): void;
+        setPort(port: number): void;
+
+        isEmpty(): void;
+    }
+
+    declare interface model$Annotation {
+        timestamp: number;
+        value: string;
+    }
+
+    declare class model$Span {
+        +traceId: string;
+        +parentId?: string;
+        +id: string;
+        +name?: string;
+        +kind?: string;
+        +timestamp?: number;
+        +duration?: number;
+        +localEndpoint?: model$Endpoint;
+        +remoteEndpoint?: model$Endpoint;
+        +annotations: model$Annotation[];
+        +tags: { [ key: string ]: string };
+        +debug: boolean;
+        +shared: boolean;
+
+        constructor(traceId: TraceId): this;
+        setName(name: string): void;
+        setKind(kind: string): void;
+        setTimestamp(timestamp: number): void;
+        setDuration(duration: number): void;
+        setLocalEndpoint(endpoint: model$Endpoint): void;
+        setRemoteEndpoint(endpoint: model$Endpoint): void;
+        addAnnotation(timestamp: number, value: string): void;
+        putTag(key: string, value: string): void;
+        setDebug(debug: boolean): void;
+        setShared(shared: boolean): void;
+    }
+
+    declare export interface JsonEncoder {
+        encode(span: model$Span): string;
+    }
+    
+    declare export class InetAddress {
+        constructor(addr: string): this;
+        static getLocalAddress(): this;
+
+        ipv4(): string;
+        toInt(): number;
+    }
+
+    declare export interface $Annotation {
+        +annotationType: string;
+    }
+
+    declare class Annotation$ClientSend implements $Annotation {
+        +annotationType: string;
+    }
+    declare class Annotation$ClientRecv implements $Annotation {
+        +annotationType: string;
+    }
+    declare class Annotation$ServerSend implements $Annotation {
+        +annotationType: string;
+    }
+    declare class Annotation$ServerRecv implements $Annotation {
+        +annotationType: string;
+    }
+    declare class Annotation$LocalOperationStart implements $Annotation {
+        constructor(name: string): this;
+        +annotationType: string;
+        name: string;
+    }
+    declare class Annotation$LocalOperationStop implements $Annotation {
+        +annotationType: string;
+    }
+
+    declare class Annotation$Message implements $Annotation {
+        constructor(message: string): this;
+        +annotationType: string;
+        message: string;
+    }
+
+    declare class Annotation$ServiceName implements $Annotation {
+        constructor(serviceName: string): this;
+        +annotationType: string;
+        serviceName: string;
+    }
+
+    declare class Annotation$Rpc implements $Annotation {
+        constructor(name: string): this;
+        +annotationType: string;
+        name: string;
+    }
+
+    declare class Annotation$ClientAddr implements $Annotation {
+        constructor(args: { host: InetAddress, port: number }): this;
+        +annotationType: string;
+    }
+
+    declare class Annotation$ServerAddr implements $Annotation {
+        constructor(args: { serviceName: string, host?: InetAddress, port?: number }): this;
+        +annotationType: string;
+        serviceName: string;
+        host: InetAddress;
+        port: number;
+    }
+
+    declare class Annotation$LocalAddr implements $Annotation {
+        constructor(args?: { host?: InetAddress, port?: number }): this;
+        +annotationType: string;
+        host: InetAddress;
+        port: number;
+    }
+
+    declare class Annotation$BinaryAnnotation implements $Annotation {
+        constructor(key: string, value: boolean | string | number): this;
+        +annotationType: string;
+        key: string;
+        value: string;
+    }
+
+    declare export var HttpHeaders: {
+        TraceId: string;
+        SpanId: string;
+        ParentSpanId: string;
+        Sampled: string;
+        Flags: string;
+    };
+
+    declare export interface Record {
+        traceId: TraceId;
+        timestamp: number;
+        annotation: $Annotation;
+    }
+
+    /** The Tracer sends each annotation to a Recorder implementation */
+    declare export interface Recorder {
+        record(rec: Record): void;
+    }
+
+    declare export class BatchRecorder implements Recorder {
+        constructor({ logger: Logger, timeout?: number }): this;
+        record: (rec: Record) => void;
+    }
+
+    declare export class ConsoleRecorder implements Recorder {
+        constructor(logger?: (message: string) => void): this;
+        record: (rec: Record) => void;
+    }
+
+    declare export class ExplicitContext implements Context<TraceId> {
+        setContext(ctx: TraceId): void;
+        getContext(): TraceId;
+        scoped<V>(callback: () => V): V;
+        letContext<V>(ctx: TraceId, callback: () => V): V;
+    }
+
+    declare export type ZipkinHeaders = {
+      'X-B3-TraceId': string,
+      'X-B3-SpanId': string,
+      'X-B3-ParentSpanId'?: string,
+      'X-B3-Sampled'?: '1' | '0'
+    }
+
+    declare type $GenericHeaders = { [string]: string }
+    declare export type RequestZipkinHeaders<T = {}, H = $GenericHeaders> = T & {
+        headers: H & ZipkinHeaders
+    };
+
+    declare class Instrumentation$HttpServer {
+      constructor({ tracer: Tracer, port: number }): this;
+
+      recordRequest(
+        method: string,
+        requestUrl: string,
+        readHeader: <T> (header: string) => option$Option<T>
+      ): TraceId;
+      recordResponse(traceId: TraceId, statusCode: string, error?: Error): void;
+    }
+
+    declare class Instrumentation$HttpClient {
+      constructor({ tracer: Tracer, remoteServiceName?: string }): this;
+
+      recordRequest<T>(
+        request: T,
+        url: string,
+        method: string
+      ): T;
+      recordResponse(traceId: TraceId, statusCode: string): void;
+      recordError(traceId: TraceId, error: Error): void;
+    }
+
+    /** The Logger (or transport) is what the Recorder uses to send spans to Zipkin.
+    * @see https://github.com/openzipkin/zipkin-js/#transports Official transport implementations
+    */
+    declare export interface Logger {
+        logSpan(span: model$Span): void;
+    }
+
+    declare export function createNoopTracer(): Tracer;
+    declare export function randomTraceId(): string;
+
+    // The TS defs provide a nested parametric *type* option.Option<T>
+    // which seems impossible in flow.  So, exporting this at the
+    // top level for now.
+    declare export type $Option<T> = option$Option<T>;
+
+    // The option "namespace" is tricky to export.
+    // AFAICT, there's no way to export an *object* containing a
+    // parameterized class, i.e. there's no way to export an options
+    // *object* that contains a parameterized Some class.
+    // Exporting a parametric class with a static property that is
+    // the parametric class seems to work.
+    declare export class option<T> {
+        static Some: Class<option$Some<T>>;
+        static None: option$None<T>;
+        static isOptional(data: any): boolean;
+        static verifyIsOptional(data: any): void; // Throw error if not a valid option
+        static verifyIsNotOptional(data: any): void; // Throw error if a valid option
+        static fromNullable<V>(nullable: ?V): option$Option<V>;
+    }
+
+    declare export var Annotation: {
+        ClientSend: Class<Annotation$ClientSend>,
+        ClientRecv: Class<Annotation$ClientRecv>,
+        ServerSend: Class<Annotation$ServerSend>,
+        ServerRecv: Class<Annotation$ServerRecv>,
+        LocalOperationStart: Class<Annotation$LocalOperationStart>,
+        LocalOperationStop: Class<Annotation$LocalOperationStop>,
+        Message: Class<Annotation$Message>,
+        ServiceName: Class<Annotation$ServiceName>,
+        Rpc: Class<Annotation$Rpc>,
+        ClientAddr: Class<Annotation$ClientAddr>,
+        ServerAddr: Class<Annotation$ServerAddr>,
+        LocalAddr: Class<Annotation$LocalAddr>,
+        BinaryAnnotation: Class<Annotation$BinaryAnnotation>,
+   }
+
+    declare export type Sampler = $Sampler
+    declare export var sampler: {
+        Sampler: Class<sampler$Sampler>,
+        CountingSampler: Class<sampler$CountingSampler>,
+        neverSample: TraceId => boolean,
+        alwaysSample: TraceId => boolean
+    }
+
+    declare export var Request: {
+        addZipkinHeaders: <T, H>(req: T & { headers?: $GenericHeaders }, traceId: TraceId) => RequestZipkinHeaders<T, H>
+    }
+
+    declare export var Instrumentation: {
+        HttpServer: Class<Instrumentation$HttpServer>,
+        HttpClient: Class<Instrumentation$HttpClient>
+    }
+
+    declare export var model: {
+        Endpoint: Class<model$Endpoint>,
+        Annotation: Class<model$Annotation>,
+        Span: Class<model$Span>
+    }
+    
+    declare export var jsonEncoder: {
+        JSON_V1: JsonEncoder,
+        JSON_V2: JsonEncoder
+    }
+
+    declare export function parseRequestUrl (requestUrl: string): { host: string, path: string };
+}


### PR DESCRIPTION
Add defs for [zipkin](https://www.npmjs.com/package/zipkin), largely ported from that package's [existing Typescript defs](https://github.com/openzipkin/zipkin-js/blob/master/packages/zipkin/index.d.ts).

Most of the tests so far focus on places that diverged from the TS defs either out of necessity (e.g. Option type) or as a result of fixing a type that was clearly incorrect (e.g. Option flatMap, Endpoint isEmpty).  There are higher level tests in test_tracer.js derived from examples in the zipkin package's README.

Things that may be worth a closer look:

* Looking at other tests for inspiration, it wasn't entirely clear whether I should use the TDD `describe`/`it` style or not.  Happy to update these tests if `describe`/`it` is preferred.
* The nested parametric Option/Some/None export seemed tricky.  If anyone has suggestions on ways to improve this, I'd be grateful 😄.