### PR TITLE
Copied Jasmine@2.4.x to Jasmine@2.9.x

### DIFF
--- a/definitions/npm/jasmine_v2.9.x/flow_v0.25.x-/jasmine_v2.9.x.js
+++ b/definitions/npm/jasmine_v2.9.x/flow_v0.25.x-/jasmine_v2.9.x.js
@@ -1,0 +1,107 @@
+/* eslint-disable flowtype/no-weak-types */
+
+type JasmineExpectType = {
+  not: JasmineExpectType,
+  toBe(value: mixed): void,
+  toBeCloseTo(num: number, delta: mixed): void,
+  toBeDefined(): void,
+  toBeFalsy(): void,
+  toBeGreaterThan(number: number): void,
+  toBeLessThan(number: number): void,
+  toBeNull(): void,
+  toBeTruthy(): void,
+  toBeUndefined(): void,
+  toContain(str: string): void,
+  toEqual(value: mixed): void,
+  toHaveBeenCalled(): void,
+  toHaveBeenCalledTimes(number: number): void,
+  toHaveBeenCalledWith(...args: Array<any>): void,
+  toMatch(regexp: RegExp): void,
+  toThrow(message?: string): void,
+  toThrowError(val: mixed): void
+};
+
+declare function describe(name: string, fn: Function): void;
+declare function fdescribe(name: string, fn: Function): void;
+declare function xdescribe(name: string, fn: Function): void;
+
+declare function beforeEach(fn: Function, timeout?: number): void;
+declare function afterEach(fn: Function, timeout?: number): void;
+declare function beforeAll(fn: Function, timeout?: number): void;
+declare function afterAll(fn: Function, timeout?: number): void;
+
+declare function it(name: string, fn: Function, timeout?: number): void;
+declare function fit(name: string, fn: Function, timeout?: number): void;
+declare function xit(name: string, fn: Function): void;
+
+declare function expect(value: mixed): JasmineExpectType;
+declare function pending(message?: string): void;
+declare function fail(err?: Error | string): void;
+
+// TODO handle return type
+// http://jasmine.github.io/2.9/introduction.html#section-Spies
+declare function spyOn(value: mixed, method: string): Object;
+
+type JasmineCallsType = {
+  allArgs(): mixed,
+  all(): mixed,
+  mostRecent(): mixed,
+  first(): mixed,
+  any(): boolean,
+  count(): number,
+  reset(): void
+};
+
+type JasmineSpyStrategyType = {
+  callFake((...args: Array<any>) => any): JasmineSpyType,
+  callThrough(): JasmineSpyType,
+  identity: string,
+  returnValue(value: any): JasmineSpyType,
+  returnValues(...values: any): JasmineSpyType,
+  stub(): JasmineSpyType,
+  throwError(errorMessage?: string): JasmineSpyType
+};
+
+type JasmineSpyTypeProto = {
+  and: JasmineSpyStrategyType,
+  calls: JasmineCallsType
+};
+
+type JasmineSpyType = JasmineSpyTypeProto & Function;
+
+type JasmineClockType = {
+  install(): void,
+  uninstall(): void,
+  tick(milliseconds?: number): void,
+  mockDate(date: Date): void
+};
+
+declare type JasmineMatcherResult = {
+  pass: boolean,
+  message?: string | (() => string)
+};
+
+declare type JasmineMatcherStruct = {
+  compare<T: any>(actual: T, expected: T): JasmineMatcherResult
+};
+
+declare type JasmineMatcher = (
+  utils?: mixed,
+  customEqualityTesters?: mixed
+) => JasmineMatcherStruct;
+
+declare type JasmineMatchers = {
+  [key: string]: JasmineMatcher
+};
+
+declare var jasmine: {
+  DEFAULT_TIMEOUT_INTERVAL: number,
+  createSpy(name?: string): JasmineSpyType,
+  any(val: mixed): void,
+  anything(): void,
+  objectContaining(val: Object): void,
+  arrayContaining(val: mixed[]): void,
+  stringMatching(val: string): void,
+  clock(): JasmineClockType,
+  addMatchers(val: JasmineMatchers): void
+};

