### PR TITLE
[react-redux_v5.x.x] Better support for HOC

### DIFF
--- a/definitions/npm/react-redux_v5.x.x/flow_v0.89.x-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.89.x-/react-redux_v5.x.x.js
@@ -67,30 +67,36 @@ declare module "react-redux" {
     static +WrappedComponent: WC;
     getWrappedInstance(): React$ElementRef<WC>;
   }
+  // The connection of the Wrapped Component and the Connected Component
+  // happens here in `MP: P`. It means that type wise MP belongs to P,
+  // so to say MP >= P.
   declare type Connector<P, OP, MP: P> = <WC: React$ComponentType<P>>(
     WC,
   ) => Class<ConnectedComponent<OP, WC>> & WC;
 
   // No `mergeProps` argument
 
+  // Got error like inexact OwnProps is incompatible with exact object type?
+  // Just make the OP parameter for `connect()` an exact object.
+  declare type MergeOP<OP, D> = {| ...$Exact<OP>, dispatch: D |};
+  declare type MergeOPSP<OP, SP> = {| ...$Exact<OP>, ...SP |};
+  declare type MergeOPDP<OP, DP> = {| ...$Exact<OP>, ...DP |};
+  declare type MergeOPSPDP<OP, SP, DP> = {| ...$Exact<OP>, ...SP, ...DP |};
+
   declare export function connect<-P, -OP, -SP, -DP, -S, -D>(
     mapStateToProps?: null | void,
     mapDispatchToProps?: null | void,
     mergeProps?: null | void,
-    options?: ?Options<S, OP, {||}, {| ...OP, dispatch: D |}>,
-    // Got error like inexact OwnProps is incompatible with exact object type?
-    // Just make your OP parameter an exact object.
-  ): Connector<P, OP, {| ...OP, dispatch: D |}>;
+    options?: ?Options<S, OP, {||}, MergeOP<OP, D>>,
+  ): Connector<P, OP, MergeOP<OP, D>>;
 
   declare export function connect<-P, -OP, -SP, -DP, -S, -D>(
     // If you get error here try adding return type to your mapStateToProps function
     mapStateToProps: MapStateToProps<S, OP, SP>,
     mapDispatchToProps?: null | void,
     mergeProps?: null | void,
-    options?: ?Options<S, OP, SP, {| ...OP, ...SP |}>,
-    // Got error like inexact OwnProps is incompatible with exact object type?
-    // Just make your OP parameter an exact object.
-  ): Connector<P, OP, {| ...OP, ...SP |}>;
+    options?: ?Options<S, OP, SP, MergeOPSP<OP, SP>>,
+  ): Connector<P, OP, MergeOPSP<OP, SP>>;
 
   // In this case DP is an object of functions which has been bound to dispatch
   // by the given mapDispatchToProps function.
@@ -98,10 +104,8 @@ declare module "react-redux" {
     mapStateToProps: null | void,
     mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
     mergeProps?: null | void,
-    options?: ?Options<S, OP, {||}, {| ...OP, ...DP |}>,
-    // Got error like inexact OwnProps is incompatible with exact object type?
-    // Just make your OP parameter an exact object.
-  ): Connector<P, OP, {| ...OP, ...DP |}>;
+    options?: ?Options<S, OP, {||}, MergeOPDP<OP, DP>>,
+  ): Connector<P, OP, MergeOPDP<OP, DP>>;
 
   // In this case DP is an object of action creators not yet bound to dispatch,
   // this difference is not important in the vanila redux,
