### PR TITLE
Added export for FetchResult in apollo-client

### DIFF
--- a/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
+++ b/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
@@ -511,7 +511,7 @@ declare module "apollo-client" {
     toKey: () => string;
   }
 
-  declare type FetchResult<
+  declare export type FetchResult<
     C = { [key: string]: any },
     E = { [key: string]: any }
   > = ExecutionResult<C> & { extension?: E, context?: C };


### PR DESCRIPTION
We need to export `FetchResult` as it is defined as `MutationOperation` return type from #2438 .
```
  declare export type MutationOperation<T = Object> = (options: MutationBaseOptions<T>) => Promise<FetchResult<T>>
```
https://github.com/dudekaa/flow-typed/blob/2f65154d319b89387e3356ff8ab04ef381c1f176/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js#L302

Not sure how it works for anybody until today?