### PR TITLE
[cloudinary_v1.x.x] Add libdefs for cloudinary

### DIFF
--- a/definitions/npm/cloudinary_v1.x.x/flow_v0.25.x-/cloudinary_v1.x.x.js
+++ b/definitions/npm/cloudinary_v1.x.x/flow_v0.25.x-/cloudinary_v1.x.x.js
@@ -1,0 +1,111 @@
+/**
+ * Flow libdef for 'cloudinary'
+ * by Vincent Driessen, 2019-01-08
+ *
+ * See https://www.npmjs.com/package/cloudinary
+ */
+
+declare module 'cloudinary' {
+  declare type __TODO__ = any;
+
+  // Source: https://cloudinary.com/documentation/image_transformation_reference
+  declare type Crop =
+    | 'scale' // default
+    | 'fit'
+    | 'limit'
+    | 'mfit'
+    | 'fill'
+    | 'lfill'
+    | 'pad'
+    | 'lpad'
+    | 'mpad'
+    | 'fill_pad'
+    | 'crop'
+    | 'thumb'
+    | 'imagga_crop'
+    | 'imagga_scale';
+
+  // Source: https://cloudinary.com/documentation/image_transformation_reference
+  declare type Gravity =
+    | 'north_west'
+    | 'north'
+    | 'north_east'
+    | 'west'
+    | 'center' // default
+    | 'east'
+    | 'south_west'
+    | 'south'
+    | 'south_east'
+    | 'xy_center'
+    | 'face'
+    | 'face:center'
+    | 'face:auto'
+    | 'faces'
+    | 'faces:center'
+    | 'faces:auto'
+    | 'body'
+    | 'body:face'
+    | 'liquid'
+    | 'ocr_text'
+    | 'adv_face'
+    | 'adv_faces'
+    | 'adv_eyes'
+    | 'custom'
+    | 'custom:face'
+    | 'custom:faces'
+    | 'custom:adv_face'
+    | 'custom:adv_faces';
+
+  declare type Transformation = {|
+    angle?: number,
+    crop?: Crop,
+    effect?: string,
+    gravity?: Gravity,
+    height?: number,
+    opacity?: number,
+    overlay?: string,
+    quality?: number,
+    width?: number,
+    x?: number,
+    y?: number,
+    zoom?: number,
+  |};
+
+  declare type Options = {|
+    secure?: boolean,
+    width?: number,
+    height?: number,
+    crop?: Crop,
+    quality?: number,
+    transformation?: Array<Transformation>,
+  |};
+
+  declare type Config = {|
+    cloud_name: string,
+    api_key: string,
+    api_secret: string,
+  |};
+
+  declare export default {|
+    CF_SHARED_CDN: string,
+    AKAMAI_SHARED_CDN: string,
+    SHARED_CDN: string,
+    BLANK: string,
+
+    config: Config => void,
+    url: (public_id: string, options?: Options) => string,
+
+    // The following exported fields haven't been typed yet
+    utils: __TODO__,
+    uploader: __TODO__,
+    api: __TODO__,
+    PreloadedFile: __TODO__,
+    Cache: __TODO__,
+    image: __TODO__,
+    video: __TODO__,
+    source: __TODO__,
+    picture: __TODO__,
+    cloudinary_js_config: __TODO__,
+    v2: __TODO__,
+  |};
+}

--- a/definitions/npm/cloudinary_v1.x.x/test_cloudinary.js
+++ b/definitions/npm/cloudinary_v1.x.x/test_cloudinary.js
@@ -1,0 +1,32 @@
+// @flow strict
+
+import cloudinary from 'cloudinary';
+import { describe, it } from 'flow-typed-test';
+
+describe('cloudinary', () => {
+  it('errors', () => {
+    // $ExpectError
+    cloudinary.config();
+    // $ExpectError
+    cloudinary.url();
+  });
+
+  it('config', () => {
+    (cloudinary.config({
+      cloud_name: 'foo',
+      api_key: 'mykey',
+      api_secret: 'mysecret',
+    }): void);
+  });
+
+  it('url', () => {
+    (cloudinary.url('foo'): string);
+    (cloudinary.url('bar', {
+      secure: true,
+      transformation: [
+        { width: 320, height: 256, crop: 'fit' },
+        { width: 320, height: 256, crop: 'limit', quality: 60 },
+      ],
+    }): string);
+  });
+});


### PR DESCRIPTION
Note that this library has only been partially typed.  I did include all the objects that are exported from the top level of this module, but marked them `__TODO__` (alias for `any`).  I'm not interested in typing those APIs out completely, as I don't personally use/need those APIs.  However, someone who's interested in them can easily update this definition later on.

I figured having a partially typed API is better than having no typing at all?  This way, coverage can be incrementally improved upon over time.  Is this considered a good or bad practice?