### PR TITLE
[query-string_v6.x.x] fix type for ObjectParameters

### DIFF
--- a/definitions/npm/query-string_v6.x.x/flow_v0.32.x-/query-string_v6.x.x.js
+++ b/definitions/npm/query-string_v6.x.x/flow_v0.32.x-/query-string_v6.x.x.js
@@ -14,7 +14,7 @@ declare module 'query-string' {
   declare type ObjectParameter = string | number | boolean | null | void;
 
   declare type ObjectParameters = {
-    [string]: ObjectParameter | Array<ObjectParameter>
+    [string]: ObjectParameter | $ReadOnlyArray<ObjectParameter>
   }
 
   declare type QueryParameters = {


### PR DESCRIPTION
- Links to documentation: [$ReadOnlyArray in Flow doc](https://flow.org/en/docs/types/arrays/#toc-readonlyarray)
- Link to GitHub or NPM: [Discussion in previous PR](https://github.com/flow-typed/flow-typed/pull/3114#pullrequestreview-199066242)
- Type of contribution: fix

Other notes:
Fix Flow error, when you put to `stringify` function object, where key have value with strict type `Array<string>`, or `Array<number>`, or another.

After fixes in code below will no error:
```ts
const arr: Array<string> = ["hello", "world"];
queryString.stringify({ key: arr }); // No more Flow errors in this line
```
