### PR TITLE
Add library definitions for react-hot-loader@4.x.x

### DIFF
--- a/definitions/npm/react-hot-loader_v4.x.x/flow_v0.53.0-/react-hot-loader_v4.x.x.js
+++ b/definitions/npm/react-hot-loader_v4.x.x/flow_v0.53.0-/react-hot-loader_v4.x.x.js
@@ -1,0 +1,26 @@
+// @flow
+declare module "react-hot-loader" {
+  declare type Module = {
+    id: string
+  };
+
+  declare type AppContainerProps = {|
+    children: React$Element<any>,
+    errorBoundary?: boolean,
+    errorReporter?: React$ComponentType<{
+      error: Error,
+      errorInfo: { componentStack: string }
+    }>
+  |};
+
+  declare export class AppContainer extends React$Component<
+    AppContainerProps
+  > {}
+
+  declare export function hot(
+    someModule: Module
+  ): <T, W: React$ComponentType<T>>(
+    wrappedComponent: W,
+    props?: $Diff<AppContainerProps, { children: React$Element<any> }>
+  ) => React$ComponentType<T>;
+}

--- a/definitions/npm/react-hot-loader_v4.x.x/flow_v0.53.0-/test_react-hot-loader_4.x.x.js
+++ b/definitions/npm/react-hot-loader_v4.x.x/flow_v0.53.0-/test_react-hot-loader_4.x.x.js
@@ -1,0 +1,116 @@
+// @flow
+import * as React from "react";
+import { describe, it } from "flow-typed-test";
+
+import { AppContainer, hot } from "react-hot-loader";
+
+describe("react-hot-loader", () => {
+  describe("hot", () => {
+    it("accepts some module", () => {
+      hot(module);
+
+      // $ExpectError
+      hot();
+
+      // $ExpectError
+      hot({});
+    });
+
+    it("returns a helper for wrapping a component in AppContainer", () => {
+      const Wrapped = () => <div />;
+
+      hot(module)(Wrapped);
+      hot(module)(Wrapped, {});
+      hot(module)(Wrapped, { errorBoundary: true });
+
+      // $ExpectError
+      hot(module)();
+
+      // $ExpectError
+      hot(module)(Wrapped, { errorBoundary: 1 });
+    });
+
+    it("returned component accepts same props as the wrapped component", () => {
+      const Wrapped = ({ someProp }: {| someProp: string |}) => <div />;
+
+      const Component = hot(module)(Wrapped);
+      <Component someProp={"some"} />;
+
+      // $ExpectError
+      <Component />;
+      // $ExpectError
+      <Component someProp={1} />;
+    });
+  });
+
+  describe("AppContainer", () => {
+    it("accepts only one child", () => {
+      <AppContainer>
+        <div />
+      </AppContainer>;
+
+      const SomeComponent = () => null;
+      <AppContainer>
+        <SomeComponent />
+      </AppContainer>;
+
+      // $ExpectError
+      <AppContainer />;
+
+      // $ExpectError
+      <AppContainer>
+        /<div />
+        <div />
+      </AppContainer>;
+    });
+
+    it("accepts an optional errorBoundary flag", () => {
+      <AppContainer errorBoundary>
+        <div />
+      </AppContainer>;
+
+      <AppContainer errorBoundary={false}>
+        <div />
+      </AppContainer>;
+
+      // $ExpectError
+      <AppContainer errorBoundary={1}>
+        <div />
+      </AppContainer>;
+    });
+
+    it("accepts an optional error reporting component that optionally accepts error and errorInfo", () => {
+      let ErrorReporter;
+
+      ErrorReporter = () => <div />;
+      <AppContainer errorReporter={ErrorReporter}>
+        <div />
+      </AppContainer>;
+
+      ErrorReporter = ({ error }: { error: Error }) => <div />;
+      <AppContainer errorReporter={ErrorReporter}>
+        <div />
+      </AppContainer>;
+
+      ErrorReporter = ({
+        errorInfo
+      }: {
+        errorInfo: { componentStack: string }
+      }) => <div />;
+      <AppContainer errorReporter={ErrorReporter}>
+        <div />
+      </AppContainer>;
+
+      // $ExpectError
+      <AppContainer errorReporter={null}>
+        <div />
+      </AppContainer>;
+
+      // $ExpectError
+      ErrorReporter = ({ error }: { error: number }) => <div />;
+      <AppContainer errorReporter={ErrorReporter}>
+        <div />
+      </AppContainer>;
+    });
+  });
+});


### PR DESCRIPTION
Adds library definitions for `react-hot-loader@4.x.x`.

See:
- https://www.npmjs.com/package/react-hot-loader
- https://github.com/gaearon/react-hot-loader/tree/v4.0.0
- https://github.com/gaearon/react-hot-loader/
- https://github.com/gaearon/react-hot-loader/tree/master/test