### PR TITLE
[ramda_v0.x.x] fixed broken ramda tests

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
@@ -1141,8 +1141,8 @@ declare module ramda {
 
   declare function pathEq(
     path: Array<string>,
-  ): ((val: any, o: Object) => boolean) &
-    ((val: any) => (o: Object) => boolean);
+  ): ((val: any) => (o: Object) => boolean) &
+    ((val: any, o: Object) => boolean);
   declare function pathEq(
     path: Array<string>,
     val: any,
@@ -1354,8 +1354,8 @@ declare module ramda {
     src: { [k: string]: T }
   ): { [k: string]: T };
 
-  declare function evolve<A: Object>(NestedObject<Function>, A): A;
   declare function evolve<A: Object>(NestedObject<Function>): A => A;
+  declare function evolve<A: Object>(NestedObject<Function>, A): A;
 
   declare function eqProps(
     key: string,
@@ -1369,8 +1369,8 @@ declare module ramda {
   ): (o2: Object) => boolean;
   declare function eqProps(key: string, o1: Object, o2: Object): boolean;
 
-  declare function has(key: string, o: Object): boolean;
   declare function has(key: string): (o: Object) => boolean;
+  declare function has(key: string, o: Object): boolean;
 
   declare function hasIn(key: string, o: Object): boolean;
   declare function hasIn(key: string): (o: Object) => boolean;


### PR DESCRIPTION
When running `node cli/dist/cli.js run-tests ramda`, there were a number of failing tests.

Swapping the order of the definitions seem to resolve this.

Want to work on some updates to Ramda over the holidays, and fixing existing broken tests seems to be a good start!