### PR TITLE
Add missing asFragment to react-testing-library

### DIFF
--- a/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-/react-testing-library_v5.x.x.js
+++ b/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-/react-testing-library_v5.x.x.js
@@ -98,6 +98,7 @@ declare module 'react-testing-library' {
     container: HTMLDivElement,
     unmount: () => void,
     baseElement: HTMLElement,
+    asFragment: () => DocumentFragment,
     debug: (baseElement?: HTMLElement) => void,
     rerender: (ui: React$Element<*>) => void,
   |} & GetsAndQueries;

--- a/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-/test_react-testing-library_v5.x.x.js
+++ b/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-/test_react-testing-library_v5.x.x.js
@@ -72,6 +72,7 @@ describe('render', () => {
     container,
     unmount,
     baseElement,
+    asFragment,
     debug,
     rerender,
     getByAltText,
@@ -133,6 +134,12 @@ describe('render', () => {
     const a: number = baseElement;
     const b: HTMLElement = baseElement;
   });
+
+  it('asFragment should return a document fragment', () => {
+    // $ExpectError
+    const a: HTMLElement = asFragment();
+    const b: DocumentFragment = asFragment();
+  })
 
   it('debug maybe has 1 argument an html element', () => {
     // $ExpectError


### PR DESCRIPTION
The object returned by the `render` function in react-testing-library contains a function called `asFragment`. This change adds types for that, mimicking the library's TypeScript definition:

https://github.com/kentcdodds/react-testing-library/blob/d41366594f55b49cb5ced38d42195af2ac5eddaa/typings/index.d.ts#L19

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/kentcdodds/react-testing-library#example
- Link to GitHub or NPM: https://github.com/kentcdodds/react-testing-library
- Type of contribution: addition