--- a/definitions/npm/jasmine_v2.9.x/test_jasmine_v2.9.x.js
+++ b/definitions/npm/jasmine_v2.9.x/test_jasmine_v2.9.x.js
@@ -1,0 +1,6 @@
+/* @flow */
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+
+// $ExpectError
+jasmine.DEFAULT_TIMEOUT_INTERVAL = null;

--- a/definitions/npm/jasmine_v2.9.x/test_jasmine_v2.9.x_addMatchers.js
+++ b/definitions/npm/jasmine_v2.9.x/test_jasmine_v2.9.x_addMatchers.js
@@ -1,0 +1,98 @@
+/* @flow */
+
+/**
+ * addMatchers
+ */
+
+jasmine.addMatchers({
+  toHaveFoo1: (utils, customEqualityTesters) => {
+    return {
+      compare: (actual: string, expected: string) => {
+        return {
+          pass: true,
+          message: "Nothing to see here"
+        };
+      }
+    }
+  }
+});
+
+jasmine.addMatchers({
+  toHaveFoo2: () => {
+    return {
+      compare: (actual, expected) => {
+        return {
+          pass: actual === expected,
+          message: "Nothing to see here"
+        };
+      }
+    }
+  }
+});
+
+jasmine.addMatchers({
+  toHaveFoo3: () => {
+    return {
+      compare: (a, b) => {
+        return {
+          pass: a === b,
+          message: () => 'A is not B'
+        };
+      }
+    }
+  }
+});
+
+
+jasmine.addMatchers({
+  toHaveFoo4: () => {
+    var check = (a, b) => a == b;
+    return {
+      compare: (a, b) => {
+        return {
+          pass: check(a, b),
+          message: () => 'A is not B'
+        };
+      }
+    }
+  }
+});
+
+// $ExpectError
+var badResult1: JasmineMatcherResult = false;
+
+// $ExpectError
+var badResult2: JasmineMatcherResult = {
+  message: 'Did not pass',
+};
+
+var badResult3: JasmineMatcherResult = {
+  pass: true,
+
+  // $ExpectError
+  message: () => false
+};
+
+// $ExpectError
+var badStruct1: JasmineMatcherStruct = 1;
+
+// $ExpectError
+var badStruct2: JasmineMatcherStruct = {
+  notCompare: (actual, expected): JasmineMatcherResult => {
+    return {
+      pass: true
+    }
+  }
+}
+
+// $ExpectError
+var badMatcher1: JasmineMatcher = (utils, customEqualityTesters, extra) => {
+  compare: (actual, expected): JasmineMatcherResult => {
+    return {
+      pass: true
+    }
+  }
+}
+
+// $ExpectError
+jasmine.addMatchers('a');

--- a/definitions/npm/jasmine_v2.9.x/test_jasmine_v2.9.x_describe.js
+++ b/definitions/npm/jasmine_v2.9.x/test_jasmine_v2.9.x_describe.js
@@ -1,0 +1,35 @@
+/* @flow */
+
+/**
+ * describe
+ */
+
+describe('desc', () => {});
+
+// $ExpectError number. This type is incompatible with function type.
+describe('desc', 12);
+// $ExpectError number. This type is incompatible with string.
+describe(12, () => {});
+
+/**
+ * fdescribe
+ */
+
+fdescribe('desc', () => {});
+
+// $ExpectError number. This type is incompatible with function type.
+fdescribe('desc', 12);
+// $ExpectError number. This type is incompatible with string.
+fdescribe(12, () => {});
+
+/**
+ * xdescribe
+ */
+
+xdescribe('desc', () => {});
+
+// $ExpectError number. This type is incompatible with function type.
+xdescribe('desc', 12);
+// $ExpectError number. This type is incompatible with string.
+xdescribe(12, () => {});
+

