### PR TITLE
Add Props type to react-media

### DIFF
--- a/definitions/npm/react-media_v1.x.x/flow_v0.54.1-/react-media_v1.x.x.js
+++ b/definitions/npm/react-media_v1.x.x/flow_v0.54.1-/react-media_v1.x.x.js
@@ -3,7 +3,7 @@ declare module 'react-media' {
     [prop: string]: string | number | boolean
   };
 
-  declare module.exports: React$ComponentType<{
+  declare type Props = {
     defaultMatches?: boolean,
     query?: string | ReactMediaQueryObject | Array<ReactMediaQueryObject>,
     render?: () => React$Node,
@@ -11,5 +11,7 @@ declare module 'react-media' {
     targetWindow?: {
       matchMedia(query: string): void
     }
-  }>;
+  };
+
+  declare module.exports: React$ComponentType<Props>;
 }


### PR DESCRIPTION
I use the `Props` type in my app when wrapping the `<Media>` component:

    import type { Props as MediaProps } from 'react-media';
    const DesktopMediaQuery = (props: MediaProps) => <Media {...props} query={{ minWidth: 1000 }} />;