### PR TITLE
callback is optional according to webpack docs 

### DIFF
--- a/definitions/npm/webpack_v4.x.x/flow_v0.71.x-/webpack_v4.x.x.js
+++ b/definitions/npm/webpack_v4.x.x/flow_v0.71.x-/webpack_v4.x.x.js
@@ -563,6 +563,6 @@ declare module 'webpack' {
 
   declare module.exports: (
     options: WebpackOptions,
-    callback: (error: WebpackError, stats: WebpackStats) => void
+    callback?: (error: WebpackError, stats: WebpackStats) => void
   ) => WebpackCompiler | WebpackMultiCompiler;
 }


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://webpack.js.org/api/node/#webpack
- Link to GitHub or NPM: 
- Type of contribution: fix

Other notes: Docs specifically point out that if a callback isn't provided, then a `Compiler` instance is returned. Since the no-callback case is an explicitly supported input, the callback param should be optional.

