### PR TITLE
Add clearStore method to ApolloClient in react-apollo.

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -441,6 +441,7 @@ declare module "react-apollo" {
     __actionHookForDevTools(cb: () => mixed): void;
     __requestRaw(payload: GraphQLRequest): Observable<ExecutionResult<>>;
     initQueryManager(): void;
+    clearStore(): Promise<void | null>;
     resetStore(): Promise<Array<ApolloQueryResult<any>> | null>;
     onResetStore(cb: () => Promise<any>): () => void;
     reFetchObservableQueries(


### PR DESCRIPTION
The clearStore method is also available on the ApolloClient. See: https://github.com/apollographql/apollo-client/blob/183c81dbf0da2d8bc905cd2881dcaea9213f18f6/packages/apollo-client/src/ApolloClient.ts#L488