### PR TITLE
[react-redux] Reintroduce default export

### DIFF
--- a/definitions/npm/react-redux_v5.x.x/flow_v0.89.x-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.89.x-/react-redux_v5.x.x.js
@@ -265,4 +265,11 @@ declare module "react-redux" {
     selectorFactory: SelectorFactory<Com, D, S, OP, EFO, CP>,
     connectAdvancedOptions: ?(ConnectAdvancedOptions & EFO),
   ): (component: Com) => React$ComponentType<OP> & $Shape<ST>;
+
+  declare export default {
+    Provider: typeof Provider,
+    createProvider: typeof createProvider,
+    connect: typeof connect,
+    connectAdvanced: typeof connectAdvanced,
+  };
 }


### PR DESCRIPTION
Recent context [here](https://github.com/flow-typed/flow-typed/pull/3012#issuecomment-452799153). Original context [here](https://github.com/flow-typed/flow-typed/pull/2018).

Though the default export does not exist in the ESM distro of `react-redux`, it does exist in the CJS distro. Node's ESM support doesn't allow named imports on CJS modules, which means the default import must be used when treating `react-redux` as CJS. Trying to use the ESM distro of `react-redux` with Node doesn't work either, since it attempts a named import on `react`, which only has a CJS distro.