### PR TITLE
[node-cache_v4.x.x]Add del and flushAll methods to node-cache

### DIFF
--- a/definitions/npm/node-cache_v4.x.x/flow_v0.25.x-/node-cache_v4.x.x.js
+++ b/definitions/npm/node-cache_v4.x.x/flow_v0.25.x-/node-cache_v4.x.x.js
@@ -16,6 +16,8 @@ declare module "node-cache" {
     constructor(options?: Options): NodeCache;
     get(key: string): mixed | void;
     set(key: string, val: mixed, ttl?: number): boolean;
+    del(key: string): number;
+    flushAll(): void;
   }
 
   declare export default Class<NodeCache>;

--- a/definitions/npm/node-cache_v4.x.x/flow_v0.25.x-/node-cache_v4.x.x.js
+++ b/definitions/npm/node-cache_v4.x.x/flow_v0.25.x-/node-cache_v4.x.x.js
@@ -16,7 +16,7 @@ declare module "node-cache" {
     constructor(options?: Options): NodeCache;
     get(key: string): mixed | void;
     set(key: string, val: mixed, ttl?: number): boolean;
-    del(key: string): number;
+    del(key: string | string[]): number;
     flushAll(): void;
   }
 

--- a/definitions/npm/node-cache_v4.x.x/test_node-cache_v4.x.x.js
+++ b/definitions/npm/node-cache_v4.x.x/test_node-cache_v4.x.x.js
@@ -14,5 +14,7 @@ describe("node-cache", () => {
     cache.set("foo", 42);
     cache.set("foo", "this is fine");
     (cache.get("foo"): mixed);
+    cache.del("foo");
+    cache.flushAll();
   });
 });

--- a/definitions/npm/node-cache_v4.x.x/test_node-cache_v4.x.x.js
+++ b/definitions/npm/node-cache_v4.x.x/test_node-cache_v4.x.x.js
@@ -15,6 +15,7 @@ describe("node-cache", () => {
     cache.set("foo", "this is fine");
     (cache.get("foo"): mixed);
     cache.del("foo");
+    cache.del(["foo"]);
     cache.flushAll();
   });
 });


### PR DESCRIPTION
This PR adds `del()` and `flushAll()` methods for node-cache as in the documentation
https://github.com/mpneuried/nodecache