### PR TITLE
fix(react-apollo): ensure subscriptionData types data the same way as query

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -2,6 +2,7 @@ declare module "react-apollo" {
   import type { ComponentType, Element, Node } from "react";
 
   declare type MakeOptional = <V>(V) => ?V;
+  declare type MakeDataOptional<TData> = $ObjMap<TData, MakeOptional> | void;
   /**
    * Copied types from Apollo Client libdef
    * Please update apollo-client libdef as well if updating these types
@@ -902,7 +903,7 @@ declare module "react-apollo" {
     TData = any,
     TVariables = OperationVariables
   > = {
-    data: $ObjMap<TData, MakeOptional> | void,
+    data: MakeDataOptional<TData>,
     loading: boolean,
     error?: ApolloError,
     variables: TVariables,
@@ -954,7 +955,7 @@ declare module "react-apollo" {
     TVariables = OperationVariables
   > = {
     loading: boolean,
-    data?: TData | {||} | void,
+    data?: MakeDataOptional<TData>,
     error?: ApolloError
   };
 

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
@@ -472,13 +472,9 @@ describe("<Subscription />", () => {
           if (!data) {
             return <div />;
           }
-          const d1: Res | {||} = data;
           // $ExpectError Cannot get `data.res` because property `res` is missing in object type
           const s: string = data.res;
-          if (d1.res) {
-            const d2: Res = d1;
-            const s: string = d1.res;
-          }
+          const s: ?string = data.res;
           return <div />;
         }}
       </Subscription>


### PR DESCRIPTION
@GAntoine there will be a CI build failure due to a bug in Flow 0.88 not producing an expected error in an unrelated test case.