### PR TITLE
Add webpack devServer configuration options

### DIFF
--- a/definitions/npm/webpack_v4.x.x/flow_v0.71.x-/webpack_v4.x.x.js
+++ b/definitions/npm/webpack_v4.x.x/flow_v0.71.x-/webpack_v4.x.x.js
@@ -1,3 +1,6 @@
+import * as http from 'http'
+import fs from 'fs'
+
 declare module 'webpack' {
   declare class WebpackError extends Error {
     constructor(message: string): WebpackError;
@@ -414,7 +417,75 @@ declare module 'webpack' {
     cache?: boolean | { [k: string]: any },
     context?: string,
     dependencies?: Array<string>,
-    devServer?: { [k: string]: any },
+    devServer?: {
+      after?: (app: any, server: http.Server) => void,
+      allowedHosts?: string[],
+      before?: (app: any, server: http.Server) => void,
+      bonjour?: boolean,
+      clientLogLevel?: 'none' | 'info' | 'error' | 'warning',
+      compress?: boolean,
+      contentBase?: false | string | string[] | number,
+      disableHostCheck?: boolean,
+      filename?: string,
+      headers?: { [key: string]: string },
+      historyApiFallback?:
+        | boolean
+        | {
+            rewrites?: Array<{ from: string, to: string }>,
+            disableDotRule?: boolean
+          },
+      host?: string,
+      hot?: boolean,
+      hotOnly?: boolean,
+      https?:
+        | boolean
+        | {
+            key: string,
+            cert: string,
+            ca?: string
+          },
+      index?: string,
+      inline?: boolean,
+      lazy?: boolean,
+      noInfo?: boolean,
+      open?: boolean | string,
+      openPage?: string,
+      overlay?:
+        | boolean
+        | {
+            errors?: boolean,
+            warnings?: boolean
+          },
+      pfx?: string,
+      pfxPassphrase?: string,
+      port?: number,
+      proxy?: Object | Array<Object | Function>,
+      public?: string,
+      publicPath?: string,
+      quiet?: boolean,
+      socket?: string,
+      staticOptions?: {
+        dotfiles?: string,
+        etag?: boolean,
+        extensions?: false | string[],
+        fallthrough?: boolean,
+        immutable?: boolean,
+        index?: false | string,
+        lastModified?: boolean,
+        maxAge?: number,
+        redirect?: boolean,
+        setHeaders?: (
+          res: http.OutgoingMessage,
+          path: string,
+          stat: fs.Stat
+        ) => void
+      },
+      stats?: StatsOptions,
+      useLocalIp?: boolean,
+      watchContentBase?: boolean,
+      watchOptions?: WatchOptions,
+      publicPath?: string
+    },
     devtool?:
       | '@cheap-eval-source-map'
       | '@cheap-module-eval-source-map'

--- a/definitions/npm/webpack_v4.x.x/flow_v0.71.x-/webpack_v4.x.x.js
+++ b/definitions/npm/webpack_v4.x.x/flow_v0.71.x-/webpack_v4.x.x.js
@@ -345,58 +345,61 @@ declare module 'webpack' {
 
   declare type FilterTypes = FilterItemTypes | Array<FilterItemTypes>;
 
-  declare type StatsOptions = {
-    all?: boolean,
-    assets?: boolean,
-    assetsSort?: string,
-    builtAt?: boolean,
-    cached?: boolean,
-    cachedAssets?: boolean,
-    children?: boolean,
-    chunkGroups?: boolean,
-    chunkModules?: boolean,
-    chunkOrigins?: boolean,
-    chunks?: boolean,
-    chunksSort?: string,
-    colors?:
-      | boolean
-      | {
-          bold?: string,
-          cyan?: string,
-          green?: string,
-          magenta?: string,
-          red?: string,
-          yellow?: string,
-        },
-    context?: string,
-    depth?: boolean,
-    entrypoints?: boolean,
-    env?: boolean,
-    errorDetails?: boolean,
-    errors?: boolean,
-    exclude?: FilterTypes | boolean,
-    excludeAssets?: FilterTypes,
-    excludeModules?: FilterTypes | boolean,
-    hash?: boolean,
-    maxModules?: number,
-    moduleAssets?: boolean,
-    moduleTrace?: boolean,
-    modules?: boolean,
-    modulesSort?: string,
-    nestedModules?: boolean,
-    optimizationBailout?: boolean,
-    outputPath?: boolean,
-    performance?: boolean,
-    providedExports?: boolean,
-    publicPath?: boolean,
-    reasons?: boolean,
-    source?: boolean,
-    timings?: boolean,
-    usedExports?: boolean,
-    version?: boolean,
-    warnings?: boolean,
-    warningsFilter?: FilterTypes,
-  };
+  declare type StatsOptions =
+    | boolean
+    | ('none' | 'errors-only' | 'minimal' | 'normal' | 'detailed' | 'verbose')
+    | {
+        all?: boolean,
+        assets?: boolean,
+        assetsSort?: string,
+        builtAt?: boolean,
+        cached?: boolean,
+        cachedAssets?: boolean,
+        children?: boolean,
+        chunkGroups?: boolean,
+        chunkModules?: boolean,
+        chunkOrigins?: boolean,
+        chunks?: boolean,
+        chunksSort?: string,
+        colors?:
+          | boolean
+          | {
+              bold?: string,
+              cyan?: string,
+              green?: string,
+              magenta?: string,
+              red?: string,
+              yellow?: string,
+            },
+        context?: string,
+        depth?: boolean,
+        entrypoints?: boolean,
+        env?: boolean,
+        errorDetails?: boolean,
+        errors?: boolean,
+        exclude?: FilterTypes | boolean,
+        excludeAssets?: FilterTypes,
+        excludeModules?: FilterTypes | boolean,
+        hash?: boolean,
+        maxModules?: number,
+        moduleAssets?: boolean,
+        moduleTrace?: boolean,
+        modules?: boolean,
+        modulesSort?: string,
+        nestedModules?: boolean,
+        optimizationBailout?: boolean,
+        outputPath?: boolean,
+        performance?: boolean,
+        providedExports?: boolean,
+        publicPath?: boolean,
+        reasons?: boolean,
+        source?: boolean,
+        timings?: boolean,
+        usedExports?: boolean,
+        version?: boolean,
+        warnings?: boolean,
+        warningsFilter?: FilterTypes,
+      };
 
   declare type WatchOptions = {
     aggregateTimeout?: number,
@@ -473,17 +476,7 @@ declare module 'webpack' {
     resolve?: ResolveOptions,
     resolveLoader?: ResolveOptions,
     serve?: { [k: string]: any },
-    stats?:
-      | StatsOptions
-      | boolean
-      | (
-          | 'none'
-          | 'errors-only'
-          | 'minimal'
-          | 'normal'
-          | 'detailed'
-          | 'verbose'
-        ),
+    stats?: StatsOptions,
     target?:
       | 'web'
       | 'webworker'

--- a/definitions/npm/webpack_v4.x.x/flow_v0.71.x-/webpack_v4.x.x.js
+++ b/definitions/npm/webpack_v4.x.x/flow_v0.71.x-/webpack_v4.x.x.js
@@ -398,6 +398,13 @@ declare module 'webpack' {
     warningsFilter?: FilterTypes,
   };
 
+  declare type WatchOptions = {
+    aggregateTimeout?: number,
+    ignored?: { [k: string]: any },
+    poll?: boolean | number,
+    stdin?: boolean
+  };
+
   declare type WebpackOptions = {
     amd?: { [k: string]: any },
     bail?: boolean,
@@ -487,12 +494,7 @@ declare module 'webpack' {
       | 'electron-renderer'
       | ((compiler: WebpackCompiler) => void),
     watch?: boolean,
-    watchOptions?: {
-      aggregateTimeout?: number,
-      ignored?: { [k: string]: any },
-      poll?: boolean | number,
-      stdin?: boolean,
-    },
+    watchOptions?: WatchOptions,
   };
 
   declare module.exports: (

--- a/definitions/npm/webpack_v4.x.x/test_webpack_v4.x.x.js
+++ b/definitions/npm/webpack_v4.x.x/test_webpack_v4.x.x.js
@@ -1,6 +1,9 @@
 import type { WebpackOptions } from 'webpack';
 
 const options: WebpackOptions = {
+  devServer: {
+    compress: true
+  },
   output: {
     filename: '[name].bundle.js',
   },


### PR DESCRIPTION
Add options for the `{ devServer }` configuration. See [documentation](https://webpack.js.org/configuration/dev-server/#devserver).

Extended the simple shape test to make sure all the `{ devServer }` options are optional.