### PR TITLE
Add definitions for semver 5.6

### DIFF
--- a/definitions/npm/semver_v5.6.x/flow_v0.92.x-/semver_v5.6.x.js
+++ b/definitions/npm/semver_v5.6.x/flow_v0.92.x-/semver_v5.6.x.js
@@ -139,7 +139,7 @@ declare module "semver" {
     options?: Options
   ): -1 | 0 | 1;
   declare function diff(v1: string | SemVer, v2: string | SemVer): ?Release;
-  declare function intersects(comparator: Comparator: boolean);
+  declare function intersects(comparator: Comparator): boolean;
   declare function sort(
     list: Array<string | SemVer>,
     options?: Options

--- a/definitions/npm/semver_v5.6.x/flow_v0.92.x-/semver_v5.6.x.js
+++ b/definitions/npm/semver_v5.6.x/flow_v0.92.x-/semver_v5.6.x.js
@@ -1,0 +1,211 @@
+declare module "semver" {
+  declare type Release =
+    | "major"
+    | "premajor"
+    | "minor"
+    | "preminor"
+    | "patch"
+    | "prepatch"
+    | "prerelease";
+
+  // The supported comparators are taken from the source here:
+  // https://github.com/npm/node-semver/blob/8bd070b550db2646362c9883c8d008d32f66a234/semver.js#L623
+  declare type Operator =
+    | "==="
+    | "!=="
+    | "=="
+    | "="
+    | "" // Not sure why you would want this, but whatever.
+    | "!="
+    | ">"
+    | ">="
+    | "<"
+    | "<=";
+
+  declare class SemVer {
+    build: Array<string>;
+    loose: ?boolean;
+    major: number;
+    minor: number;
+    patch: number;
+    prerelease: Array<string | number>;
+    raw: string;
+    version: string;
+
+    constructor(version: string | SemVer, options?: Options): SemVer;
+    compare(other: string | SemVer): -1 | 0 | 1;
+    compareMain(other: string | SemVer): -1 | 0 | 1;
+    comparePre(other: string | SemVer): -1 | 0 | 1;
+    format(): string;
+    inc(release: Release, identifier: string): this;
+  }
+
+  declare class Comparator {
+    options?: Options;
+    operator: Operator;
+    semver: SemVer;
+    value: string;
+
+    constructor(comp: string | Comparator, options?: Options): Comparator;
+    parse(comp: string): void;
+    test(version: string): boolean;
+  }
+
+  declare class Range {
+    loose: ?boolean;
+    raw: string;
+    set: Array<Array<Comparator>>;
+
+    constructor(range: string | Range, options?: Options): Range;
+    format(): string;
+    parseRange(range: string): Array<Comparator>;
+    test(version: string): boolean;
+    toString(): string;
+  }
+
+  declare var SEMVER_SPEC_VERSION: string;
+  declare var re: Array<RegExp>;
+  declare var src: Array<string>;
+
+  declare type Options = {
+    options?: Options,
+    includePrerelease?: boolean,
+  } | boolean;
+
+  // Functions
+  declare function valid(v: string | SemVer, options?: Options): string | null;
+  declare function clean(v: string | SemVer, options?: Options): string | null;
+  declare function inc(
+    v: string | SemVer,
+    release: Release,
+    options?: Options,
+    identifier?: string
+  ): string | null;
+  declare function inc(
+    v: string | SemVer,
+    release: Release,
+    identifier: string
+  ): string | null;
+  declare function major(v: string | SemVer, options?: Options): number;
+  declare function minor(v: string | SemVer, options?: Options): number;
+  declare function patch(v: string | SemVer, options?: Options): number;
+  declare function intersects(r1: string | SemVer, r2: string | SemVer, loose?: boolean): boolean;
+
+  // Comparison
+  declare function gt(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    options?: Options
+  ): boolean;
+  declare function gte(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    options?: Options
+  ): boolean;
+  declare function lt(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    options?: Options
+  ): boolean;
+  declare function lte(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    options?: Options
+  ): boolean;
+  declare function eq(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    options?: Options
+  ): boolean;
+  declare function neq(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    options?: Options
+  ): boolean;
+  declare function cmp(
+    v1: string | SemVer,
+    comparator: Operator,
+    v2: string | SemVer,
+    options?: Options
+  ): boolean;
+  declare function compare(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    options?: Options
+  ): -1 | 0 | 1;
+  declare function rcompare(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    options?: Options
+  ): -1 | 0 | 1;
+  declare function diff(v1: string | SemVer, v2: string | SemVer): ?Release;
+  declare function intersects(comparator: Comparator: boolean);
+  declare function sort(
+    list: Array<string | SemVer>,
+    options?: Options
+  ): Array<string | SemVer>;
+  declare function rsort(
+    list: Array<string | SemVer>,
+    options?: Options
+  ): Array<string | SemVer>;
+  declare function compareIdentifiers(
+    v1: string | SemVer,
+    v2: string | SemVer
+  ): -1 | 0 | 1;
+  declare function rcompareIdentifiers(
+    v1: string | SemVer,
+    v2: string | SemVer
+  ): -1 | 0 | 1;
+
+  // Ranges
+  declare function validRange(
+    range: string | Range,
+    options?: Options
+  ): string | null;
+  declare function satisfies(
+    version: string | SemVer,
+    range: string | Range,
+    options?: Options
+  ): boolean;
+  declare function maxSatisfying(
+    versions: Array<string | SemVer>,
+    range: string | Range,
+    options?: Options
+  ): string | SemVer | null;
+  declare function minSatisfying(
+    versions: Array<string | SemVer>,
+    range: string | Range,
+    options?: Options
+  ): string | SemVer | null;
+  declare function gtr(
+    version: string | SemVer,
+    range: string | Range,
+    options?: Options
+  ): boolean;
+  declare function ltr(
+    version: string | SemVer,
+    range: string | Range,
+    options?: Options
+  ): boolean;
+  declare function outside(
+    version: string | SemVer,
+    range: string | Range,
+    hilo: ">" | "<",
+    options?: Options
+  ): boolean;
+  declare function intersects(
+    range: Range
+  ): boolean;
+
+  // Coercion
+  declare function coerce(
+    version: string | SemVer
+  ): ?SemVer
+
+  // Not explicitly documented, or deprecated
+  declare function parse(version: string, options?: Options): ?SemVer;
+  declare function toComparators(
+    range: string | Range,
+    options?: Options
+  ): Array<Array<string>>;
+}

--- a/definitions/npm/semver_v5.6.x/test_semver.js
+++ b/definitions/npm/semver_v5.6.x/test_semver.js
@@ -1,10 +1,7 @@
 // @flow
 
+import { describe, it } from 'flow-typed-test';
 import semver, {Comparator, Range, SemVer} from 'semver';
-
-new SemVer('^3.2.0');
-
-(semver.cmp('1.2.3', '>', '1.2.4'): boolean);
 
 const optionOne = true;
 const optionTwo = {
@@ -12,78 +9,89 @@ const optionTwo = {
   includePrerelease: false,
 };
 
-// Comparator
-const comp = new Comparator('>=3.2.0');
-comp.test('5.3.2');
-(comp.operator: string);
-(comp.value: string);
+describe('semver', () => {
+  it('should flowtype comparators proprely', () => {
+    new SemVer('^3.2.0');
+    (semver.cmp('1.2.3', '>', '1.2.4'): boolean);
 
-// comparator object as a ctor arg is okay
-new Comparator(comp);
+    // Comparator
+    const comp = new Comparator('>=3.2.0');
+    comp.test('5.3.2');
+    (comp.operator: string);
+    (comp.value: string);
 
-// static/exported properties
-(semver.SEMVER_SPEC_VERSION: string);
-semver.re.forEach(r => r.test('foo'));
-semver.src.forEach(r => r.match(/foo/));
+    // comparator object as a ctor arg is okay
+    new Comparator(comp);
+  });
 
-// exported functions
-(semver.outside('1.2.3', '1.2', '>'): boolean);
-semver.clean('     =v3.0.2   ');
-semver.valid('foobar');
-semver.inc('1.2.3', 'major', true);
-semver.inc('1.2.3', 'major', true, 'beta');
-semver.inc('1.2.3', 'major', 'beta');
-semver.inc(new SemVer('1.2.3'), 'major', 'beta');
-(semver.major('1.2.3'): number);
-(semver.major(new SemVer('1.2.3')): number);
-(semver.minor('1.2.3'): number);
-(semver.minor(new SemVer('1.2.3')): number);
-(semver.patch('1.2.3'): number);
-(semver.patch(new SemVer('1.2.3')): number);
-(semver.intersects('1.2.3', Semver('2.9.2'), true) : boolean);
-(semver.intersects(new Range('3.x || 4.x')) : boolean);
-semver.sort(['9.8.7', new SemVer('1.2.3')]).forEach(x => console.log(x));
-semver.rsort(['9.8.7', new SemVer('1.2.3')]).forEach(x => console.log(x));
-semver.compareIdentifiers('9.8.7', new SemVer('1.2.3'));
-semver.rcompareIdentifiers('9.8.7', new SemVer('1.2.3'));
-semver.rcompare('9.8.7', new SemVer('1.2.3'));
-semver.diff('9.8.7', new SemVer('1.2.3'));
+  it('should flowtype exported functions/propeties properly', () => {
+    // static/exported properties
+    (semver.SEMVER_SPEC_VERSION: string);
+    semver.re.forEach(r => r.test('foo'));
+    semver.src.forEach(r => r.match(/foo/));
 
-semver.validRange('3.x || 4.x');
-semver.validRange(new Range('3.x || 4.x'));
-semver.satisfies('3.5.0', new Range('3.x || 4.x'));
-semver.satisfies('3.5.0', '3.x || 4.x', true);
-semver.maxSatisfying(['3.5.0', new SemVer('3.15.10')], '3.x || 4.x');
-semver.minSatisfying(['3.5.0', new SemVer('3.15.10')], '3.x || 4.x');
-semver.gtr('3.5.0', '3.x || 4.x');
-semver.gtr(new SemVer('3.5.0'), new Range('3.x || 4.x'));
-semver.ltr('3.5.0', '3.x || 4.x');
-semver.ltr(new SemVer('3.5.0'), new Range('3.x || 4.x'));
-semver.outside('2.5.0', '3.x || 4.x', '<');
-semver.outside(new SemVer('2.5.0'), new Range('3.x || 4.x'), '>', true);
-semver.parse('3.5.2');
-semver.parse('3.5.2', true);
-semver.toComparators('3.x || 4.x');
-semver.toComparators(new Range('3.x || 4.x'), true);
+    // exported functions
+    (semver.outside('1.2.3', '1.2', '>'): boolean);
+    semver.clean('     =v3.0.2   ');
+    semver.valid('foobar');
+    semver.inc('1.2.3', 'major', optionOne);
+    semver.inc('1.2.3', 'major', true, 'beta');
+    semver.inc('1.2.3', 'major', 'beta');
+    semver.inc(new SemVer('1.2.3'), 'major', 'beta');
+    (semver.major('1.2.3'): number);
+    (semver.major(new SemVer('1.2.3')): number);
+    (semver.minor('1.2.3'): number);
+    (semver.minor(new SemVer('1.2.3')): number);
+    (semver.patch('1.2.3'): number);
+    (semver.patch(new SemVer('1.2.3')): number);
+    (semver.intersects('1.2.3', Semver('2.9.2'), optionTwo) : boolean);
+    (semver.intersects(new Range('3.x || 4.x')) : boolean);
+    semver.sort(['9.8.7', new SemVer('1.2.3')]).forEach(x => console.log(x));
+    semver.rsort(['9.8.7', new SemVer('1.2.3')]).forEach(x => console.log(x));
+    semver.compareIdentifiers('9.8.7', new SemVer('1.2.3'));
+    semver.rcompareIdentifiers('9.8.7', new SemVer('1.2.3'));
+    semver.rcompare('9.8.7', new SemVer('1.2.3'));
+    semver.diff('9.8.7', new SemVer('1.2.3'));
 
-(semver.coerce('4.6.3.9.2-alpha2'): SemVer);
+    semver.validRange('3.x || 4.x');
+    semver.validRange(new Range('3.x || 4.x'));
+    semver.satisfies('3.5.0', new Range('3.x || 4.x'));
+    semver.satisfies('3.5.0', '3.x || 4.x', true);
+    semver.maxSatisfying(['3.5.0', new SemVer('3.15.10')], '3.x || 4.x');
+    semver.minSatisfying(['3.5.0', new SemVer('3.15.10')], '3.x || 4.x');
+    semver.gtr('3.5.0', '3.x || 4.x');
+    semver.gtr(new SemVer('3.5.0'), new Range('3.x || 4.x'));
+    semver.ltr('3.5.0', '3.x || 4.x');
+    semver.ltr(new SemVer('3.5.0'), new Range('3.x || 4.x'));
+    semver.outside('2.5.0', '3.x || 4.x', '<');
+    semver.outside(new SemVer('2.5.0'), new Range('3.x || 4.x'), '>', optionOne);
+    semver.parse('3.5.2');
+    semver.parse('3.5.2', true);
+    semver.toComparators('3.x || 4.x');
+    semver.toComparators(new Range('3.x || 4.x'), optionTwo);
 
-// $ExpectError
-semver.cmp('1.2.3', '> ', '1.2.4');
+    (semver.coerce('4.6.3.9.2-alpha2'): SemVer);
 
-// $ExpectError
-semver.outside('1.2.3', '1.2', '> ');
+    // $ExpectError
+    semver.cmp('1.2.3', '> ', '1.2.4');
 
-// Range
-new semver.Range('^1.2.x');
-const range = new Range('3.x || 4.x');
+    // $ExpectError
+    semver.outside('1.2.3', '1.2', '> ');
+  });
 
-range.test('3.4.5');
-(range.raw: string);
-(range.set[0][0].semver.version: string);
-(range.format(): string);
-(range.test('1.2.3'): boolean);
-(range.toString(): string);
+  it('should flowtype range functions properly', () => {
+    // Range
+    new semver.Range('^1.2.x');
+    const range = new Range('3.x || 4.x');
 
-// range object as a ctor arg is okay
-new Range(range);
+    range.test('3.4.5');
+    (range.raw: string);
+    (range.set[0][0].semver.version: string);
+    (range.format(): string);
+    (range.test('1.2.3'): boolean);
+    (range.toString(): string);
+
+    // range object as a ctor arg is okay
+    new Range(range);
+  });
+});

--- a/definitions/npm/semver_v5.6.x/test_semver.js
+++ b/definitions/npm/semver_v5.6.x/test_semver.js
@@ -45,7 +45,7 @@ describe('semver', () => {
     (semver.patch('1.2.3'): number);
     (semver.patch(new SemVer('1.2.3')): number);
     // According to the docs, this function takes 'loose' instead oy 'options'
-    (semver.intersects('1.2.3', SemVer('2.9.2'), false) : boolean);
+    (semver.intersects('1.2.3', new SemVer('2.9.2'), false) : boolean);
     (semver.intersects(new Range('3.x || 4.x')) : boolean);
     semver.sort(['9.8.7', new SemVer('1.2.3')]).forEach(x => console.log(x));
     semver.rsort(['9.8.7', new SemVer('1.2.3')]).forEach(x => console.log(x));

--- a/definitions/npm/semver_v5.6.x/test_semver.js
+++ b/definitions/npm/semver_v5.6.x/test_semver.js
@@ -44,7 +44,8 @@ describe('semver', () => {
     (semver.minor(new SemVer('1.2.3')): number);
     (semver.patch('1.2.3'): number);
     (semver.patch(new SemVer('1.2.3')): number);
-    (semver.intersects('1.2.3', Semver('2.9.2'), optionTwo) : boolean);
+    // According to the docs, this function takes 'loose' instead oy 'options'
+    (semver.intersects('1.2.3', SemVer('2.9.2'), false) : boolean);
     (semver.intersects(new Range('3.x || 4.x')) : boolean);
     semver.sort(['9.8.7', new SemVer('1.2.3')]).forEach(x => console.log(x));
     semver.rsort(['9.8.7', new SemVer('1.2.3')]).forEach(x => console.log(x));
@@ -70,7 +71,7 @@ describe('semver', () => {
     semver.toComparators('3.x || 4.x');
     semver.toComparators(new Range('3.x || 4.x'), optionTwo);
 
-    (semver.coerce('4.6.3.9.2-alpha2'): SemVer);
+    (semver.coerce('4.6.3.9.2-alpha2'): ?SemVer);
 
     // $ExpectError
     semver.cmp('1.2.3', '> ', '1.2.4');

--- a/definitions/npm/semver_v5.6.x/test_semver.js
+++ b/definitions/npm/semver_v5.6.x/test_semver.js
@@ -1,0 +1,89 @@
+// @flow
+
+import semver, {Comparator, Range, SemVer} from 'semver';
+
+new SemVer('^3.2.0');
+
+(semver.cmp('1.2.3', '>', '1.2.4'): boolean);
+
+const optionOne = true;
+const optionTwo = {
+  loose: true,
+  includePrerelease: false,
+};
+
+// Comparator
+const comp = new Comparator('>=3.2.0');
+comp.test('5.3.2');
+(comp.operator: string);
+(comp.value: string);
+
+// comparator object as a ctor arg is okay
+new Comparator(comp);
+
+// static/exported properties
+(semver.SEMVER_SPEC_VERSION: string);
+semver.re.forEach(r => r.test('foo'));
+semver.src.forEach(r => r.match(/foo/));
+
+// exported functions
+(semver.outside('1.2.3', '1.2', '>'): boolean);
+semver.clean('     =v3.0.2   ');
+semver.valid('foobar');
+semver.inc('1.2.3', 'major', true);
+semver.inc('1.2.3', 'major', true, 'beta');
+semver.inc('1.2.3', 'major', 'beta');
+semver.inc(new SemVer('1.2.3'), 'major', 'beta');
+(semver.major('1.2.3'): number);
+(semver.major(new SemVer('1.2.3')): number);
+(semver.minor('1.2.3'): number);
+(semver.minor(new SemVer('1.2.3')): number);
+(semver.patch('1.2.3'): number);
+(semver.patch(new SemVer('1.2.3')): number);
+(semver.intersects('1.2.3', Semver('2.9.2'), true) : boolean);
+(semver.intersects(new Range('3.x || 4.x')) : boolean);
+semver.sort(['9.8.7', new SemVer('1.2.3')]).forEach(x => console.log(x));
+semver.rsort(['9.8.7', new SemVer('1.2.3')]).forEach(x => console.log(x));
+semver.compareIdentifiers('9.8.7', new SemVer('1.2.3'));
+semver.rcompareIdentifiers('9.8.7', new SemVer('1.2.3'));
+semver.rcompare('9.8.7', new SemVer('1.2.3'));
+semver.diff('9.8.7', new SemVer('1.2.3'));
+
+semver.validRange('3.x || 4.x');
+semver.validRange(new Range('3.x || 4.x'));
+semver.satisfies('3.5.0', new Range('3.x || 4.x'));
+semver.satisfies('3.5.0', '3.x || 4.x', true);
+semver.maxSatisfying(['3.5.0', new SemVer('3.15.10')], '3.x || 4.x');
+semver.minSatisfying(['3.5.0', new SemVer('3.15.10')], '3.x || 4.x');
+semver.gtr('3.5.0', '3.x || 4.x');
+semver.gtr(new SemVer('3.5.0'), new Range('3.x || 4.x'));
+semver.ltr('3.5.0', '3.x || 4.x');
+semver.ltr(new SemVer('3.5.0'), new Range('3.x || 4.x'));
+semver.outside('2.5.0', '3.x || 4.x', '<');
+semver.outside(new SemVer('2.5.0'), new Range('3.x || 4.x'), '>', true);
+semver.parse('3.5.2');
+semver.parse('3.5.2', true);
+semver.toComparators('3.x || 4.x');
+semver.toComparators(new Range('3.x || 4.x'), true);
+
+(semver.coerce('4.6.3.9.2-alpha2'): SemVer);
+
+// $ExpectError
+semver.cmp('1.2.3', '> ', '1.2.4');
+
+// $ExpectError
+semver.outside('1.2.3', '1.2', '> ');
+
+// Range
+new semver.Range('^1.2.x');
+const range = new Range('3.x || 4.x');
+
+range.test('3.4.5');
+(range.raw: string);
+(range.set[0][0].semver.version: string);
+(range.format(): string);
+(range.test('1.2.3'): boolean);
+(range.toString(): string);
+
+// range object as a ctor arg is okay
+new Range(range);


### PR DESCRIPTION
- Links to documentation: https://www.npmjs.com/package/semver
- Link to GitHub or NPM: https://github.com/npm/node-semver
- Type of contribution: new definition

Other notes:s
This is just an update to the flowtype definitions for the semver library, bumping from 5.1 to the current 5.6. It builds off of the 5.1 definitions.

