### PR TITLE
Redux reducers: Make actions contravariant

### DIFF
--- a/definitions/npm/redux_v4.x.x/flow_v0.55.x-/redux_v4.x.x.js
+++ b/definitions/npm/redux_v4.x.x/flow_v0.55.x-/redux_v4.x.x.js
@@ -24,7 +24,7 @@ declare module 'redux' {
     replaceReducer(nextReducer: Reducer<S, A>): void
   };
 
-  declare export type Reducer<S, A> = (state: S | void, action: A) => S;
+  declare export type Reducer<S, -A> = (state: S | void, action: A) => S;
 
   declare export type CombinedReducer<S, A> = (state: $Shape<S> & {} | void, action: A) => S;
 


### PR DESCRIPTION
Redux reducers can legitimately be contravariant
with regard to the actions they accept.

The action is used only in a parameter
position and constructs like this would be
useful, particularly when a base action
typedef (specifying a string 'type' property) is
used.

```js
const reducers : Array<Reducer<TState,BaseAction>> = [];
const specificReducer : Reducer<TState,TDerivedAction> = getSpecificReducer();
reducers.push(specificReducer);
```

- Type of contribution: Small feature enhancement to existing definition.

**Other notes**
FWIW I noticed that the PR changed the line break at the end of the file. That wasn't intended and was added by the editor I used. Feel free to revert that bit out if you want (I created/submitted this PR from a mobile device & editor).