### PR TITLE
[redux-saga_v1.x.x] Fix createSagaMiddleware

### DIFF
--- a/definitions/npm/redux-saga_v1.x.x/flow_v0.76.0-/redux-saga_v1.x.x.js
+++ b/definitions/npm/redux-saga_v1.x.x/flow_v0.76.0-/redux-saga_v1.x.x.js
@@ -7,7 +7,7 @@ declare module "redux-saga" {
 
   // * remove next types
   declare type DispatchAPI<A> = (action: A) => A;
-  declare type Dispatch<A: { type: $Subtype<string> }> = DispatchAPI<A>;
+  declare type Dispatch<A: { type: string }> = DispatchAPI<A>;
 
   declare type MiddlewareAPI<S, A, D = Dispatch<A>> = {
     dispatch: D,
@@ -197,8 +197,8 @@ declare module "redux-saga" {
   };
 
   declare export type SagaMiddleware<C: {}> =
-    | Middleware<*, *>
-    | {
+    {
+        <S, A, D>(api: MiddlewareAPI<S, A, D>): (next: D) => D,
         run: {
           <R, Fn: () => Saga<R>>(saga: Fn): Task<R>,
           <R, T1, Fn: T1 => Saga<R>>(saga: Fn, T1): Task<R>,

--- a/definitions/npm/redux-saga_v1.x.x/flow_v0.76.0-/test_redux-saga_1.x.x_createSagaMiddleware.js
+++ b/definitions/npm/redux-saga_v1.x.x/flow_v0.76.0-/test_redux-saga_1.x.x_createSagaMiddleware.js
@@ -1,0 +1,24 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import createSagaMiddleware from 'redux-saga';
+
+// Emulate redux
+type DispatchAPI<A> = (action: A) => A;
+type Dispatch<A: { type: string }> = DispatchAPI<A>;
+type MiddlewareAPI<S, A, D = Dispatch<A>> = {
+  dispatch: D,
+  getState(): S,
+};
+type Middleware<S, A, D = Dispatch<A>> = (
+  api: MiddlewareAPI<S, A, D>
+) => (next: D) => D;
+declare function applyMiddleware<S, A, D>(
+  ...middlewares: Array<Middleware<S, A, D>>
+): {};
+
+describe('createSagaMiddleware', () => {
+  it('works with redux applyMiddleware', () => {
+    const sagaMiddleware = createSagaMiddleware();
+    const enhancer = applyMiddleware(sagaMiddleware);
+  });
+});


### PR DESCRIPTION
- Fix the createSagaMiddleware return type to work correctly with redux applyMiddleware function
    - Previous error: `Cannot call applyMiddleware because a callable signature is missing in object type`
- Remove use of deprecated `$Subtype`