### PR TITLE
[firebase_v5.x.x] Add missing firestore definitions

### DIFF
--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
@@ -567,9 +567,12 @@ declare class $npm$firebase$firestore$FieldPath {
   documentId(): typeof $npm$firebase$firestore$FieldPath;
 }
 
-declare interface $npm$firebase$firestore$FieldValue {
-  delete(): $npm$firebase$firestore$FieldValue;
-  serverTimestamp(): $npm$firebase$firestore$FieldValue;
+declare class $npm$firebase$firestore$FieldValue {
+  static delete(): $npm$firebase$firestore$FieldValue;
+  static serverTimestamp(): $npm$firebase$firestore$FieldValue;
+  static arrayUnion(...elements: any[]): $npm$firebase$firestore$FieldValue;
+  static arrayRemove(...elements: any[]): $npm$firebase$firestore$FieldValue;
+  isEqual(other: $npm$firebase$firestore$FieldPath): boolean;
 }
 
 declare type $npm$firebase$firestore$FirestoreError =

--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
@@ -871,7 +871,7 @@ declare module '@firebase/firestore' {
     DocumentReference: typeof $npm$firebase$firestore$DocumentReference,
     DocumentSnapshot: typeof $npm$firebase$firestore$DocumentSnapshot,
     FieldPath: typeof $npm$firebase$firestore$FieldPath,
-    FieldValue: $npm$firebase$firestore$FieldValue,
+    FieldValue: typeof $npm$firebase$firestore$FieldValue,
     Firestore: typeof $npm$firebase$firestore$Firestore,
     FirestoreError: $npm$firebase$firestore$FirestoreError,
     GeoPoint: typeof $npm$firebase$firestore$GeoPoint,

--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
@@ -533,6 +533,9 @@ declare class $npm$firebase$firestore$CollectionReference extends $npm$firebase$
 
 declare interface $npm$firebase$firestore$DocumentChange {
   type: 'added' | 'removed' | 'modified';
+  doc: $npm$firebase$firestore$DocumentSnapshot;
+  oldIndex: number;
+  newIndex: number;
 }
 
 declare class $npm$firebase$firestore$DocumentReference {

--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/test_firebase.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/test_firebase.js
@@ -301,7 +301,7 @@ firebase
 firebase
   .firestore()
   .getAll(
-    firebase.firestore().doc('col/doc1'), 
+    firebase.firestore().doc('col/doc1'),
     firebase.firestore().doc('col/doc2'));
 
 // #31
@@ -352,3 +352,17 @@ firebase
   .then(object => {
     const foo = object.foo
   })
+
+// #37
+firebase
+  .firestore()
+  .collection('/foo')
+  .doc('bar')
+  .update({ regions: firebase.firestore.FieldValue.arrayUnion("east_coast") });
+
+// #38
+firebase
+  .firestore()
+  .collection('/foo')
+  .doc('bar')
+  .update({ regions: firebase.firestore.FieldValue.arrayRemove("east_coast") });


### PR DESCRIPTION
Changelog:
- Make the `FieldValue` definition in sync with official TS definition
- Make the `DocumentChange` definition in sync with official TS definition.

The added test cases are mostly from the official docs of Firebase, whose link is included below..

- Links to documentation: 
  - [FieldValue](https://firebase.google.com/docs/firestore/manage-data/add-data)
  - [DocumentChange](https://firebase.google.com/docs/firestore/query-data/listen)
- Link to GitHub or NPM: 
  - [FieldValue](https://github.com/firebase/firebase-js-sdk/blob/548e4a7d235bd96fd8306f2f3490a6c55b923509/packages/firestore-types/index.d.ts#L1245-L1291)
  - [DocumentChange](https://github.com/firebase/firebase-js-sdk/blob/4d82d1e6e697d2a3fef09757a7cac3700116c052/packages/firestore-types/index.d.ts#L1166-L1187)
- Type of contribution: addition & fix