### PR TITLE
Update type definition for `react-nativation`

### DIFF
--- a/definitions/npm/react-navigation_v3.x.x/flow_v0.60.x-/react-navigation_v3.x.x.js
+++ b/definitions/npm/react-navigation_v3.x.x/flow_v0.60.x-/react-navigation_v3.x.x.js
@@ -1208,19 +1208,19 @@ declare module 'react-navigation' {
   };
   declare export var TabBarBottom: React$ComponentType<_TabBarBottomProps>;
 
-  declare export function withNavigation<Props: {}>(
-    Component: React$ComponentType<Props>
+  declare export function withNavigation<Props: {}, ComponentType: React$ComponentType<Props>>(
+    Component: ComponentType
   ): React$ComponentType<
     $Diff<
-      Props,
+      React$ElementConfig<ComponentType>,
       {
         navigation: NavigationScreenProp<NavigationStateRoute> | void,
       }
     >
   >;
-  declare export function withNavigationFocus<Props: {}>(
-    Component: React$ComponentType<Props>
-  ): React$ComponentType<$Diff<Props, { isFocused: boolean | void }>>;
+  declare export function withNavigationFocus<Props: {}, ComponentType: React$ComponentType<Props>>(
+    Component: ComponentType
+  ): React$ComponentType<$Diff<React$ElementConfig<ComponentType>, { isFocused: boolean | void }>>;
 
   declare export function getNavigation<State: NavigationState, Options: {}>(
     router: NavigationRouter<State, Options>,


### PR DESCRIPTION
More context: https://github.com/react-navigation/react-navigation/pull/5398

Currently if you wrap a component that uses `defaultProps` with `withNavigation` or `withNavigationFocus` the `defaultProps` will become non-optional.

This PR updates the flow definition for these higher order components to use [`React.ElementConfig`](https://flow.org/en/docs/react/types/#toc-react-elementconfig) which correctly preserves the optionality of `defaultProps`.

These changes aren't required on flow >= 0.89, but most people aren't running the latest version because React Native usually lags behind by a few versions.

Here's a [before/after example](https://flow.org/try/#0PTAEAEDMBsHsHcBQiCWBbADrATgF1AFSgCGAzqAEoCmxAxvpNrGqAOTY32sDcykArgDt6KWINDwUuABYA5YgDcUAc2K5RggGKxa-UrKrwAPAAUmGUgC5QAbwC+AGlABhZlkFVBuACoBPDFTW1HS4ACSumGKePv5UpuakAHyJABSIoC5uUV7WEe7RfgGIAJRBnGF52TEBRqEAIiiQkEbB9KEAotBUaNGugpAqRpUeXoVUiU42oCik2rqkVAAm1gBGsLBdxOIAPqAKsCiLoHbJtumgHLj82OIpGAnWZrAWxaAAvImgQ1kj+DYAdID7s9SHZprMdHolqBgIlEHY+EIRGIJFI5IoVGoNHM9AB5aCLeIg6z2VLnYbRMohcI-AqxIkWOGlSjlGmRX5jWoNJoM0iTcE4hbLUBrDY0HZ7A5HE6fGznS7XW7AiyPBKvD5fCleWyA-7K0ECyFCmFwhGIXCxUBPCzvM4ZSDrVbrTaCBznFbEbBOsVbN0ZGaCpbel2gXb7Q5uuy8ATCdQorW4ADqaLqVEgxH40Fw1tIdweVrVdouVCuN1Agkz0F4CITyZkqfTmezCX+izTGazOdtcvtjtAuGw-Cokd4iFoYlI+E0KAAHtC3qiZPIlKo41ojQZ4Clayn202c8VeOPBJPQAAhJgAa08tskS4xq+xRvxi23tK8dekDY7zZBh8RsYaKA3hUJOKSvD2xalrc5wZC05T-Jo2DEMoPReHCGSYV805zkcHrYCasGYUYF6wNe4j4YRWFGMArS4IhyGodEGGgP+dhAA) on the Flow Try page.