### PR TITLE
[react-hot-loader_v4.6.x] add types for new API hot function

### DIFF
--- a/definitions/npm/react-hot-loader_v4.6.x/flow_v0.53.0-/react-hot-loader_v4.6.x.js
+++ b/definitions/npm/react-hot-loader_v4.6.x/flow_v0.53.0-/react-hot-loader_v4.6.x.js
@@ -1,34 +1,33 @@
 // @flow
-declare type ErrorReporterProps = {|
-  error: any,
+declare type errorReporterProps = {|
+  error: Error,
+  errorInfo: { componentStack: string }
 |}
 
-declare type AppContainerProps = {|
+declare type ContainerProps = {|
+  children: React$Element<any>,
   errorBoundary?: boolean,
-  errorReporter?: React$ComponentType<ErrorReporterProps>,
+  errorReporter?: React$ComponentType<errorReporterProps>,
 |}
 
 declare module "react-hot-loader" {
   declare type Module = {
-    id: string
+    id: string,
   };
 
-  declare type AppChildren = {|
-    children?: React$Element<any>
-  |}
+  declare export class AppContainer extends React$Component<ContainerProps> {}
 
-  declare export class AppContainer extends React$Component<AppContainerProps & AppChildren> {}
-
-  declare export function hot(module: Module): <T: React$ComponentType<any>>(Component: T, props?: AppContainerProps) => T
+  declare export function hot(module: Module): <T: React$ComponentType<any>>(
+    Component: T,
+    props?: $Diff<ContainerProps, { children: React$Element<any> }>
+  ) => T
 
   declare export function cold<T: React$ComponentType<any>>(component: T): T
 
-  declare export function areComponentsEqual<T>(typeA: React$ComponentType<T>, typeB: React$ComponentType<T>): boolean
-
-  declare type HotError = {|
-    error: Error,
-    errorInfo?: { componentStack: string },
-  |}
+  declare export function areComponentsEqual<T>(
+    typeA: React$ComponentType<T>,
+    typeB: React$ComponentType<T>
+  ): boolean
 
   declare type Config = {|
     logLevel: 'debug' | 'log' | 'warn' | 'error',
@@ -39,8 +38,8 @@ declare module "react-hot-loader" {
     disableHotRendererWhenInjected: boolean,
     ignoreSFC: boolean,
     ignoreComponents: boolean,
-    errorReporter: React$ComponentType<HotError>,
-    ErrorOverlay: React$ComponentType<{ errors: Array<HotError> }>,
+    errorReporter: React$ComponentType<errorReporterProps>,
+    ErrorOverlay: React$ComponentType<{ errors: Array<errorReporterProps> }>,
     onComponentRegister: (type: any, uniqueLocalName: string, fileName: string) => any,
     onComponentCreate: (type: any, displayName: string) => any,
   |}
@@ -51,6 +50,6 @@ declare module "react-hot-loader" {
 declare module "react-hot-loader/root" {
   declare export function hot<T: React$ComponentType<any>>(
     Component: T,
-    props?: AppContainerProps
+    props?: $Diff<ContainerProps, { children: React$Element<any> }>
   ): T;
 }

--- a/definitions/npm/react-hot-loader_v4.6.x/flow_v0.53.0-/react-hot-loader_v4.6.x.js
+++ b/definitions/npm/react-hot-loader_v4.6.x/flow_v0.53.0-/react-hot-loader_v4.6.x.js
@@ -1,19 +1,19 @@
 // @flow
-declare type errorReporterProps = {|
-  error: Error,
-  errorInfo: { componentStack: string }
-|}
-
-declare type ContainerProps = {|
-  children: React$Element<any>,
-  errorBoundary?: boolean,
-  errorReporter?: React$ComponentType<errorReporterProps>,
-|}
-
 declare module "react-hot-loader" {
   declare type Module = {
     id: string,
   };
+
+  declare type ErrorReporterProps = {|
+    error: Error,
+    errorInfo: { componentStack: string }
+  |}
+
+  declare export type ContainerProps = {|
+    children: React$Element<any>,
+    errorBoundary?: boolean,
+    errorReporter?: React$ComponentType<ErrorReporterProps>,
+  |}
 
   declare export class AppContainer extends React$Component<ContainerProps> {}
 
@@ -38,8 +38,8 @@ declare module "react-hot-loader" {
     disableHotRendererWhenInjected: boolean,
     ignoreSFC: boolean,
     ignoreComponents: boolean,
-    errorReporter: React$ComponentType<errorReporterProps>,
-    ErrorOverlay: React$ComponentType<{ errors: Array<errorReporterProps> }>,
+    errorReporter: React$ComponentType<ErrorReporterProps>,
+    ErrorOverlay: React$ComponentType<{ errors: Array<ErrorReporterProps> }>,
     onComponentRegister: (type: any, uniqueLocalName: string, fileName: string) => any,
     onComponentCreate: (type: any, displayName: string) => any,
   |}
@@ -48,6 +48,8 @@ declare module "react-hot-loader" {
 }
 
 declare module "react-hot-loader/root" {
+  import type { ContainerProps } from 'react-hot-loader';
+
   declare export function hot<T: React$ComponentType<any>>(
     Component: T,
     props?: $Diff<ContainerProps, { children: React$Element<any> }>

--- a/definitions/npm/react-hot-loader_v4.6.x/flow_v0.53.0-/react-hot-loader_v4.6.x.js
+++ b/definitions/npm/react-hot-loader_v4.6.x/flow_v0.53.0-/react-hot-loader_v4.6.x.js
@@ -1,0 +1,56 @@
+// @flow
+declare type ErrorReporterProps = {|
+  error: any,
+|}
+
+declare type AppContainerProps = {|
+  errorBoundary?: boolean,
+  errorReporter?: React$ComponentType<ErrorReporterProps>,
+|}
+
+declare module "react-hot-loader" {
+  declare type Module = {
+    id: string
+  };
+
+  declare type AppChildren = {|
+    children?: React$Element<any>
+  |}
+
+  declare export class AppContainer extends React$Component<AppContainerProps & AppChildren> {}
+
+  declare export function hot(module: Module): <T: React$ComponentType<any>>(Component: T, props?: AppContainerProps) => T
+
+  declare export function cold<T: React$ComponentType<any>>(component: T): T
+
+  declare export function areComponentsEqual<T>(typeA: React$ComponentType<T>, typeB: React$ComponentType<T>): boolean
+
+  declare type HotError = {|
+    error: Error,
+    errorInfo?: { componentStack: string },
+  |}
+
+  declare type Config = {|
+    logLevel: 'debug' | 'log' | 'warn' | 'error',
+    pureSFC: boolean,
+    pureRender: boolean,
+    allowSFC: boolean,
+    disableHotRenderer: boolean,
+    disableHotRendererWhenInjected: boolean,
+    ignoreSFC: boolean,
+    ignoreComponents: boolean,
+    errorReporter: React$ComponentType<HotError>,
+    ErrorOverlay: React$ComponentType<{ errors: Array<HotError> }>,
+    onComponentRegister: (type: any, uniqueLocalName: string, fileName: string) => any,
+    onComponentCreate: (type: any, displayName: string) => any,
+  |}
+
+  declare export function setConfig(config: $Shape<Config>): void
+}
+
+declare module "react-hot-loader/root" {
+  declare export function hot<T: React$ComponentType<any>>(
+    Component: T,
+    props?: AppContainerProps
+  ): T;
+}

--- a/definitions/npm/react-hot-loader_v4.6.x/flow_v0.53.0-/test_react-hot-loader_4.6.x.js
+++ b/definitions/npm/react-hot-loader_v4.6.x/flow_v0.53.0-/test_react-hot-loader_4.6.x.js
@@ -1,0 +1,124 @@
+// @flow
+import * as React from "react";
+import { describe, it } from "flow-typed-test";
+
+import { AppContainer, hot, setConfig } from "react-hot-loader";
+
+describe("react-hot-loader", () => {
+  describe("hot", () => {
+    it("accepts some module", () => {
+      hot(module);
+
+      // $ExpectError
+      hot();
+
+      // $ExpectError
+      hot({});
+    });
+
+    it("returns a helper for wrapping a component in AppContainer", () => {
+      const Wrapped = () => <div />;
+
+      hot(module)(Wrapped);
+      hot(module)(Wrapped, {});
+      hot(module)(Wrapped, { errorBoundary: true });
+
+      // $ExpectError
+      hot(module)();
+
+      // $ExpectError
+      hot(module)(Wrapped, { errorBoundary: 1 });
+    });
+
+    it("returned component accepts same props as the wrapped component", () => {
+      const Wrapped = ({ someProp }: {| someProp: string |}) => <div />;
+
+      const Component = hot(module)(Wrapped);
+      <Component someProp={"some"} />;
+
+      // $ExpectError
+      <Component />;
+      // $ExpectError
+      <Component someProp={1} />;
+    });
+  });
+
+  describe("AppContainer", () => {
+    it("accepts only one child", () => {
+      <AppContainer>
+        <div />
+      </AppContainer>;
+
+      const SomeComponent = () => null;
+      <AppContainer>
+        <SomeComponent />
+      </AppContainer>;
+
+      // $ExpectError
+      <AppContainer />;
+
+      // $ExpectError
+      <AppContainer>
+        /<div />
+        <div />
+      </AppContainer>;
+    });
+
+    it("accepts an optional errorBoundary flag", () => {
+      <AppContainer errorBoundary>
+        <div />
+      </AppContainer>;
+
+      <AppContainer errorBoundary={false}>
+        <div />
+      </AppContainer>;
+
+      // $ExpectError
+      <AppContainer errorBoundary={1}>
+        <div />
+      </AppContainer>;
+    });
+
+    it("accepts an optional error reporting component that optionally accepts error and errorInfo", () => {
+      let ErrorReporter;
+
+      ErrorReporter = () => <div />;
+      <AppContainer errorReporter={ErrorReporter}>
+        <div />
+      </AppContainer>;
+
+      ErrorReporter = ({ error }: { error: Error }) => <div />;
+      <AppContainer errorReporter={ErrorReporter}>
+        <div />
+      </AppContainer>;
+
+      ErrorReporter = ({
+        errorInfo
+      }: {
+        errorInfo: { componentStack: string }
+      }) => <div />;
+      <AppContainer errorReporter={ErrorReporter}>
+        <div />
+      </AppContainer>;
+
+      // $ExpectError
+      <AppContainer errorReporter={null}>
+        <div />
+      </AppContainer>;
+
+      // $ExpectError
+      ErrorReporter = ({ error }: { error: number }) => <div />;
+      <AppContainer errorReporter={ErrorReporter}>
+        <div />
+      </AppContainer>;
+    });
+
+    it('can use setConfig', () => {
+      setConfig({
+        logLevel: 'error',
+        errorReporter: ({ error }: { error: Error }) => <div />,
+        ErrorOverlay: () => null,
+      });
+    });
+  });
+});

--- a/definitions/npm/react-hot-loader_v4.6.x/flow_v0.53.0-/test_react-hot-loader_4.6.x.js
+++ b/definitions/npm/react-hot-loader_v4.6.x/flow_v0.53.0-/test_react-hot-loader_4.6.x.js
@@ -2,47 +2,10 @@
 import * as React from "react";
 import { describe, it } from "flow-typed-test";
 
-import { AppContainer, hot, setConfig } from "react-hot-loader";
+import { AppContainer, hot, setConfig, areComponentsEqual, cold } from "react-hot-loader";
+import { hot as rootHot } from "react-hot-loader/root";
 
 describe("react-hot-loader", () => {
-  describe("hot", () => {
-    it("accepts some module", () => {
-      hot(module);
-
-      // $ExpectError
-      hot();
-
-      // $ExpectError
-      hot({});
-    });
-
-    it("returns a helper for wrapping a component in AppContainer", () => {
-      const Wrapped = () => <div />;
-
-      hot(module)(Wrapped);
-      hot(module)(Wrapped, {});
-      hot(module)(Wrapped, { errorBoundary: true });
-
-      // $ExpectError
-      hot(module)();
-
-      // $ExpectError
-      hot(module)(Wrapped, { errorBoundary: 1 });
-    });
-
-    it("returned component accepts same props as the wrapped component", () => {
-      const Wrapped = ({ someProp }: {| someProp: string |}) => <div />;
-
-      const Component = hot(module)(Wrapped);
-      <Component someProp={"some"} />;
-
-      // $ExpectError
-      <Component />;
-      // $ExpectError
-      <Component someProp={1} />;
-    });
-  });
-
   describe("AppContainer", () => {
     it("accepts only one child", () => {
       <AppContainer>
@@ -59,7 +22,7 @@ describe("react-hot-loader", () => {
 
       // $ExpectError
       <AppContainer>
-        /<div />
+        <div />
         <div />
       </AppContainer>;
     });
@@ -112,13 +75,146 @@ describe("react-hot-loader", () => {
         <div />
       </AppContainer>;
     });
+  });
 
-    it('can use setConfig', () => {
+  describe("hot", () => {
+    it("accepts some module", () => {
+      hot(module);
+
+      // $ExpectError
+      hot();
+
+      // $ExpectError
+      hot({});
+    });
+
+    it("returns a helper for wrapping a component in AppContainer", () => {
+      const Wrapped = () => <div />;
+
+      hot(module)(Wrapped);
+      hot(module)(Wrapped, {});
+      hot(module)(Wrapped, { errorBoundary: true });
+
+      // $ExpectError
+      hot(module)();
+
+      // $ExpectError
+      hot(module)(Wrapped, { errorBoundary: 1 });
+    });
+
+    it("returned component accepts same props as the wrapped component", () => {
+      const Wrapped = ({ someProp }: $Exact<{ someProp: string }>) => <div />;
+
+      const Component = hot(module)(Wrapped);
+
+      <Component someProp={"some"} />;
+
+      // $ExpectError
+      <Component />;
+
+      // $ExpectError
+      <Component someProp={1} />;
+    });
+  });
+
+  describe("cold", () => {
+    it('pass wrong parameters', () => {
+      const Component1 = () => <div />;
+
+      cold(Component1);
+
+      // $ExpectError
+      cold({});
+
+      // $ExpectError
+      cold(1);
+
+      // $ExpectError
+      cold(true);
+
+      // $ExpectError
+      cold(<div />);
+    });
+  });
+
+  describe("areComponentsEqual", () => {
+    it('pass wrong parameters', () => {
+      const Component1 = () => <div />;
+      const Component2 = () => <div />;
+      const Component3 = () => <div />;
+
+      areComponentsEqual(Component1, Component2);
+
+      // $ExpectError
+      areComponentsEqual(Component1, {});
+
+      // $ExpectError
+      areComponentsEqual(1, Component2);
+
+      // $ExpectError
+      areComponentsEqual(Component1, true);
+
+      // $ExpectError
+      areComponentsEqual(Component1, Component2, Component3);
+    });
+  });
+
+  describe("setConfig", () => {
+    it('can use', () => {
       setConfig({
         logLevel: 'error',
         errorReporter: ({ error }: { error: Error }) => <div />,
         ErrorOverlay: () => null,
       });
+    });
+
+    it('can pass partial config', () => {
+      setConfig({
+        pureSFC: false,
+        allowSFC: true,
+        ignoreSFC: false,
+      });
+    });
+
+    it('error when type not match', () => {
+      // $ExpectError
+      setConfig({
+        logLevel: 'my value',
+        pureSFC: 1,
+        ignoreSFC: 0,
+      });
+    });
+  });
+});
+
+describe("react-hot-loader/root", () => {
+  describe("hot", () => {
+    it("returns a helper for wrapping a component in AppContainer", () => {
+      const Wrapped = () => <div />;
+
+      rootHot(Wrapped);
+      rootHot(Wrapped, {});
+      rootHot(Wrapped, { errorBoundary: true });
+
+      // $ExpectError
+      rootHot();
+
+      // $ExpectError
+      rootHot(Wrapped, { errorBoundary: 1 });
+    });
+
+    it("returned component accepts same props as the wrapped component", () => {
+      const Wrapped = ({ someProp }: $Exact<{ someProp: string }>) => <div />;
+
+      const Component = rootHot(Wrapped);
+
+      <Component someProp={"some"} />;
+
+      // $ExpectError
+      <Component />;
+
+      // $ExpectError
+      <Component someProp={1} />;
     });
   });
 });


### PR DESCRIPTION
- Links to documentation: [Look at **note** in Getting started](https://github.com/gaearon/react-hot-loader#getting-started)
- Link to GitHub or NPM: https://github.com/gaearon/react-hot-loader
- Type of contribution: addition

Other notes:
In 4.6 version [was added new `root/hot` API](https://github.com/gaearon/react-hot-loader/releases/tag/4.6.0). I duplicated `react-hot-loader_v4.x.x` folder and added types for new features. And wrote some tests.

I'm new in Flow. Need thorough review, please.
