### PR TITLE
[firebase_v5.x.x] Add missing firestore definitions and fix incorrect definitions

### DIFF
--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
@@ -567,9 +567,12 @@ declare class $npm$firebase$firestore$FieldPath {
   documentId(): typeof $npm$firebase$firestore$FieldPath;
 }
 
-declare interface $npm$firebase$firestore$FieldValue {
-  delete(): $npm$firebase$firestore$FieldValue;
-  serverTimestamp(): $npm$firebase$firestore$FieldValue;
+declare class $npm$firebase$firestore$FieldValue {
+  static delete(): $npm$firebase$firestore$FieldValue;
+  static serverTimestamp(): $npm$firebase$firestore$FieldValue;
+  static arrayUnion(...elements: any[]): $npm$firebase$firestore$FieldValue;
+  static arrayRemove(...elements: any[]): $npm$firebase$firestore$FieldValue;
+  isEqual(other: $npm$firebase$firestore$FieldPath): boolean;
 }
 
 declare type $npm$firebase$firestore$FirestoreError =

--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
@@ -871,7 +871,7 @@ declare module '@firebase/firestore' {
     DocumentReference: typeof $npm$firebase$firestore$DocumentReference,
     DocumentSnapshot: typeof $npm$firebase$firestore$DocumentSnapshot,
     FieldPath: typeof $npm$firebase$firestore$FieldPath,
-    FieldValue: $npm$firebase$firestore$FieldValue,
+    FieldValue: typeof $npm$firebase$firestore$FieldValue,
     Firestore: typeof $npm$firebase$firestore$Firestore,
     FirestoreError: $npm$firebase$firestore$FirestoreError,
     GeoPoint: typeof $npm$firebase$firestore$GeoPoint,

--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
@@ -530,7 +530,7 @@ declare class $npm$firebase$firestore$CollectionReference extends $npm$firebase$
   constructor(): $npm$firebase$firestore$CollectionReference;
   id: string;
   parent: $npm$firebase$firestore$DocumentReference | null;
-  add(data: Object): Promise<$npm$firebase$firestore$DocumentReference>;
+  add(data: { +[string]: mixed }): Promise<$npm$firebase$firestore$DocumentReference>;
   doc(documentPath?: string): $npm$firebase$firestore$DocumentReference;
 }
 
@@ -558,7 +558,7 @@ declare class $npm$firebase$firestore$DocumentReference {
     | $npm$firebase$firestore$observerError,
     onError?: $npm$firebase$firestore$observerError
   ): () => void;
-  set(data: Object, options?: {| merge?: boolean, mergeFields?: string[] |} | null): Promise<void>;
+  set(data: { +[string]: mixed }, options?: {| merge?: boolean, mergeFields?: string[] |} | null): Promise<void>;
   update(...args: Array<any>): Promise<void>;
 }
 
