### PR TITLE
make axios.create return a callable result

### DIFF
--- a/definitions/npm/axios_v0.11.x/test_axios-v0.11.js
+++ b/definitions/npm/axios_v0.11.x/test_axios-v0.11.js
@@ -9,3 +9,5 @@ import axios from 'axios';
 }): Promise<*>);
 // $ExpectError
 (axios.post(123): Promise<*>)
+
+axios({method: 'post', url: 'https://foo.bar'})

--- a/definitions/npm/axios_v0.18.x/flow_v0.75.x-/axios_v0.18.x.js
+++ b/definitions/npm/axios_v0.18.x/flow_v0.75.x-/axios_v0.18.x.js
@@ -96,8 +96,8 @@ declare module "axios" {
   }
   declare type AxiosPromise<T,R = T> = Promise<AxiosXHR<T,R>>;
   declare class Axios {
+    <T,R>(config: AxiosXHRConfig<T,R> | string, config?: AxiosXHRConfig<T,R>): AxiosPromise<T,R>;
     constructor<T,R>(config?: AxiosXHRConfigBase<T,R>): void;
-    static <T,R>(config: AxiosXHRConfig<T,R> | string, config?: AxiosXHRConfig<T,R>): AxiosPromise<T,R>;
     request<T,R>(config: AxiosXHRConfig<T,R>): AxiosPromise<T,R>;
     delete<T,R>(url: string, config?: AxiosXHRConfigBase<T,R>): AxiosPromise<T,R>;
     get<T,R>(url: string, config?: AxiosXHRConfigBase<T,R>): AxiosPromise<T,R>;

--- a/definitions/npm/axios_v0.18.x/test_axios_v0.18.x.js
+++ b/definitions/npm/axios_v0.18.x/test_axios_v0.18.x.js
@@ -1,4 +1,5 @@
 // @flow
+import { describe, it } from 'flow-typed-test';
 import axios from 'axios';
 import type {
   $AxiosXHR,
@@ -99,3 +100,10 @@ const promise2: AxiosPromise<{ foo: number }> = axios({ url: '/', method: 'post'
 promise2.then(({ data }) => {
   data.foo + 1;
 });
+
+describe('create', () => {
+  it('returns a callable axios instance', () => {
+    const a = axios.create();
+    a({ method: 'post', url: 'https://foo.bar' })
+  })
+})


### PR DESCRIPTION
(stealing text from my commit):

The object returned from `axios.create` can be called just like the main `axios` export directly. The create function is used to produce default settings in a non-global way for `axios`.

The `Axios` class was marked as callable but only as a static form. I'm not sure what that was doing, but it didn't work in the case of `axios.create`, and removing the static bit didn't break any tests.

The callable signature on `AxiosExport` needs to remain, despite it extending the `Axios` class.

I added a simple callable test to an older `axios` as well.