### PR TITLE
[react-redux] Pass dispatch prop when no dispatch function provided.

### DIFF
--- a/definitions/npm/react-redux_v5.x.x/flow_v0.89.x-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.89.x-/react-redux_v5.x.x.js
@@ -79,7 +79,7 @@ declare module "react-redux" {
   // Got error like inexact OwnProps is incompatible with exact object type?
   // Just make the OP parameter for `connect()` an exact object.
   declare type MergeOP<OP, D> = {| ...$Exact<OP>, dispatch: D |};
-  declare type MergeOPSP<OP, SP> = {| ...$Exact<OP>, ...SP |};
+  declare type MergeOPSP<OP, SP, D> = {| ...$Exact<OP>, ...SP, dispatch: D |};
   declare type MergeOPDP<OP, DP> = {| ...$Exact<OP>, ...DP |};
   declare type MergeOPSPDP<OP, SP, DP> = {| ...$Exact<OP>, ...SP, ...DP |};
 
@@ -95,8 +95,8 @@ declare module "react-redux" {
     mapStateToProps: MapStateToProps<S, OP, SP>,
     mapDispatchToProps?: null | void,
     mergeProps?: null | void,
-    options?: ?Options<S, OP, SP, MergeOPSP<OP, SP>>,
-  ): Connector<P, OP, MergeOPSP<OP, SP>>;
+    options?: ?Options<S, OP, SP, MergeOPSP<OP, SP, D>>,
+  ): Connector<P, OP, MergeOPSP<OP, SP, D>>;
 
   // In this case DP is an object of functions which has been bound to dispatch
   // by the given mapDispatchToProps function.

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.89.x-/test_connect.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.89.x-/test_connect.js
@@ -154,13 +154,15 @@ function doesNotRequireDefinedComponentToTypeCheck5case() {
 }
 
 function testExactProps() {
+  type Dispatch = () => void;
   type OwnProps = {|
     passthrough: number,
     forMapStateToProps: string,
   |};
   type Props = {|
     ...OwnProps,
-    fromStateToProps: string
+    fromStateToProps: string,
+    dispatch: Dispatch,
   |};
 
   class Com extends React.Component<Props> {
@@ -721,4 +723,24 @@ function checkIfStateTypeIsRespectedAgain() {
   const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps)(Com);
   <Connected />;
   e.push(Connected);
+}
+
+function testPassingDispatchPropWithoutDispatchFunction() {
+  type OwnProps = {||}
+  type Props = {| ...OwnProps, dispatch: any |};
+  class Com extends React.Component<Props> {
+    render() {
+      return <div />;
+    }
+  }
+
+  type State = {a: number};
+  type InputProps = {};
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {}
+  };
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected />;
 }

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.89.x-/test_connect.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.89.x-/test_connect.js
@@ -183,7 +183,7 @@ function testExactProps() {
     }
   };
 
-  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  const Connected = connect<Props, OwnProps,_,_,_,Dispatch>(mapStateToProps)(Com);
   e.push(Connected);
   <Connected passthrough={123} forMapStateToProps={'data'} />;
   //$ExpectError extraProp what exact props does not allow
@@ -195,7 +195,7 @@ function testExactProps() {
   //$ExpectError forMapStateToProps missing
   <Connected passthrough={123}/>;
   //$ExpectError takes in only React components
-  const Connected2 = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)('');
+  const Connected2 = connect<Props, OwnProps,_,_,_,Dispatch>(mapStateToProps)('');
   e.push(Connected2);
 }
 
