### PR TITLE
Fix typing on enzyme's Wrapper.find(Component)

### DIFF
--- a/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/enzyme_v3.x.x.js
+++ b/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/enzyme_v3.x.x.js
@@ -4,16 +4,19 @@ declare module "enzyme" {
     index: number
   ) => boolean;
   declare type NodeOrNodes = React$Node | Array<React$Node>;
-  declare type EnzymeSelector = string | {} | React$ElementType;
+  declare type UntypedSelector = string | {[key: string]: number|string|boolean};
+  declare type EnzymeSelector = UntypedSelector | React$ElementType;
 
   // CheerioWrapper is a type alias for an actual cheerio instance
   // TODO: Reference correct type from cheerio's type declarations
   declare type CheerioWrapper = any;
 
   declare class Wrapper<RootComponent> {
-    find(selector: EnzymeSelector): this,
+    find(selector: UntypedSelector): this,
+    find<T: React$ElementType>(selector: T): ReactWrapper<T>,
     findWhere(predicate: PredicateFunction<this>): this,
-    filter(selector: EnzymeSelector): this,
+    filter(selector: UntypedSelector): this,
+    filter<T: React$ElementType>(selector: T): ReactWrapper<T>,
     filterWhere(predicate: PredicateFunction<this>): this,
     hostNodes(): this,
     contains(nodeOrNodes: NodeOrNodes): boolean,
@@ -28,11 +31,14 @@ declare module "enzyme" {
     is(selector: EnzymeSelector): boolean,
     isEmpty(): boolean,
     not(selector: EnzymeSelector): this,
-    children(selector?: EnzymeSelector): this,
+    children(selector?: UntypedSelector): this,
+    children<T: React$ElementType>(selector: T): ReactWrapper<T>,
     childAt(index: number): this,
-    parents(selector?: EnzymeSelector): this,
+    parents(selector?: UntypedSelector): this,
+    parents<T: React$ElementType>(selector: T): ReactWrapper<T>,
     parent(): this,
-    closest(selector: EnzymeSelector): this,
+    closest(selector: UntypedSelector): this,
+    closest<T: React$ElementType>(selector: T): ReactWrapper<T>,
     render(): CheerioWrapper,
     renderProp(propName: string): (...args: Array<any>) => this,
     unmount(): this,

--- a/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/test_enzyme-v3.x.js
+++ b/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/test_enzyme-v3.x.js
@@ -125,3 +125,21 @@ shallow(<TestInstance />).instance().method();
 (shallow(<div />).simulateError(new Error('error')): ShallowWrapper<'div'>);
 // $ExpectError
 (shallow(<div />).simulateError('error'): ShallowWrapper<'div'>);
+
+class DeepInstance extends React.Component<{onChange: () => void}> {}
+mount(<div><DeepInstance onChange={() => {}}/></div>).find(DeepInstance).instance().props.onChange();
+mount(<div><DeepInstance onChange={() => {}}/></div>).filter(DeepInstance).instance().props.onChange();
+mount(<div><DeepInstance onChange={() => {}}/></div>).closest(DeepInstance).instance().props.onChange();
+mount(<div><DeepInstance onChange={() => {}}/></div>).parents(DeepInstance).instance().props.onChange();
+mount(<div><DeepInstance onChange={() => {}}/></div>).children(DeepInstance).instance().props.onChange();
+
+// $ExpectError
+mount(<div><DeepInstance onChange={() => {}}/></div>).find(DeepInstance).instance().props.onChangeX();
+// $ExpectError
+mount(<div><DeepInstance onChange={() => {}}/></div>).filter(DeepInstance).instance().props.onChangeX();
+// $ExpectError
+mount(<div><DeepInstance onChange={() => {}}/></div>).closest(DeepInstance).instance().props.onChangeX();
+// $ExpectError
+mount(<div><DeepInstance onChange={() => {}}/></div>).parents(DeepInstance).instance().props.onChangeX();
+// $ExpectError
+mount(<div><DeepInstance onChange={() => {}}/></div>).children(DeepInstance).instance().props.onChangeX();


### PR DESCRIPTION
- Links to documentation: https://airbnb.io/enzyme/docs/api/selector.html
- Link to GitHub or NPM: https://github.com/airbnb/enzyme/blob/master/packages/enzyme/src/ReactWrapper.js
- Type of contribution: addition

Other notes:

When using Enzyme's `find` methods:
```js
const wrapper = mount(<RootComponent />)
const child = wrapper.find(SomeDeeperComponent)
```

\- prior to this PR, `child` has a type of `Wrapper<RootComponent>`, but it ought to have a type of `Wrapper<SomeDeeperComponent>`.

This PR special-cases the find/parent/closest/children methods so that if you pass a component type to them, the result will be of that component type.

---

Enzyme also supports passing strings or object literals to `find` - eg `wrapper.find(".foo")` - in which case we don't have enough type information to know what the result will be.  The type declaration currently returns `this` - ie, `Wrapper<RootComponent>`:
```js
  declare class Wrapper<RootComponent> {
    find(selector: UntypedSelector): this,
    find<T: React$ElementType>(selector: T): ReactWrapper<T>
```

\- but perhaps we ought to change it to something like:

```js
  declare class Wrapper<RootComponent> {
    find(selector: UntypedSelector): ReactWrapper<React$ElementType>,
    find<T: React$ElementType>(selector: T): ReactWrapper<T>
```

@marudor it looks like you created that typing originally - any opinions?