### PR TITLE
Add additional typings for react-testing-library v5.

### DIFF
--- a/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-/react-testing-library_v5.x.x.js
+++ b/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-/react-testing-library_v5.x.x.js
@@ -10,11 +10,23 @@ declare module 'react-testing-library' {
     collapseWhitespace?: boolean,
   };
 
+  declare type SelectorMatchOptions = {selector?: string} & TextMatchOptions;
+
+  declare type AllByText = (
+    text: TextMatch,
+    options?: TextMatchOptions
+  ) => Array<HTMLElement>;
+
+  declare type QueryByText = (
+      text: TextMatch,
+      options?: TextMatchOptions,
+    ) => ?HTMLElement;
+
   declare type GetsAndQueries = {|
     getByTestId: (id: TextMatch, options?: TextMatchOptions) => HTMLElement,
     getByText: (
       text: TextMatch,
-      options?: {selector?: string} & TextMatchOptions,
+      options?: SelectorMatchOptions,
     ) => HTMLElement,
     getByPlaceholderText: (
       text: TextMatch,
@@ -22,24 +34,17 @@ declare module 'react-testing-library' {
     ) => HTMLElement,
     getByLabelText: (
       text: TextMatch,
-      options?: {selector?: string} & TextMatchOptions,
+      options?: SelectorMatchOptions,
     ) => HTMLElement,
+    getAllByLabelText: AllByText,
     getByAltText: (text: TextMatch, options?: TextMatchOptions) => HTMLElement,
     getAll: (text: TextMatch, options?: TextMatchOptions) => Array<HTMLElement>,
+    getAllByText: AllByText,
     queryByTestId: (id: TextMatch, options?: TextMatchOptions) => ?HTMLElement,
     queryByText: (text: TextMatch, options?: TextMatchOptions) => ?HTMLElement,
-    queryByPlaceholderText: (
-      text: TextMatch,
-      options?: TextMatchOptions,
-    ) => ?HTMLElement,
-    queryByLabelText: (
-      text: TextMatch,
-      options?: TextMatchOptions,
-    ) => ?HTMLElement,
-    queryByAltText: (
-      text: TextMatch,
-      options?: TextMatchOptions,
-    ) => ?HTMLElement,
+    queryByPlaceholderText: QueryByText,
+    queryByLabelText: QueryByText,
+    queryByAltText: QueryByText,
     queryAll: (
       text: TextMatch,
       options?: TextMatchOptions,
@@ -82,7 +87,7 @@ declare module 'react-testing-library' {
         timeout?: number,
         mutationObserverOptions?: MutationObserverInit,
       },
-    ) => Promise<T | void>,
+    ) => Promise<T>,
 
     within: (
       element: HTMLElement,

--- a/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-/test_react-testing-library_v5.x.x.js
+++ b/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-/test_react-testing-library_v5.x.x.js
@@ -41,6 +41,13 @@ describe('waitForElement', () => {
       timeout: 100,
     });
   });
+
+  it('should return a usable value.', async (n) => {
+    const usernameElement = await waitForElement(
+      () => document.createElement('input'));
+
+    usernameElement.value = 'chucknorris';
+  })
 });
 
 describe('render', () => {
@@ -325,9 +332,11 @@ describe('text matching API', () => {
     getByTestId,
     queryByText,
     getByText,
+    getAllByText,
     queryByPlaceholderText,
     getByPlaceholderText,
     queryByLabelText,
+    getAllByLabelText,
     getByLabelText,
     queryByAltText,
     getByAltText,
@@ -385,6 +394,14 @@ describe('text matching API', () => {
       collapseWhitespace: true,
       exact: true,
     });
+  });
+
+  it('getAllByText should return array value.', () => {
+    const result: HTMLElement[] = getAllByText('1');
+  });
+
+  it('getAllByLabelText should return array value.', () => {
+    const result: HTMLElement[] = getAllByLabelText('1');
   });
 
   it('queryByPlaceholderText should accept text match arguments', () => {


### PR DESCRIPTION
  * Removes the nullable option for the return value of waitForElement. That null is not in the typescript typings and the return value is truthy or throws an error.
  * Adds getAllByText typings.
  * Adds getAllByLabelText typings.