### PR TITLE
[lodash-es_v4.x.x] add defs for standalone lodash-es modules

### DIFF
--- a/definitions/npm/lodash-es_v4.x.x/flow_v0.63.x-/lodash-es_v4.x.x.js
+++ b/definitions/npm/lodash-es_v4.x.x/flow_v0.63.x-/lodash-es_v4.x.x.js
@@ -1394,3 +1394,918 @@ declare module "lodash-es" {
   declare export function toPath(value: any): Array<string>;
   declare export function uniqueId(prefix?: ?string): string;
 }
+declare module "lodash-es/chunk" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "chunk">;
+}
+declare module "lodash-es/compact" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "compact">;
+}
+declare module "lodash-es/concat" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "concat">;
+}
+declare module "lodash-es/difference" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "difference">;
+}
+declare module "lodash-es/differenceBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "differenceBy">;
+}
+declare module "lodash-es/differenceWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "differenceWith">;
+}
+declare module "lodash-es/drop" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "drop">;
+}
+declare module "lodash-es/dropRight" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "dropRight">;
+}
+declare module "lodash-es/dropRightWhile" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "dropRightWhile">;
+}
+declare module "lodash-es/dropWhile" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "dropWhile">;
+}
+declare module "lodash-es/fill" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "fill">;
+}
+declare module "lodash-es/findIndex" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "findIndex">;
+}
+declare module "lodash-es/findLastIndex" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "findLastIndex">;
+}
+declare module "lodash-es/first" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "first">;
+}
+declare module "lodash-es/flatten" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "flatten">;
+}
+declare module "lodash-es/flattenDeep" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "flattenDeep">;
+}
+declare module "lodash-es/flattenDepth" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "flattenDepth">;
+}
+declare module "lodash-es/fromPairs" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "fromPairs">;
+}
+declare module "lodash-es/head" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "head">;
+}
+declare module "lodash-es/indexOf" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "indexOf">;
+}
+declare module "lodash-es/initial" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "initial">;
+}
+declare module "lodash-es/intersection" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "intersection">;
+}
+declare module "lodash-es/intersectionBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "intersectionBy">;
+}
+declare module "lodash-es/intersectionWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "intersectionWith">;
+}
+declare module "lodash-es/join" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "join">;
+}
+declare module "lodash-es/last" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "last">;
+}
+declare module "lodash-es/lastIndexOf" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "lastIndexOf">;
+}
+declare module "lodash-es/nth" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "nth">;
+}
+declare module "lodash-es/pull" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "pull">;
+}
+declare module "lodash-es/pullAll" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "pullAll">;
+}
+declare module "lodash-es/pullAllBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "pullAllBy">;
+}
+declare module "lodash-es/pullAllWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "pullAllWith">;
+}
+declare module "lodash-es/pullAt" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "pullAt">;
+}
+declare module "lodash-es/remove" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "remove">;
+}
+declare module "lodash-es/reverse" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "reverse">;
+}
+declare module "lodash-es/slice" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "slice">;
+}
+declare module "lodash-es/sortedIndex" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "sortedIndex">;
+}
+declare module "lodash-es/sortedIndexBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "sortedIndexBy">;
+}
+declare module "lodash-es/sortedIndexOf" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "sortedIndexOf">;
+}
+declare module "lodash-es/sortedLastIndex" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "sortedLastIndex">;
+}
+declare module "lodash-es/sortedLastIndexBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "sortedLastIndexBy">;
+}
+declare module "lodash-es/sortedLastIndexOf" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "sortedLastIndexOf">;
+}
+declare module "lodash-es/sortedUniq" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "sortedUniq">;
+}
+declare module "lodash-es/sortedUniqBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "sortedUniqBy">;
+}
+declare module "lodash-es/tail" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "tail">;
+}
+declare module "lodash-es/take" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "take">;
+}
+declare module "lodash-es/takeRight" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "takeRight">;
+}
+declare module "lodash-es/takeRightWhile" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "takeRightWhile">;
+}
+declare module "lodash-es/takeWhile" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "takeWhile">;
+}
+declare module "lodash-es/union" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "union">;
+}
+declare module "lodash-es/unionBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "unionBy">;
+}
+declare module "lodash-es/unionWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "unionWith">;
+}
+declare module "lodash-es/uniq" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "uniq">;
+}
+declare module "lodash-es/uniqBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "uniqBy">;
+}
+declare module "lodash-es/uniqWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "uniqWith">;
+}
+declare module "lodash-es/unzip" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "unzip">;
+}
+declare module "lodash-es/unzipWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "unzipWith">;
+}
+declare module "lodash-es/without" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "without">;
+}
+declare module "lodash-es/xor" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "xor">;
+}
+declare module "lodash-es/xorBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "xorBy">;
+}
+declare module "lodash-es/xorWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "xorWith">;
+}
+declare module "lodash-es/zip" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "zip">;
+}
+declare module "lodash-es/zipObject" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "zipObject">;
+}
+declare module "lodash-es/zipObjectDeep" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "zipObjectDeep">;
+}
+declare module "lodash-es/zipWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "zipWith">;
+}
+declare module "lodash-es/countBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "countBy">;
+}
+declare module "lodash-es/each" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "each">;
+}
+declare module "lodash-es/eachRight" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "eachRight">;
+}
+declare module "lodash-es/every" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "every">;
+}
+declare module "lodash-es/filter" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "filter">;
+}
+declare module "lodash-es/find" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "find">;
+}
+declare module "lodash-es/findLast" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "findLast">;
+}
+declare module "lodash-es/flatMap" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "flatMap">;
+}
+declare module "lodash-es/flatMapDeep" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "flatMapDeep">;
+}
+declare module "lodash-es/flatMapDepth" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "flatMapDepth">;
+}
+declare module "lodash-es/forEach" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "forEach">;
+}
+declare module "lodash-es/forEachRight" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "forEachRight">;
+}
+declare module "lodash-es/groupBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "groupBy">;
+}
+declare module "lodash-es/includes" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "includes">;
+}
+declare module "lodash-es/invokeMap" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "invokeMap">;
+}
+declare module "lodash-es/keyBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "keyBy">;
+}
+declare module "lodash-es/map" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "map">;
+}
+declare module "lodash-es/orderBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "orderBy">;
+}
+declare module "lodash-es/partition" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "partition">;
+}
+declare module "lodash-es/reduce" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "reduce">;
+}
+declare module "lodash-es/reduceRight" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "reduceRight">;
+}
+declare module "lodash-es/reject" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "reject">;
+}
+declare module "lodash-es/sample" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "sample">;
+}
+declare module "lodash-es/sampleSize" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "sampleSize">;
+}
+declare module "lodash-es/shuffle" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "shuffle">;
+}
+declare module "lodash-es/size" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "size">;
+}
+declare module "lodash-es/some" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "some">;
+}
+declare module "lodash-es/sortBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "sortBy">;
+}
+declare module "lodash-es/now" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "now">;
+}
+declare module "lodash-es/after" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "after">;
+}
+declare module "lodash-es/ary" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "ary">;
+}
+declare module "lodash-es/before" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "before">;
+}
+declare module "lodash-es/bind" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "bind">;
+}
+declare module "lodash-es/bindKey" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "bindKey">;
+}
+declare module "lodash-es/curry" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "curry">;
+}
+declare module "lodash-es/curryRight" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "curryRight">;
+}
+declare module "lodash-es/debounce" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "debounce">;
+}
+declare module "lodash-es/defer" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "defer">;
+}
+declare module "lodash-es/delay" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "delay">;
+}
+declare module "lodash-es/flip" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "flip">;
+}
+declare module "lodash-es/memoize" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "memoize">;
+}
+declare module "lodash-es/negate" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "negate">;
+}
+declare module "lodash-es/once" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "once">;
+}
+declare module "lodash-es/overArgs" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "overArgs">;
+}
+declare module "lodash-es/partial" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "partial">;
+}
+declare module "lodash-es/partialRight" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "partialRight">;
+}
+declare module "lodash-es/rearg" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "rearg">;
+}
+declare module "lodash-es/rest" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "rest">;
+}
+declare module "lodash-es/spread" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "spread">;
+}
+declare module "lodash-es/throttle" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "throttle">;
+}
+declare module "lodash-es/unary" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "unary">;
+}
+declare module "lodash-es/wrap" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "wrap">;
+}
+declare module "lodash-es/castArray" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "castArray">;
+}
+declare module "lodash-es/clone" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "clone">;
+}
+declare module "lodash-es/cloneDeep" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "cloneDeep">;
+}
+declare module "lodash-es/cloneDeepWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "cloneDeepWith">;
+}
+declare module "lodash-es/cloneWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "cloneWith">;
+}
+declare module "lodash-es/conformsTo" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "conformsTo">;
+}
+declare module "lodash-es/eq" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "eq">;
+}
+declare module "lodash-es/gt" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "gt">;
+}
+declare module "lodash-es/gte" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "gte">;
+}
+declare module "lodash-es/isArguments" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isArguments">;
+}
+declare module "lodash-es/isArray" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isArray">;
+}
+declare module "lodash-es/isArrayBuffer" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isArrayBuffer">;
+}
+declare module "lodash-es/isArrayLike" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isArrayLike">;
+}
+declare module "lodash-es/isArrayLikeObject" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isArrayLikeObject">;
+}
+declare module "lodash-es/isBoolean" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isBoolean">;
+}
+declare module "lodash-es/isBuffer" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isBuffer">;
+}
+declare module "lodash-es/isDate" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isDate">;
+}
+declare module "lodash-es/isElement" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isElement">;
+}
+declare module "lodash-es/isEmpty" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isEmpty">;
+}
+declare module "lodash-es/isEqual" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isEqual">;
+}
+declare module "lodash-es/isEqualWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isEqualWith">;
+}
+declare module "lodash-es/isError" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isError">;
+}
+declare module "lodash-es/isFinite" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isFinite">;
+}
+declare module "lodash-es/isFunction" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isFunction">;
+}
+declare module "lodash-es/isInteger" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isInteger">;
+}
+declare module "lodash-es/isLength" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isLength">;
+}
+declare module "lodash-es/isMap" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isMap">;
+}
+declare module "lodash-es/isMatch" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isMatch">;
+}
+declare module "lodash-es/isMatchWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isMatchWith">;
+}
+declare module "lodash-es/isNaN" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isNaN">;
+}
+declare module "lodash-es/isNative" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isNative">;
+}
+declare module "lodash-es/isNil" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isNil">;
+}
+declare module "lodash-es/isNull" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isNull">;
+}
+declare module "lodash-es/isNumber" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isNumber">;
+}
+declare module "lodash-es/isObject" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isObject">;
+}
+declare module "lodash-es/isObjectLike" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isObjectLike">;
+}
+declare module "lodash-es/isPlainObject" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isPlainObject">;
+}
+declare module "lodash-es/isRegExp" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isRegExp">;
+}
+declare module "lodash-es/isSafeInteger" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isSafeInteger">;
+}
+declare module "lodash-es/isSet" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isSet">;
+}
+declare module "lodash-es/isString" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isString">;
+}
+declare module "lodash-es/isSymbol" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isSymbol">;
+}
+declare module "lodash-es/isTypedArray" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isTypedArray">;
+}
+declare module "lodash-es/isUndefined" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isUndefined">;
+}
+declare module "lodash-es/isWeakMap" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isWeakMap">;
+}
+declare module "lodash-es/isWeakSet" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "isWeakSet">;
+}
+declare module "lodash-es/lt" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "lt">;
+}
+declare module "lodash-es/lte" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "lte">;
+}
+declare module "lodash-es/toArray" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "toArray">;
+}
+declare module "lodash-es/toFinite" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "toFinite">;
+}
+declare module "lodash-es/toInteger" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "toInteger">;
+}
+declare module "lodash-es/toLength" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "toLength">;
+}
+declare module "lodash-es/toNumber" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "toNumber">;
+}
+declare module "lodash-es/toPlainObject" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "toPlainObject">;
+}
+declare module "lodash-es/toSafeInteger" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "toSafeInteger">;
+}
+declare module "lodash-es/toString" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "toString">;
+}
+declare module "lodash-es/add" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "add">;
+}
+declare module "lodash-es/ceil" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "ceil">;
+}
+declare module "lodash-es/divide" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "divide">;
+}
+declare module "lodash-es/floor" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "floor">;
+}
+declare module "lodash-es/max" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "max">;
+}
+declare module "lodash-es/maxBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "maxBy">;
+}
+declare module "lodash-es/mean" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "mean">;
+}
+declare module "lodash-es/meanBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "meanBy">;
+}
+declare module "lodash-es/min" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "min">;
+}
+declare module "lodash-es/minBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "minBy">;
+}
+declare module "lodash-es/multiply" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "multiply">;
+}
+declare module "lodash-es/round" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "round">;
+}
+declare module "lodash-es/subtract" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "subtract">;
+}
+declare module "lodash-es/sum" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "sum">;
+}
+declare module "lodash-es/sumBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "sumBy">;
+}
+declare module "lodash-es/clamp" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "clamp">;
+}
+declare module "lodash-es/inRange" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "inRange">;
+}
+declare module "lodash-es/random" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "random">;
+}
+declare module "lodash-es/assign" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "assign">;
+}
+declare module "lodash-es/assignIn" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "assignIn">;
+}
+declare module "lodash-es/assignInWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "assignInWith">;
+}
+declare module "lodash-es/assignWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "assignWith">;
+}
+declare module "lodash-es/at" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "at">;
+}
+declare module "lodash-es/create" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "create">;
+}
+declare module "lodash-es/create" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "create">;
+}
+declare module "lodash-es/defaults" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "defaults">;
+}
+declare module "lodash-es/defaultsDeep" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "defaultsDeep">;
+}
+declare module "lodash-es/entries" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "entries">;
+}
+declare module "lodash-es/entriesIn" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "entriesIn">;
+}
+declare module "lodash-es/extend" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "extend">;
+}
+declare module "lodash-es/extendWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "extendWith">;
+}
+declare module "lodash-es/findKey" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "findKey">;
+}
+declare module "lodash-es/findLastKey" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "findLastKey">;
+}
+declare module "lodash-es/forIn" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "forIn">;
+}
+declare module "lodash-es/forInRight" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "forInRight">;
+}
+declare module "lodash-es/forOwn" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "forOwn">;
+}
+declare module "lodash-es/forOwnRight" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "forOwnRight">;
+}
+declare module "lodash-es/functions" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "functions">;
+}
+declare module "lodash-es/functionsIn" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "functionsIn">;
+}
+declare module "lodash-es/get" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "get">;
+}
+declare module "lodash-es/has" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "has">;
+}
+declare module "lodash-es/hasIn" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "hasIn">;
+}
+declare module "lodash-es/invert" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "invert">;
+}
+declare module "lodash-es/invertBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "invertBy">;
+}
+declare module "lodash-es/invoke" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "invoke">;
+}
+declare module "lodash-es/keys" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "keys">;
+}
+declare module "lodash-es/keysIn" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "keysIn">;
+}
+declare module "lodash-es/mapKeys" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "mapKeys">;
+}
+declare module "lodash-es/mapValues" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "mapValues">;
+}
+declare module "lodash-es/merge" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "merge">;
+}
+declare module "lodash-es/mergeWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "mergeWith">;
+}
+declare module "lodash-es/omit" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "omit">;
+}
+declare module "lodash-es/omitBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "omitBy">;
+}
+declare module "lodash-es/pick" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "pick">;
+}
+declare module "lodash-es/pickBy" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "pickBy">;
+}
+declare module "lodash-es/result" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "result">;
+}
+declare module "lodash-es/set" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "set">;
+}
+declare module "lodash-es/setWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "setWith">;
+}
+declare module "lodash-es/toPairs" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "toPairs">;
+}
+declare module "lodash-es/toPairsIn" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "toPairsIn">;
+}
+declare module "lodash-es/transform" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "transform">;
+}
+declare module "lodash-es/unset" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "unset">;
+}
+declare module "lodash-es/update" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "update">;
+}
+declare module "lodash-es/updateWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "updateWith">;
+}
+declare module "lodash-es/values" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "values">;
+}
+declare module "lodash-es/valuesIn" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "valuesIn">;
+}
+declare module "lodash-es/chain" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "chain">;
+}
+declare module "lodash-es/tap" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "tap">;
+}
+declare module "lodash-es/thru" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "thru">;
+}
+declare module "lodash-es/camelCase" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "camelCase">;
+}
+declare module "lodash-es/capitalize" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "capitalize">;
+}
+declare module "lodash-es/deburr" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "deburr">;
+}
+declare module "lodash-es/endsWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "endsWith">;
+}
+declare module "lodash-es/escape" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "escape">;
+}
+declare module "lodash-es/escapeRegExp" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "escapeRegExp">;
+}
+declare module "lodash-es/kebabCase" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "kebabCase">;
+}
+declare module "lodash-es/lowerCase" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "lowerCase">;
+}
+declare module "lodash-es/lowerFirst" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "lowerFirst">;
+}
+declare module "lodash-es/pad" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "pad">;
+}
+declare module "lodash-es/padEnd" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "padEnd">;
+}
+declare module "lodash-es/padStart" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "padStart">;
+}
+declare module "lodash-es/parseInt" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "parseInt">;
+}
+declare module "lodash-es/repeat" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "repeat">;
+}
+declare module "lodash-es/replace" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "replace">;
+}
+declare module "lodash-es/snakeCase" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "snakeCase">;
+}
+declare module "lodash-es/split" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "split">;
+}
+declare module "lodash-es/startCase" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "startCase">;
+}
+declare module "lodash-es/startsWith" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "startsWith">;
+}
+declare module "lodash-es/template" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "template">;
+}
+declare module "lodash-es/toLower" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "toLower">;
+}
+declare module "lodash-es/toUpper" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "toUpper">;
+}
+declare module "lodash-es/trim" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "trim">;
+}
+declare module "lodash-es/trimEnd" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "trimEnd">;
+}
+declare module "lodash-es/trimStart" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "trimStart">;
+}
+declare module "lodash-es/truncate" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "truncate">;
+}
+declare module "lodash-es/unescape" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "unescape">;
+}
+declare module "lodash-es/upperCase" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "upperCase">;
+}
+declare module "lodash-es/upperFirst" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "upperFirst">;
+}
+declare module "lodash-es/words" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "words">;
+}
+declare module "lodash-es/attempt" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "attempt">;
+}
+declare module "lodash-es/bindAll" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "bindAll">;
+}
+declare module "lodash-es/cond" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "cond">;
+}
+declare module "lodash-es/conforms" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "conforms">;
+}
+declare module "lodash-es/constant" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "constant">;
+}
+declare module "lodash-es/defaultTo" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "defaultTo">;
+}
+declare module "lodash-es/flow" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "flow">;
+}
+declare module "lodash-es/flowRight" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "flowRight">;
+}
+declare module "lodash-es/identity" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "identity">;
+}
+declare module "lodash-es/iteratee" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "iteratee">;
+}
+declare module "lodash-es/matches" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "matches">;
+}
+declare module "lodash-es/matchesProperty" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "matchesProperty">;
+}
+declare module "lodash-es/method" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "method">;
+}
+declare module "lodash-es/methodOf" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "methodOf">;
+}
+declare module "lodash-es/mixin" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "mixin">;
+}
+declare module "lodash-es/noop" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "noop">;
+}
+declare module "lodash-es/nthArg" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "nthArg">;
+}
+declare module "lodash-es/over" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "over">;
+}
+declare module "lodash-es/overEvery" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "overEvery">;
+}
+declare module "lodash-es/overSome" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "overSome">;
+}
+declare module "lodash-es/property" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "property">;
+}
+declare module "lodash-es/propertyOf" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "propertyOf">;
+}
+declare module "lodash-es/range" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "range">;
+}
+declare module "lodash-es/rangeRight" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "rangeRight">;
+}
+declare module "lodash-es/runInContext" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "runInContext">;
+}
+declare module "lodash-es/stubArray" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "stubArray">;
+}
+declare module "lodash-es/stubFalse" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "stubFalse">;
+}
+declare module "lodash-es/stubObject" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "stubObject">;
+}
+declare module "lodash-es/stubString" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "stubString">;
+}
+declare module "lodash-es/stubTrue" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "stubTrue">;
+}
+declare module "lodash-es/times" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "times">;
+}
+declare module "lodash-es/toPath" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "toPath">;
+}
+declare module "lodash-es/uniqueId" {
+  declare export default $PropertyType<$Exports<"lodash-es">, "uniqueId">;
+}