--- a/definitions/npm/jasmine_v2.9.x/test_jasmine_v2.9.x_fail.js
+++ b/definitions/npm/jasmine_v2.9.x/test_jasmine_v2.9.x_fail.js
@@ -1,0 +1,8 @@
+/* @flow */
+
+fail('test failed');
+fail(new Error('error'));
+fail();
+
+// $ExpectError string. This type is incompatible with string.
+fail(true);

--- a/definitions/npm/jasmine_v2.9.x/test_jasmine_v2.9.x_hooks.js
+++ b/definitions/npm/jasmine_v2.9.x/test_jasmine_v2.9.x_hooks.js
@@ -1,0 +1,34 @@
+/* @flow */
+
+/**
+ * beforeAll
+ */
+
+beforeAll(() => {});
+// $ExpectError
+beforeAll();
+
+/**
+ * beforeEach
+ */
+
+beforeEach(() => {});
+// $ExpectError
+beforeEach();
+
+
+/**
+ * afterAll
+ */
+
+afterAll(() => {});
+// $ExpectError
+afterAll();
+
+/**
+ * afterEach
+ */
+
+afterEach(() => {});
+// $ExpectError
+afterEach();

--- a/definitions/npm/jasmine_v2.9.x/test_jasmine_v2.9.x_it.js
+++ b/definitions/npm/jasmine_v2.9.x/test_jasmine_v2.9.x_it.js
@@ -1,0 +1,36 @@
+/* @flow */
+
+/**
+ * it
+ */
+
+it('desc', () => {});
+
+// $ExpectError number. This type is incompatible with function type.
+it('desc', 12);
+// $ExpectError number. This type is incompatible with string.
+it(12, () => {});
+
+
+/**
+ * fit
+ */
+
+fit('desc', () => {});
+
+// $ExpectError number. This type is incompatible with function type.
+fit('desc', 12);
+// $ExpectError number. This type is incompatible with string.
+fit(12, () => {});
+
+
+/**
+ * xit
+ */
+
+xit('desc', () => {});
+
+// $ExpectError number. This type is incompatible with function type.
+xit('desc', 12);
+// $ExpectError number. This type is incompatible with string.
+xit(12, () => {});

--- a/definitions/npm/jasmine_v2.9.x/test_jasmine_v2.9.x_pending.js
+++ b/definitions/npm/jasmine_v2.9.x/test_jasmine_v2.9.x_pending.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+pending('this is not written yet');
+pending();
+
+// $ExpectError
+pending(true);

--- a/definitions/npm/jasmine_v2.9.x/test_jasmine_v2.9.x_spies.js
+++ b/definitions/npm/jasmine_v2.9.x/test_jasmine_v2.9.x_spies.js
@@ -1,0 +1,30 @@
+/* @flow */
+
+const namelessSpy = jasmine.createSpy();
+const spy = jasmine.createSpy('mySpy');
+
+// $ExpectError
+const badName = jasmine.createSpy(12);
+
+spy.calls.allArgs();
+spy.calls.all();
+spy.calls.mostRecent();
+spy.calls.first();
+spy.calls.any();
+spy.calls.count();
+spy.calls.reset();
+
+spy.and.callFake(() => {});
+
+// $ExpectError
+spy.and.callFake();
+
+spy.and.callThrough();
+spy.and.identity;
+spy.and.returnValue(undefined);
+spy.and.returnValue(null);
+spy.and.returnValue({});
+spy.and.returnValues({}, null, 12);
+spy.and.stub();
+spy.and.throwError('a bad thing happened');
+spy.and.throwError();


### PR DESCRIPTION
- I did not change the definitions at all because 2.9 should be
  backwards compatible with 2.4.
- Verified that the bindings work for simple tests with the default
  expectations.