### PR TITLE
docs(numeral_v2.x.x): fix spelling errors

### DIFF
--- a/definitions/npm/numeral_v2.x.x/flow_v0.25.x-/numeral_v2.x.x.js
+++ b/definitions/npm/numeral_v2.x.x/flow_v0.25.x-/numeral_v2.x.x.js
@@ -39,8 +39,8 @@ declare interface Numeral {
     /**
      * Registers a language definition or a custom format definition.
      * @param what Allowed values are: either 'format' or 'locale'
-     * @param key The key of the registerd type, e.g. 'de' for a german locale definition
-     * @param value The locale definition or the format definitiion
+     * @param key The key of the registered type, e.g. 'de' for a german locale definition
+     * @param value The locale definition or the format definition
      */
     register(
         what: RegisterType,


### PR DESCRIPTION
Just fixed a couple small spelling errors I noticed

- Type of contribution: fix