@@ -643,7 +643,7 @@ declare interface $npm$firebase$firestore$Transaction {
   get(documentRef: $npm$firebase$firestore$DocumentReference): Promise<$npm$firebase$firestore$DocumentSnapshot>;
   set(
     documentRef: $npm$firebase$firestore$DocumentReference,
-    data: Object,
+    data: { +[string]: mixed },
     options?: { merge: boolean }
   ): $npm$firebase$firestore$Transaction;
   update(documentRef: $npm$firebase$firestore$DocumentReference, ...args: Array<any>): $npm$firebase$firestore$Transaction;
@@ -654,7 +654,7 @@ declare interface $npm$firebase$firestore$WriteBatch {
   delete(documentRef: $npm$firebase$firestore$DocumentReference): $npm$firebase$firestore$WriteBatch;
   set(
     documentRef: $npm$firebase$firestore$DocumentReference,
-    data: Object,
+    data: { +[string]: mixed },
     options?: { merge: boolean }
   ): $npm$firebase$firestore$WriteBatch;
   update(documentRef: $npm$firebase$firestore$DocumentReference, ...args: Array<any>): $npm$firebase$firestore$WriteBatch;

--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
@@ -85,9 +85,9 @@ declare type $npm$firebase$auth$Auth$Persistence = {
   +LOCAL: 'local',
   +SESSION: 'session',
   +NONE: 'none',
-}
+};
 
-declare type $npm$firebase$auth$Auth$Persistence$Enum = $Values<$npm$firebase$auth$Auth$Persistence>
+declare type $npm$firebase$auth$Auth$Persistence$Enum = $Values<$npm$firebase$auth$Auth$Persistence>;
 
 declare class $npm$firebase$auth$Auth {
   static Persistence: $npm$firebase$auth$Auth$Persistence;
@@ -473,7 +473,9 @@ declare class $npm$firebase$firestore$Firestore {
   batch(): $npm$firebase$firestore$WriteBatch;
   collection(collectionPath: string): $npm$firebase$firestore$CollectionReference;
   doc(documentPath: string): $npm$firebase$firestore$DocumentReference;
-  enablePersistence(): Promise<void>;
+  enableNetwork(): Promise<void>;
+  disableNetwork(): Promise<void>;
+  enablePersistence(settings?: $npm$firebase$firestore$PersistenceSettings): Promise<void>;
   runTransaction(updateFunction: (transaction: $npm$firebase$firestore$Transaction) => Promise<any>): Promise<any>;
   setLogLevel(logLevel: 'debug' | 'error' | 'silent'): void;
   settings(settings: $npm$firebase$firestore$Settings): void;
@@ -506,6 +508,7 @@ declare class $npm$firebase$firestore$Query {
   endAt(snapshotOrVarArgs: $npm$firebase$firestore$DocumentSnapshot | {}): $npm$firebase$firestore$Query;
   endBefore(snapshotOrVarArgs: $npm$firebase$firestore$DocumentSnapshot | {}): $npm$firebase$firestore$Query;
   get(getOptions?: $npm$firebase$firestore$GetOptions): Promise<$npm$firebase$firestore$QuerySnapshot>;
+  isEqual(other: $npm$firebase$firestore$Query): boolean;
   limit(limit: number): $npm$firebase$firestore$Query;
   onSnapshot(
     optionsOrObserverOrOnNext: $npm$firebase$firestore$QueryListenOptions | $npm$firebase$firestore$queryObserver,
@@ -513,7 +516,7 @@ declare class $npm$firebase$firestore$Query {
     | $npm$firebase$firestore$queryObserver
     | $npm$firebase$firestore$observerError,
     onError?: $npm$firebase$firestore$observerError
-  ): Function;
+  ): () => void;
   orderBy(
     fieldPath: $npm$firebase$firestore$FieldPath | string,
     directionStr: 'asc' | 'desc'
@@ -541,24 +544,28 @@ declare interface $npm$firebase$firestore$DocumentChange {
 declare class $npm$firebase$firestore$DocumentReference {
   firestore: $npm$firebase$firestore$Firestore;
   id: string;
+  path: string;
   parent: typeof $npm$firebase$firestore$CollectionReference;
   collection(collectionPath: string): $npm$firebase$firestore$CollectionReference;
   delete(): Promise<void>;
   get(): Promise<$npm$firebase$firestore$DocumentSnapshot>;
+  isEqual(other: $npm$firebase$firestore$DocumentReference): boolean;
   onSnapshot(
-    optionsOrObserverOrOnNext: $npm$firebase$firestore$QueryListenOptions | $npm$firebase$firestore$documentObserver,
+    optionsOrObserverOrOnNext: $npm$firebase$firestore$QueryListenOptions
+    | $npm$firebase$firestore$documentObserver,
     observerOrOnNextOrOnError?: | $npm$firebase$firestore$QueryListenOptions
     | $npm$firebase$firestore$documentObserver
     | $npm$firebase$firestore$observerError,
     onError?: $npm$firebase$firestore$observerError
-  ): Function;
+  ): () => void;
   set(data: Object, options?: {| merge?: boolean, mergeFields?: string[] |} | null): Promise<void>;
   update(...args: Array<any>): Promise<void>;
 }
 
 declare class $npm$firebase$firestore$DocumentSnapshot {
-  data(): Object;
+  data(): Object | void;
   get(fieldpath: typeof $npm$firebase$firestore$FieldPath): any;
+  isEqual(other: $npm$firebase$firestore$DocumentSnapshot): boolean;
   exists: boolean;
   id: string;
   metadata: $npm$firebase$firestore$SnapshotMetadata;
@@ -567,7 +574,8 @@ declare class $npm$firebase$firestore$DocumentSnapshot {
 
 declare class $npm$firebase$firestore$FieldPath {
   constructor(...args: Array<any>): $npm$firebase$firestore$FieldPath;
-  documentId(): typeof $npm$firebase$firestore$FieldPath;
+  static documentId(): typeof $npm$firebase$firestore$FieldPath;
+  isEqual(other: $npm$firebase$firestore$FieldPath): boolean;
 }
 
 declare class $npm$firebase$firestore$FieldValue {
@@ -600,6 +608,7 @@ declare class $npm$firebase$firestore$GeoPoint {
   constructor(latitude: number, longitude: number): $npm$firebase$firestore$GeoPoint;
   latitude: number;
   longitude: number;
+  isEqual(other: $npm$firebase$firestore$GeoPoint): boolean;
 }
 
 declare class $npm$firebase$firestore$QuerySnapshot {
@@ -610,9 +619,19 @@ declare class $npm$firebase$firestore$QuerySnapshot {
   query: $npm$firebase$firestore$Query;
   size: number;
   forEach((snapshot: $npm$firebase$firestore$DocumentSnapshot, thisArg?: any) => void): void;
+  isEqual(other: $npm$firebase$firestore$QuerySnapshot): boolean;
 }
 
-declare interface $npm$firebase$firestore$Settings {}
+declare type $npm$firebase$firestore$Settings = {|
+  +host?: string;
+  +ssl?: boolean;
+  +timestampsInSnapshots?: boolean;
+  +cacheSizeBytes?: number;
+|};
+
+declare type $npm$firebase$firestore$PersistenceSettings = {|
+  +experimentalTabSynchronization?: boolean;
+|};
 
 declare interface $npm$firebase$firestore$SnapshotMetadata {
   fromCache: boolean;

--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
@@ -533,6 +533,9 @@ declare class $npm$firebase$firestore$CollectionReference extends $npm$firebase$
 
 declare interface $npm$firebase$firestore$DocumentChange {
   type: 'added' | 'removed' | 'modified';
+  doc: $npm$firebase$firestore$DocumentSnapshot;
+  oldIndex: number;
+  newIndex: number;
 }
 
 declare class $npm$firebase$firestore$DocumentReference {

--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/firebase_v5.x.x.js
@@ -563,7 +563,7 @@ declare class $npm$firebase$firestore$DocumentReference {
 }
 
 declare class $npm$firebase$firestore$DocumentSnapshot {
-  data(): Object | void;
+  data(): {| +[string]: any |};
   get(fieldpath: typeof $npm$firebase$firestore$FieldPath): any;
   isEqual(other: $npm$firebase$firestore$DocumentSnapshot): boolean;
   exists: boolean;

--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/test_firebase.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/test_firebase.js
@@ -407,7 +407,6 @@ firebase
   .firestore()
   .collection('listened-collection')
   .onSnapshot((snapshot) => {
-    // te
     snapshot.docChanges().forEach(c => {
       // test the newly added typedef for doc change
       (c.type: string);

--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/test_firebase.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/test_firebase.js
@@ -358,11 +358,61 @@ firebase
   .firestore()
   .collection('/foo')
   .doc('bar')
-  .update({ regions: firebase.firestore.FieldValue.arrayUnion("east_coast") });
+  .update({ regions: firebase.firestore.FieldValue.arrayUnion('east_coast') });
 
 // #38
 firebase
   .firestore()
   .collection('/foo')
   .doc('bar')
-  .update({ regions: firebase.firestore.FieldValue.arrayRemove("east_coast") });
+  .update({ regions: firebase.firestore.FieldValue.arrayRemove('east_coast') });
+
+// #39
+firebase
+  .firestore()
+  .enableNetwork()
+  .then(() => {});
+
+// #40
+firebase
+  .firestore()
+  .disableNetwork()
+  .then(() => {});
+
+// #41
+firebase
+  .firestore()
+  .settings({ /* empty settings option */ });
+
+// #42
+firebase
+  .firestore()
+  .settings({ host: 'random_host', ssl: true, timestampsInSnapshots: false, cacheSizeBytes: 0 });
+
+// #43
+firebase
+  .firestore()
+  .enablePersistence()
+  .then(() => {});
+
+// #44
+firebase
+  .firestore()
+  .enablePersistence({ experimentalTabSynchronization: true })
+  .then(() => {});
+
+// #45
+
+firebase
+  .firestore()
+  .collection('listened-collection')
+  .onSnapshot((snapshot) => {
+    // te
+    snapshot.docChanges().forEach(c => {
+      // test the newly added typedef for doc change
+      (c.type: string);
+      (c.doc.id: string);
+      (c.oldIndex: number);
+      (c.newIndex: number);
+    });
+  });

--- a/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/test_firebase.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.34.x-/test_firebase.js
@@ -301,7 +301,7 @@ firebase
 firebase
   .firestore()
   .getAll(
-    firebase.firestore().doc('col/doc1'), 
+    firebase.firestore().doc('col/doc1'),
     firebase.firestore().doc('col/doc2'));
 
 // #31
@@ -352,3 +352,17 @@ firebase
   .then(object => {
     const foo = object.foo
   })
+
+// #37
+firebase
+  .firestore()
+  .collection('/foo')
+  .doc('bar')
+  .update({ regions: firebase.firestore.FieldValue.arrayUnion("east_coast") });
+
+// #38
+firebase
+  .firestore()
+  .collection('/foo')
+  .doc('bar')
+  .update({ regions: firebase.firestore.FieldValue.arrayRemove("east_coast") });


### PR DESCRIPTION
Changelog:
- Added `enableNetwork`, `disableNetwork` and `enablePersistence` methods for `firebase.firestore` that currently exist in TS but not in flow-typed.
  - https://github.com/firebase/firebase-js-sdk/blob/4d82d1e6e697d2a3fef09757a7cac3700116c052/packages/firestore-types/index.d.ts#L119-L139
  - https://github.com/firebase/firebase-js-sdk/blob/4d82d1e6e697d2a3fef09757a7cac3700116c052/packages/firestore-types/index.d.ts#L188-L204
- Added missing type `firebase.firestore.Settings` and `firebase.firestore.PersistanceSettings`.
  - https://github.com/firebase/firebase-js-sdk/blob/4d82d1e6e697d2a3fef09757a7cac3700116c052/packages/firestore-types/index.d.ts#L40-L99
- Added many missing `isEqual` methods that exist in TS but not in flow-typed.
- Added the `path` field to `firebase.firestore.DocumentReference`.
  - https://github.com/firebase/firebase-js-sdk/blob/4d82d1e6e697d2a3fef09757a7cac3700116c052/packages/firestore-types/index.d.ts#L584-L605
- Changed `documentId` method in `FieldPath` from instance method to static method to match the definition in TS.
  - https://github.com/firebase/firebase-js-sdk/blob/4d82d1e6e697d2a3fef09757a7cac3700116c052/packages/firestore-types/index.d.ts#L1293-L1312
- Changed many unclear type `Function` to `() => void` to match the definition in TS.

Links:
- Links to documentation: https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore-types/index.d.ts
- Link to GitHub or NPM: https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore-types/index.d.ts
- Type of contribution: addition & fix

