### PR TITLE
[react-navigation] Get rid of deprecated Navigator exports in 3.0

### DIFF
--- a/definitions/npm/react-navigation_v3.x.x/flow_v0.60.x-/react-navigation_v3.x.x.js
+++ b/definitions/npm/react-navigation_v3.x.x/flow_v0.60.x-/react-navigation_v3.x.x.js
@@ -892,10 +892,6 @@ declare module 'react-navigation' {
     navigatorConfig?: NavigatorConfig
   ): NavigationNavigator<S, O, *>;
 
-  declare export function StackNavigator(
-    routeConfigMap: NavigationRouteConfigMap,
-    stackConfig?: StackNavigatorConfig
-  ): NavigationNavigator<*, *, *>;
   declare export function createStackNavigator(
     routeConfigMap: NavigationRouteConfigMap,
     stackConfig?: StackNavigatorConfig
@@ -920,14 +916,6 @@ declare module 'react-navigation' {
     removeClippedSubviews?: boolean,
     containerOptions?: void,
   |};
-  declare export function TabNavigator(
-    routeConfigs: NavigationRouteConfigMap,
-    config?: _TabNavigatorConfig
-  ): NavigationNavigator<*, *, *>;
-  declare export function createTabNavigator(
-    routeConfigs: NavigationRouteConfigMap,
-    config?: _TabNavigatorConfig
-  ): NavigationNavigator<*, *, *>;
   /* TODO: fix the config for each of these tab navigator types */
   declare export function createBottomTabNavigator(
     routeConfigs: NavigationRouteConfigMap,
@@ -940,10 +928,6 @@ declare module 'react-navigation' {
   declare type _SwitchNavigatorConfig = {|
     ...NavigationSwitchRouterConfig,
   |};
-  declare export function SwitchNavigator(
-    routeConfigs: NavigationRouteConfigMap,
-    config?: _SwitchNavigatorConfig
-  ): NavigationNavigator<*, *, *>;
   declare export function createSwitchNavigator(
     routeConfigs: NavigationRouteConfigMap,
     config?: _SwitchNavigatorConfig
@@ -965,10 +949,6 @@ declare module 'react-navigation' {
     ..._DrawerViewConfig,
     containerConfig?: void,
   }>;
-  declare export function DrawerNavigator(
-    routeConfigs: NavigationRouteConfigMap,
-    config?: _DrawerNavigatorConfig
-  ): NavigationNavigator<*, *, *>;
   declare export function createDrawerNavigator(
     routeConfigs: NavigationRouteConfigMap,
     config?: _DrawerNavigatorConfig

--- a/definitions/npm/react-navigation_v3.x.x/test_react-navigation.js
+++ b/definitions/npm/react-navigation_v3.x.x/test_react-navigation.js
@@ -5,9 +5,9 @@ import type {
 } from 'react-navigation';
 
 import {
-  TabNavigator,
-  StackNavigator,
-  DrawerNavigator,
+  createBottomTabNavigator,
+  createStackNavigator,
+  createDrawerNavigator,
 } from 'react-navigation';
 import React from 'react';
 
@@ -20,7 +20,7 @@ const FunctionalScreenComponent = (
 ) => {
   return "Test";
 };
-TabNavigator({
+createBottomTabNavigator({
   Test1: { screen: FunctionalScreenComponent },
 });
 
@@ -29,21 +29,21 @@ class ClassScreenComponent extends React.Component<*> {
     return "Test";
   }
 }
-StackNavigator({
+createStackNavigator({
   Test1: { screen: ClassScreenComponent },
 });
 
 // $ExpectError numbers can never be components
-StackNavigator({
+createStackNavigator({
   Test1: { screen: 5 },
 });
 
 // $ExpectError you need a screen!
-TabNavigator({
+createBottomTabNavigator({
   Test1: { blah: "test" },
 });
 
-DrawerNavigator({
+createDrawerNavigator({
   Test1: { getScreen: () => FunctionalScreenComponent },
 });
 
@@ -51,7 +51,7 @@ DrawerNavigator({
  * Configs
  */
 
-StackNavigator(
+createStackNavigator(
   {
     Test1: { screen: FunctionalScreenComponent },
   },
@@ -61,7 +61,7 @@ StackNavigator(
   },
 );
 
-StackNavigator(
+createStackNavigator(
   {
     Test1: { screen: FunctionalScreenComponent },
   },
@@ -72,7 +72,7 @@ StackNavigator(
   },
 );
 
-TabNavigator(
+createBottomTabNavigator(
   {
     Test1: { screen: FunctionalScreenComponent },
   },
@@ -82,7 +82,7 @@ TabNavigator(
   },
 );
 
-TabNavigator(
+createBottomTabNavigator(
   {
     Test1: { screen: FunctionalScreenComponent },
   },
@@ -91,7 +91,7 @@ TabNavigator(
   },
 );
 
-DrawerNavigator(
+createDrawerNavigator(
   {
     Test1: { screen: FunctionalScreenComponent },
   },
@@ -100,7 +100,7 @@ DrawerNavigator(
   },
 );
 
-DrawerNavigator(
+createDrawerNavigator(
   {
     Test1: { screen: FunctionalScreenComponent },
   },
@@ -114,7 +114,7 @@ DrawerNavigator(
  * Nav options
  */
 
-StackNavigator({
+createStackNavigator({
   Test1: {
     screen: FunctionalScreenComponent,
     navigationOptions: {
@@ -131,7 +131,7 @@ class ComponentWithNavOptions extends React.Component<*> {
     return "Test";
   }
 }
-StackNavigator({
+createStackNavigator({
   Test1: { screen: ComponentWithNavOptions },
 });
 
@@ -150,10 +150,10 @@ class ComponentWithFunctionalNavOptions extends React.Component<*> {
  * Nested
  */
 
-const nestedNavigator = TabNavigator({
+const nestedNavigator = createBottomTabNavigator({
   Test1: { screen: FunctionalScreenComponent },
 });
-StackNavigator({
+createStackNavigator({
   Test2: { screen: nestedNavigator },
   Test3: { screen: ClassScreenComponent },
 });


### PR DESCRIPTION
These were deprecated in 3.0, but I forgot to remove them from the libdef.