### PR TITLE
[ramda_v0.x.x] use $ReadOnlyArray for lensPath

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
@@ -1392,7 +1392,7 @@ declare module ramda {
 
   declare function lensIndex(n: number): Lens;
 
-  declare function lensPath(a: Array<string | number>): Lens;
+  declare function lensPath(a: $ReadOnlyArray<string | number>): Lens;
 
   declare function lensProp(str: string): Lens;
 

--- a/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/test_ramda_v0.x.x_lensPath.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/test_ramda_v0.x.x_lensPath.js
@@ -1,0 +1,41 @@
+// @flow
+import R, {type Lens} from "ramda";
+import { it, describe } from "flow-typed-test";
+
+describe("R.lensPath()", () => {
+  it("should except implicit input type strings only", () => {
+    const path = ["a", "b"];
+
+    (R.lensPath(path): Lens);
+  });
+
+  it("should except implicit input type numbers only", () => {
+    const path = [1, 2];
+
+    (R.lensPath(path): Lens);
+  });
+
+  it("should except implicit input type mixed", () => {
+    const path = ["a", 1];
+
+    (R.lensPath(path): Lens);
+  });
+
+  it("should except explicit number array", () => {
+    const path: number[] = [1, 2];
+
+    (R.lensPath(path): Lens);
+  });
+
+  it("should except explicit string array", () => {
+    const path: string[] = ["a", "b"];
+
+    (R.lensPath(path): Lens);
+  });
+
+  it("should except explicit mixed array", () => {
+    const path: (string | number)[] = ["a", 1];
+
+    (R.lensPath(path): Lens);
+  });
+});


### PR DESCRIPTION
It was not possible to use lensPath with an parameter which had the explicit type `string[]`. The problem is the expected Type `Array<string | number>`. Array has to be replaced with `$ReadOnlyArray`.

You can see an example about this assigning problem in the following flow examples:
[Error Example](https://flow.org/try/#0PTAEAEDMBsHsHcBQjIFcB2BjALgS1uqNgIYDWApgM4CCAMrpdgPKQDK2ATrugOYByqALYAjchwCq6fOgAU0BtgBcoGYy69QAH1DohojgEoA2gF0DoAN4BfZJgKNQ3SGI7kAJqAC8oIwEYATADMJogkFDT0jCzs6vx6YpLSMk4u7gaIdugO5AAeAA7ymLhKOvEcpl4+AcGhZFR0CtGc3HEiCVIEMrkFuEXY5iCgLrAclIhAA)
[Working Example](https://flow.org/try/#0PTAEAEDMBsHsHcBQjIFcB2BjALgS1uqNgIYDWApgM4CCAMrpdgPKQDK2ATrugOYByqALYAjchwCq6fOgAU0BtgBcoACQAlcsQAmTdNACe1Dh2L6APIy69QAH1DohojgD4AlKADeAX2SYCjUG5IMQ5yLVAAXlAAbQBGACYAZgBdRBIKGnpGFnYrfkcxSWkZIJCw10Q-dADyAA8AB3lMXCV7Ao5o5MiYhJS0sio6BRzObnyRQqkCGWiAOnm6xtxm7GT3EFB4WA5SYg5YDC1+jKHstlHeAQmJKdlFppb1sBDtykQgA)

Tests for implicit and explicit types has been added.

Best regards
Daniel