### PR TITLE
[next_v7.x.x] Added next/config definition to nextjs flow types

### DIFF
--- a/definitions/npm/next_v7.x.x/flow_v0.53.x-/next_v7.x.x.js
+++ b/definitions/npm/next_v7.x.x/flow_v0.53.x-/next_v7.x.x.js
@@ -65,6 +65,13 @@ declare module "next/head" {
   declare module.exports: Class<React$Component<any, any>>;
 }
 
+declare module "next/config" {
+  declare module.exports: () => {
+    publicRuntimeConfig: { [string]: string },
+    serverRuntimeConfig: { [string]: string }
+  };
+}
+
 declare type URLObject = {
   +href?: string,
   +protocol?: string,

--- a/definitions/npm/next_v7.x.x/test_next_v7.x.x.js
+++ b/definitions/npm/next_v7.x.x/test_next_v7.x.x.js
@@ -6,6 +6,7 @@ import Router, {type RouteError} from "next/router";
 import Document, {Head as DocumentHead, Main, NextScript} from "next/document";
 import App, {type AppInitialProps, Container} from "next/app";
 import dynamic from "next/dynamic";
+import getConfig from "next/config";
 
 const { createServer } = require("http");
 const { parse } = require("url");
@@ -49,6 +50,18 @@ app.prepare().then(() => {
 });
 
 app.setAssetPrefix('');
+
+class ConfigAwareComponent extends React.Component<*> {
+  render() {
+    const { publicRuntimeConfig, serverRuntimeConfig } = getConfig();
+    return (
+      <div>
+        {publicRuntimeConfig.publicConfigVar}
+        {serverRuntimeConfig.privateConfigVar}
+      </div>
+    );
+  }
+}
 
 <Head>
   <meta charSet="utf-8" />


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://nextjs.org/docs/#exposing-configuration-to-the-server--client-side
- Link to GitHub or NPM: https://github.com/zeit/next.js
- Type of contribution: addition

Other notes:
Just adds the type definition for the 'next/config' module.
