### PR TITLE
Fix return type for a Reselect method

### DIFF
--- a/definitions/npm/re-reselect_v2.x.x/flow_v0.67.1-/re-reselect_v2.x.x.js
+++ b/definitions/npm/re-reselect_v2.x.x/flow_v0.67.1-/re-reselect_v2.x.x.js
@@ -16,7 +16,7 @@ declare module 're-reselect' {
     & InputSelector<TState, TProps, TResult>
     & {
       recomputations(): number,
-      resetRecomputations(): void,
+      resetRecomputations(): number,
       resultFunc(state: TState, props: TProps, ...rest: Array<any>): TResult,
     };
 

--- a/definitions/npm/reselect_v3.x.x/flow_v0.47.x-/reselect_v3.x.x.js
+++ b/definitions/npm/reselect_v3.x.x/flow_v0.47.x-/reselect_v3.x.x.js
@@ -8,7 +8,7 @@ declare module "reselect" {
     & InputSelector<TState, TProps, TResult>
     & {
       recomputations(): number,
-      resetRecomputations(): void,
+      resetRecomputations(): number,
       resultFunc(state: TState, props: TProps, ...rest: Array<any>): TResult,
     };
 

--- a/definitions/npm/reselect_v4.x.x/flow_v0.47.x-/reselect_v4.x.x.js
+++ b/definitions/npm/reselect_v4.x.x/flow_v0.47.x-/reselect_v4.x.x.js
@@ -8,7 +8,7 @@ declare module "reselect" {
     & InputSelector<TState, TProps, TResult>
     & {
       recomputations(): number,
-      resetRecomputations(): void,
+      resetRecomputations(): number,
       resultFunc(state: TState, props: TProps, ...rest: Array<any>): TResult,
     };
 


### PR DESCRIPTION
The `resetRecomputations` methods returns: 0 not: void.

This is wrong both in Reselect and in Re-reselect (as that uses a copy-paste of the same def).

The (official) Typescript defs have this as 'number' as well:
https://github.com/reduxjs/reselect/blob/fda697a5b21959d55123bb8a3fdb6192f9cdc984/src/index.d.ts#L8