### PR TITLE
[react-testing-library_v5.x.x] Add missing dom-testing-library helpers

### DIFF
--- a/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-/react-testing-library_v5.x.x.js
+++ b/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-/react-testing-library_v5.x.x.js
@@ -12,40 +12,86 @@ declare module 'react-testing-library' {
 
   declare type SelectorMatchOptions = { selector?: string } & TextMatchOptions;
 
-  declare type AllByText = (
+  declare type GetByText = (
     text: TextMatch,
-    options?: TextMatchOptions
-  ) => Array<HTMLElement>;
+    options?: SelectorMatchOptions
+  ) => HTMLElement;
 
   declare type QueryByText = (
+    text: TextMatch,
+    options?: SelectorMatchOptions
+  ) => ?HTMLElement;
+
+  declare type AllByText = (
+    text: TextMatch,
+    options?: SelectorMatchOptions
+  ) => Array<HTMLElement>;
+
+  declare type GetByBoundAttribute = (
+    text: TextMatch,
+    options?: TextMatchOptions
+  ) => HTMLElement;
+
+  declare type QueryByBoundAttribute = (
     text: TextMatch,
     options?: TextMatchOptions
   ) => ?HTMLElement;
 
+  declare type AllByBoundAttribute = (
+    text: TextMatch,
+    options?: TextMatchOptions
+  ) => Array<HTMLElement>;
+
   declare type GetsAndQueries = {|
-    getByTestId: (id: TextMatch, options?: TextMatchOptions) => HTMLElement,
-    getByText: (text: TextMatch, options?: SelectorMatchOptions) => HTMLElement,
-    getByPlaceholderText: (
-      text: TextMatch,
-      options?: TextMatchOptions
-    ) => HTMLElement,
-    getByLabelText: (
-      text: TextMatch,
-      options?: SelectorMatchOptions
-    ) => HTMLElement,
+    getByAltText: GetByBoundAttribute,
+    getAllByAltText: AllByBoundAttribute,
+    queryByAltText: QueryByBoundAttribute,
+    queryAllByAltText: AllByBoundAttribute,
+
+    getByDisplayValue: GetByBoundAttribute,
+    getAllByDisplayValue: AllByBoundAttribute,
+    queryByDisplayValue: QueryByBoundAttribute,
+    queryAllByDisplayValue: AllByBoundAttribute,
+
+    getByLabelText: GetByText,
     getAllByLabelText: AllByText,
-    getByAltText: (text: TextMatch, options?: TextMatchOptions) => HTMLElement,
-    getAll: (text: TextMatch, options?: TextMatchOptions) => Array<HTMLElement>,
-    getAllByText: AllByText,
-    queryByTestId: (id: TextMatch, options?: TextMatchOptions) => ?HTMLElement,
-    queryByText: (text: TextMatch, options?: TextMatchOptions) => ?HTMLElement,
-    queryByPlaceholderText: QueryByText,
     queryByLabelText: QueryByText,
-    queryByAltText: QueryByText,
-    queryAll: (
-      text: TextMatch,
-      options?: TextMatchOptions
-    ) => Array<HTMLElement>,
+    queryAllByLabelText: AllByText,
+
+    getByPlaceholderText: GetByBoundAttribute,
+    getAllByPlaceholderText: AllByBoundAttribute,
+    queryByPlaceholderText: QueryByBoundAttribute,
+    queryAllByPlaceholderText: AllByBoundAttribute,
+
+    getByRole: GetByBoundAttribute,
+    getAllByRole: AllByBoundAttribute,
+    queryByRole: QueryByBoundAttribute,
+    queryAllByRole: AllByBoundAttribute,
+
+    getBySelectText: GetByBoundAttribute,
+    getAllBySelectText: AllByBoundAttribute,
+    queryBySelectText: QueryByBoundAttribute,
+    queryAllBySelectText: AllByBoundAttribute,
+
+    getByTestId: GetByBoundAttribute,
+    getAllByTestId: AllByBoundAttribute,
+    queryByTestId: QueryByBoundAttribute,
+    queryAllByTestId: AllByBoundAttribute,
+
+    getByText: GetByText,
+    getAllByText: AllByText,
+    queryByText: QueryByText,
+    queryAllByText: AllByText,
+
+    getByTitle: GetByBoundAttribute,
+    getAllByTitle: AllByBoundAttribute,
+    queryByTitle: QueryByBoundAttribute,
+    queryAllByTitle: AllByBoundAttribute,
+
+    getByValue: GetByBoundAttribute,
+    getAllByValue: AllByBoundAttribute,
+    queryByValue: QueryByBoundAttribute,
+    queryAllByValue: AllByBoundAttribute,
   |};
 
   declare type RenderResult = {|
@@ -76,6 +122,12 @@ declare module 'react-testing-library' {
         interval?: number,
       }
     ) => Promise<void>,
+
+    waitForDomChange: <T>(options?: {
+      container?: HTMLElement,
+      timeout?: number,
+      mutationObserverOptions?: MutationObserverInit,
+    }) => Promise<T>,
 
     waitForElement: <T>(
       callback?: () => T,

--- a/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-/react-testing-library_v5.x.x.js
+++ b/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-/react-testing-library_v5.x.x.js
@@ -10,7 +10,7 @@ declare module 'react-testing-library' {
     collapseWhitespace?: boolean,
   };
 
-  declare type SelectorMatchOptions = {selector?: string} & TextMatchOptions;
+  declare type SelectorMatchOptions = { selector?: string } & TextMatchOptions;
 
   declare type AllByText = (
     text: TextMatch,
@@ -18,23 +18,20 @@ declare module 'react-testing-library' {
   ) => Array<HTMLElement>;
 
   declare type QueryByText = (
-      text: TextMatch,
-      options?: TextMatchOptions,
-    ) => ?HTMLElement;
+    text: TextMatch,
+    options?: TextMatchOptions
+  ) => ?HTMLElement;
 
   declare type GetsAndQueries = {|
     getByTestId: (id: TextMatch, options?: TextMatchOptions) => HTMLElement,
-    getByText: (
-      text: TextMatch,
-      options?: SelectorMatchOptions,
-    ) => HTMLElement,
+    getByText: (text: TextMatch, options?: SelectorMatchOptions) => HTMLElement,
     getByPlaceholderText: (
       text: TextMatch,
-      options?: TextMatchOptions,
+      options?: TextMatchOptions
     ) => HTMLElement,
     getByLabelText: (
       text: TextMatch,
-      options?: SelectorMatchOptions,
+      options?: SelectorMatchOptions
     ) => HTMLElement,
     getAllByLabelText: AllByText,
     getByAltText: (text: TextMatch, options?: TextMatchOptions) => HTMLElement,
@@ -47,7 +44,7 @@ declare module 'react-testing-library' {
     queryByAltText: QueryByText,
     queryAll: (
       text: TextMatch,
-      options?: TextMatchOptions,
+      options?: TextMatchOptions
     ) => Array<HTMLElement>,
   |};
 
@@ -61,13 +58,13 @@ declare module 'react-testing-library' {
 
   declare type FireEvent<TInit> = (
     element: HTMLElement,
-    eventProperties?: TInit,
+    eventProperties?: TInit
   ) => boolean;
 
   declare module.exports: {
     render: (
       ui: React$Element<*>,
-      options?: {container: HTMLElement, baseElement?: HTMLElement},
+      options?: { container: HTMLElement, baseElement?: HTMLElement }
     ) => RenderResult,
 
     cleanup: () => void,
@@ -77,7 +74,7 @@ declare module 'react-testing-library' {
       options?: {
         timeout?: number,
         interval?: number,
-      },
+      }
     ) => Promise<void>,
 
     waitForElement: <T>(
@@ -86,12 +83,12 @@ declare module 'react-testing-library' {
         container?: HTMLElement,
         timeout?: number,
         mutationObserverOptions?: MutationObserverInit,
-      },
+      }
     ) => Promise<T>,
 
     within: (
       element: HTMLElement,
-      queriesToBind?: GetsAndQueries | Array<GetsAndQueries>,
+      queriesToBind?: GetsAndQueries | Array<GetsAndQueries>
     ) => GetsAndQueries,
 
     fireEvent: {|
@@ -172,52 +169,52 @@ declare module 'react-testing-library' {
     queryByTestId: (
       container: HTMLElement,
       id: TextMatch,
-      options?: TextMatchOptions,
+      options?: TextMatchOptions
     ) => ?HTMLElement,
     getByTestId: (
       container: HTMLElement,
       id: TextMatch,
-      options?: TextMatchOptions,
+      options?: TextMatchOptions
     ) => HTMLElement,
     queryByText: (
       container: HTMLElement,
       text: TextMatch,
-      options?: TextMatchOptions,
+      options?: TextMatchOptions
     ) => ?HTMLElement,
     getByText: (
       container: HTMLElement,
       text: TextMatch,
-      options?: {selector?: string} & TextMatchOptions,
+      options?: { selector?: string } & TextMatchOptions
     ) => HTMLElement,
     queryByPlaceholderText: (
       container: HTMLElement,
       text: TextMatch,
-      options?: TextMatchOptions,
+      options?: TextMatchOptions
     ) => ?HTMLElement,
     getByPlaceholderText: (
       container: HTMLElement,
       text: TextMatch,
-      options?: TextMatchOptions,
+      options?: TextMatchOptions
     ) => HTMLElement,
     queryByLabelText: (
       container: HTMLElement,
       text: TextMatch,
-      options?: TextMatchOptions,
+      options?: TextMatchOptions
     ) => ?HTMLElement,
     getByLabelText: (
       container: HTMLElement,
       text: TextMatch,
-      options?: {selector?: string} & TextMatchOptions,
+      options?: { selector?: string } & TextMatchOptions
     ) => HTMLElement,
     queryByAltText: (
       container: HTMLElement,
       text: TextMatch,
-      options?: TextMatchOptions,
+      options?: TextMatchOptions
     ) => ?HTMLElement,
     getByAltText: (
       container: HTMLElement,
       text: TextMatch,
-      options?: TextMatchOptions,
+      options?: TextMatchOptions
     ) => HTMLElement,
   };
 }

--- a/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-/test_react-testing-library_v5.x.x.js
+++ b/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-/test_react-testing-library_v5.x.x.js
@@ -6,6 +6,7 @@ import {
   wait,
   fireEvent,
   cleanup,
+  waitForDomChange,
   waitForElement,
   within,
 } from 'react-testing-library';
@@ -23,6 +24,20 @@ describe('wait', () => {
   it('should pass on correct inputs', () => {
     wait(() => {});
     wait(() => {}, { timeout: 1 });
+  });
+});
+
+describe('waitForDomChange', () => {
+  it('should fail on invalid inputs', () => {
+    // $ExpectError
+    waitForDomChange(1);
+    // $ExpectError
+    waitForDomChange('1');
+  });
+
+  it('should pass on correct inputs', () => {
+    waitForDomChange({ container: document.createElement('div') });
+    waitForDomChange({ timeout: 1 });
   });
 });
 
@@ -59,18 +74,46 @@ describe('render', () => {
     baseElement,
     debug,
     rerender,
-    queryByTestId,
-    getByTestId,
-    queryByText,
-    getByText,
-    queryByPlaceholderText,
-    getByPlaceholderText,
-    queryByLabelText,
-    getByLabelText,
-    queryByAltText,
     getByAltText,
-    queryAll,
-    getAll,
+    getAllByAltText,
+    queryByAltText,
+    queryAllByAltText,
+    getByDisplayValue,
+    getAllByDisplayValue,
+    queryByDisplayValue,
+    queryAllByDisplayValue,
+    getByLabelText,
+    getAllByLabelText,
+    queryByLabelText,
+    queryAllByLabelText,
+    getByPlaceholderText,
+    getAllByPlaceholderText,
+    queryByPlaceholderText,
+    queryAllByPlaceholderText,
+    getByRole,
+    getAllByRole,
+    queryByRole,
+    queryAllByRole,
+    getBySelectText,
+    getAllBySelectText,
+    queryBySelectText,
+    queryAllBySelectText,
+    getByTestId,
+    getAllByTestId,
+    queryByTestId,
+    queryAllByTestId,
+    getByText,
+    getAllByText,
+    queryByText,
+    queryAllByText,
+    getByTitle,
+    getAllByTitle,
+    queryByTitle,
+    queryAllByTitle,
+    getByValue,
+    getAllByValue,
+    queryByValue,
+    queryAllByValue,
   } = render(<Component />);
 
   it('unmount should has 0 arguments', () => {
@@ -103,66 +146,224 @@ describe('render', () => {
     rerender(<Component />);
   });
 
-  it('queryByTestId should return maybe html element', () => {
+  it('getByAltText should return HTML element', () => {
+    const a: HTMLElement = getByAltText('1');
+  });
+
+  it('getAllByAltText should return array of HTML element', () => {
     // $ExpectError
-    const a: HTMLElement = queryByTestId('1');
-    const b: ?HTMLElement = queryByTestId('2');
+    const a: HTMLElement = getAllByAltText('1');
+    const b: Array<HTMLElement> = getAllByAltText('2');
   });
 
-  it('getByTestId should return html element', () => {
-    const a: HTMLElement = getByTestId('1');
-  });
-
-  it('queryByText should return maybe html element', () => {
-    // $ExpectError
-    const a: HTMLElement = queryByText('1');
-    const b: ?HTMLElement = queryByText('2');
-  });
-
-  it('queryByText should return html element', () => {
-    const a: HTMLElement = getByText('1');
-  });
-
-  it('queryByPlaceholderText should return maybe html element', () => {
-    // $ExpectError
-    const a: HTMLElement = queryByPlaceholderText('1');
-    const b: ?HTMLElement = queryByPlaceholderText('2');
-  });
-
-  it('getByPlaceholderText should return html element', () => {
-    const a: HTMLElement = getByPlaceholderText('1');
-  });
-
-  it('queryByLabelText should return maybe html element', () => {
-    // $ExpectError
-    const a: HTMLElement = queryByLabelText('1');
-    const b: ?HTMLElement = queryByLabelText('2');
-  });
-
-  it('getByLabelText should return html element', () => {
-    const a: HTMLElement = getByLabelText('1');
-  });
-
-  it('queryByAltText should return maybe html element', () => {
+  it('queryByAltText should return maybe HTML element', () => {
     // $ExpectError
     const a: HTMLElement = queryByAltText('1');
     const b: ?HTMLElement = queryByAltText('2');
   });
 
-  it('getByAltText should return html element', () => {
-    const a: HTMLElement = getByAltText('1');
+  it('queryAllByAltText should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryAllByAltText('1');
+    const b: Array<HTMLElement> = queryAllByAltText('2');
   });
 
-  it('queryAll should return empty array of html element', () => {
-    // $ExpectError
-    const a: HTMLElement = queryAll('1');
-    const b: Array<HTMLElement> = queryAll('2');
+  it('getByDisplayValue should return HTML element', () => {
+    const a: HTMLElement = getByDisplayValue('1');
   });
 
-  it('getAll should return array of html element', () => {
+  it('getAllByDisplayValue should return array of HTML element', () => {
     // $ExpectError
-    const a: HTMLElement = getAll('1');
-    const b: Array<HTMLElement> = getAll('2');
+    const a: HTMLElement = getAllByDisplayValue('1');
+    const b: Array<HTMLElement> = getAllByDisplayValue('2');
+  });
+
+  it('queryByDisplayValue should return maybe HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryByDisplayValue('1');
+    const b: ?HTMLElement = queryByDisplayValue('2');
+  });
+
+  it('queryAllByDisplayValue should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryAllByDisplayValue('1');
+    const b: Array<HTMLElement> = queryAllByDisplayValue('2');
+  });
+
+  it('getByLabelText should return HTML element', () => {
+    const a: HTMLElement = getByLabelText('1');
+  });
+
+  it('getAllByLabelText should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = getAllByLabelText('1');
+    const b: Array<HTMLElement> = getAllByLabelText('2');
+  });
+
+  it('queryByLabelText should return maybe HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryByLabelText('1');
+    const b: ?HTMLElement = queryByLabelText('2');
+  });
+
+  it('queryAllByLabelText should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryAllByLabelText('1');
+    const b: Array<HTMLElement> = queryAllByLabelText('2');
+  });
+
+  it('getByPlaceholderText should return HTML element', () => {
+    const a: HTMLElement = getByPlaceholderText('1');
+  });
+
+  it('getAllByPlaceholderText should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = getAllByPlaceholderText('1');
+    const b: Array<HTMLElement> = getAllByPlaceholderText('2');
+  });
+
+  it('queryByPlaceholderText should return maybe HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryByPlaceholderText('1');
+    const b: ?HTMLElement = queryByPlaceholderText('2');
+  });
+
+  it('queryAllByPlaceholderText should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryAllByPlaceholderText('1');
+    const b: Array<HTMLElement> = queryAllByPlaceholderText('2');
+  });
+
+  it('getByRole should return HTML element', () => {
+    const a: HTMLElement = getByRole('1');
+  });
+
+  it('getAllByRole should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = getAllByRole('1');
+    const b: Array<HTMLElement> = getAllByRole('2');
+  });
+
+  it('queryByRole should return maybe HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryByRole('1');
+    const b: ?HTMLElement = queryByRole('2');
+  });
+
+  it('queryAllByRole should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryAllByRole('1');
+    const b: Array<HTMLElement> = queryAllByRole('2');
+  });
+
+  it('getBySelectText should return HTML element', () => {
+    const a: HTMLElement = getBySelectText('1');
+  });
+
+  it('getAllBySelectText should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = getAllBySelectText('1');
+    const b: Array<HTMLElement> = getAllBySelectText('2');
+  });
+
+  it('queryBySelectText should return maybe HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryBySelectText('1');
+    const b: ?HTMLElement = queryBySelectText('2');
+  });
+
+  it('queryAllBySelectText should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryAllBySelectText('1');
+    const b: Array<HTMLElement> = queryAllBySelectText('2');
+  });
+
+  it('getByTestId should return HTML element', () => {
+    const a: HTMLElement = getByTestId('1');
+  });
+
+  it('getAllByTestId should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = getAllByTestId('1');
+    const b: Array<HTMLElement> = getAllByTestId('2');
+  });
+
+  it('queryByTestId should return maybe HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryByTestId('1');
+    const b: ?HTMLElement = queryByTestId('2');
+  });
+
+  it('queryAllByTestId should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryAllByTestId('1');
+    const b: Array<HTMLElement> = queryAllByTestId('2');
+  });
+
+  it('getByText should return HTML element', () => {
+    const a: HTMLElement = getByText('1');
+  });
+
+  it('getAllByText should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = getAllByText('1');
+    const b: Array<HTMLElement> = getAllByText('2');
+  });
+
+  it('queryByText should return maybe HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryByText('1');
+    const b: ?HTMLElement = queryByText('2');
+  });
+
+  it('queryAllByText should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryAllByText('1');
+    const b: Array<HTMLElement> = queryAllByText('2');
+  });
+
+  it('getByTitle should return HTML element', () => {
+    const a: HTMLElement = getByTitle('1');
+  });
+
+  it('getAllByTitle should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = getAllByTitle('1');
+    const b: Array<HTMLElement> = getAllByTitle('2');
+  });
+
+  it('queryByTitle should return maybe HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryByTitle('1');
+    const b: ?HTMLElement = queryByTitle('2');
+  });
+
+  it('queryAllByTitle should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryAllByTitle('1');
+    const b: Array<HTMLElement> = queryAllByTitle('2');
+  });
+
+  it('getByValue should return HTML element', () => {
+    const a: HTMLElement = getByValue('1');
+  });
+
+  it('getAllByValue should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = getAllByValue('1');
+    const b: Array<HTMLElement> = getAllByValue('2');
+  });
+
+  it('queryByValue should return maybe HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryByValue('1');
+    const b: ?HTMLElement = queryByValue('2');
+  });
+
+  it('queryAllByValue should return array of HTML element', () => {
+    // $ExpectError
+    const a: HTMLElement = queryAllByValue('1');
+    const b: Array<HTMLElement> = queryAllByValue('2');
   });
 });
 
