### PR TITLE
Fix react-router-dom Route path to allow arrays of string

### DIFF
--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/react-router-dom_v4.x.x.js
@@ -142,7 +142,7 @@ declare module "react-router-dom" {
     component?: ComponentType<*>,
     render?: (router: ContextRouter) => Node,
     children?: ComponentType<ContextRouter> | Node,
-    path?: string,
+    path?: string | Array<string>,
     exact?: boolean,
     strict?: boolean,
     location?: LocationShape,

--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/test_react-router-dom.js
@@ -338,6 +338,8 @@ describe("react-router-dom", () => {
       const Component = ({}) => <div>Hi!</div>;
       <Route path="/login" />;
 
+      <Route path={["/login", "/logout"]} />;
+
       <Route path="/login" component={Component} />;
 
       <Route path="/login" render={(context: ContextRouter) => <Component />} />;


### PR DESCRIPTION
Allow arrays in Route path:
```jsx
<Route path={["/login", "/logout"]} />
```


https://reacttraining.com/react-router/web/api/Route/path-string-string