### PR TITLE
[ramda_0.x.x][Issue #1899] Update `pipe()` types and add tests 

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
@@ -311,37 +311,52 @@ declare module ramda {
       args: [A, B, C, D, E, F, G, H, I]
     ) => () => R);
 
-  declare type Pipe = (<A, B, C, D, E, F, G>(
-    ab: UnaryFn<A, B>,
-    bc: UnaryFn<B, C>,
-    cd: UnaryFn<C, D>,
-    de: UnaryFn<D, E>,
-    ef: UnaryFn<E, F>,
-    fg: UnaryFn<F, G>,
-  ) => UnaryFn<A, G>) &
-    (<A, B, C, D, E, F>(
-      ab: UnaryFn<A, B>,
-      bc: UnaryFn<B, C>,
-      cd: UnaryFn<C, D>,
-      de: UnaryFn<D, E>,
-      ef: UnaryFn<E, F>,
-    ) => UnaryFn<A, F>) &
-    (<A, B, C, D, E>(
-      ab: UnaryFn<A, B>,
-      bc: UnaryFn<B, C>,
-      cd: UnaryFn<C, D>,
-      de: UnaryFn<D, E>,
-    ) => UnaryFn<A, E>) &
-    (<A, B, C, D>(
-      ab: UnaryFn<A, B>,
-      bc: UnaryFn<B, C>,
-      cd: UnaryFn<C, D>,
-    ) => UnaryFn<A, D>) &
-    (<A, B, C>(
-      ab: UnaryFn<A, B>,
-      bc: UnaryFn<B, C>,
-    ) => UnaryFn<A, C>) &
-    (<A, B>(ab: UnaryFn<A, B>) => UnaryFn<A, B>);
+  declare var pipe: {
+    <A, B, C, D, E, F, G>(ab: UnaryFn<A, B>, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>, ef: UnaryFn<E, F>, fg: UnaryFn<F, G>): UnaryFn<A, G>,
+    <A0, A1, B, C, D, E, F, G>(ab: (A0, A1) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>, ef: UnaryFn<E, F>, fg: UnaryFn<F, G>): (A0, A1) => G,
+    <A0, A1, A2, B, C, D, E, F, G>(ab: (A0, A1, A2) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>, ef: UnaryFn<E, F>, fg: UnaryFn<F, G>): (A0, A1, A2) => G,
+    <A0, A1, A2, A3, B, C, D, E, F, G>(ab: (A0, A1, A2, A3) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>, ef: UnaryFn<E, F>, fg: UnaryFn<F, G>): (A0, A1, A2, A3) => G,
+    <A0, A1, A2, A3, A4, B, C, D, E, F, G>(ab: (A0, A1, A2, A3, A4) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>, ef: UnaryFn<E, F>, fg: UnaryFn<F, G>): (A0, A1, A2, A3, A4) => G,
+    <A0, A1, A2, A3, A4, A5, B, C, D, E, F, G>(ab: (A0, A1, A2, A3, A4, A5) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>, ef: UnaryFn<E, F>, fg: UnaryFn<F, G>): (A0, A1, A2, A3, A4, A5) => G,
+
+    <A, B, C, D, E, F>(ab: UnaryFn<A, B>, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>, ef: UnaryFn<E, F>): UnaryFn<A, F>,
+    <A0, A1, B, C, D, E, F>(ab: (A0, A1) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>, ef: UnaryFn<E, F>): (A0, A1) => F,
+    <A0, A1, A2, B, C, D, E, F>(ab: (A0, A1, A2) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>, ef: UnaryFn<E, F>): (A0, A1, A2) => F,
+    <A0, A1, A2, A3, B, C, D, E, F>(ab: (A0, A1, A2, A3) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>, ef: UnaryFn<E, F>): (A0, A1, A2, A3) => F,
+    <A0, A1, A2, A3, A4, B, C, D, E, F>(ab: (A0, A1, A2, A3, A4) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>, ef: UnaryFn<E, F>): (A0, A1, A2, A3, A4) => F,
+    <A0, A1, A2, A3, A4, A5, B, C, D, E, F>(ab: (A0, A1, A2, A3, A4, A5) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>, ef: UnaryFn<E, F>): (A0, A1, A2, A3, A4, A5) => F,
+
+    <A, B, C, D, E>(ab: UnaryFn<A, B>, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>): UnaryFn<A, E>,
+    <A0, A1, B, C, D, E>(ab: (A0, A1) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>): (A0, A1) => E,
+    <A0, A1, A2, B, C, D, E>(ab: (A0, A1, A2) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>): (A0, A1, A2) => E,
+    <A0, A1, A2, A3, B, C, D, E>(ab: (A0, A1, A2, A3) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>): (A0, A1, A2, A3) => E,
+    <A0, A1, A2, A3, A4, B, C, D, E>(ab: (A0, A1, A2, A3, A4) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>): (A0, A1, A2, A3, A4) => E,
+    <A0, A1, A2, A3, A4, A5, B, C, D, E>(ab: (A0, A1, A2, A3, A4, A5) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>, de: UnaryFn<D, E>): (A0, A1, A2, A3, A4, A5) => E,
+
+    <A, B, C, D>(ab: UnaryFn<A, B>, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>): UnaryFn<A, D>,
+    <A0, A1, B, C, D>(ab: (A0, A1) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>): (A0, A1) => D,
+    <A0, A1, A2, B, C, D>(ab: (A0, A1, A2) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>): (A0, A1, A2) => D,
+    <A0, A1, A2, A3, B, C, D>(ab: (A0, A1, A2, A3) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>): (A0, A1, A2, A3) => D,
+    <A0, A1, A2, A3, A4, B, C, D>(ab: (A0, A1, A2, A3, A4) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>): (A0, A1, A2, A3, A4) => D,
+    <A0, A1, A2, A3, A4, A5, B, C, D>(ab: (A0, A1, A2, A3, A4, A5) => B, bc: UnaryFn<B, C>, cd: UnaryFn<C, D>): (A0, A1, A2, A3, A4, A5) => D,
+
+    <A, B, C>(ab: UnaryFn<A, B>, bc: UnaryFn<B, C>): UnaryFn<A, C>,
+    <A0, A1, B, C>(ab: (A0, A1) => B, bc: UnaryFn<B, C>): (A0, A1) => C,
+    <A0, A1, A2, B, C>(ab: (A0, A1, A2) => B, bc: UnaryFn<B, C>): (A0, A1, A2) => C,
+    <A0, A1, A2, A3, B, C>(ab: (A0, A1, A2, A3) => B, bc: UnaryFn<B, C>): (A0, A1, A2, A3) => C,
+    <A0, A1, A2, A3, A4, B, C>(ab: (A0, A1, A2, A3, A4) => B, bc: UnaryFn<B, C>): (A0, A1, A2, A3, A4) => C,
+    <A0, A1, A2, A3, A4, A5, B, C>(ab: (A0, A1, A2, A3, A4, A5) => B, bc: UnaryFn<B, C>): (A0, A1, A2, A3, A4, A5) => C,
+
+
+    <A, B>(ab: UnaryFn<A, B>): UnaryFn<A, B>,
+    <A0, A1, B>(ab: (A0, A1) => B): (A0, A1) => B,
+    <A0, A1, A2, B>(ab: (A0, A1, A2) => B): (A0, A1, A2) => B,
+    <A0, A1, A2, A3, B>(ab: (A0, A1, A2, A3) => B): (A0, A1, A2, A3) => B,
+    <A0, A1, A2, A3, A4, B>(ab: (A0, A1, A2, A3, A4) => B): (A0, A1, A2, A3, A4) => B,
+    <A0, A1, A2, A3, A4, A5, B>(ab: (A0, A1, A2, A3, A4, A5) => B): (A0, A1, A2, A3, A4, A5) => B,
+  };
+
+  declare type Pipe = typeof pipe;
 
   declare type PipeP = (<A, B, C, D, E, F, G>(
     ab: UnaryPromiseFn<A, B>,
@@ -461,7 +476,6 @@ declare module ramda {
    */
 
   declare var compose: Compose;
-  declare var pipe: Pipe;
   declare var pipeK: PipeK;
   declare var pipeP: PipeP;
   declare var curry: Curry;

--- a/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/test_ramda_v0.x.x_pipe.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/test_ramda_v0.x.x_pipe.js
@@ -1,0 +1,228 @@
+// @flow
+import { describe, it } from "flow-typed-test";
+import { pipe } from "ramda";
+
+// f - function
+// a - argument
+// unf - unary function
+function f1(a1: number): number {
+  return 69;
+}
+
+function f2(a1: number, a2: string): number {
+  return 69;
+}
+
+function f3(a1: number, a2: string, a3: boolean): number {
+  return 69;
+}
+
+function f4(a1: number, a2: string, a3: boolean, a4: number): number {
+  return 69;
+}
+
+function f5(a1: number, a2: string, a3: boolean, a4: number, a5: string): number {
+  return 69;
+}
+
+function unf1(a1: number): string {
+  return "69";
+}
+
+function unf2(a1: string): boolean {
+  return false;
+}
+
+function unf3(a1: boolean): number {
+  return 69;
+}
+
+function unf4(a1: number): string {
+  return "69";
+}
+
+function unf5(a1: string): boolean {
+  return true;
+}
+
+describe("pipe(...fn)", () => {
+  describe('call "pipe" with unary function', () => {
+    it("rises an error when function chain broken", () => {
+      // $ExpectError - unf1 return string but unf3 first argument boolean
+      pipe(f1, unf1, unf3, unf4, unf5)(1);
+    });
+
+    it("passes when used properly", () => {
+      (pipe(f1, unf1, unf2, unf3, unf4, unf5)(1): boolean);
+      (pipe(f1, unf1, unf2, unf3, unf4)(1): string);
+      (pipe(f1, unf1, unf2, unf3)(1): number);
+      (pipe(f1, unf1, unf2)(1): boolean);
+      (pipe(f1, unf1)(1): string);
+      (pipe(f1)(1): number);
+    });
+
+    it("raises an error when passed more arguments than it need", () => {
+      // $ExpectError - too many arguments
+      pipe(f1)(1, "1", true);
+    });
+
+    it("raises an error when passed too few arguments", () => {
+      // $ExpectError - too few arguments
+      pipe(f1)();
+    });
+
+    it("raises an error when passed an invalid argument", () => {
+      //$ExpectError - boolean  is incompatible with number
+      pipe(f1, unf1)(true);
+    });
+
+    it("raises an error when trying to recognize an unexpected type", () => {
+      //$ExpectError - boolean  is incompatible with string
+      (pipe(f1, unf1)(1): boolean);
+    });
+  });
+
+  describe('call "pipe" with double function', () => {
+    it("rises an error when function chain broken", () => {
+      // $ExpectError - unf1 return string but unf3 first argument boolean
+      pipe(f2, unf1, unf3, unf4, unf5)(1, "2");
+    });
+
+    it("passes when used properly", () => {
+      (pipe(f2, unf1, unf2, unf3, unf4, unf5)(1, "2"): boolean);
+      (pipe(f2, unf1, unf2, unf3, unf4)(1, "2"): string);
+      (pipe(f2, unf1, unf2, unf3)(1, "2"): number);
+      (pipe(f2, unf1, unf2)(1, "2"): boolean);
+      (pipe(f2, unf1)(1, "2"): string);
+      (pipe(f2)(1, "2"): number);
+    });
+
+    it("raises an error when passed more arguments than it need", () => {
+      // $ExpectError - too many arguments
+      pipe(f2)(1, "2", true, 4, "5");
+    });
+
+    it("raises an error when passed too few arguments", () => {
+      // $ExpectError - too few arguments
+      pipe(f2)(1);
+    });
+
+    it("raises an error when passed an invalid argument", () => {
+      //$ExpectError - boolean  is incompatible with string
+      pipe(f2, unf1)(1, true);
+    });
+
+    it("raises an error when trying to recognize an unexpected type", () => {
+      //$ExpectError - boolean  is incompatible with string
+      (pipe(f2, unf1)(1, "2"): boolean);
+    });
+  });
+
+  describe('call "pipe" with triple function', () => {
+    it("rises an error when function chain broken", () => {
+      // $ExpectError - unf1 return string but unf3 first argument boolean
+      pipe(f3, unf1, unf3, unf4, unf5)(1, "2", true);
+    });
+
+    it("passes when used properly", () => {
+      (pipe(f3, unf1, unf2, unf3, unf4, unf5)(1, "2", true): boolean);
+      (pipe(f3, unf1, unf2, unf3, unf4)(1, "2", true): string);
+      (pipe(f3, unf1, unf2, unf3)(1, "2", true): number);
+      (pipe(f3, unf1, unf2)(1, "2", true): boolean);
+      (pipe(f3, unf1)(1, "2", true): string);
+      (pipe(f3)(1, "2", true): number);
+    });
+
+    it("raises an error when passed more arguments than it need", () => {
+      // $ExpectError - too many arguments
+      pipe(f3)(1, "2", true, 4, "5");
+    });
+
+    it("raises an error when passed too few arguments", () => {
+      // $ExpectError - too few arguments
+      pipe(f3)(1, "2");
+    });
+
+    it("raises an error when passed an invalid argument", () => {
+      //$ExpectError - number is incompatible with boolean
+      pipe(f3, unf1)(1, "2", 999);
+    });
+
+    it("raises an error when trying to recognize an unexpected type", () => {
+      //$ExpectError - boolean  is incompatible with string
+      (pipe(f3, unf1)(1, "2", true): boolean);
+    });
+  });
+
+  describe('call "pipe" with function that takes 4 arguments', () => {
+    it("rises an error when function chain broken", () => {
+      // $ExpectError - unf1 return string but unf3 first argument boolean
+      pipe(f4, unf1, unf3, unf4, unf5)(1, "2", true, 4);
+    });
+
+    it("passes when used properly", () => {
+      (pipe(f4, unf1, unf2, unf3, unf4, unf5)(1, "2", true, 4): boolean);
+      (pipe(f4, unf1, unf2, unf3, unf4)(1, "2", true, 4): string);
+      (pipe(f4, unf1, unf2, unf3)(1, "2", true, 4): number);
+      (pipe(f4, unf1, unf2)(1, "2", true, 4): boolean);
+      (pipe(f4, unf1)(1, "2", true, 4): string);
+      (pipe(f4)(1, "2", true, 4): number);
+    });
+
+    it("raises an error when passed more arguments than it need", () => {
+      // $ExpectError - too many arguments
+      pipe(f4)(1, "2", true, 4, "5", 6, false);
+    });
+
+    it("raises an error when passed too few arguments", () => {
+      // $ExpectError - too few arguments
+      pipe(f4)(1, "2", true);
+    });
+
+    it("raises an error when passed an invalid argument", () => {
+      //$ExpectError - string is incompatible with number
+      pipe(f4, unf1)(1, "2", true, "new number");
+    });
+
+    it("raises an error when trying to recognize an unexpected type", () => {
+      //$ExpectError - boolean  is incompatible with string
+      (pipe(f4, unf1)(1, "2", true, 4): boolean);
+    });
+  });
+
+  describe('call "pipe" with function that takes 5 arguments', () => {
+    it("rises an error when function chain broken", () => {
+      // $ExpectError - unf1 return string but unf3 first argument boolean
+      pipe(f5, unf1, unf3, unf4, unf5)(1, "2", true, 4, "5");
+    });
+
+    it("passes when used properly", () => {
+      (pipe(f5, unf1, unf2, unf3, unf4, unf5)(1, "2", true, 4, "5"): boolean);
+      (pipe(f5, unf1, unf2, unf3, unf4)(1, "2", true, 4, "5"): string);
+      (pipe(f5, unf1, unf2, unf3)(1, "2", true, 4, "5"): number);
+      (pipe(f5, unf1, unf2)(1, "2", true, 4, "5"): boolean);
+      (pipe(f5, unf1)(1, "2", true, 4, "5"): string);
+      (pipe(f5)(1, "2", true, 4, "5"): number);
+    });
+
+    it("raises an error when passed more arguments than it need", () => {
+      // $ExpectError - too many arguments
+      pipe(f5)(1, "2", true, 4, "5", 6, 7, 8);
+    });
+
+    it("raises an error when passed too few arguments", () => {
+      // $ExpectError - too few arguments
+      pipe(f5)(1, "2", true, 4);
+    });
+
+    it("raises an error when passed an invalid argument", () => {
+      //$ExpectError - boolean is incompatible with string
+      pipe(f5, unf1)(1, "2", true, 4, false);
+    });
+
+    it("raises an error when trying to recognize an unexpected type", () => {
+      //$ExpectError - boolean  is incompatible with string
+      (pipe(f5, unf1)(1, "2", true, 4, "5"): boolean);
+    });
+  });
+});


### PR DESCRIPTION
Сurrently all arguments will passed to first function:
```js
import R from 'ramda';
R.pipe((a,b,c) => {
	console.log({a,b,c})
	return 69
})(1,2,3,4,5,6,7,9)
// {a: 1, b: 2, c: 3}
// 69
```