### PR TITLE
[enzyme] Add new definition - Wrapper.renderProp

### DIFF
--- a/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/enzyme_v3.x.x.js
+++ b/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/enzyme_v3.x.x.js
@@ -36,6 +36,7 @@ declare module "enzyme" {
     parent(): this,
     closest(selector: EnzymeSelector): this,
     render(): CheerioWrapper,
+    renderProp(propName: string): (...args: Array<any>) => this,
     unmount(): this,
     text(): string,
     html(): string,

--- a/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/test_enzyme-v3.x.js
+++ b/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/test_enzyme-v3.x.js
@@ -51,6 +51,16 @@ shallowWrapper.slice()
 shallowWrapper.slice(0)
 shallowWrapper.slice(0, 1)
 
+shallowWrapper
+  .renderProp("render")(1, "hi")
+  .find("SomeSelector");
+
+// Need to invoke the returned renderProp fn
+// $ExpectError
+shallowWrapper
+  .renderProp("render")
+  .find("SomeSelector")
+
 // shallow's getNode(s) was replaced by getElement(s) in enzyme v3
 // $ExpectError
 shallowWrapper.getNode();
@@ -78,6 +88,7 @@ shallowWrapper.getElements();
 // $ExpectError
 (mount(<div />).setProps(null): ReactWrapper);
 
+(mount(<div />).renderProp("render")(1, "hi"): ReactWrapper);
 
 // mount's getNode(s) were removed in enzyme v3
 // $ExpectError


### PR DESCRIPTION
Added def for new `renderProp` method in enzyme 3.8:
- https://github.com/airbnb/enzyme/blob/master/docs/api/ShallowWrapper/renderProp.md
- https://github.com/airbnb/enzyme/blob/master/docs/api/ReactWrapper/renderProp.md

I tried to add a test or two but wasn't able to run them locally? On a fresh clone, `./build_and_test_cli.sh` failed during runTests-test & install-test 🤷‍♂️.