### PR TITLE
Update react-select libdef

### DIFF
--- a/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/react-select_v1.x.x.js
+++ b/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/react-select_v1.x.x.js
@@ -1,14 +1,14 @@
-declare module "react-select" {
+declare module 'react-select' {
   declare type OptionType = Object;
   declare type OptionsType = OptionType[];
 
   declare type Props = {|
     // html id(s) of element(s) that should be used to describe this input (for assistive tech)
-    "aria-describedby"?: string,
+    'aria-describedby'?: string,
     // aria label (for assistive tech)
-    "aria-label"?: string,
+    'aria-label'?: string,
     // html id of an element that should be used as the label (for assistive tech)
-    "aria-labelledby"?: string,
+    'aria-labelledby'?: string,
     // placeholder displayed when you want to add a label on a multi-value input
     addLabelText?: string,
     // Create drop-down caret element
@@ -71,9 +71,9 @@ declare module "react-select" {
     // path of the label value in option objects
     labelKey?: string,
     // (any|start) match the start or entire string when filtering
-    matchPos?: "any" | "start",
+    matchPos?: 'any' | 'start',
     // (any|label|value) which option property to filter on
-    matchProp?: "any" | "label" | "value",
+    matchProp?: 'any' | 'label' | 'value',
     // optional buffer (in px) between the bottom of the viewport and the bottom of the menu
     menuBuffer?: number,
     // optional style to apply to the menu container

--- a/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/react-select_v1.x.x.js
+++ b/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/react-select_v1.x.x.js
@@ -1,5 +1,5 @@
 declare module 'react-select' {
-  declare type OptionType = Object;
+  declare type OptionType = { [string]: any };
   declare type OptionsType = OptionType[];
 
   declare type Props = {|

--- a/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/react-select_v1.x.x.js
+++ b/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/react-select_v1.x.x.js
@@ -1,19 +1,19 @@
-declare module 'react-select' {
-  declare type OptionType = Object
-  declare type OptionsType = OptionType[]
+declare module "react-select" {
+  declare type OptionType = Object;
+  declare type OptionsType = OptionType[];
 
-  declare type Props = {
+  declare type Props = {|
     // html id(s) of element(s) that should be used to describe this input (for assistive tech)
-    'aria-describedby'?: string,
+    "aria-describedby"?: string,
     // aria label (for assistive tech)
-    'aria-label'?: string,
+    "aria-label"?: string,
     // html id of an element that should be used as the label (for assistive tech)
-    'aria-labelledby'?: string,
+    "aria-labelledby"?: string,
     // placeholder displayed when you want to add a label on a multi-value input
     addLabelText?: string,
     // Create drop-down caret element
     arrowRenderer?: React$ComponentType<{
-      onMouseDown?: SyntheticMouseEvent<*>,
+      onMouseDown?: SyntheticMouseEvent<*>
     }>,
     // automatically blur the component when an option is selected
     autoBlur?: boolean,
@@ -71,9 +71,9 @@ declare module 'react-select' {
     // path of the label value in option objects
     labelKey?: string,
     // (any|start) match the start or entire string when filtering
-    matchPos?: 'any' | 'start',
+    matchPos?: "any" | "start",
     // (any|label|value) which option property to filter on
-    matchProp?: 'any' | 'label' | 'value',
+    matchProp?: "any" | "label" | "value",
     // optional buffer (in px) between the bottom of the viewport and the bottom of the menu
     menuBuffer?: number,
     // optional style to apply to the menu container
@@ -156,9 +156,24 @@ declare module 'react-select' {
     valueRenderer?: (option: OptionType, idx?: number) => React$Node,
     // optional style to apply to the component wrapper
     wrapperStyle?: {},
-  };
+    isSearchable?: boolean
+  |};
 
-  declare class Select extends React$Component<Props> {}
+  declare type AsyncProps = {|
+    /* The default set of options to show before the user starts searching. When
+     set to `true`, the results for loadOptions('') will be autoloaded. */
+    defaultOptions?: OptionsType | boolean,
+    /* Function that returns a promise, which is the set of options to be used
+     once the promise resolves. */
+    loadOptions: (string, (OptionsType) => void) => Promise<*> | void,
+    /* If cacheOptions is truthy, then the loaded data will be cached. The cache
+     will remain until `cacheOptions` changes value. */
+    cacheOptions?: any
+  |};
 
-  declare module.exports: typeof Select;
+  declare export default class Select extends React$Component<Props> {}
+  declare export class Async extends React$Component<{|
+    ...Props,
+    ...AsyncProps
+  |}> {}
 }

--- a/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/test_react-select_v1.x.x.js
+++ b/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/test_react-select_v1.x.x.js
@@ -1,8 +1,8 @@
 // @flow
 
-import { describe, it } from 'flow-typed-test';
-import React from 'react';
-import Select from 'react-select';
+import { describe, it } from "flow-typed-test";
+import React from "react";
+import Select from "react-select";
 
 let ArrowRenderer = () => <span />;
 let ClearRenderer = () => <span />;
@@ -12,9 +12,9 @@ let MenuRenderer = (props: {}) => [<span />];
 let OptionComponent = (props: {}) => <span />;
 let OptionRenderer = () => <span />;
 let options = [
-  { value: 123, label: 'first item' },
-  { value: 345, label: 'second item' },
-  { value: 'foo', label: 'third item', clearableValue: true },
+  { value: 123, label: "first item" },
+  { value: 345, label: "second item" },
+  { value: "foo", label: "third item", clearableValue: true }
 ];
 let ValueComponent = (props: {}) => <span />;
 let ValueRenderer = (option: { label: string }) => option.label;
@@ -23,18 +23,18 @@ type ParentType = {
   type: "parent",
   disabled: true,
   commonData: string
-}
+};
 
 type ChildType = {
   type: "child",
   disabled: false,
   commonData: string,
-  childData: string,
-}
+  childData: string
+};
 
-type OptionType = ParentType | ChildType
+type OptionType = ParentType | ChildType;
 
-let customOptions: OptionType[] =[
+let customOptions: OptionType[] = [
   {
     type: "parent",
     disabled: true,
@@ -54,8 +54,8 @@ let customOptions: OptionType[] =[
   }
 ];
 
-  describe('The `Select` component', () => {
-  it('should validate on proper props usage', () => {
+describe("The `Select` component", () => {
+  it("should validate on proper props usage", () => {
     <Select
       addLabelText="Add label, plz"
       aria-describedby="aria-describedby"
@@ -89,9 +89,9 @@ let customOptions: OptionType[] =[
       matchPos="start"
       matchProp="label"
       menuBuffer={10}
-      menuContainerStyle={{ color: 'green' }}
+      menuContainerStyle={{ color: "green" }}
       menuRenderer={MenuRenderer}
-      menuStyle={{ color: 'green' }}
+      menuStyle={{ color: "green" }}
       multi={false}
       name="fance name"
       noResultsText="No results found. I'm so terribly sorry. I'll just go now. :´("
@@ -102,7 +102,7 @@ let customOptions: OptionType[] =[
       onCloseResetsInput={false}
       onFocus={event => {}}
       onInputChange={(value: any) => {
-        return 'foo';
+        return "foo";
       }}
       onInputKeyDown={event => {}}
       onMenuScrollToBottom={(): void => {}}
@@ -121,28 +121,29 @@ let customOptions: OptionType[] =[
       scrollMenuIntoView={false}
       searchable={true}
       simpleValue={false}
-      style={{ color: 'gray' }}
+      style={{ color: "gray" }}
       tabIndex={-1}
       tabSelectsValue={false}
       value={0}
       valueComponent={ValueComponent}
       valueKey="valueKey"
       valueRenderer={ValueRenderer}
-      wrapperStyle={{ backgroundColor: 'white' }}
+      wrapperStyle={{ backgroundColor: "white" }}
     />;
   });
 
-  it('should error on invalid props usage', () => {
+  it("should error on invalid props usage", () => {
     // $ExpectError addLabelText cannot be number
     <Select addLabelText={123} />;
   });
 
-  it('should handle custom options', () => {
-    let customOptionRenderer = (o: OptionType) => <span/>;
-    let customFilterOption = (options: OptionType[], filterValue: string) => options;
+  it("should handle custom options", () => {
+    let customOptionRenderer = (o: OptionType) => <span />;
+    let customFilterOption = (options: OptionType[], filterValue: string) =>
+      options;
     <Select
       name="name"
-      autoFocus
+      autofocus
       placeholder="Enter data"
       valueKey="id"
       labelKey="data"
@@ -150,36 +151,36 @@ let customOptions: OptionType[] =[
       value=""
       optionRenderer={customOptionRenderer}
       filterOptions={customFilterOption}
-    />
-  })
+    />;
+  });
 
-  it('should error when optionRenderer option param type is not the same as options element type', () => {
-    let invalidRenderer = (o: string) => <span/>;
+  it("should error when optionRenderer option param type is not the same as options element type", () => {
+    let invalidRenderer = (o: string) => <span />;
     // $ExpectError
     <Select
       name="name"
-      autoFocus
+      autofocus
       placeholder="Enter data"
       valueKey="id"
       labelKey="data"
       options={customOptions}
       value=""
       optionRenderer={invalidRenderer}
-    />
-  })
+    />;
+  });
 
-  it('should error when filterOptions options param type is not an array of options element type', () => {
-    let invalidFilterOptions = (o: string) => <span/>;
+  it("should error when filterOptions options param type is not an array of options element type", () => {
+    let invalidFilterOptions = (o: string) => <span />;
     // $ExpectError
     <Select
       name="name"
-      autoFocus
+      autofocus
       placeholder="Enter data"
       valueKey="id"
       labelKey="data"
       options={customOptions}
       value=""
       filterOptions={invalidFilterOptions}
-    />
-  })
+    />;
+  });
 });

--- a/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/test_react-select_v1.x.x.js
+++ b/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/test_react-select_v1.x.x.js
@@ -19,20 +19,7 @@ let options = [
 let ValueComponent = (props: {}) => <span />;
 let ValueRenderer = (option: { label: string }) => option.label;
 
-type ParentType = {
-  type: 'parent',
-  disabled: true,
-  commonData: string
-};
-
-type ChildType = {
-  type: 'child',
-  disabled: false,
-  commonData: string,
-  childData: string
-};
-
-type OptionType = ParentType | ChildType;
+type OptionType = { [string]: any };
 
 let customOptions: OptionType[] = [
   {

--- a/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/test_react-select_v1.x.x.js
+++ b/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/test_react-select_v1.x.x.js
@@ -1,8 +1,8 @@
 // @flow
 
-import { describe, it } from "flow-typed-test";
-import React from "react";
-import Select from "react-select";
+import { describe, it } from 'flow-typed-test';
+import React from 'react';
+import Select from 'react-select';
 
 let ArrowRenderer = () => <span />;
 let ClearRenderer = () => <span />;
@@ -12,21 +12,21 @@ let MenuRenderer = (props: {}) => [<span />];
 let OptionComponent = (props: {}) => <span />;
 let OptionRenderer = () => <span />;
 let options = [
-  { value: 123, label: "first item" },
-  { value: 345, label: "second item" },
-  { value: "foo", label: "third item", clearableValue: true }
+  { value: 123, label: 'first item' },
+  { value: 345, label: 'second item' },
+  { value: 'foo', label: 'third item', clearableValue: true }
 ];
 let ValueComponent = (props: {}) => <span />;
 let ValueRenderer = (option: { label: string }) => option.label;
 
 type ParentType = {
-  type: "parent",
+  type: 'parent',
   disabled: true,
   commonData: string
 };
 
 type ChildType = {
-  type: "child",
+  type: 'child',
   disabled: false,
   commonData: string,
   childData: string
@@ -36,26 +36,26 @@ type OptionType = ParentType | ChildType;
 
 let customOptions: OptionType[] = [
   {
-    type: "parent",
+    type: 'parent',
     disabled: true,
-    commonData: "data"
+    commonData: 'data'
   },
   {
-    type: "child",
+    type: 'child',
     disabled: false,
-    commonData: "data",
-    childData: "child data 1"
+    commonData: 'data',
+    childData: 'child data 1'
   },
   {
-    type: "child",
+    type: 'child',
     disabled: false,
-    commonData: "data",
-    childData: "child data 2"
+    commonData: 'data',
+    childData: 'child data 2'
   }
 ];
 
-describe("The `Select` component", () => {
-  it("should validate on proper props usage", () => {
+describe('The `Select` component', () => {
+  it('should validate on proper props usage', () => {
     <Select
       addLabelText="Add label, plz"
       aria-describedby="aria-describedby"
@@ -89,9 +89,9 @@ describe("The `Select` component", () => {
       matchPos="start"
       matchProp="label"
       menuBuffer={10}
-      menuContainerStyle={{ color: "green" }}
+      menuContainerStyle={{ color: 'green' }}
       menuRenderer={MenuRenderer}
-      menuStyle={{ color: "green" }}
+      menuStyle={{ color: 'green' }}
       multi={false}
       name="fance name"
       noResultsText="No results found. I'm so terribly sorry. I'll just go now. :´("
@@ -102,7 +102,7 @@ describe("The `Select` component", () => {
       onCloseResetsInput={false}
       onFocus={event => {}}
       onInputChange={(value: any) => {
-        return "foo";
+        return 'foo';
       }}
       onInputKeyDown={event => {}}
       onMenuScrollToBottom={(): void => {}}
@@ -121,23 +121,23 @@ describe("The `Select` component", () => {
       scrollMenuIntoView={false}
       searchable={true}
       simpleValue={false}
-      style={{ color: "gray" }}
+      style={{ color: 'gray' }}
       tabIndex={-1}
       tabSelectsValue={false}
       value={0}
       valueComponent={ValueComponent}
       valueKey="valueKey"
       valueRenderer={ValueRenderer}
-      wrapperStyle={{ backgroundColor: "white" }}
+      wrapperStyle={{ backgroundColor: 'white' }}
     />;
   });
 
-  it("should error on invalid props usage", () => {
+  it('should error on invalid props usage', () => {
     // $ExpectError addLabelText cannot be number
     <Select addLabelText={123} />;
   });
 
-  it("should handle custom options", () => {
+  it('should handle custom options', () => {
     let customOptionRenderer = (o: OptionType) => <span />;
     let customFilterOption = (options: OptionType[], filterValue: string) =>
       options;
@@ -154,7 +154,7 @@ describe("The `Select` component", () => {
     />;
   });
 
-  it("should error when optionRenderer option param type is not the same as options element type", () => {
+  it('should error when optionRenderer option param type is not the same as options element type', () => {
     let invalidRenderer = (o: string) => <span />;
     // $ExpectError
     <Select
@@ -169,7 +169,7 @@ describe("The `Select` component", () => {
     />;
   });
 
-  it("should error when filterOptions options param type is not an array of options element type", () => {
+  it('should error when filterOptions options param type is not an array of options element type', () => {
     let invalidFilterOptions = (o: string) => <span />;
     // $ExpectError
     <Select

--- a/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/test_react-select_v1.x.x.js
+++ b/definitions/npm/react-select_v1.x.x/flow_v0.53.x-/test_react-select_v1.x.x.js
@@ -170,4 +170,17 @@ describe('The `Select` component', () => {
       filterOptions={invalidFilterOptions}
     />;
   });
+
+  it('should error when given non-existent prop', () => {
+    // $ExpectError
+    <Select
+      name="name"
+      autoFocus
+      placeholder="Enter data"
+      valueKey="id"
+      labelKey="data"
+      options={customOptions}
+      value=""
+    />;
+  });
 });


### PR DESCRIPTION
- Adds `Select.Async`
- Makes `Props` exact so that they're actually type-safe
- Fixes faulty autofocus test (as found by exact `Props`)
- Defines `OptionType` in tests [the same way as it is defined in react-select](https://github.com/JedWatson/react-select/blob/c22d296d50917e210836fb011ae3e565895e6440/src/types.js#L4)
- Adds a test for an invalid prop