### PR TITLE
Lodash tests failing with flow v0.89.0

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -6081,3 +6081,4 @@ declare module "lodash/fp/toPath" {
 declare module "lodash/fp/uniqueId" {
   declare module.exports: $PropertyType<$Exports<"lodash/fp">, "uniqueId">;
 }
+// lol


### PR DESCRIPTION
I tried adding an overload of `lodash.values` (#3005 ) however the [CI failed](https://travis-ci.org/flow-typed/flow-typed/jobs/470129954#L938).

I found it highly suspicious that a single addition to `lodash.values` would cause this so I tested a branch that introduces no changes and the same errors exist.

This PR is to show the failures exist in `flow-typed/flow-typed master`.