### PR TITLE
enforce 1st param on ramda's is function is a type (Class)

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.25.x-v0.27.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.25.x-v0.27.x/ramda_v0.x.x.js
@@ -1078,8 +1078,8 @@ declare module "ramda" {
   }
 
   declare class RType {
-    is(ctor: Class<any>, instance: any): boolean;
-    is(ctor: Class<any>): (instance: any) => boolean;
+    is(ctor: Class<mixed>, instance: mixed): boolean;
+    is(ctor: Class<mixed>): (instance: mixed) => boolean;
     isArrayLike(x: any): boolean;
     isNil(x: ?any): boolean;
     propIs(ctor: any, prop: string, o: Object): boolean;

--- a/definitions/npm/ramda_v0.x.x/flow_v0.25.x-v0.27.x/test_ramda_v0.21.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.25.x-v0.27.x/test_ramda_v0.21.x.js
@@ -2,13 +2,8 @@
 /*eslint-disable no-undef, no-unused-vars, no-console*/
 "use strict";
 const _ = require("ramda");
-function describe(tag, fn) {
-  fn();
-}
 
-function it(tag, fn) {
-  fn();
-}
+import { describe, it } from 'flow-typed-test';
 
 describe("Functions", () => {
   it("T and F", () => {
@@ -403,6 +398,10 @@ describe("Function", function() {
   it("should typecheck is", function() {
     const x = _.is(Number, 1);
   });
+  it('does not allow non-types for the first argument', () => {
+    // $ExpectError
+    const x = _.is({}, 1)
+  })
 });
 
 describe("transducers", () => {

--- a/definitions/npm/ramda_v0.x.x/flow_v0.28.x-v0.30.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.28.x-v0.30.x/ramda_v0.x.x.js
@@ -232,8 +232,8 @@ declare module ramda {
   declare function trim(a: string): string;
 
   // *Type
-  declare function is<T>(t: T, ...rest: Array<void>): (v: any) => boolean;
-  declare function is<T>(t: T, v: any): boolean;
+  declare function is<T: Class<mixed>>(t: T): (v: mixed) => boolean;
+  declare function is<T: Class<mixed>>(t: T, v: mixed): boolean;
   declare var propIs: CurriedFunction3<any, string, Object, boolean>;
   declare function type(x: ?any): string;
   declare function isArrayLike(x: any): boolean;

--- a/definitions/npm/ramda_v0.x.x/flow_v0.28.x-v0.30.x/test_ramda_v0.x.x_misc.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.28.x-v0.30.x/test_ramda_v0.x.x_misc.js
@@ -1,6 +1,17 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from 'ramda'
+import _, {
+  compose,
+  curry,
+  filter,
+  find,
+  is,
+  pipe,
+  repeat,
+  zipWith,
+} from 'ramda'
+
+import { describe, it } from 'flow-typed-test';
 
 const ns: Array<number> = [ 1, 2, 3, 4, 5 ]
 const ss: Array<string> = [ 'one', 'two', 'three', 'four' ]
@@ -36,7 +47,26 @@ const str: string = 'hello world'
 }
 //Type
 {
-  const x: boolean = _.is(Number, 1)
   const x1: boolean = _.isNil(1)
   const x2: boolean = _.propIs(1, 'num', { num: 1 })
 }
+
+describe('is', () => {
+  it('allows testing a value against a type', () => {
+    // Lifted right out of the examples.
+    // See https://ramdajs.com/docs/#is
+    is(Object, {}); //=> true
+    is(Number, 1); //=> true
+    is(Object, 1); //=> false
+    is(String, 's'); //=> true
+    is(String, new String('')); //=> true
+    is(Object, new String('')); //=> true
+    is(Object, 's'); //=> false
+    is(Number, {}); //=> false
+  })
+
+  it('does not allow non-types for the first argument', () => {
+    // $ExpectError
+    is({}, 1)
+  })
+})

--- a/definitions/npm/ramda_v0.x.x/flow_v0.31.x-v0.33.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.31.x-v0.33.x/ramda_v0.x.x.js
@@ -232,8 +232,8 @@ declare module ramda {
   declare function trim(a: string): string;
 
   // *Type
-  declare function is<T>(t: T, ...rest: Array<void>): (v: any) => boolean;
-  declare function is<T>(t: T, v: any): boolean;
+  declare function is<T: Class<mixed>>(t: T): (v: mixed) => boolean;
+  declare function is<T: Class<mixed>>(t: T, v: mixed): boolean;
   declare var propIs: CurriedFunction3<any, string, Object, boolean>;
   declare function type(x: ?any): string;
   declare function isArrayLike(x: any): boolean;

--- a/definitions/npm/ramda_v0.x.x/flow_v0.31.x-v0.33.x/test_ramda_v0.x.x_misc.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.31.x-v0.33.x/test_ramda_v0.x.x_misc.js
@@ -1,6 +1,17 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from 'ramda'
+import _, {
+  compose,
+  curry,
+  filter,
+  find,
+  is,
+  pipe,
+  repeat,
+  zipWith,
+} from 'ramda'
+
+import { describe, it } from 'flow-typed-test';
 
 const ns: Array<number> = [ 1, 2, 3, 4, 5 ]
 const ss: Array<string> = [ 'one', 'two', 'three', 'four' ]
@@ -34,7 +45,26 @@ const str: string = 'hello world'
 }
 //Type
 {
-  const x: boolean = _.is(Number, 1)
   const x1: boolean = _.isNil(1)
   const x2: boolean = _.propIs(1, 'num', { num: 1 })
 }
+
+describe('is', () => {
+  it('allows testing a value against a type', () => {
+    // Lifted right out of the examples.
+    // See https://ramdajs.com/docs/#is
+    is(Object, {}); //=> true
+    is(Number, 1); //=> true
+    is(Object, 1); //=> false
+    is(String, 's'); //=> true
+    is(String, new String('')); //=> true
+    is(Object, new String('')); //=> true
+    is(Object, 's'); //=> false
+    is(Number, {}); //=> false
+  })
+
+  it('does not allow non-types for the first argument', () => {
+    // $ExpectError
+    is({}, 1)
+  })
+})

--- a/definitions/npm/ramda_v0.x.x/flow_v0.34.x-v0.38.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.34.x-v0.38.x/ramda_v0.x.x.js
@@ -233,8 +233,8 @@ declare module ramda {
   declare function trim(a: string): string;
 
   // *Type
-  declare function is<T>(t: T, ...rest: Array<void>): (v: any) => boolean;
-  declare function is<T>(t: T, v: any): boolean;
+  declare function is<T: Class<mixed>>(t: T): (v: mixed) => boolean;
+  declare function is<T: Class<mixed>>(t: T, v: mixed): boolean;
   declare var propIs: CurriedFunction3<any, string, Object, boolean>;
   declare function type(x: ?any): string;
   declare function isArrayLike(x: any): boolean;

--- a/definitions/npm/ramda_v0.x.x/flow_v0.34.x-v0.38.x/test_ramda_v0.x.x_misc.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.34.x-v0.38.x/test_ramda_v0.x.x_misc.js
@@ -1,6 +1,17 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from 'ramda'
+import _, {
+  compose,
+  curry,
+  filter,
+  find,
+  is,
+  pipe,
+  repeat,
+  zipWith,
+} from 'ramda'
+
+import { describe, it } from 'flow-typed-test';
 
 const ns: Array<number> = [ 1, 2, 3, 4, 5 ]
 const ss: Array<string> = [ 'one', 'two', 'three', 'four' ]
@@ -36,9 +47,28 @@ const str: string = 'hello world'
 }
 //Type
 {
-  const x: boolean = _.is(Number, 1)
   const x1: false = _.isNil(1)
   const x1a: true = _.isNil()
   const x1b: true = _.isNil(null)
   const x2: boolean = _.propIs(1, 'num', { num: 1 })
 }
+
+describe('is', () => {
+  it('allows testing a value against a type', () => {
+    // Lifted right out of the examples.
+    // See https://ramdajs.com/docs/#is
+    is(Object, {}); //=> true
+    is(Number, 1); //=> true
+    is(Object, 1); //=> false
+    is(String, 's'); //=> true
+    is(String, new String('')); //=> true
+    is(Object, new String('')); //=> true
+    is(Object, 's'); //=> false
+    is(Number, {}); //=> false
+  })
+
+  it('does not allow non-types for the first argument', () => {
+    // $ExpectError
+    is({}, 1)
+  })
+})

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-v0.48.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-v0.48.x/ramda_v0.x.x.js
@@ -383,8 +383,8 @@ declare module ramda {
   declare function trim(a: string): string;
 
   // *Type
-  declare function is<T>(t: T, ...rest: Array<void>): (v: any) => boolean;
-  declare function is<T>(t: T, v: any): boolean;
+  declare function is<T: Class<mixed>>(t: T): (v: mixed) => boolean;
+  declare function is<T: Class<mixed>>(t: T, v: mixed): boolean;
   declare var propIs: CurriedFunction3<any, string, Object, boolean>;
   declare function type(x: ?any): string;
   declare function isArrayLike(x: any): boolean;

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-v0.48.x/test_ramda_v0.x.x_misc.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-v0.48.x/test_ramda_v0.x.x_misc.js
@@ -1,6 +1,17 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from "ramda";
+import _, {
+  compose,
+  curry,
+  filter,
+  find,
+  is,
+  pipe,
+  repeat,
+  zipWith,
+} from 'ramda'
+
+import { describe, it } from 'flow-typed-test';
 
 const ns: Array<number> = [1, 2, 3, 4, 5];
 const ss: Array<string> = ["one", "two", "three", "four"];
@@ -35,9 +46,28 @@ const str: string = "hello world";
 }
 //Type
 {
-  const x: boolean = _.is(Number, 1);
   const x1: false = _.isNil(1);
   const x1a: true = _.isNil();
   const x1b: true = _.isNil(null);
   const x2: boolean = _.propIs(1, "num", { num: 1 });
 }
+
+describe('is', () => {
+  it('allows testing a value against a type', () => {
+    // Lifted right out of the examples.
+    // See https://ramdajs.com/docs/#is
+    is(Object, {}); //=> true
+    is(Number, 1); //=> true
+    is(Object, 1); //=> false
+    is(String, 's'); //=> true
+    is(String, new String('')); //=> true
+    is(Object, new String('')); //=> true
+    is(Object, 's'); //=> false
+    is(Number, {}); //=> false
+  })
+
+  it('does not allow non-types for the first argument', () => {
+    // $ExpectError
+    is({}, 1)
+  })
+})

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-v0.61.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-v0.61.x/ramda_v0.x.x.js
@@ -506,8 +506,8 @@ declare module ramda {
   declare function trim(a: string): string;
 
   // *Type
-  declare function is<T>(t: T, ...rest: Array<void>): (v: any) => boolean;
-  declare function is<T>(t: T, v: any): boolean;
+  declare function is<T: Class<mixed>>(t: T): (v: mixed) => boolean;
+  declare function is<T: Class<mixed>>(t: T, v: mixed): boolean;
   declare var propIs: CurriedFunction3<any, string, Object, boolean>;
   declare function type(x: ?any): string;
   declare function isArrayLike(x: any): boolean;

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-v0.61.x/test_ramda_v0.x.x_misc.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-v0.61.x/test_ramda_v0.x.x_misc.js
@@ -2,14 +2,17 @@
 /*eslint-disable no-undef, no-unused-vars, no-console*/
 import _, {
   compose,
-  pipe,
   curry,
   filter,
   find,
+  is,
   isNil,
+  pipe,
   repeat,
   zipWith
 } from "ramda";
+
+import { describe, it } from 'flow-typed-test';
 
 const ns: Array<number> = [1, 2, 3, 4, 5];
 const ss: Array<string> = ["one", "two", "three", "four"];
@@ -44,7 +47,6 @@ const str: string = "hello world";
 }
 //Type
 {
-  const x: boolean = _.is(Number, 1);
   const x1: boolean = isNil(1);
 
   // should refine type
@@ -57,3 +59,23 @@ const str: string = "hello world";
 
   const x2: boolean = _.propIs(1, "num", { num: 1 });
 }
+
+describe('is', () => {
+  it('allows testing a value against a type', () => {
+    // Lifted right out of the examples.
+    // See https://ramdajs.com/docs/#is
+    is(Object, {}); //=> true
+    is(Number, 1); //=> true
+    is(Object, 1); //=> false
+    is(String, 's'); //=> true
+    is(String, new String('')); //=> true
+    is(Object, new String('')); //=> true
+    is(Object, 's'); //=> false
+    is(Number, {}); //=> false
+  })
+
+  it('does not allow non-types for the first argument', () => {
+    // $ExpectError
+    is({}, 1)
+  })
+})

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-v0.81.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-v0.81.x/ramda_v0.x.x.js
@@ -597,13 +597,13 @@ declare module ramda {
   declare var startsWith: EdgeWith<*>;
   declare var endsWith: EdgeWith<*>;
   declare function toLower(a: string): string;
-  declare function toString(x: any): string;
+  declare function toString(x: mixed): string;
   declare function toUpper(a: string): string;
   declare function trim(a: string): string;
 
   // *Type
-  declare function is<T>(t: T): (v: any) => boolean;
-  declare function is<T>(t: T, v: any): boolean;
+  declare function is<T: Class<mixed>>(t: T): (v: mixed) => boolean;
+  declare function is<T: Class<mixed>>(t: T, v: mixed): boolean;
   declare var propIs: CurriedFunction3<any, string, Object, boolean>;
   declare function type(x: ?any): string;
   declare function isArrayLike(x: any): boolean;

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-v0.81.x/test_ramda_v0.x.x_misc.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-v0.81.x/test_ramda_v0.x.x_misc.js
@@ -6,10 +6,13 @@ import _, {
   curry,
   filter,
   find,
+  is,
   isNil,
   repeat,
   zipWith
 } from "ramda";
+
+import { describe, it } from 'flow-typed-test';
 
 const ns: Array<number> = [1, 2, 3, 4, 5];
 const ss: Array<string> = ["one", "two", "three", "four"];
@@ -44,7 +47,6 @@ const str: string = "hello world";
 }
 //Type
 {
-  const x: boolean = _.is(Number, 1);
   const x1: boolean = isNil(1);
 
   // should refine type
@@ -57,3 +59,23 @@ const str: string = "hello world";
 
   const x2: boolean = _.propIs(1, "num", { num: 1 });
 }
+
+describe('is', () => {
+  it('allows testing a value against a type', () => {
+    // Lifted right out of the examples.
+    // See https://ramdajs.com/docs/#is
+    is(Object, {}); //=> true
+    is(Number, 1); //=> true
+    is(Object, 1); //=> false
+    is(String, 's'); //=> true
+    is(String, new String('')); //=> true
+    is(Object, new String('')); //=> true
+    is(Object, 's'); //=> false
+    is(Number, {}); //=> false
+  })
+
+  it('does not allow non-types for the first argument', () => {
+    // $ExpectError
+    is({}, 1)
+  })
+})


### PR DESCRIPTION
Prior to this change, `is` would accept anything for its type in many of the
Flow versions. Now it only accepts a class (`Number`, `String`, etc) which could be
realistically enforced by `is`.

There's also an auxiliary change of `any` -> `mixed` where it applies to `is` and in
many cases more tests for how `is` works as well as negative tests.

As of writing these changes have some broken tests that are unrelated to `is`
and instead seem to be resulting from the problem that https://github.com/flow-typed/flow-typed/pull/2793 is attempting to fix.