### PR TITLE
Add static now() to moment libdef

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_v0.25.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.25.x-/moment_v2.x.x.js
@@ -350,6 +350,7 @@ declare class moment$Moment {
   locale(): string;
   static months(): Array<string>;
   static monthsShort(): Array<string>;
+  static now(): number;
   static weekdays(): Array<string>;
   static weekdaysShort(): Array<string>;
   static weekdaysMin(): Array<string>;

--- a/definitions/npm/moment_v2.x.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.x.x/test_moment-v2.js
@@ -294,3 +294,17 @@ moment.defineLocale('fakeLocale', { parentLocale: 'xyz' });
 moment.defineLocale('fakeLocale', 'not an object');
 // $ExpectError
 moment.defineLocale(); // no arguments
+
+describe('now', () => {
+  it('takes no parameter', () => {
+    moment.now()
+    // $ExpectError
+    moment.now('Lorem')
+  });
+
+  it('returns a number', () => {
+    const a: number = moment.now()
+    // $ExpectError
+    const b: string = moment.now()
+  })
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://momentjs.com/docs/#/customization/now/
- Link to GitHub or NPM: https://github.com/moment/moment/
- Type of contribution: addition

Other notes:
Noticed the definition for `moment.now()` was missing while working on a project.
