### PR TITLE
fix (npm: chai_v4) export any since expect is missing in chai export

### DIFF
--- a/definitions/npm/chai_v4.x.x/flow_v0.25.0-/chai_v4.x.x.js
+++ b/definitions/npm/chai_v4.x.x/flow_v0.25.0-/chai_v4.x.x.js
@@ -1,4 +1,5 @@
 declare module "chai" {
+  declare module.exports: any;
   declare type ExpectChain<T> = {
     and: ExpectChain<T>,
     at: ExpectChain<T>,


### PR DESCRIPTION
## Background 
Fixes issues https://github.com/flow-typed/flow-typed/issues/482

- [x] export any from chai so expect can be found by Flow 

## Test Plan
```
./build_and_test_cli.sh 
```