@@ -110,10 +114,8 @@ declare module "react-redux" {
     mapStateToProps: null | void,
     mapDispatchToProps: DP,
     mergeProps?: null | void,
-    options?: ?Options<S, OP, {||}, {| ...OP, ...DP |}>,
-    // Got error like inexact OwnProps is incompatible with exact object type?
-    // Just make your OP parameter an exact object.
-  ): Connector<P, OP, {| ...OP, ...$ObjMap<DP, Bind<D>> |}>;
+    options?: ?Options<S, OP, {||}, MergeOPDP<OP, DP>>,
+  ): Connector<P, OP, MergeOPDP<OP, $ObjMap<DP, Bind<D>>>>;
 
   declare export function connect<-P, -OP, -SP, -DP, S, D>(
     // If you get error here try adding return type to your mapStateToProps function
@@ -121,8 +123,6 @@ declare module "react-redux" {
     mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
     mergeProps?: null | void,
     options?: ?Options<S, OP, SP, {| ...OP, ...SP, ...DP |}>,
-    // Got error like inexact OwnProps is incompatible with exact object type?
-    // Just make your OP parameter an exact object.
   ): Connector<P, OP, {| ...OP, ...SP, ...DP |}>;
 
   declare export function connect<-P, -OP, -SP, -DP, S, D>(
@@ -130,10 +130,8 @@ declare module "react-redux" {
     mapStateToProps: MapStateToProps<S, OP, SP>,
     mapDispatchToProps: DP,
     mergeProps?: null | void,
-    options?: ?Options<S, OP, SP, {| ...OP, ...SP, ...DP |}>,
-    // Got error like inexact OwnProps is incompatible with exact object type?
-    // Just make your OP parameter an exact object.
-  ): Connector<P, OP, {| ...OP, ...SP, ...$ObjMap<DP, Bind<D>> |}>;
+    options?: ?Options<S, OP, SP, MergeOPSPDP<OP, SP, DP>>,
+  ): Connector<P, OP, MergeOPSPDP<OP, SP, $ObjMap<DP, Bind<D>>>>;
 
   // With `mergeProps` argument
 

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.89.x-/test_connect.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.89.x-/test_connect.js
@@ -197,6 +197,50 @@ function testExactProps() {
   e.push(Connected2);
 }
 
+function testInexactOwnProps() {
+  type OwnProps = {
+    passthrough: number,
+    forMapStateToProps: string,
+  };
+  type Props = {
+    ...$Exact<OwnProps>, // to eliminate the cripy `undefined`
+    fromStateToProps: string
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = {a: number};
+  type InputProps = {
+    forMapStateToProps: string,
+    passthrough: number,
+  };
+
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+  //$ExpectError extraProp what exact props does not allow
+  <Connected passthrough={123} forMapStateToProps={321} extraProp={123}/>;
+  //$ExpectError wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321}/>;
+  //$ExpectError passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$ExpectError forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$ExpectError takes in only React components
+  const Connected2 = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)('');
+  e.push(Connected2);
+}
+
 function testWithStatelessFunctionalComponent() {
   type OwnProps = {|
     passthrough: number,
@@ -566,7 +610,7 @@ function testNoDispatch() {
 function testHoistConnectedComponent() {
   type OwnProps = {|
     passthrough: number,
-    passthroughWithDefaultProp: number,
+    passthroughWithDefaultProp?: number,
     forMapStateToProps: string
   |};
   type Props = {
@@ -594,7 +638,7 @@ function testHoistConnectedComponent() {
 
   const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
   e.push(Connected);
-  // $ExpectError should be OK without passthroughWithDefaultProp
+  // OK without passthroughWithDefaultProp
   <Connected passthrough={123} forMapStateToProps={'data'}/>;
   // OK with passthroughWithDefaultProp
   <Connected passthrough={123} passthroughWithDefaultProp={456} forMapStateToProps={'data'}/>;

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.89.x-/test_connectHOC.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.89.x-/test_connectHOC.js
@@ -1,0 +1,161 @@
+// @flow
+import * as React from "react";
+import { connect } from "react-redux";
+
+export let e = [];
+
+function checkSimplePropertyInjection() {
+  type OwnProps = {|
+    foo: number,
+    bar: string,
+  |};
+  type Props = { ...OwnProps, foo: number };
+  const mapStateToProps = () => ({ foo: 5 });
+
+  class Com extends React.Component<Props> {}
+
+  const Connected = connect<Props, OwnProps, _, _, _, _>(mapStateToProps)(Com);
+
+  <Connected foo={42} bar="str" />;
+  //$ExpectError property `foo` is missing in props [1] but exists in `OwnProps`
+  <Connected bar="str" />;
+  e.push(Connected);
+
+  function injectProp<Config: {}>(
+    Component: React.AbstractComponent<Config>,
+  ): React.AbstractComponent<$Diff<Config, { foo: number | void }>> {
+    return function WrapperComponent(
+      props: $Diff<Config, { foo: number | void }>,
+    ) {
+      return <Component {...props} foo={42} />;
+    };
+  }
+
+  const Decorated = injectProp(Connected);
+  // OK without `foo`
+  <Decorated bar="str" />;
+  // OK with a not needed `foo`
+  <Decorated foo={42} bar="str" />;
+  //$ExpectError property `bar` is missing in props [3] but exists in `Props` [4]
+  <Decorated />;
+  e.push(Decorated);
+}
+
+function composeWithOtherHOC_OK() {
+  type OwnProps = {
+    own1: number,
+    injected1: string,
+  };
+  type Props = {
+    ...$Exact<OwnProps>,
+    state1: number,
+  };
+  const mapStateToProps = () => ({ state1: 5 });
+
+  class Com extends React.Component<Props> {}
+
+  function injectProp<Config: {}>(
+    Component: React.AbstractComponent<Config>,
+  ): React.AbstractComponent<$Diff<Config, { injected1: string | void }>> {
+    return function WrapperComponent(
+      props: $Diff<Config, { injected1: string | void }>,
+    ) {
+      return <Component {...props} injected1="str" />;
+    };
+  }
+
+  declare var compose: $Compose;
+
+  const composedDecorators = compose(
+    injectProp,
+    connect<Props, OwnProps, _, _, _, _>(mapStateToProps),
+  );
+
+  const Decorated = composedDecorators(Com);
+  // OK without `injected1`
+  <Decorated own1={1} />;
+  // OK with a not needed `injected1`
+  <Decorated own1={1} injected1="str" />;
+  //$ExpectError property `own1` is missing in props [3] but exists in `Props` [4]
+  <Decorated />;
+  e.push(Decorated);
+}
+
+function composeWithOtherHOC_exactOK() {
+  type OwnProps = {|
+    own1: number,
+    injected1: string,
+  |};
+  type Props = {
+    ...$Exact<OwnProps>,
+    state1: number,
+  };
+  const mapStateToProps = () => ({ state1: 5 });
+
+  class Com extends React.Component<Props> {}
+
+  function injectProp<Config: {}>(
+    Component: React.AbstractComponent<Config>,
+  ): React.AbstractComponent<$Diff<Config, { injected1: string | void }>> {
+    return function WrapperComponent(
+      props: $Diff<Config, { injected1: string | void }>,
+    ) {
+      return <Component {...props} injected1="str" />;
+    };
+  }
+
+  declare var compose: $Compose;
+
+  const composedDecorators = compose(
+    injectProp,
+    connect<Props, OwnProps, _, _, _, _>(mapStateToProps),
+  );
+
+  const Decorated = composedDecorators(Com);
+  // OK without `injected1`
+  <Decorated own1={1} />;
+  //$ExpectError property `injected1` is missing in `OwnProps` [1] but exists in props
+  <Decorated own1={1} injected1="str" />;
+  // the ExpectError above masks the misssing `own1` error below :(
+  <Decorated />;
+  e.push(Decorated);
+}
+
+function composeWithOtherHOC_wrongOrder() {
+  type OwnProps = {
+    own1: number,
+    injected1: string,
+  };
+  type Props = {
+    ...$Exact<OwnProps>,
+    state1: number,
+  };
+  const mapStateToProps = () => ({ state1: 5 });
+
+  class Com extends React.Component<Props> {}
+
+  function injectProp<Config: {}>(
+    Component: React.AbstractComponent<Config>,
+  ): React.AbstractComponent<$Diff<Config, { injected1: string | void }>> {
+    return function WrapperComponent(
+      props: $Diff<Config, { injected1: string | void }>,
+    ) {
+      return <Component {...props} injected1="str" />;
+    };
+  }
+
+  declare var compose: $Compose;
+
+  // injectProp must go before connect()
+  const composedDecorators = compose(
+    connect<Props, OwnProps, _, _, _, _>(mapStateToProps),
+    injectProp,
+  );
+
+  const Decorated = composedDecorators(Com);
+  //$ExpectError property `injected1` is missing in props
+  <Decorated own1={1} />;
+  // OK with an explicitly provided `injected1`
+  <Decorated own1={1} injected1="str" />;
+  e.push(Decorated);
+}


### PR DESCRIPTION
Addressing an issue with HOC described in #3072 by making it possible to provide inexact `OwnProps` type parameter and also by adding tests for the basic HOC use cases.

More example are welcome!