### PR TITLE
[use-dark-mode_v2.2.x] Add definitions

### DIFF
--- a/definitions/npm/use-dark-mode_v2.2.x/flow_v0.30.x-/test_use-dark-mode_v2.2.x.js
+++ b/definitions/npm/use-dark-mode_v2.2.x/flow_v0.30.x-/test_use-dark-mode_v2.2.x.js
@@ -1,0 +1,67 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+
+import React from 'react';
+import useDarkMode from 'use-dark-mode';
+
+function DarkModeToggle() {
+  const darkMode = useDarkMode(false);
+
+  return (
+    <>
+      <button type="button" onClick={darkMode.disable} />
+      <input
+        type="checkbox"
+        checked={darkMode.value}
+        onChange={darkMode.toggle}
+      />
+      <button type="button" onClick={darkMode.enable} />
+    </>
+  );
+}
+
+describe('The `useDarkMode` hook', () => {
+  it('should accept booleans as initialState', () => {
+    useDarkMode();
+    useDarkMode(false);
+    useDarkMode(true);
+    // $ExpectError
+    useDarkMode('');
+  });
+
+  it('should validate the config object', () => {
+    useDarkMode(false, {
+      classNameDark: '',
+      classNameLight: '',
+      element: document.createElement('div'),
+      onChange: value => {
+        (value: boolean);
+      },
+    });
+
+    // $ExpectError
+    useDarkMode(false, false);
+    // $ExpectError
+    useDarkMode({}, false);
+    // $ExpectError
+    useDarkMode(false, {
+      classNameDark: true,
+      element: () => <div />,
+    });
+  });
+
+  it('should validate the return object', () => {
+    const darkMode = useDarkMode();
+
+    (darkMode.value: boolean);
+    darkMode.enable();
+    darkMode.disable();
+    darkMode.toggle();
+
+    // $ExpectError
+    darkMode.value = true;
+    // $ExpectError
+    darkMode.enable = false;
+  });
+});

--- a/definitions/npm/use-dark-mode_v2.2.x/flow_v0.30.x-/use-dark-mode_v2.2.x.js
+++ b/definitions/npm/use-dark-mode_v2.2.x/flow_v0.30.x-/use-dark-mode_v2.2.x.js
@@ -1,0 +1,20 @@
+declare module 'use-dark-mode' {
+  declare export type DarkModeConfig = {|
+    classNameDark?: string,
+    classNameLight?: string,
+    element?: HTMLElement,
+    onChange?: (value: boolean) => void,
+  |};
+
+  declare export type DarkMode = {|
+    +value: boolean,
+    enable: () => void,
+    disable: () => void,
+    toggle: () => void,
+  |};
+
+  declare export default function useDarkMode(
+    initialState?: boolean,
+    config?: DarkModeConfig
+  ): DarkMode;
+}


### PR DESCRIPTION
- Links to documentation: https://github.com/donavon/use-dark-mode
- Link to GitHub or NPM: https://github.com/donavon/use-dark-mode
- Type of contribution: new definition