--- a/definitions/npm/lodash-es_v4.x.x/flow_v0.63.x-/test_modules-lodash-es-v4.x.x.js
+++ b/definitions/npm/lodash-es_v4.x.x/flow_v0.63.x-/test_modules-lodash-es-v4.x.x.js
@@ -1,0 +1,121 @@
+// @flow
+import assignIn from 'lodash-es/assignIn'
+import attempt from 'lodash-es/attempt'
+import clone from 'lodash-es/clone'
+import concat from 'lodash-es/concat'
+import conformsTo from 'lodash-es/conformsTo'
+import countBy from 'lodash-es/countBy'
+import defaultTo from 'lodash-es/defaultTo'
+import difference from 'lodash-es/difference'
+import differenceBy from 'lodash-es/differenceBy'
+import each from 'lodash-es/each'
+import extend from 'lodash-es/extend'
+import find from 'lodash-es/find'
+import first from 'lodash-es/first'
+import flatMap from 'lodash-es/flatMap'
+import forEach from 'lodash-es/forEach'
+import get from 'lodash-es/get'
+import groupBy from 'lodash-es/groupBy'
+import intersectionBy from 'lodash-es/intersectionBy'
+import isEqual from 'lodash-es/isEqual'
+import keyBy from 'lodash-es/keyBy'
+import pullAllBy from 'lodash-es/pullAllBy'
+import range from 'lodash-es/range'
+import tap from 'lodash-es/tap'
+import thru from 'lodash-es/thru'
+import times from 'lodash-es/times'
+import zip from 'lodash-es/zip'
+
+/**
+ * _.attempt
+ */
+attempt(() => void 0);
+
+/**
+ * _.countBy
+ */
+countBy([6.1, 4.2, 6.3], Math.floor);
+
+/**
+ * _.difference
+ */
+difference((["a", "b"]: $ReadOnlyArray<string>), (["b"]: $ReadOnlyArray<string>));
+
+/**
+ * _.differenceBy
+ */
+differenceBy(([2.1, 1.2]: $ReadOnlyArray<*>), [2.3, 3.4], Math.floor);
+
+/**
+ * _.each
+ */
+each(([1, 2]: $ReadOnlyArray<number>), (item: number) => false);
+
+/**
+ * _.find
+ */
+find([1, 2, 3], x => x * 1 == 3);
+
+/**
+ * _.forEach
+ */
+forEach(([1, 2]: $ReadOnlyArray<number>), (item: number) => false);
+
+/**
+ * _.groupBy
+ */
+var numbersGroupedByMathFloor = groupBy([6.1, 4.2, 6.3], Math.floor);
+
+/**
+ * _.intersectionBy
+ */
+intersectionBy([2.1, 1.2], [2.3, 3.4], Math.floor);
+
+/**
+ * _.get
+ */
+
+var exampleObjectForGetTest = { a: [{ b: { c: 3 } }] };
+get(exampleObjectForGetTest, "a[0].b.c");
+
+/**
+ * _.keyBy
+ */
+keyBy([{ dir: "left", code: 97 }, { dir: "right", code: 100 }], function(o) {
+  return String.fromCharCode(o.code);
+});
+
+/**
+ * _.pullAllBy
+ */
+pullAllBy([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 1 }], [{ x: 1 }, { x: 3 }], "x");
+
+/**
+ * _.clone
+ */
+clone({ a: 1 }).a == 1;
+
+/**
+ * _.isEqual
+ */
+isEqual("a", "b");
+
+/**
+ * _.range
+ */
+range(0, 10)[4] == 4;
+
+/**
+ * _.extend
+ */
+extend({ a: 1 }, { b: 2 }).a;
+
+/**
+ * _.zip
+ */
+zip(["a", "b", "c"], ["d", "e", "f"])[0].length;
+
+/**
+ * _.find
+ */
+find([1, 2, 3], x => x == 1);


### PR DESCRIPTION
Sadly some module bundlers still can't manage to shrink size to a minimum when using named imports from `lodash-es`, see e.g. https://github.com/rollup/rollup/issues/1403 and https://github.com/rollup/rollup/issues/691. Because of this, it makes sense to include standalone module definitions as well.

- [x] Add all standalone lodash modules
- [x] Test