### PR TITLE
[react-navigation] Introduce SafeAreaViewInsets type

### DIFF
--- a/definitions/npm/@react-navigation/core_v3.x.x/flow_v0.60.x-/core_v3.x.x.js
+++ b/definitions/npm/@react-navigation/core_v3.x.x/flow_v0.60.x-/core_v3.x.x.js
@@ -630,8 +630,8 @@ declare module '@react-navigation/core' {
     // The value that represents the progress of the transition when navigation
     // state changes from one to another. Its numeric value will range from 0
     // to 1.
-    //  progress.__getAnimatedValue() < 1 : transtion is happening.
-    //  progress.__getAnimatedValue() == 1 : transtion completes.
+    //  progress.__getAnimatedValue() < 1 : transition is happening.
+    //  progress.__getAnimatedValue() == 1 : transition completes.
     progress: AnimatedValue,
 
     // All the scenes of the transitioner.

--- a/definitions/npm/@react-navigation/core_v3.x.x/flow_v0.60.x-/core_v3.x.x.js
+++ b/definitions/npm/@react-navigation/core_v3.x.x/flow_v0.60.x-/core_v3.x.x.js
@@ -771,14 +771,14 @@ declare module '@react-navigation/core' {
   ): NavigationRouter<*, *>;
 
   declare type _SafeAreaViewForceInsetValue = 'always' | 'never' | number;
-  declare type _SafeAreaViewInsets = $Shape<{|
+  declare type _SafeAreaViewInsets = $Shape<{
     top: _SafeAreaViewForceInsetValue,
     bottom: _SafeAreaViewForceInsetValue,
     left: _SafeAreaViewForceInsetValue,
     right: _SafeAreaViewForceInsetValue,
     vertical: _SafeAreaViewForceInsetValue,
     horizontal: _SafeAreaViewForceInsetValue,
-  |}>;
+  }>;
 
   declare export function withNavigation<Props: {}, ComponentType: React$ComponentType<Props>>(
     Component: ComponentType

--- a/definitions/npm/@react-navigation/core_v3.x.x/flow_v0.60.x-/core_v3.x.x.js
+++ b/definitions/npm/@react-navigation/core_v3.x.x/flow_v0.60.x-/core_v3.x.x.js
@@ -85,15 +85,6 @@ declare module '@react-navigation/core' {
     track(tracking: AnimatedTracking): void;
   }
 
-  declare type HeaderForceInset = {
-    horizontal?: string,
-    vertical?: string,
-    left?: string,
-    right?: string,
-    top?: string,
-    bottom?: string,
-  };
-
   /**
    * Next, all the type declarations
    */
@@ -422,7 +413,7 @@ declare module '@react-navigation/core' {
     headerPressColorAndroid?: string,
     headerRight?: React$Node,
     headerStyle?: ViewStyleProp,
-    headerForceInset?: HeaderForceInset,
+    headerForceInset?: _SafeAreaViewInsets,
     headerBackground?: React$Node | React$ElementType,
     gesturesEnabled?: boolean,
     gestureResponseDistance?: { vertical?: number, horizontal?: number },
@@ -778,6 +769,16 @@ declare module '@react-navigation/core' {
     routeConfigs: NavigationRouteConfigMap,
     config?: NavigationTabRouterConfig
   ): NavigationRouter<*, *>;
+
+  declare type _SafeAreaViewForceInsetValue = 'always' | 'never' | number;
+  declare type _SafeAreaViewInsets = $Shape<{|
+    top: _SafeAreaViewForceInsetValue,
+    bottom: _SafeAreaViewForceInsetValue,
+    left: _SafeAreaViewForceInsetValue,
+    right: _SafeAreaViewForceInsetValue,
+    vertical: _SafeAreaViewForceInsetValue,
+    horizontal: _SafeAreaViewForceInsetValue,
+  |}>;
 
   declare export function withNavigation<Props: {}, ComponentType: React$ComponentType<Props>>(
     Component: ComponentType

--- a/definitions/npm/react-navigation_v3.x.x/flow_v0.60.x-/react-navigation_v3.x.x.js
+++ b/definitions/npm/react-navigation_v3.x.x/flow_v0.60.x-/react-navigation_v3.x.x.js
@@ -1079,14 +1079,14 @@ declare module 'react-navigation' {
   declare export var Card: React$ComponentType<_CardProps>;
 
   declare type _SafeAreaViewForceInsetValue = 'always' | 'never' | number;
-  declare type _SafeAreaViewInsets = $Shape<{|
+  declare type _SafeAreaViewInsets = $Shape<{
     top: _SafeAreaViewForceInsetValue,
     bottom: _SafeAreaViewForceInsetValue,
     left: _SafeAreaViewForceInsetValue,
     right: _SafeAreaViewForceInsetValue,
     vertical: _SafeAreaViewForceInsetValue,
     horizontal: _SafeAreaViewForceInsetValue,
-  |}>;
+  }>;
   declare type _SafeAreaViewProps = {
     forceInset?: _SafeAreaViewInsets,
     children?: React$Node,

--- a/definitions/npm/react-navigation_v3.x.x/flow_v0.60.x-/react-navigation_v3.x.x.js
+++ b/definitions/npm/react-navigation_v3.x.x/flow_v0.60.x-/react-navigation_v3.x.x.js
@@ -107,15 +107,6 @@ declare module 'react-navigation' {
     track(tracking: AnimatedTracking): void;
   }
 
-  declare type HeaderForceInset = {
-    horizontal?: string,
-    vertical?: string,
-    left?: string,
-    right?: string,
-    top?: string,
-    bottom?: string,
-  };
-
   /**
    * Next, all the type declarations
    */
@@ -444,7 +435,7 @@ declare module 'react-navigation' {
     headerPressColorAndroid?: string,
     headerRight?: React$Node,
     headerStyle?: ViewStyleProp,
-    headerForceInset?: HeaderForceInset,
+    headerForceInset?: _SafeAreaViewInsets,
     headerBackground?: React$Node | React$ElementType,
     gesturesEnabled?: boolean,
     gestureResponseDistance?: { vertical?: number, horizontal?: number },
@@ -1088,15 +1079,16 @@ declare module 'react-navigation' {
   declare export var Card: React$ComponentType<_CardProps>;
 
   declare type _SafeAreaViewForceInsetValue = 'always' | 'never' | number;
+  declare type _SafeAreaViewInsets = $Shape<{|
+    top: _SafeAreaViewForceInsetValue,
+    bottom: _SafeAreaViewForceInsetValue,
+    left: _SafeAreaViewForceInsetValue,
+    right: _SafeAreaViewForceInsetValue,
+    vertical: _SafeAreaViewForceInsetValue,
+    horizontal: _SafeAreaViewForceInsetValue,
+  |}>;
   declare type _SafeAreaViewProps = {
-    forceInset?: {
-      top?: _SafeAreaViewForceInsetValue,
-      bottom?: _SafeAreaViewForceInsetValue,
-      left?: _SafeAreaViewForceInsetValue,
-      right?: _SafeAreaViewForceInsetValue,
-      vertical?: _SafeAreaViewForceInsetValue,
-      horizontal?: _SafeAreaViewForceInsetValue,
-    },
+    forceInset?: _SafeAreaViewInsets,
     children?: React$Node,
     style?: AnimatedViewStyleProp,
   };

--- a/definitions/npm/react-navigation_v3.x.x/flow_v0.60.x-/react-navigation_v3.x.x.js
+++ b/definitions/npm/react-navigation_v3.x.x/flow_v0.60.x-/react-navigation_v3.x.x.js
@@ -728,8 +728,8 @@ declare module 'react-navigation' {
     // The value that represents the progress of the transition when navigation
     // state changes from one to another. Its numeric value will range from 0
     // to 1.
-    //  progress.__getAnimatedValue() < 1 : transtion is happening.
-    //  progress.__getAnimatedValue() == 1 : transtion completes.
+    //  progress.__getAnimatedValue() < 1 : transition is happening.
+    //  progress.__getAnimatedValue() == 1 : transition completes.
     progress: AnimatedValue,
 
     // All the scenes of the transitioner.


### PR DESCRIPTION
This type is used in two separate places in the libdef. I've updated it to use `$Shape` and an exact type.

This is a follow-up from a review comment to #3139.