### PR TITLE
Update firebase@5.X.X libdef

### DIFF
--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
@@ -638,7 +638,7 @@ declare interface $npm$firebase$firestore$WriteBatch {
 /** **** messaging ******/
 declare class $npm$firebase$messaging$Messaging {
   deleteToken(token: string): Promise<any>;
-  getToken(): Promise<string>;
+  getToken(): Promise<?string>;
   onMessage(nextOrObserver: ({}) => void | {}): () => void;
   onTokenRefresh(nextOrObserver: ({}) => void | {}): () => void;
   requestPermission(): Promise<any>;


### PR DESCRIPTION
Regarding the actual firebase implementation, the `getToken` method can return a string
or a null if the `Notification.permission === 'default'`

Link to FCM source: https://github.com/firebase/firebase-js-sdk/blob/master/packages/messaging/src/controllers/base-controller.ts#L77