### PR TITLE
[lodash_v4.x.x] Add potentially-void return types for lodash functions

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -260,7 +260,7 @@ declare module "lodash" {
       fromIndex?: ?number
     ): -1;
     // alias of _.head
-    first<T>(array: ?$ReadOnlyArray<T>): T;
+    first<T>(array: ?$ReadOnlyArray<T>): T | void;
     flatten<T, X>(array?: ?Array<Array<T> | X>): Array<T | X>;
     flattenDeep<T>(array?: ?(any[])): Array<T>;
     flattenDepth(array?: ?(any[]), depth?: ?number): any[];
@@ -318,7 +318,7 @@ declare module "lodash" {
     ): Array<T>;
     join<T>(array: Array<T>, separator?: ?string): string;
     join<T>(array: void | null, separator?: ?string): "";
-    last<T>(array: ?$ReadOnlyArray<T>): T;
+    last<T>(array: ?$ReadOnlyArray<T>): T | void;
     lastIndexOf<T>(array: Array<T>, value?: ?T, fromIndex?: ?number): number;
     lastIndexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
     nth<T>(array: T[], n?: ?number): T;
@@ -935,12 +935,12 @@ declare module "lodash" {
     ceil(number: number, precision?: number): number;
     divide(dividend: number, divisor: number): number;
     floor(number: number, precision?: number): number;
-    max<T>(array: ?Array<T>): T;
-    maxBy<T>(array: ?$ReadOnlyArray<T>, iteratee?: Iteratee<T>): T;
+    max<T>(array: ?Array<T>): T | void;
+    maxBy<T>(array: ?$ReadOnlyArray<T>, iteratee?: Iteratee<T>): T | void;
     mean(array: Array<*>): number;
     meanBy<T>(array: Array<T>, iteratee?: Iteratee<T>): number;
-    min<T>(array: ?Array<T>): T;
-    minBy<T>(array: ?$ReadOnlyArray<T>, iteratee?: Iteratee<T>): T;
+    min<T>(array: ?Array<T>): T | void;
+    minBy<T>(array: ?$ReadOnlyArray<T>, iteratee?: Iteratee<T>): T | void;
     multiply(multiplier: number, multiplicand: number): number;
     round(number: number, precision?: number): number;
     subtract(minuend: number, subtrahend: number): number;
@@ -1752,7 +1752,7 @@ declare module "lodash/fp" {
       array: $ReadOnlyArray<T>
     ): number;
     // alias of _.head
-    first<T>(array: $ReadOnlyArray<T>): T;
+    first<T>(array: $ReadOnlyArray<T>): T | void;
     flatten<T, X>(array: Array<Array<T> | X>): Array<T | X>;
     unnest<T, X>(array: Array<Array<T> | X>): Array<T | X>;
     flattenDeep<T>(array: any[]): Array<T>;
@@ -1800,7 +1800,7 @@ declare module "lodash/fp" {
     ): Array<T>;
     join<T>(separator: string): (array: Array<T>) => string;
     join<T>(separator: string, array: Array<T>): string;
-    last<T>(array: Array<T>): T;
+    last<T>(array: Array<T>): T | void;
     lastIndexOf<T>(value: T): (array: Array<T>) => number;
     lastIndexOf<T>(value: T, array: Array<T>): number;
     lastIndexOfFrom<T>(
@@ -2558,15 +2558,15 @@ declare module "lodash/fp" {
     divide(dividend: number): (divisor: number) => number;
     divide(dividend: number, divisor: number): number;
     floor(number: number): number;
-    max<T>(array: Array<T>): T;
-    maxBy<T>(iteratee: Iteratee<T>): (array: Array<T>) => T;
-    maxBy<T>(iteratee: Iteratee<T>, array: Array<T>): T;
+    max<T>(array: Array<T>): T | void;
+    maxBy<T>(iteratee: Iteratee<T>): (array: Array<T>) => T | void;
+    maxBy<T>(iteratee: Iteratee<T>, array: Array<T>): T | void;
     mean(array: Array<*>): number;
     meanBy<T>(iteratee: Iteratee<T>): (array: Array<T>) => number;
     meanBy<T>(iteratee: Iteratee<T>, array: Array<T>): number;
-    min<T>(array: Array<T>): T;
-    minBy<T>(iteratee: Iteratee<T>): (array: Array<T>) => T;
-    minBy<T>(iteratee: Iteratee<T>, array: Array<T>): T;
+    min<T>(array: Array<T>): T | void;
+    minBy<T>(iteratee: Iteratee<T>): (array: Array<T>) => T | void;
+    minBy<T>(iteratee: Iteratee<T>, array: Array<T>): T | void;
     multiply(multiplier: number): (multiplicand: number) => number;
     multiply(multiplier: number, multiplicand: number): number;
     round(number: number): number;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -263,7 +263,7 @@ declare module "lodash" {
     first<T>(array: ?$ReadOnlyArray<T>): T | void;
     flatten<T, X>(array?: ?Array<Array<T> | X>): Array<T | X>;
     flattenDeep<T>(array?: ?(any[])): Array<T>;
-    flattenDepth(array?: ?(any[]), depth?: ?number): any[];
+    flattenDepth(array?: ?(any[]), depth?: ?number): Array<mixed>;
     fromPairs<A, B>(pairs?: ?Array<[A, B]>): { [key: A]: B };
     head<T>(array: ?$ReadOnlyArray<T>): T;
     indexOf<T>(array: Array<T>, value: T, fromIndex?: number): number;
@@ -633,12 +633,12 @@ declare module "lodash" {
       array?: ?$ReadOnlyArray<T>,
       path?: ?((value: T) => Array<string> | string) | Array<string> | string,
       ...args?: Array<any>
-    ): Array<any>;
+    ): Array<mixed>;
     invokeMap<T: Object>(
       object: T,
       path: ((value: any) => Array<string> | string) | Array<string> | string,
       ...args?: Array<any>
-    ): Array<any>;
+    ): Array<mixed>;
     keyBy<T, V>(
       array: $ReadOnlyArray<T>,
       iteratee?: ?ValueOnlyIteratee<T>
@@ -806,7 +806,7 @@ declare module "lodash" {
     wrap(value?: any, wrapper?: ?Function): Function;
 
     // Lang
-    castArray(value: *): any[];
+    castArray(value: *): Array<mixed>;
     clone<T>(value: T): T;
     cloneDeep<T>(value: T): T;
     cloneDeepWith<T, U>(
@@ -915,7 +915,7 @@ declare module "lodash" {
     isWeakSet(value: any): false;
     lt(value: any, other: any): boolean;
     lte(value: any, other: any): boolean;
-    toArray(value: any): Array<any>;
+    toArray(value: any): Array<mixed>;
     toFinite(value: void | null): 0;
     toFinite(value: any): number;
     toInteger(value: void | null): 0;
@@ -1062,8 +1062,8 @@ declare module "lodash" {
         source: A | B | C | D
       ) => any | void
     ): Object;
-    at(object?: ?Object, ...paths: Array<string>): Array<any>;
-    at(object?: ?Object, paths: Array<string>): Array<any>;
+    at(object?: ?Object, ...paths: Array<string>): Array<mixed>;
+    at(object?: ?Object, paths: Array<string>): Array<mixed>;
     create(prototype: void | null, properties: void | null): {};
     create<T>(prototype: T, properties: Object): $Supertype<T>;
     create(prototype: any, properties: void | null): {};
@@ -1302,8 +1302,8 @@ declare module "lodash" {
       updater?: ?Function,
       customizer?: ?Function
     ): T;
-    values(object?: ?Object): Array<any>;
-    valuesIn(object?: ?Object): Array<any>;
+    values(object?: ?Object): Array<mixed>;
+    valuesIn(object?: ?Object): Array<mixed>;
 
     // Seq
     // harder to read, but this is _()
@@ -1756,8 +1756,8 @@ declare module "lodash/fp" {
     flatten<T, X>(array: Array<Array<T> | X>): Array<T | X>;
     unnest<T, X>(array: Array<Array<T> | X>): Array<T | X>;
     flattenDeep<T>(array: any[]): Array<T>;
-    flattenDepth(depth: number): (array: any[]) => any[];
-    flattenDepth(depth: number, array: any[]): any[];
+    flattenDepth(depth: number): (array: any[]) => Array<mixed>;
+    flattenDepth(depth: number, array: any[]): Array<mixed>;
     fromPairs<A, B>(pairs: Array<[A, B]>): { [key: A]: B };
     head<T>(array: $ReadOnlyArray<T>): T;
     indexOf<T>(value: T): (array: Array<T>) => number;
@@ -1989,7 +1989,7 @@ declare module "lodash/fp" {
     ): Array<T>;
     zip<A, B>(a1: A[]): (a2: B[]) => Array<[A, B]>;
     zip<A, B>(a1: A[], a2: B[]): Array<[A, B]>;
-    zipAll(arrays: Array<Array<any>>): Array<any>;
+    zipAll(arrays: Array<Array<any>>): Array<mixed>;
     zipObject<K, V>(props?: Array<K>): (values?: Array<V>) => { [key: K]: V };
     zipObject<K, V>(props?: Array<K>, values?: Array<V>): { [key: K]: V };
     zipObj(props: Array<any>): (values: Array<any>) => Object;
@@ -2181,11 +2181,11 @@ declare module "lodash/fp" {
     includesFrom<T>(value: T, fromIndex: number, collection: Array<T>): boolean;
     invokeMap<T>(
       path: ((value: T) => Array<string> | string) | Array<string> | string
-    ): (collection: Array<T> | { [id: any]: T }) => Array<any>;
+    ): (collection: Array<T> | { [id: any]: T }) => Array<mixed>;
     invokeMap<T>(
       path: ((value: T) => Array<string> | string) | Array<string> | string,
       collection: Array<T> | { [id: any]: T }
-    ): Array<any>;
+    ): Array<mixed>;
     invokeArgsMap<T>(
       path: ((value: T) => Array<string> | string) | Array<string> | string
     ): ((
@@ -2198,12 +2198,12 @@ declare module "lodash/fp" {
     invokeArgsMap<T>(
       path: ((value: T) => Array<string> | string) | Array<string> | string,
       collection: Array<T> | { [id: any]: T }
-    ): (args: Array<any>) => Array<any>;
+    ): (args: Array<any>) => Array<mixed>;
     invokeArgsMap<T>(
       path: ((value: T) => Array<string> | string) | Array<string> | string,
       collection: Array<T> | { [id: any]: T },
       args: Array<any>
-    ): Array<any>;
+    ): Array<mixed>;
     keyBy<T, V>(
       iteratee: ValueOnlyIteratee<T>
     ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => { [key: V]: T };
@@ -2385,7 +2385,7 @@ declare module "lodash/fp" {
     wrap(wrapper: Function, value: any): Function;
 
     // Lang
-    castArray(value: *): any[];
+    castArray(value: *): Array<mixed>;
     clone<T>(value: T): T;
     cloneDeep<T>(value: T): T;
     cloneDeepWith<T, U>(
@@ -2542,7 +2542,7 @@ declare module "lodash/fp" {
     lt(value: any, other: any): boolean;
     lte(value: any): (other: any) => boolean;
     lte(value: any, other: any): boolean;
-    toArray(value: any): Array<any>;
+    toArray(value: any): Array<mixed>;
     toFinite(value: any): number;
     toInteger(value: any): number;
     toLength(value: any): number;
@@ -2717,12 +2717,12 @@ declare module "lodash/fp" {
       ) => any | void,
       objects: Array<Object>
     ): Object;
-    at(paths: Array<string>): (object: Object) => Array<any>;
-    at(paths: Array<string>, object: Object): Array<any>;
-    props(paths: Array<string>): (object: Object) => Array<any>;
-    props(paths: Array<string>, object: Object): Array<any>;
-    paths(paths: Array<string>): (object: Object) => Array<any>;
-    paths(paths: Array<string>, object: Object): Array<any>;
+    at(paths: Array<string>): (object: Object) => Array<mixed>;
+    at(paths: Array<string>, object: Object): Array<mixed>;
+    props(paths: Array<string>): (object: Object) => Array<mixed>;
+    props(paths: Array<string>, object: Object): Array<mixed>;
+    paths(paths: Array<string>): (object: Object) => Array<mixed>;
+    paths(paths: Array<string>, object: Object): Array<mixed>;
     create<T>(prototype: T): $Supertype<T>;
     defaults(source: Object): (object: Object) => Object;
     defaults(source: Object, object: Object): Object;
@@ -3055,8 +3055,8 @@ declare module "lodash/fp" {
       updater: Function,
       object: Object
     ): Object;
-    values(object: Object): Array<any>;
-    valuesIn(object: Object): Array<any>;
+    values(object: Object): Array<mixed>;
+    valuesIn(object: Object): Array<mixed>;
 
     tap<T>(interceptor: (value: T) => any): (value: T) => T;
     tap<T>(interceptor: (value: T) => any, value: T): T;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-fp-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-fp-v4.x.x.js
@@ -398,7 +398,7 @@ directSquares = map(function(num) {
   return num * num;
 }, nums);
 
-num = first(nums);
+num = first(nums) || 0;
 
 // return type of iterator is reflected in result and chain
 nativeStrings = nums.map(function(num) {

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -21,8 +21,13 @@ import intersectionBy from "lodash/intersectionBy";
 import isEqual from "lodash/isEqual";
 import isString from "lodash/isString";
 import keyBy from "lodash/keyBy";
+import last from "lodash/last";
 import map from "lodash/map";
+import max from "lodash/max";
+import maxBy from "lodash/maxBy";
 import memoize from "lodash/memoize";
+import min from "lodash/min";
+import minBy from "lodash/minBy";
 import noop from "lodash/noop";
 import omitBy from "lodash/omitBy";
 import pickBy from "lodash/pickBy";
@@ -502,3 +507,39 @@ pairs = toPairsIn({ a: 12, b: 100 });
 (omitBy(null, num => num % 2): {});
 (omitBy(undefined, num => num % 2): {});
 (omitBy({ [1]: 1, [2]: 2 }, num => num === 2): { [prop: number]: number });
+
+/**
+ * _.first
+ */
+(first([3, 2, 1]): number);
+(first([]): void);
+
+/**
+ * _.last
+ */
+(last([3, 2, 1]): number);
+(last([]): void);
+
+/**
+ * _.min
+ */
+(min([3, 2, 1]): number);
+(min([]): void);
+
+/**
+ * _.minBy
+ */
+(minBy([3, 2, 1], x => x): number);
+(minBy([], x => x): void);
+
+/**
+ * _.max
+ */
+(max([3, 2, 1]): number);
+(max([]): void);
+
+/**
+ * _.maxBy
+ */
+(maxBy([3, 2, 1], x => x): number);
+(maxBy([], x => x): void);

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -412,7 +412,7 @@ directSquares = map(nums, function(num) {
   return num * num;
 });
 
-num = first(nums);
+num = first(nums) || 0;
 
 // return type of iterator is reflected in result and chain
 nativeStrings = nums.map(function(num) {
@@ -511,35 +511,35 @@ pairs = toPairsIn({ a: 12, b: 100 });
 /**
  * _.first
  */
-(first([3, 2, 1]): number);
-(first([]): void);
+(first([3, 2, 1]): number | void);
+(first([]): number | void);
 
 /**
  * _.last
  */
-(last([3, 2, 1]): number);
-(last([]): void);
+(last([3, 2, 1]): number | void);
+(last([]): number | void);
 
 /**
  * _.min
  */
-(min([3, 2, 1]): number);
-(min([]): void);
+(min([3, 2, 1]): number | void);
+(min([]): number | void);
 
 /**
  * _.minBy
  */
-(minBy([3, 2, 1], x => x): number);
-(minBy([], x => x): void);
+(minBy([3, 2, 1], x => x): number | void);
+(minBy([], x => x): number | void);
 
 /**
  * _.max
  */
-(max([3, 2, 1]): number);
-(max([]): void);
+(max([3, 2, 1]): number | void);
+(max([]): number | void);
 
 /**
  * _.maxBy
  */
-(maxBy([3, 2, 1], x => x): number);
-(maxBy([], x => x): void);
+(maxBy([3, 2, 1], x => x): number | void);
+(maxBy([], x => x): number | void);


### PR DESCRIPTION
Functions like `maxBy()`, `first()`, `last()`, etc. may return `undefined` potentially, typically when called on the empty array.  This is a common case that requires explicit handling at call sites when using these APIs.