### PR TITLE
[react-native-video_v3.x.x] Add missing setNativeProps method

### DIFF
--- a/definitions/npm/react-native-video_v3.x.x/flow_v0.68.0-/react-native-video_v3.x.x.js
+++ b/definitions/npm/react-native-video_v3.x.x/flow_v0.68.0-/react-native-video_v3.x.x.js
@@ -97,7 +97,7 @@ declare module "react-native-video" {
     +metadata: $ReadOnlyArray<TimedMetadata>
   }>;
 
-  declare export type VideoProps = $ReadOnly<{
+  declare export type VideoProps = {
     source: number | {| uri: string |},
     // https://github.com/react-native-community/react-native-video/blob/master/VideoResizeMode.js#L4-L6
     resizeMode?: ?("contain" | "cover" | "stretch"),
@@ -149,12 +149,13 @@ declare module "react-native-video" {
     translateX?: ?number,
     translateY?: ?number,
     rotation?: ?number
-  }>;
+  };
 
   declare export default class Video extends React$Component<VideoProps> {
     dismissFullscreenPlayer(): void;
     presentFullscreenPlayer(): void;
     // Tolerance is the max distance in milliseconds from the seconds position that's allowed. (tolerance supported on iOS)
     seek(seconds: number, toleranceIOS?: number): void;
+    setNativeProps(params: $Shape<VideoProps>): void;
   }
 }

--- a/definitions/npm/react-native-video_v3.x.x/flow_v0.68.0-/test_react-native-video.js
+++ b/definitions/npm/react-native-video_v3.x.x/flow_v0.68.0-/test_react-native-video.js
@@ -95,6 +95,15 @@ describe("public class methods", () => {
   describe("must call presentFullscreenPlayer", () => {
     video.presentFullscreenPlayer();
   });
+
+  describe("setNativeProps", () => {
+    it("must call with valid props", () => {
+      video.setNativeProps({ paused: true });
+
+      // $ExpectError
+      video.setNativeProps({ foo: 'bar' });
+    });
+  });
 });
 
 describe("props", () => {


### PR DESCRIPTION
Flow type for setNativeProps method (https://github.com/react-native-community/react-native-video/blob/master/Video.js#L27)

I had to make props not readonly because some versions of flow had a bug and though passing an object was assigning to a readonly property... This should be fine since props are assumed to be immutable by react anyway.