### PR TITLE
Fix flow 0.82 ramda MergeWith and MergeWithKey

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-v0.81.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-v0.81.x/ramda_v0.x.x.js
@@ -653,8 +653,11 @@ declare module ramda {
   declare function chain<A, B>(f: (x: A) => B[], xs: A[]): B[]
   declare function chain<A, B>(f: (x: A) => B[]): (xs: A[]) => B[]
 
-  declare function concat<V, T: Array<V> | string>(x: T, y: T): T;
-  declare function concat<V, T: Array<V> | string>(x: T): (y: T) => T;
+  declare function concat<V, T: Array<V>>(x: T, y: T): T;
+  declare function concat<V, T: Array<V>>(x: T): (y: T) => T;
+
+  declare function concat(x: string, y: string): string;
+  declare function concat(x: string): (y: string) => string;
 
   declare function contains<E, T: Array<E> | string>(x: E, xs: T): boolean;
   declare function contains<E, T: Array<E> | string>(

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-v0.81.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-v0.81.x/ramda_v0.x.x.js
@@ -1501,21 +1501,21 @@ declare module ramda {
 
   declare type MergeWithKey = (<
     S: string,
+    T,
     A: { [k: string]: T },
-    B: { [k: string]: T },
-    T
+    B: { [k: string]: T }
   >(
     fn: (s: S, a: T, b: T) => T,
     a: A,
     b: B
   ) => A & B) &
-    (<S: string, A: { [k: string]: T }, B: { [k: string]: T }, T>(
+    (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
       fn: (s: S, a: T, b: T) => T,
     ) => (a: A, b: B) => A & B) &
-    (<S: string, A: { [k: string]: T }, B: { [k: string]: T }, T>(
+    (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
       fn: (s: S, a: T, b: T) => T,
     ) => (a: A) => (b: B) => A & B) &
-    (<S: string, A: { [k: string]: T }, B: { [k: string]: T }, T>(
+    (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
       fn: (s: S, a: T, b: T) => T,
       a: A,
     ) => (b: B) => A & B);

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-v0.81.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-v0.81.x/ramda_v0.x.x.js
@@ -1486,7 +1486,7 @@ declare module ramda {
   declare var mergeDeepRight: (<A, B>(a: A, b: B) => B & A) &
     (<A, B>(a: A) => (b: B) => B & A);
 
-  declare type MergeWith = (<A: { [k: string]: T }, B: { [k: string]: T }, T>(
+  declare type MergeWith = (<A, B, T: $Values<A> & $Values<B>>(
     fn: (a: T, b: T) => T,
     a: A,
     b: B
@@ -1503,22 +1503,22 @@ declare module ramda {
     ) => (b: B) => A & B);
 
   declare type MergeWithKey = (<
-    S: string,
-    T,
-    A: { [k: string]: T },
-    B: { [k: string]: T }
+    A,
+    B,
+    S: $Keys<A> & $Keys<B>,
+    T: $ElementType<A, $Keys<A>> & $ElementType<B, $Keys<B>>,
   >(
     fn: (s: S, a: T, b: T) => T,
     a: A,
     b: B
   ) => A & B) &
-    (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
+    (<S, T, A, B>(
       fn: (s: S, a: T, b: T) => T,
     ) => (a: A, b: B) => A & B) &
-    (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
+    (<S, T, A, B>(
       fn: (s: S, a: T, b: T) => T,
     ) => (a: A) => (b: B) => A & B) &
-    (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
+    (<S, T, A, B>(
       fn: (s: S, a: T, b: T) => T,
       a: A,
     ) => (b: B) => A & B);

--- a/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
@@ -1410,7 +1410,7 @@ declare module ramda {
   declare var mergeDeepRight: (<A, B>(a: A, b: B) => B & A) &
     (<A, B>(a: A) => (b: B) => B & A);
 
-  declare type MergeWith = (<A: { [k: string]: mixed }, B: { [k: string]: mixed }, T>(
+  declare type MergeWith = (<A, B, T: $Values<A> & $Values<B>>(
     fn: (a: T, b: T) => T,
     a: A,
     b: B
@@ -1427,22 +1427,22 @@ declare module ramda {
     ) => (b: B) => A & B);
 
   declare type MergeWithKey = (<
-    S: string,
-    T,
-    A: { [k: string]: T },
-    B: { [k: string]: T }
+    A,
+    B,
+    S: $Keys<A> & $Keys<B>,
+    T: $ElementType<A, $Keys<A>> & $ElementType<B, $Keys<B>>,
   >(
     fn: (s: S, a: T, b: T) => T,
     a: A,
     b: B
   ) => A & B) &
-    (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
+    (<S, T, A, B>(
       fn: (s: S, a: T, b: T) => T,
     ) => (a: A, b: B) => A & B) &
-      (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
+    (<S, T, A, B>(
       fn: (s: S, a: T, b: T) => T,
     ) => (a: A) => (b: B) => A & B) &
-      (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
+    (<S, T, A, B>(
       fn: (s: S, a: T, b: T) => T,
       a: A,
     ) => (b: B) => A & B);

--- a/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
@@ -577,8 +577,11 @@ declare module ramda {
   declare function chain<A, B>(f: (x: A) => B[], xs: A[]): B[]
   declare function chain<A, B>(f: (x: A) => B[]): (xs: A[]) => B[]
 
-  declare function concat<V, T: Array<V> | string>(x: T, y: T): T;
-  declare function concat<V, T: Array<V> | string>(x: T): (y: T) => T;
+  declare function concat<V, T: Array<V>>(x: T, y: T): T;
+  declare function concat<V, T: Array<V>>(x: T): (y: T) => T;
+
+  declare function concat(x: string, y: string): string;
+  declare function concat(x: string): (y: string) => string;
 
   declare function contains<E, T: Array<E> | string>(x: E, xs: T): boolean;
   declare function contains<E, T: Array<E> | string>(
@@ -1425,21 +1428,21 @@ declare module ramda {
 
   declare type MergeWithKey = (<
     S: string,
-    A: { [k: string]: mixed },
-    B: { [k: string]: mixed },
-    T
+    T,
+    A: { [k: string]: T },
+    B: { [k: string]: T }
   >(
     fn: (s: S, a: T, b: T) => T,
     a: A,
     b: B
   ) => A & B) &
-    (<S: string, A: { [k: string]: mixed }, B: { [k: string]: mixed }, T>(
+    (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
       fn: (s: S, a: T, b: T) => T,
     ) => (a: A, b: B) => A & B) &
-    (<S: string, A: { [k: string]: mixed }, B: { [k: string]: mixed }, T>(
+      (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
       fn: (s: S, a: T, b: T) => T,
     ) => (a: A) => (b: B) => A & B) &
-    (<S: string, A: { [k: string]: mixed }, B: { [k: string]: mixed }, T>(
+      (<S: string, T, A: { [k: string]: T }, B: { [k: string]: T }>(
       fn: (s: S, a: T, b: T) => T,
       a: A,
     ) => (b: B) => A & B);


### PR DESCRIPTION
This is another take on #2793.

Flow introduces stricter typing in 0.82.0 which causes the definition with `MergeWith` and `MergeWithKey` to fail. These changes should bring the `MergeWith*` definitions into better soundness and also get them to pass again.

One thing of note is that there's no reason the change couldn't be backported to prior versions of Flow, since it should also increase strictness/soundness. This PR also handles that for the last version but I'm not sure how far back I can go with `$ElementType`.

Thanks @Jabher for the initial pass on this! It helped me come to the conclusion I have here.