### PR TITLE
Update firebase_v5.x.x.js

### DIFF
--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
@@ -539,7 +539,7 @@ declare class $npm$firebase$firestore$DocumentReference {
   firestore: $npm$firebase$firestore$Firestore;
   id: string;
   parent: typeof $npm$firebase$firestore$CollectionReference;
-  collection(collectionPath: string): typeof $npm$firebase$firestore$CollectionReference;
+  collection(collectionPath: string): $npm$firebase$firestore$CollectionReference;
   delete(): Promise<void>;
   get(): Promise<$npm$firebase$firestore$DocumentSnapshot>;
   onSnapshot(
@@ -549,7 +549,7 @@ declare class $npm$firebase$firestore$DocumentReference {
     | $npm$firebase$firestore$observerError,
     onError?: $npm$firebase$firestore$observerError
   ): Function;
-  set(data: Object, options?: { merge: boolean } | null): Promise<void>;
+  set(data: Object, options?: {| merge?: boolean, mergeFields?: string[] |} | null): Promise<void>;
   update(...args: Array<any>): Promise<void>;
 }
 


### PR DESCRIPTION
Fixes a bug in the definition of the return value of `collection()`, and adds a missing parameter to `set()`.

Documentation for `collection()`: https://firebase.google.com/docs/reference/js/firebase.firestore.DocumentReference#collection

Documentation for `mergeFields`: https://firebase.google.com/docs/reference/js/firebase.firestore.SetOptions