### PR TITLE
Add all webpack devtool variants

### DIFF
--- a/definitions/npm/webpack_v4.x.x/flow_v0.71.x-/webpack_v4.x.x.js
+++ b/definitions/npm/webpack_v4.x.x/flow_v0.71.x-/webpack_v4.x.x.js
@@ -405,7 +405,48 @@ declare module 'webpack' {
     context?: string,
     dependencies?: Array<string>,
     devServer?: { [k: string]: any },
-    devtool?: string | false,
+    devtool?:
+      | '@cheap-eval-source-map'
+      | '@cheap-module-eval-source-map'
+      | '@cheap-module-source-map'
+      | '@cheap-source-map'
+      | '@eval-source-map'
+      | '@eval'
+      | '@hidden-source-map'
+      | '@inline-source-map'
+      | '@nosources-source-map'
+      | '@source-map'
+      | '#@cheap-eval-source-map'
+      | '#@cheap-module-eval-source-map'
+      | '#@cheap-module-source-map'
+      | '#@cheap-source-map'
+      | '#@eval-source-map'
+      | '#@eval'
+      | '#@hidden-source-map'
+      | '#@inline-source-map'
+      | '#@nosources-source-map'
+      | '#@source-map'
+      | '#cheap-eval-source-map'
+      | '#cheap-module-eval-source-map'
+      | '#cheap-module-source-map'
+      | '#cheap-source-map'
+      | '#eval-source-map'
+      | '#eval'
+      | '#hidden-source-map'
+      | '#inline-source-map'
+      | '#nosources-source-map'
+      | '#source-map'
+      | 'cheap-eval-source-map'
+      | 'cheap-module-eval-source-map'
+      | 'cheap-module-source-map'
+      | 'cheap-source-map'
+      | 'eval-source-map'
+      | 'eval'
+      | 'hidden-source-map'
+      | 'inline-source-map'
+      | 'nosources-source-map'
+      | 'source-map'
+      | false,
     entry?: Entry,
     externals?: Externals,
     loader?: { [k: string]: any },


### PR DESCRIPTION
Adds all the possible options for configuring [`{ devtool }`](https://webpack.js.org/configuration/devtool/) with webpack.