### PR TITLE
[http-errors] Allow message in constructor

### DIFF
--- a/definitions/npm/http-errors_v1.x.x/flow_v0.25.x-/http-errors_v1.x.x.js
+++ b/definitions/npm/http-errors_v1.x.x/flow_v0.25.x-/http-errors_v1.x.x.js
@@ -1,6 +1,6 @@
 declare module 'http-errors' {
   declare class SpecialHttpError extends HttpError {
-    constructor(): SpecialHttpError;
+    constructor(message?: string): SpecialHttpError;
   }
   declare class HttpError extends Error {
     expose: bool;

--- a/definitions/npm/http-errors_v1.x.x/test_http-errors_v1.x.x.js
+++ b/definitions/npm/http-errors_v1.x.x/test_http-errors_v1.x.x.js
@@ -7,6 +7,7 @@ const C: HttpErrors.HttpError = HttpErrors(200, 'foo', {});
 const D: HttpErrors.HttpError = HttpErrors('500');
 const E: HttpErrors.NotFound = new HttpErrors.NotFound();
 const F: HttpErrors.HttpError = new HttpErrors.LengthRequired;
+const F: HttpErrors.HttpError = new HttpErrors.HttpError('foo');
 
 (F.expose: bool);
 (F.message: string);

--- a/definitions/npm/http-errors_v1.x.x/test_http-errors_v1.x.x.js
+++ b/definitions/npm/http-errors_v1.x.x/test_http-errors_v1.x.x.js
@@ -7,7 +7,7 @@ const C: HttpErrors.HttpError = HttpErrors(200, 'foo', {});
 const D: HttpErrors.HttpError = HttpErrors('500');
 const E: HttpErrors.NotFound = new HttpErrors.NotFound();
 const F: HttpErrors.HttpError = new HttpErrors.LengthRequired;
-const F: HttpErrors.HttpError = new HttpErrors.HttpError('foo');
+const G: HttpErrors.HttpError = new HttpErrors.HttpError('foo');
 
 (F.expose: bool);
 (F.message: string);


### PR DESCRIPTION
Looks like constructor actually allows custom error message https://github.com/jshttp/http-errors/blob/master/index.js#L135 & https://github.com/jshttp/http-errors/blob/master/index.js#L183