@@ -184,52 +385,164 @@ describe('within', () => {
     within(container);
   });
 
-  it('should has getByTestId', () => {
-    within(container).getByTestId('1');
-  });
-
-  it('should has getByText', () => {
-    within(container).getByText('1');
-  });
-
-  it('should has getByPlaceholderText', () => {
-    within(container).getByPlaceholderText('1');
-  });
-
-  it('should has getByLabelText', () => {
-    within(container).getByLabelText('1');
-  });
-
-  it('should has getByAltText', () => {
+  it('should have getByAltText', () => {
     within(container).getByAltText('1');
   });
 
-  it('should has getAll', () => {
-    within(container).getAll('1');
+  it('should have getAllByAltText', () => {
+    within(container).getAllByAltText('1');
   });
 
-  it('should has queryByTestId', () => {
-    within(container).queryByTestId('1');
-  });
-
-  it('should has queryByText', () => {
-    within(container).queryByText('1');
-  });
-
-  it('should has queryByPlaceholderText', () => {
-    within(container).queryByPlaceholderText('1');
-  });
-
-  it('should has queryByLabelText', () => {
-    within(container).queryByLabelText('1');
-  });
-
-  it('should has queryByAltText', () => {
+  it('should have queryByAltText', () => {
     within(container).queryByAltText('1');
   });
 
-  it('should has queryAll', () => {
-    within(container).queryAll('1');
+  it('should have queryAllByAltText', () => {
+    within(container).queryAllByAltText('1');
+  });
+
+  it('should have getByDisplayValue', () => {
+    within(container).getByDisplayValue('1');
+  });
+
+  it('should have getAllByDisplayValue', () => {
+    within(container).getAllByDisplayValue('1');
+  });
+
+  it('should have queryByDisplayValue', () => {
+    within(container).queryByDisplayValue('1');
+  });
+
+  it('should have queryAllByDisplayValue', () => {
+    within(container).queryAllByDisplayValue('1');
+  });
+
+  it('should have getByLabelText', () => {
+    within(container).getByLabelText('1');
+  });
+
+  it('should have getAllByLabelText', () => {
+    within(container).getAllByLabelText('1');
+  });
+
+  it('should have queryByLabelText', () => {
+    within(container).queryByLabelText('1');
+  });
+
+  it('should have queryAllByLabelText', () => {
+    within(container).queryAllByLabelText('1');
+  });
+
+  it('should have getByPlaceholderText', () => {
+    within(container).getByPlaceholderText('1');
+  });
+
+  it('should have getAllByPlaceholderText', () => {
+    within(container).getAllByPlaceholderText('1');
+  });
+
+  it('should have queryByPlaceholderText', () => {
+    within(container).queryByPlaceholderText('1');
+  });
+
+  it('should have queryAllByPlaceholderText', () => {
+    within(container).queryAllByPlaceholderText('1');
+  });
+
+  it('should have getByRole', () => {
+    within(container).getByRole('1');
+  });
+
+  it('should have getAllByRole', () => {
+    within(container).getAllByRole('1');
+  });
+
+  it('should have queryByRole', () => {
+    within(container).queryByRole('1');
+  });
+
+  it('should have queryAllByRole', () => {
+    within(container).queryAllByRole('1');
+  });
+
+  it('should have getBySelectText', () => {
+    within(container).getBySelectText('1');
+  });
+
+  it('should have getAllBySelectText', () => {
+    within(container).getAllBySelectText('1');
+  });
+
+  it('should have queryBySelectText', () => {
+    within(container).queryBySelectText('1');
+  });
+
+  it('should have queryAllBySelectText', () => {
+    within(container).queryAllBySelectText('1');
+  });
+
+  it('should have getByTestId', () => {
+    within(container).getByTestId('1');
+  });
+
+  it('should have getAllByTestId', () => {
+    within(container).getAllByTestId('1');
+  });
+
+  it('should have queryByTestId', () => {
+    within(container).queryByTestId('1');
+  });
+
+  it('should have queryAllByTestId', () => {
+    within(container).queryAllByTestId('1');
+  });
+
+  it('should have getByText', () => {
+    within(container).getByText('1');
+  });
+
+  it('should have getAllByText', () => {
+    within(container).getAllByText('1');
+  });
+
+  it('should have queryByText', () => {
+    within(container).queryByText('1');
+  });
+
+  it('should have queryAllByText', () => {
+    within(container).queryAllByText('1');
+  });
+
+  it('should have getByTitle', () => {
+    within(container).getByTitle('1');
+  });
+
+  it('should have getAllByTitle', () => {
+    within(container).getAllByTitle('1');
+  });
+
+  it('should have queryByTitle', () => {
+    within(container).queryByTitle('1');
+  });
+
+  it('should have queryAllByTitle', () => {
+    within(container).queryAllByTitle('1');
+  });
+
+  it('should have getByValue', () => {
+    within(container).getByValue('1');
+  });
+
+  it('should have getAllByValue', () => {
+    within(container).getAllByValue('1');
+  });
+
+  it('should have queryByValue', () => {
+    within(container).queryByValue('1');
+  });
+
+  it('should have queryAllByValue', () => {
+    within(container).queryAllByValue('1');
   });
 });
 
@@ -329,101 +642,171 @@ describe('fireEvent', () => {
 describe('text matching API', () => {
   class Component extends React.Component<{}> {}
   const {
-    queryByTestId,
+    getByAltText,
+    getAllByAltText,
+    queryByAltText,
+    queryAllByAltText,
+    getByDisplayValue,
+    getAllByDisplayValue,
+    queryByDisplayValue,
+    queryAllByDisplayValue,
+    getByLabelText,
+    getAllByLabelText,
+    queryByLabelText,
+    queryAllByLabelText,
+    getByPlaceholderText,
+    getAllByPlaceholderText,
+    queryByPlaceholderText,
+    queryAllByPlaceholderText,
+    getByRole,
+    getAllByRole,
+    queryByRole,
+    queryAllByRole,
+    getBySelectText,
+    getAllBySelectText,
+    queryBySelectText,
+    queryAllBySelectText,
     getByTestId,
-    queryByText,
+    getAllByTestId,
+    queryByTestId,
+    queryAllByTestId,
     getByText,
     getAllByText,
-    queryByPlaceholderText,
-    getByPlaceholderText,
-    queryByLabelText,
-    getAllByLabelText,
-    getByLabelText,
-    queryByAltText,
-    getByAltText,
-    queryAll,
-    getAll,
+    queryByText,
+    queryAllByText,
+    getByTitle,
+    getAllByTitle,
+    queryByTitle,
+    queryAllByTitle,
+    getByValue,
+    getAllByValue,
+    queryByValue,
+    queryAllByValue,
   } = render(<Component />);
 
-  it('queryByTestId should accept text match arguments', () => {
-    queryByTestId('1');
-    queryByTestId('1', { trim: true, collapseWhitespace: true, exact: true });
-    queryByTestId(/1/);
-    queryByTestId(/1/, { trim: true, collapseWhitespace: true, exact: true });
-    queryByTestId((content: string, element) => true);
-    queryByTestId((content: string, element) => true, {
+  it('getByAltText should accept text match arguments', () => {
+    getByAltText('1');
+    getByAltText('1', { trim: true, collapseWhitespace: true, exact: true });
+    getByAltText(/1/);
+    getByAltText(/1/, { trim: true, collapseWhitespace: true, exact: true });
+    getByAltText((content: string, element) => true);
+    getByAltText((content: string, element) => true, {
       trim: true,
       collapseWhitespace: true,
       exact: true,
     });
   });
 
-  it('getByTestId should accept text match arguments', () => {
-    getByTestId('1');
-    getByTestId('1', { trim: true, collapseWhitespace: true, exact: true });
-    getByTestId(/1/);
-    getByTestId(/1/, { trim: true, collapseWhitespace: true, exact: true });
-    getByTestId((content: string, element) => true);
-    getByTestId((content: string, element) => true, {
+  it('getAllByAltText should accept text match arguments', () => {
+    const result: Array<HTMLElement> = getAllByAltText('1');
+  });
+
+  it('queryByAltText should accept text match arguments', () => {
+    queryByAltText('1');
+    queryByAltText('1', { trim: true, collapseWhitespace: true, exact: true });
+    queryByAltText(/1/);
+    queryByAltText(/1/, { trim: true, collapseWhitespace: true, exact: true });
+    queryByAltText((content: string, element) => true);
+    queryByAltText((content: string, element) => true, {
       trim: true,
       collapseWhitespace: true,
       exact: true,
     });
   });
 
-  it('queryByText should accept text match arguments', () => {
-    queryByText('1');
-    queryByText('1', { trim: true, collapseWhitespace: true, exact: true });
-    queryByText(/1/);
-    queryByText(/1/, { trim: true, collapseWhitespace: true, exact: true });
-    queryByText((content: string, element) => true);
-    queryByText((content: string, element) => true, {
+  it('queryAllByAltText should accept text match arguments', () => {
+    const result: Array<HTMLElement> = queryAllByAltText('1');
+  });
+
+  it('getByDisplayValue should accept text match arguments', () => {
+    getByDisplayValue('1');
+    getByDisplayValue('1', {
+      trim: true,
+      collapseWhitespace: true,
+      exact: true,
+    });
+    getByDisplayValue(/1/);
+    getByDisplayValue(/1/, {
+      trim: true,
+      collapseWhitespace: true,
+      exact: true,
+    });
+    getByDisplayValue((content: string, element) => true);
+    getByDisplayValue((content: string, element) => true, {
       trim: true,
       collapseWhitespace: true,
       exact: true,
     });
   });
 
-  it('getByText should accept text match arguments', () => {
-    getByText('1');
-    getByText('1', { trim: true, collapseWhitespace: true, exact: true });
-    getByText(/1/);
-    getByText(/1/, { trim: true, collapseWhitespace: true, exact: true });
-    getByText((content: string, element) => true);
-    getByText((content: string, element) => true, {
+  it('getAllByDisplayValue should accept text match arguments', () => {
+    const result: Array<HTMLElement> = getAllByDisplayValue('1');
+  });
+
+  it('queryByDisplayValue should accept text match arguments', () => {
+    queryByDisplayValue('1');
+    queryByDisplayValue('1', {
+      trim: true,
+      collapseWhitespace: true,
+      exact: true,
+    });
+    queryByDisplayValue(/1/);
+    queryByDisplayValue(/1/, {
+      trim: true,
+      collapseWhitespace: true,
+      exact: true,
+    });
+    queryByDisplayValue((content: string, element) => true);
+    queryByDisplayValue((content: string, element) => true, {
       trim: true,
       collapseWhitespace: true,
       exact: true,
     });
   });
 
-  it('getAllByText should return array value.', () => {
-    const result: HTMLElement[] = getAllByText('1');
+  it('queryAllByDisplayValue should accept text match arguments', () => {
+    const result: Array<HTMLElement> = queryAllByDisplayValue('1');
   });
 
-  it('getAllByLabelText should return array value.', () => {
-    const result: HTMLElement[] = getAllByLabelText('1');
+  it('getByLabelText should accept text match arguments', () => {
+    getByLabelText('1');
+    getByLabelText('1', { trim: true, collapseWhitespace: true, exact: true });
+    getByLabelText(/1/);
+    getByLabelText(/1/, { trim: true, collapseWhitespace: true, exact: true });
+    getByLabelText((content: string, element) => true);
+    getByLabelText((content: string, element) => true, {
+      trim: true,
+      collapseWhitespace: true,
+      exact: true,
+      selector: 'A',
+    });
   });
 
-  it('queryByPlaceholderText should accept text match arguments', () => {
-    queryByPlaceholderText('1');
-    queryByPlaceholderText('1', {
+  it('getAllByLabelText should accept text match arguments', () => {
+    const result: Array<HTMLElement> = getAllByLabelText('1');
+  });
+
+  it('queryByLabelText should accept text match arguments', () => {
+    queryByLabelText('1');
+    queryByLabelText('1', { trim: true, collapseWhitespace: true, exact: true });
+    queryByLabelText(/1/);
+    queryByLabelText(/1/, {
       trim: true,
       collapseWhitespace: true,
       exact: true,
+      selector: 'A',
     });
-    queryByPlaceholderText(/1/);
-    queryByPlaceholderText(/1/, {
+    queryByLabelText((content: string, element) => true);
+    queryByLabelText((content: string, element) => true, {
       trim: true,
       collapseWhitespace: true,
       exact: true,
+      selector: 'A',
     });
-    queryByPlaceholderText((content: string, element) => true);
-    queryByPlaceholderText((content: string, element) => true, {
-      trim: true,
-      collapseWhitespace: true,
-      exact: true,
-    });
+  });
+
+  it('queryAllByLabelText should accept text match arguments', () => {
+    const result: Array<HTMLElement> = queryAllByLabelText('1');
   });
 
   it('getByPlaceholderText should accept text match arguments', () => {
@@ -447,89 +830,246 @@ describe('text matching API', () => {
     });
   });
 
-  it('queryByLabelText should accept text match arguments', () => {
-    queryByLabelText('1');
-    queryByLabelText('1', {
+  it('getAllByPlaceholderText should accept text match arguments', () => {
+    const result: Array<HTMLElement> = getAllByPlaceholderText('1');
+  });
+
+  it('queryByPlaceholderText should accept text match arguments', () => {
+    queryByPlaceholderText('1');
+    queryByPlaceholderText('1', {
       trim: true,
       collapseWhitespace: true,
       exact: true,
     });
-    queryByLabelText(/1/);
-    queryByLabelText(/1/, {
+    queryByPlaceholderText(/1/);
+    queryByPlaceholderText(/1/, {
       trim: true,
       collapseWhitespace: true,
       exact: true,
     });
-    queryByLabelText((content: string, element) => true);
-    queryByLabelText((content: string, element) => true, {
+    queryByPlaceholderText((content: string, element) => true);
+    queryByPlaceholderText((content: string, element) => true, {
       trim: true,
       collapseWhitespace: true,
       exact: true,
     });
   });
 
-  it('getByLabelText should accept text match arguments', () => {
-    getByLabelText('1');
-    getByLabelText('1', { trim: true, collapseWhitespace: true, exact: true });
-    getByLabelText(/1/);
-    getByLabelText(/1/, { trim: true, collapseWhitespace: true, exact: true });
-    getByLabelText((content: string, element) => true);
-    getByLabelText((content: string, element) => true, {
+  it('queryAllByPlaceholderText should accept text match arguments', () => {
+    const result: Array<HTMLElement> = queryAllByPlaceholderText('1');
+  });
+
+  it('getByRole should accept text match arguments', () => {
+    getByRole('1');
+    getByRole('1', { trim: true, collapseWhitespace: true, exact: true });
+    getByRole(/1/);
+    getByRole(/1/, { trim: true, collapseWhitespace: true, exact: true });
+    getByRole((content: string, element) => true);
+    getByRole((content: string, element) => true, {
       trim: true,
       collapseWhitespace: true,
       exact: true,
     });
   });
 
-  it('queryByAltText should accept text match arguments', () => {
-    queryByAltText('1');
-    queryByAltText('1', { trim: true, collapseWhitespace: true, exact: true });
-    queryByAltText(/1/);
-    queryByAltText(/1/, { trim: true, collapseWhitespace: true, exact: true });
-    queryByAltText((content: string, element) => true);
-    queryByAltText((content: string, element) => true, {
+  it('getAllByRole should accept text match arguments', () => {
+    const result: Array<HTMLElement> = getAllByRole('1');
+  });
+
+  it('queryByRole should accept text match arguments', () => {
+    queryByRole('1');
+    queryByRole('1', { trim: true, collapseWhitespace: true, exact: true });
+    queryByRole(/1/);
+    queryByRole(/1/, { trim: true, collapseWhitespace: true, exact: true });
+    queryByRole((content: string, element) => true);
+    queryByRole((content: string, element) => true, {
       trim: true,
       collapseWhitespace: true,
       exact: true,
     });
   });
 
-  it('getByAltText should accept text match arguments', () => {
-    getByAltText('1');
-    getByAltText('1', { trim: true, collapseWhitespace: true, exact: true });
-    getByAltText(/1/);
-    getByAltText(/1/, { trim: true, collapseWhitespace: true, exact: true });
-    getByAltText((content: string, element) => true);
-    getByAltText((content: string, element) => true, {
+  it('queryAllByRole should accept text match arguments', () => {
+    const result: Array<HTMLElement> = queryAllByRole('1');
+  });
+
+  it('getBySelectText should accept text match arguments', () => {
+    getBySelectText('1');
+    getBySelectText('1', { trim: true, collapseWhitespace: true, exact: true });
+    getBySelectText(/1/);
+    getBySelectText(/1/, { trim: true, collapseWhitespace: true, exact: true });
+    getBySelectText((content: string, element) => true);
+    getBySelectText((content: string, element) => true, {
       trim: true,
       collapseWhitespace: true,
       exact: true,
     });
   });
 
-  it('queryAll should accept text match arguments', () => {
-    queryAll('1');
-    queryAll('1', { trim: true, collapseWhitespace: true, exact: true });
-    queryAll(/1/);
-    queryAll(/1/, { trim: true, collapseWhitespace: true, exact: true });
-    queryAll((content: string, element) => true);
-    queryAll((content: string, element) => true, {
+  it('getAllBySelectText should accept text match arguments', () => {
+    const result: Array<HTMLElement> = getAllBySelectText('1');
+  });
+
+  it('queryBySelectText should accept text match arguments', () => {
+    queryBySelectText('1');
+    queryBySelectText('1', {
+      trim: true,
+      collapseWhitespace: true,
+      exact: true,
+    });
+    queryBySelectText(/1/);
+    queryBySelectText(/1/, {
+      trim: true,
+      collapseWhitespace: true,
+      exact: true,
+    });
+    queryBySelectText((content: string, element) => true);
+    queryBySelectText((content: string, element) => true, {
       trim: true,
       collapseWhitespace: true,
       exact: true,
     });
   });
 
-  it('getAll should accept text match arguments', () => {
-    getAll('1');
-    getAll('1', { trim: true, collapseWhitespace: true, exact: true });
-    getAll(/1/);
-    getAll(/1/, { trim: true, collapseWhitespace: true, exact: true });
-    getAll((content: string, element) => true);
-    getAll((content: string, element) => true, {
+  it('queryAllBySelectText should accept text match arguments', () => {
+    const result: Array<HTMLElement> = queryAllBySelectText('1');
+  });
+
+  it('getByTestId should accept text match arguments', () => {
+    getByTestId('1');
+    getByTestId('1', { trim: true, collapseWhitespace: true, exact: true });
+    getByTestId(/1/);
+    getByTestId(/1/, { trim: true, collapseWhitespace: true, exact: true });
+    getByTestId((content: string, element) => true);
+    getByTestId((content: string, element) => true, {
       trim: true,
       collapseWhitespace: true,
       exact: true,
     });
+  });
+
+  it('getAllByTestId should accept text match arguments', () => {
+    const result: Array<HTMLElement> = getAllByTestId('1');
+  });
+
+  it('queryByTestId should accept text match arguments', () => {
+    queryByTestId('1');
+    queryByTestId('1', { trim: true, collapseWhitespace: true, exact: true });
+    queryByTestId(/1/);
+    queryByTestId(/1/, { trim: true, collapseWhitespace: true, exact: true });
+    queryByTestId((content: string, element) => true);
+    queryByTestId((content: string, element) => true, {
+      trim: true,
+      collapseWhitespace: true,
+      exact: true,
+    });
+  });
+
+  it('queryAllByTestId should accept text match arguments', () => {
+    const result: Array<HTMLElement> = queryAllByTestId('1');
+  });
+
+  it('getByText should accept text match arguments', () => {
+    getByText('1');
+    getByText('1', { trim: true, collapseWhitespace: true, exact: true });
+    getByText(/1/);
+    getByText(/1/, { trim: true, collapseWhitespace: true, exact: true });
+    getByText((content: string, element) => true);
+    getByText((content: string, element) => true, {
+      trim: true,
+      collapseWhitespace: true,
+      exact: true,
+      selector: 'A',
+    });
+  });
+
+  it('getAllByText should accept text match arguments', () => {
+    const result: Array<HTMLElement> = getAllByText('1');
+  });
+
+  it('queryByText should accept text match arguments', () => {
+    queryByText('1');
+    queryByText('1', { trim: true, collapseWhitespace: true, exact: true });
+    queryByText(/1/);
+    queryByText(/1/, { trim: true, collapseWhitespace: true, exact: true });
+    queryByText((content: string, element) => true);
+    queryByText((content: string, element) => true, {
+      trim: true,
+      collapseWhitespace: true,
+      exact: true,
+      selector: 'A',
+    });
+  });
+
+  it('queryAllByText should accept text match arguments', () => {
+    const result: Array<HTMLElement> = queryAllByText('1');
+  });
+
+  it('getByTitle should accept text match arguments', () => {
+    getByTitle('1');
+    getByTitle('1', { trim: true, collapseWhitespace: true, exact: true });
+    getByTitle(/1/);
+    getByTitle(/1/, { trim: true, collapseWhitespace: true, exact: true });
+    getByTitle((content: string, element) => true);
+    getByTitle((content: string, element) => true, {
+      trim: true,
+      collapseWhitespace: true,
+      exact: true,
+    });
+  });
+
+  it('getAllByTitle should accept text match arguments', () => {
+    const result: Array<HTMLElement> = getAllByTitle('1');
+  });
+
+  it('queryByTitle should accept text match arguments', () => {
+    queryByTitle('1');
+    queryByTitle('1', { trim: true, collapseWhitespace: true, exact: true });
+    queryByTitle(/1/);
+    queryByTitle(/1/, { trim: true, collapseWhitespace: true, exact: true });
+    queryByTitle((content: string, element) => true);
+    queryByTitle((content: string, element) => true, {
+      trim: true,
+      collapseWhitespace: true,
+      exact: true,
+    });
+  });
+
+  it('queryAllByTitle should accept text match arguments', () => {
+    const result: Array<HTMLElement> = queryAllByTitle('1');
+  });
+
+  it('getByValue should accept text match arguments', () => {
+    getByValue('1');
+    getByValue('1', { trim: true, collapseWhitespace: true, exact: true });
+    getByValue(/1/);
+    getByValue(/1/, { trim: true, collapseWhitespace: true, exact: true });
+    getByValue((content: string, element) => true);
+    getByValue((content: string, element) => true, {
+      trim: true,
+      collapseWhitespace: true,
+      exact: true,
+    });
+  });
+
+  it('getAllByValue should accept text match arguments', () => {
+    const result: Array<HTMLElement> = getAllByValue('1');
+  });
+
+  it('queryByValue should accept text match arguments', () => {
+    queryByValue('1');
+    queryByValue('1', { trim: true, collapseWhitespace: true, exact: true });
+    queryByValue(/1/);
+    queryByValue(/1/, { trim: true, collapseWhitespace: true, exact: true });
+    queryByValue((content: string, element) => true);
+    queryByValue((content: string, element) => true, {
+      trim: true,
+      collapseWhitespace: true,
+      exact: true,
+    });
+  });
+
+  it('queryAllByValue should accept text match arguments', () => {
+    const result: Array<HTMLElement> = queryAllByValue('1');
   });
 });

--- a/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-/test_react-testing-library_v5.x.x.js
+++ b/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-/test_react-testing-library_v5.x.x.js
@@ -9,8 +9,8 @@ import {
   waitForElement,
   within,
 } from 'react-testing-library';
-import {describe, it} from 'flow-typed-test';
-import {domainToASCII} from 'url';
+import { describe, it } from 'flow-typed-test';
+import { domainToASCII } from 'url';
 
 describe('wait', () => {
   it('should fail on invalid inputs', () => {
@@ -22,7 +22,7 @@ describe('wait', () => {
 
   it('should pass on correct inputs', () => {
     wait(() => {});
-    wait(() => {}, {timeout: 1});
+    wait(() => {}, { timeout: 1 });
   });
 });
 
@@ -42,12 +42,13 @@ describe('waitForElement', () => {
     });
   });
 
-  it('should return a usable value.', async (n) => {
-    const usernameElement = await waitForElement(
-      () => document.createElement('input'));
+  it('should return a usable value.', async n => {
+    const usernameElement = await waitForElement(() =>
+      document.createElement('input')
+    );
 
     usernameElement.value = 'chucknorris';
-  })
+  });
 });
 
 describe('render', () => {
@@ -175,7 +176,7 @@ describe('cleanup', () => {
 
 describe('within', () => {
   class Component extends React.Component<{}> {}
-  const {container} = render(<Component />);
+  const { container } = render(<Component />);
 
   it('should has html element as argument', () => {
     // $ExpectError
@@ -241,7 +242,7 @@ describe('fireEvent', () => {
       new MouseEvent('click', {
         bubbles: true,
         cancelable: true,
-      }),
+      })
     );
   });
 
@@ -346,9 +347,9 @@ describe('text matching API', () => {
 
   it('queryByTestId should accept text match arguments', () => {
     queryByTestId('1');
-    queryByTestId('1', {trim: true, collapseWhitespace: true, exact: true});
+    queryByTestId('1', { trim: true, collapseWhitespace: true, exact: true });
     queryByTestId(/1/);
-    queryByTestId(/1/, {trim: true, collapseWhitespace: true, exact: true});
+    queryByTestId(/1/, { trim: true, collapseWhitespace: true, exact: true });
     queryByTestId((content: string, element) => true);
     queryByTestId((content: string, element) => true, {
       trim: true,
@@ -359,9 +360,9 @@ describe('text matching API', () => {
 
   it('getByTestId should accept text match arguments', () => {
     getByTestId('1');
-    getByTestId('1', {trim: true, collapseWhitespace: true, exact: true});
+    getByTestId('1', { trim: true, collapseWhitespace: true, exact: true });
     getByTestId(/1/);
-    getByTestId(/1/, {trim: true, collapseWhitespace: true, exact: true});
+    getByTestId(/1/, { trim: true, collapseWhitespace: true, exact: true });
     getByTestId((content: string, element) => true);
     getByTestId((content: string, element) => true, {
       trim: true,
@@ -372,9 +373,9 @@ describe('text matching API', () => {
 
   it('queryByText should accept text match arguments', () => {
     queryByText('1');
-    queryByText('1', {trim: true, collapseWhitespace: true, exact: true});
+    queryByText('1', { trim: true, collapseWhitespace: true, exact: true });
     queryByText(/1/);
-    queryByText(/1/, {trim: true, collapseWhitespace: true, exact: true});
+    queryByText(/1/, { trim: true, collapseWhitespace: true, exact: true });
     queryByText((content: string, element) => true);
     queryByText((content: string, element) => true, {
       trim: true,
@@ -385,9 +386,9 @@ describe('text matching API', () => {
 
   it('getByText should accept text match arguments', () => {
     getByText('1');
-    getByText('1', {trim: true, collapseWhitespace: true, exact: true});
+    getByText('1', { trim: true, collapseWhitespace: true, exact: true });
     getByText(/1/);
-    getByText(/1/, {trim: true, collapseWhitespace: true, exact: true});
+    getByText(/1/, { trim: true, collapseWhitespace: true, exact: true });
     getByText((content: string, element) => true);
     getByText((content: string, element) => true, {
       trim: true,
@@ -448,9 +449,17 @@ describe('text matching API', () => {
 
   it('queryByLabelText should accept text match arguments', () => {
     queryByLabelText('1');
-    queryByLabelText('1', {trim: true, collapseWhitespace: true, exact: true});
+    queryByLabelText('1', {
+      trim: true,
+      collapseWhitespace: true,
+      exact: true,
+    });
     queryByLabelText(/1/);
-    queryByLabelText(/1/, {trim: true, collapseWhitespace: true, exact: true});
+    queryByLabelText(/1/, {
+      trim: true,
+      collapseWhitespace: true,
+      exact: true,
+    });
     queryByLabelText((content: string, element) => true);
     queryByLabelText((content: string, element) => true, {
       trim: true,
@@ -461,9 +470,9 @@ describe('text matching API', () => {
 
   it('getByLabelText should accept text match arguments', () => {
     getByLabelText('1');
-    getByLabelText('1', {trim: true, collapseWhitespace: true, exact: true});
+    getByLabelText('1', { trim: true, collapseWhitespace: true, exact: true });
     getByLabelText(/1/);
-    getByLabelText(/1/, {trim: true, collapseWhitespace: true, exact: true});
+    getByLabelText(/1/, { trim: true, collapseWhitespace: true, exact: true });
     getByLabelText((content: string, element) => true);
     getByLabelText((content: string, element) => true, {
       trim: true,
@@ -474,9 +483,9 @@ describe('text matching API', () => {
 
   it('queryByAltText should accept text match arguments', () => {
     queryByAltText('1');
-    queryByAltText('1', {trim: true, collapseWhitespace: true, exact: true});
+    queryByAltText('1', { trim: true, collapseWhitespace: true, exact: true });
     queryByAltText(/1/);
-    queryByAltText(/1/, {trim: true, collapseWhitespace: true, exact: true});
+    queryByAltText(/1/, { trim: true, collapseWhitespace: true, exact: true });
     queryByAltText((content: string, element) => true);
     queryByAltText((content: string, element) => true, {
       trim: true,
@@ -487,9 +496,9 @@ describe('text matching API', () => {
 
   it('getByAltText should accept text match arguments', () => {
     getByAltText('1');
-    getByAltText('1', {trim: true, collapseWhitespace: true, exact: true});
+    getByAltText('1', { trim: true, collapseWhitespace: true, exact: true });
     getByAltText(/1/);
-    getByAltText(/1/, {trim: true, collapseWhitespace: true, exact: true});
+    getByAltText(/1/, { trim: true, collapseWhitespace: true, exact: true });
     getByAltText((content: string, element) => true);
     getByAltText((content: string, element) => true, {
       trim: true,
@@ -500,9 +509,9 @@ describe('text matching API', () => {
 
   it('queryAll should accept text match arguments', () => {
     queryAll('1');
-    queryAll('1', {trim: true, collapseWhitespace: true, exact: true});
+    queryAll('1', { trim: true, collapseWhitespace: true, exact: true });
     queryAll(/1/);
-    queryAll(/1/, {trim: true, collapseWhitespace: true, exact: true});
+    queryAll(/1/, { trim: true, collapseWhitespace: true, exact: true });
     queryAll((content: string, element) => true);
     queryAll((content: string, element) => true, {
       trim: true,
@@ -513,9 +522,9 @@ describe('text matching API', () => {
 
   it('getAll should accept text match arguments', () => {
     getAll('1');
-    getAll('1', {trim: true, collapseWhitespace: true, exact: true});
+    getAll('1', { trim: true, collapseWhitespace: true, exact: true });
     getAll(/1/);
-    getAll(/1/, {trim: true, collapseWhitespace: true, exact: true});
+    getAll(/1/, { trim: true, collapseWhitespace: true, exact: true });
     getAll((content: string, element) => true);
     getAll((content: string, element) => true, {
       trim: true,


### PR DESCRIPTION
Current definitions don't include all query helpers defined in [`dom-testing-library`](https://testing-library.com/docs/api-queries). This PR adds the missing ones.

It also adds definition for [`waitForDomChange`](https://testing-library.com/docs/api-async#waitfordomchange) async helper.