### PR TITLE
Fix: Add non-static localeData method to moment declaration

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_v0.25.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.25.x-/moment_v2.x.x.js
@@ -359,6 +359,7 @@ declare class moment$Moment {
   static weekdaysShort(): string;
   static weekdaysMin(): string;
   static localeData(key?: string): moment$LocaleData;
+  localeData(): moment$LocaleData;
   static duration(
     value: number | Object | string,
     unit?: string

--- a/definitions/npm/moment_v2.x.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.x.x/test_moment-v2.js
@@ -284,6 +284,9 @@ const getLocale: string = moment.locale();
 const setLocale: string = moment.locale("en");
 const setArrayLocale: string = moment.locale(["en", "de"]);
 
+// Locales
+const localeData = moment().locale('fr').localeData();
+
 // Customize
 moment.defineLocale('fakeLocale');
 moment.defineLocale('fakeLocale', { parentLocale: 'xyz' });


### PR DESCRIPTION
![screen shot 2018-11-28 at 11 58 51](https://user-images.githubusercontent.com/21029500/49150506-017aa100-f305-11e8-9bea-8ecd374cb7a5.png)

When calling upon `moment().locale(string).localeData()` whilst using the `moment_v2.x.x.js` library defintion the following error is produced as the only exposed property is static:

`Cannot call localeConfig.localeData because property localeData is missing in moment$Moment` 

This PR adds in the non-static type property, so that the flow error is not produced 😄 