### PR TITLE
[query-string_v6.x.x] Allow number, boolean, null, and void for stringify values

### DIFF
--- a/definitions/npm/query-string_v6.x.x/flow_v0.32.x-/query-string_v6.x.x.js
+++ b/definitions/npm/query-string_v6.x.x/flow_v0.32.x-/query-string_v6.x.x.js
@@ -11,6 +11,12 @@ declare module 'query-string' {
     sort?: false | <A, B>(A, B) => number,
   |}
 
+  declare type ObjectParameter = string | number | boolean | null | void;
+
+  declare type ObjectParameters = {
+    [string]: ObjectParameter | Array<ObjectParameter>
+  }
+
   declare type QueryParameters = {
     [string]: string | Array<string> | null
   }
@@ -19,6 +25,6 @@ declare module 'query-string' {
     extract(str: string): string,
     parse(str: string, opts?: ParseOptions): QueryParameters,
     parseUrl(str: string, opts?: ParseOptions): { url: string, query: QueryParameters },
-    stringify(obj: QueryParameters, opts?: StringifyOptions): string,
+    stringify(obj: ObjectParameters, opts?: StringifyOptions): string,
   }
 }

--- a/definitions/npm/query-string_v6.x.x/test_query-string_v6.x.x.js
+++ b/definitions/npm/query-string_v6.x.x/test_query-string_v6.x.x.js
@@ -32,6 +32,16 @@ stringify("test");
 // $ExpectError: true is not a stringify option
 stringify({ test: null }, { test: true });
 
+stringify({ test: 1 });
+
+stringify({ test: [1, 2, 3] });
+
+stringify({ test: false });
+
+stringify({ test: null });
+
+stringify({ test: undefined });
+
 parseUrl("test");
 
 parseUrl("test", { arrayFormat: "bracket" });


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/sindresorhus/query-string#falsy-values
- Link to GitHub or NPM: https://github.com/sindresorhus/query-string
- Type of contribution: fix

Other notes:

This is a followup to https://github.com/flow-typed/flow-typed/pull/2657

According to the query-string docs boolean, number, null, and void are also [valid values into `stringify`](https://github.com/sindresorhus/query-string#falsy-values)

```js

//=> 'foo=false'

queryString.stringify({foo: null});
//=> 'foo'

queryString.stringify({foo: undefined});
//=> ''
```

cc: @callumlocke @villesau
