### PR TITLE
[copy-to-clipboard-v3.x.x] Scope Options type to module

### DIFF
--- a/definitions/npm/copy-to-clipboard_v3.x.x/flow_v0.25.x-/copy-to-clipboard_v3.x.x.js
+++ b/definitions/npm/copy-to-clipboard_v3.x.x/flow_v0.25.x-/copy-to-clipboard_v3.x.x.js
@@ -1,8 +1,8 @@
-type Options = {
-  debug?: boolean,
-  message?: string
-};
-
 declare module 'copy-to-clipboard' {
+  declare export type Options = {|
+    debug?: boolean,
+    message?: string,
+  |};
+
   declare module.exports: (text: string, options?: Options) => boolean;
 }

--- a/definitions/npm/copy-to-clipboard_v3.x.x/test_copy-to-clipboard_v3.x.x.js
+++ b/definitions/npm/copy-to-clipboard_v3.x.x/test_copy-to-clipboard_v3.x.x.js
@@ -24,3 +24,6 @@ copyToClipboard({});
 
 // $ExpectError
 copyToClipboard('a string to copy', null);
+
+// $ExpectError
+copyToClipboard('a string to copy', { test: '' });


### PR DESCRIPTION
- Links to documentation: https://github.com/sudodoki/copy-to-clipboard
- Link to GitHub or NPM: https://github.com/sudodoki/copy-to-clipboard
- Type of contribution: fix

Other notes: Just scope the `Options` type to the module, prevent global types pollution. 

