### PR TITLE
Fix cookies.get in Koa v2

### DIFF
--- a/definitions/npm/koa_v2.0.x/flow_v0.47.x-/koa_v2.0.x.js
+++ b/definitions/npm/koa_v2.0.x/flow_v0.47.x-/koa_v2.0.x.js
@@ -199,7 +199,7 @@ declare module 'koa' {
     overwrite?: boolean, //  whether to overwrite previously set cookies of the same name (false by default).
   };
   declare type Cookies = {
-    get: (name: string, options: {signed: boolean}) => string|void,
+    get: (name: string, options?: {signed: boolean}) => string|void,
     set: ((name: string, value: string, options?: CookiesSetOptions) => Context)&
     // delete cookie (an outbound header with an expired date is used.)
     ( (name: string) => Context),


### PR DESCRIPTION
Mark cookies.get options as optional, since it's optional in the cookies library (ref: https://github.com/pillarjs/cookies#cookiesget-name--options--)