### PR TITLE
[ramda] fixed a bug with the flow 0.88.0 and higher

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
@@ -1141,8 +1141,8 @@ declare module ramda {
 
   declare function pathEq(
     path: Array<string>,
-  ): ((val: any, o: Object) => boolean) &
-    ((val: any) => (o: Object) => boolean);
+  ): ((val: any) => (o: Object) => boolean) &
+    ((val: any, o: Object) => boolean);
   declare function pathEq(
     path: Array<string>,
     val: any,
@@ -1354,8 +1354,8 @@ declare module ramda {
     src: { [k: string]: T }
   ): { [k: string]: T };
 
-  declare function evolve<A: Object>(NestedObject<Function>, A): A;
   declare function evolve<A: Object>(NestedObject<Function>): A => A;
+  declare function evolve<A: Object>(NestedObject<Function>, A): A;
 
   declare function eqProps(
     key: string,
@@ -1369,8 +1369,8 @@ declare module ramda {
   ): (o2: Object) => boolean;
   declare function eqProps(key: string, o1: Object, o2: Object): boolean;
 
-  declare function has(key: string, o: Object): boolean;
   declare function has(key: string): (o: Object) => boolean;
+  declare function has(key: string, o: Object): boolean;
 
   declare function hasIn(key: string, o: Object): boolean;
   declare function hasIn(key: string): (o: Object) => boolean;


### PR DESCRIPTION
When I tried to improve types for ramda I found that types have an error for flow version 0.88.0 and higher. This commit will fix this.

Error example: 
```
ERROR: ramda_v0.x.x/flow_v0.82.x-
* ramda_v0.x.x/flow_v0.82.x- (flow-v0.89.0): Unexpected Flow errors (2):

    Error ------------------------------------------------------------------------------- test_ramda_v0.x.x_object.js:127:18

    Cannot call `_.evolve(...)` because undefined [1] is not a function.

       test_ramda_v0.x.x_object.js:127:18
                             v---------
       127| const evolved2 = _.evolve({
       128|   foo: x => x + 1,
       129|   bar: x => x + 2
       130| })({
       131|   foo: 1,
       132|   bar: 2
       133| });
            -^

    References:
       test_ramda_v0.x.x_object.js:127:18
                             v---------
       127| const evolved2 = _.evolve({
       128|   foo: x => x + 1,
       129|   bar: x => x + 2
       130| })({
            -^ [1]
```