### PR TITLE
[lodash_v4.x.x] Avoid use of $SuperType<>

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -1065,7 +1065,7 @@ declare module "lodash" {
     at(object?: ?Object, ...paths: Array<string>): Array<any>;
     at(object?: ?Object, paths: Array<string>): Array<any>;
     create(prototype: void | null, properties: void | null): {};
-    create<T>(prototype: T, properties: Object): $Supertype<T>;
+    create<T>(prototype: T, properties: Object): T;
     create(prototype: any, properties: void | null): {};
     defaults(object?: ?Object, ...sources?: Array<?Object>): Object;
     defaultsDeep(object?: ?Object, ...sources?: Array<?Object>): Object;
@@ -2723,7 +2723,7 @@ declare module "lodash/fp" {
     props(paths: Array<string>, object: Object): Array<any>;
     paths(paths: Array<string>): (object: Object) => Array<any>;
     paths(paths: Array<string>, object: Object): Array<any>;
-    create<T>(prototype: T): $Supertype<T>;
+    create<T>(prototype: T): T;
     defaults(source: Object): (object: Object) => Object;
     defaults(source: Object, object: Object): Object;
     defaultsAll(objects: Array<Object>): Object;


### PR DESCRIPTION
The construct has been removed from Flow 0.89+ so at first I considered forking this into a `flow_v0.89.x-` directory, but then I realized that the `$SuperType<>` wrapper didn't really add anything and should probably just be `T` anyway.