@@ -349,6 +349,26 @@ function testMapDispatchToProps() {
   <Connected passthrough={123} forMapDispatchToProps={'more data'} />;
   //$ExpectError forMapDispatchToProps missing
   <Connected passthrough={123} forMapStateToProps={'data'} />;
+}
+
+function testMapDispatchToPropsDoesNotPassDispatch() {
+  type Dispatch = () => void;
+  type OwnProps = {||};
+  type Props = {| ...OwnProps, fromMapDispatchToProps: string, dispatch: Dispatch |};
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.fromMapDispatchToProps}</div>;
+    }
+  }
+
+  const mapStateToProps = (state: *, props: *) => ({})
+  const mapDispatchToProps = (dispatch: *, ownProps: *) => {
+    return {fromMapDispatchToProps: 'yo'}
+  }
+  // $ExpectError dispatch should not be provided in Props when mapDispatchToProps is present
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(mapStateToProps, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
 }
 
 function testMapDispatchToPropsWithoutMapStateToProps() {
@@ -726,8 +746,9 @@ function checkIfStateTypeIsRespectedAgain() {
 }
 
 function testPassingDispatchPropWithoutDispatchFunction() {
+  type Dispatch = () => void;
   type OwnProps = {||}
-  type Props = {| ...OwnProps, dispatch: any |};
+  type Props = {| ...OwnProps, dispatch: Dispatch |};
   class Com extends React.Component<Props> {
     render() {
       return <div />;
@@ -740,7 +761,25 @@ function testPassingDispatchPropWithoutDispatchFunction() {
     return {}
   };
 
-  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  const Connected = connect<Props, OwnProps,_,_,_,Dispatch>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function testPassingDispatchTypeIsPassedThrough() {
+  type Dispatch = () => void;
+  type OwnProps = {||}
+  type Props = {| ...OwnProps, dispatch: string |};
+  class Com extends React.Component<Props> {
+    render() {
+      return <div />;
+    }
+  }
+
+  const mapStateToProps = (state: *, props: *) => ({});
+
+  // $ExpectError dispatch mismatched from type Dispatch
+  const Connected = connect<Props, OwnProps,_,_,_,Dispatch>(mapStateToProps)(Com);
   e.push(Connected);
   <Connected />;
 }

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.89.x-/test_connectInfer.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.89.x-/test_connectInfer.js
@@ -75,45 +75,6 @@ function doesNotRequireDefinedComponentToTypeCheck5case() {
   connect(mapStateToProps, mapDispatchToProps, mergeProps)(Component);
 }
 
-function testExactProps() {
-  type Props = {|
-    forMapStateToProps: string,
-    passthrough: number,
-    fromStateToProps: string
-  |};
-
-  class Com extends React.Component<Props> {
-    render() {
-      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
-    }
-  }
-
-  type State = {a: number};
-  type InputProps = {|
-    forMapStateToProps: string,
-    passthrough: number,
-  |};
-
-  const mapStateToProps = (state: State, props: InputProps) => {
-    return {
-      fromStateToProps: 'str' + state.a
-    }
-  };
-
-  const Connected = connect(mapStateToProps)(Com);
-  <Connected passthrough={123} forMapStateToProps={'data'} />;
-  //$ExpectError extra prop what exact props does not allow
-  <Connected passthrough={123} forMapStateToProps={321} extraProp={123}/>;
-  //$ExpectError wrong type for forMapStateToProps
-  <Connected passthrough={123} forMapStateToProps={321}/>;
-  //$ExpectError passthrough missing
-  <Connected forMapStateToProps={'data'} />;
-  //$ExpectError forMapStateToProps missing
-  <Connected passthrough={123}/>;
-  //$ExpectError takes in only React components
-  connect(mapStateToProps)('');
-}
-
 function testWithStatelessFunctionalComponent() {
   type Props = {passthrough: number, fromStateToProps: string};
   const Com = (props: Props) => <div>{props.passthrough} {props.fromStateToProps}</div>


### PR DESCRIPTION
Provides a `dispatch` property when no dispatch function is provided.

Downside is that it requires people to specify a `dispatch` property when they're using exact props on `Props`, but I think that's worth the cost of being able to correctly type the component. We use this pattern throughout our codebase.

Also apparently it makes it no longer possible to infer types in this use case. Didn't seem like a terrible cost.

@peter-leonov @villesau 