### PR TITLE
fix(sequelize): add a Transaction.afterCommit typedef

### DIFF
--- a/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/sequelize_v4.x.x.js
+++ b/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/sequelize_v4.x.x.js
@@ -7208,6 +7208,11 @@ declare module "sequelize" {
     rollback(): Promise<void>,
 
     /**
+     * A hook that is run after a transaction is committed
+     */
+    afterCommit(hook: (transaction: Transaction) => Promise<void>): void,
+
+    /**
      * Isolations levels can be set per-transaction by passing `options.isolationLevel` to
      * `sequelize.transaction`. Default to `REPEATABLE_READ` but you can override the default isolation level
      by passing

--- a/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/test_sequelize.js
+++ b/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/test_sequelize.js
@@ -1213,7 +1213,7 @@ User.update( {
 User.unscoped().find( { where : { username : 'bob' } } );
 User.unscoped().count();
 
-// 
+//
 //  Model Statics
 // ~~~~~~~~~~~~~~~
 //
@@ -1925,6 +1925,12 @@ s.transaction( { type : s.Transaction.TYPES.EXCLUSIVE }, (t) => Promise.resolve(
 // promise transaction
 let asyncAutoCallback = async (t: Transaction):Promise<string> => 'a'
 s.transaction( asyncAutoCallback ).then( callbackValidator );
+
+// afterCommit hook
+s.transaction(async (t: Transaction): Promise<void> => {
+  t.afterCommit(async (t: Transaction): Promise<void> => {
+  });
+});
 
 // sync options types
 s.sync({


### PR DESCRIPTION
It has been ported from v5 back to v4.42.0: https://github.com/sequelize/sequelize/commit/d2428dd580c1adb0a4c763a30499da2d87b19b3d
Note that because of the drawbacks of how flow-typed typedef versioning is designed, it will fail to give users of < 4.42.0 an error if they use an `afterCommit` hook, even though it should because it isn't present in earlier versions. ¯\_(ツ)_/¯
@GAntoine once again, there are unrelated buggy flow errors in 0.88 and 0.89 😕 