### PR TITLE
add 1s delay for 404 retrying

### DIFF
--- a/cli/src/lib/npm/npmLibDefs.js
+++ b/cli/src/lib/npm/npmLibDefs.js
@@ -76,7 +76,13 @@ async function extractLibDefsFromNpmPkgDir(
         if (error.statusCode === 404) {
           // Some times NPM returns 404 even though the package exists.
           // Try to avoid false negatives by retrying
-          return _npmExists(fullPkgName);
+          return new Promise((resolve, reject) =>
+            setTimeout(() => {
+              _npmExists(fullPkgName)
+                .then(resolve)
+                .catch(reject);
+            }, 1000),
+          );
         }
       })
       .then()


### PR DESCRIPTION
Previous PR: https://github.com/flow-typed/flow-typed/pull/3117

this happened right after merging the retrying: https://travis-ci.org/flow-typed/flow-typed/jobs/487150074

Which means the retry was not as successful as thought. Let's try 1s delay to see if it's any better.

