### PR TITLE
[newrelic_v4.0.0] Improve/fix startSegment

### DIFF
--- a/definitions/npm/newrelic_v4.x.x/flow_v0.53.x-/newrelic_v4.x.x.js
+++ b/definitions/npm/newrelic_v4.x.x/flow_v0.53.x-/newrelic_v4.x.x.js
@@ -35,7 +35,7 @@ declare module 'newrelic' {
     instrumentMessages: Instrument,
     startWebTransaction: (url: string, handle: () => any) => any,
     startBackgroundTransaction: (name: string, group?: string, handle: () => any) => any;
-    startSegment: <T>(name: string, record: boolean, handler: (cd: T => any) => T | Promise<T>) => Promise<T>,
+    startSegment: <T>(name: string, record: boolean, handler: (cb: Function) => T, callback?: Function) => T;
     getTransaction: () => TransactionHandle,
     endTransaction: () => void,
 

--- a/definitions/npm/newrelic_v4.x.x/flow_v0.53.x-/test_newrelic_v4.x.x.js
+++ b/definitions/npm/newrelic_v4.x.x/flow_v0.53.x-/test_newrelic_v4.x.x.js
@@ -49,7 +49,21 @@ describe('newrelic', () => {
   })
 
   it('should start segment', () => {
-    const seg: Promise<string> = newrelic.startSegment('sqg', true, (cb) => cb(''))
+    const seg = newrelic.startSegment(
+      'seg',
+      true,
+      (cb) => {
+        cb && cb()
+        return 'return'
+      },
+      () => {}
+    )
+
+    const seg2 = newrelic.startSegment(
+      'seg2',
+      true,
+      () => 'return'
+    )
   })
 
   it('should instrument', () => {


### PR DESCRIPTION
I couldn't actually make the tests fail in any way so I just did my best.

Also, this type, although better than what came previously, is still a compromise. 
Really it has two signatures:
```js
<T>(name: string, record: boolean, handler: () => T) => T;
<T, U: Function>(name: string, record: boolean, handler: (cb: U) => T, callback: U) => T;
```
But I don't know how to express a function with multiple signatures with flow.

Documentation for the implementation of `startSegment` can be found here: https://docs.newrelic.com/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#custom-instrumentation-api