### PR TITLE
[algoliasearch_v3.x.x] allow host to be string or array of string

### DIFF
--- a/definitions/npm/algoliasearch_v3.x.x/flow_v0.56.x-v0.70.x/algoliasearch_v3.x.x.js
+++ b/definitions/npm/algoliasearch_v3.x.x/flow_v0.56.x-v0.70.x/algoliasearch_v3.x.x.js
@@ -64,8 +64,8 @@ declare type $algoliasearch$ClientOptions = {|
   protocol?: "http:" | "https:",
   httpClient?: HTTPClient,
   hosts?: {|
-    read?: string,
-    write?: string
+    read?: string | Array<string>,
+    write?: string | Array<string>
   |}
 |};
 

--- a/definitions/npm/algoliasearch_v3.x.x/flow_v0.56.x-v0.70.x/algoliasearch_v3.x.x.js
+++ b/definitions/npm/algoliasearch_v3.x.x/flow_v0.56.x-v0.70.x/algoliasearch_v3.x.x.js
@@ -64,8 +64,8 @@ declare type $algoliasearch$ClientOptions = {|
   protocol?: "http:" | "https:",
   httpClient?: HTTPClient,
   hosts?: {|
-    read?: string | Array<string>,
-    write?: string | Array<string>
+    read?: Array<string>,
+    write?: Array<string>
   |}
 |};
 

--- a/definitions/npm/algoliasearch_v3.x.x/flow_v0.71.x-/algoliasearch_v3.x.x.js
+++ b/definitions/npm/algoliasearch_v3.x.x/flow_v0.71.x-/algoliasearch_v3.x.x.js
@@ -64,8 +64,8 @@ declare type $algoliasearch$ClientOptions = {|
   protocol?: "http:" | "https:",
   httpClient?: HTTPClient,
   hosts?: {|
-    read?: string,
-    write?: string
+    read?: string | Array<string>,
+    write?: string | Array<string>
   |}
 |};
 

--- a/definitions/npm/algoliasearch_v3.x.x/flow_v0.71.x-/algoliasearch_v3.x.x.js
+++ b/definitions/npm/algoliasearch_v3.x.x/flow_v0.71.x-/algoliasearch_v3.x.x.js
@@ -64,8 +64,8 @@ declare type $algoliasearch$ClientOptions = {|
   protocol?: "http:" | "https:",
   httpClient?: HTTPClient,
   hosts?: {|
-    read?: string | Array<string>,
-    write?: string | Array<string>
+    read?: Array<string>,
+    write?: Array<string>
   |}
 |};
 

--- a/definitions/npm/algoliasearch_v3.x.x/test_algoliasearch-v3.x.x.js
+++ b/definitions/npm/algoliasearch_v3.x.x/test_algoliasearch-v3.x.x.js
@@ -9,6 +9,26 @@ describe("algoliasearch", () => {
     searchIndex.search("test").then(result => result.hits);
   });
 
+  it("works with provided hosts", () => {
+    const algoliasearch = require("algoliasearch");
+    const options = {
+      hosts: {
+        read: [
+          '-1.algolianet.com',
+          '-2.algolianet.com',
+          '-3.algolianet.com',
+        ],
+        write: [
+          '-1.algolianet.com',
+          '-2.algolianet.com',
+          '-3.algolianet.com',
+        ],
+      },
+    };
+    const searchIndex = algoliasearch("", "", options).initIndex("");
+    searchIndex.search("test").then(result => result.hits);
+  });
+
   it("works with `import` syntax", () => {
     const searchIndex = algoliasearchImport("", "").initIndex("");
     searchIndex.search("test").then(result => result.hits);


### PR DESCRIPTION
- Links to documentation: https://github.com/algolia/algoliasearch-client-javascript#client-options
- Link to GitHub or NPM: https://github.com/algolia/algoliasearch-client-javascript/blob/develop/src/AlgoliaSearchCore.js#L100
- Type of contribution: fix

Other notes:
Algolia can receive array of hosts for read/write
