### PR TITLE
[verror_v1.10.x] Add definitions

### DIFF
--- a/definitions/npm/verror_v1.10.x/flow_v0.30.x-/test_verror_v1.10.x.js
+++ b/definitions/npm/verror_v1.10.x/flow_v0.30.x-/test_verror_v1.10.x.js
@@ -1,0 +1,209 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import fs from 'fs';
+
+const VError = require('verror');
+const SError = require('verror').SError;
+const WError = require('verror').WError;
+const MultiError = require('verror').MultiError;
+
+import type { Info } from 'verror';
+
+// import { VError, SError, WError, MultiError, type Info } from 'verror';
+
+let filename = '/nonexistent';
+let error = new Error();
+let options = {
+  name: '',
+  cause: error,
+  strict: true,
+  info: {
+    errno: '',
+  },
+  constructorOpt: () => {},
+};
+
+describe('VError constructor', () => {
+  new VError();
+  new VError('');
+  new VError('', '');
+  new VError(options);
+  new VError(options, '');
+  new VError(options, '', '');
+  new VError(error);
+  new VError(error, '');
+  new VError(error, '', '');
+  // $ExpectError
+  new VError(() => {});
+});
+
+describe('VError Function', () => {
+  VError();
+  VError('');
+  VError('', '');
+  VError(options);
+  VError(options, '');
+  VError(options, '', '');
+  VError(error);
+  VError(error, '');
+  VError(error, '', '');
+  // $ExpectError
+  VError(() => {});
+});
+
+describe('SError constructor', () => {
+  new SError();
+  new SError('');
+  new SError('', '');
+  new SError(options);
+  new SError(options, '');
+  new SError(options, '', '');
+  new SError(error);
+  new SError(error, '');
+  new SError(error, '', '');
+  // $ExpectError
+  new SError(() => {});
+});
+
+describe('SError Function', () => {
+  SError();
+  SError('');
+  SError('', '');
+  SError(options);
+  SError(options, '');
+  SError(options, '', '');
+  SError(error);
+  SError(error, '');
+  SError(error, '', '');
+  // $ExpectError
+  SError(() => {});
+});
+
+describe('WError constructor', () => {
+  new WError();
+  new WError('');
+  new WError('', '');
+  new WError(options);
+  new WError(options, '');
+  new WError(options, '', '');
+  new WError(error);
+  new WError(error, '');
+  new WError(error, '', '');
+  // $ExpectError
+  new WError(() => {});
+});
+
+describe('WError Function', () => {
+  WError();
+  WError('');
+  WError('', '');
+  WError(options);
+  WError(options, '');
+  WError(options, '', '');
+  WError(error);
+  WError(error, '');
+  WError(error, '', '');
+  // $ExpectError
+  WError(() => {});
+});
+
+describe('MultiError constructor', () => {
+  it('should require an Array of errors as parameter', () => {
+    new MultiError([error]);
+    // $ExpectError
+    new MultiError();
+    // $ExpectError
+    new MultiError('');
+  });
+});
+
+describe('VError', () => {
+  fs.stat(filename, err1 => {
+    if (err1) {
+      let err2 = new VError(err1, 'stat "%s" failed', filename);
+      let cause = err2.cause();
+
+      (err2.message: string);
+
+      if (cause instanceof Error) {
+        (cause.message: string);
+      }
+    }
+  });
+});
+
+describe('VError varargs', () => {
+  let opname = 'read';
+  let err = new VError('"%s" operation failed', opname);
+
+  (err.message: string);
+  (err.stack: string);
+});
+
+describe('VError fullStack', () => {
+  let err1 = new VError('something bad happened');
+  let err2 = new VError(err1, 'something really bad happened here');
+
+  (VError.fullStack(err2): string);
+});
+
+describe('VError info', () => {
+  let err1 = new VError('something bad happened');
+  let err2 = new VError(
+    {
+      name: 'ConnectionError',
+      cause: err1,
+      info: {
+        errno: 'ECONNREFUSED',
+        remote_ip: '127.0.0.1',
+        port: 215,
+      },
+    },
+    'failed to connect to "%s:%d"',
+    '127.0.0.1',
+    215
+  );
+
+  (err2.message: string);
+  (err2.name: string);
+  (VError.info(err2): Info);
+  (err2.stack: string);
+
+  let err3 = new VError(
+    {
+      name: 'RequestError',
+      cause: err2,
+      info: {
+        errno: 'EBADREQUEST',
+      },
+    },
+    'request failed'
+  );
+
+  (err3.message: string);
+  (err3.name: string);
+  (VError.info(err3): Info);
+  (err3.stack: string);
+});
+
+describe('MultiError', () => {
+  let error = new MultiError([new Error(''), new Error('')]);
+
+  error.errors().forEach(err => {
+    (err: Error);
+  });
+});
+
+describe('WError', () => {
+  fs.stat(filename, err1 => {
+    if (err1) {
+      let err2 = new WError(err1, 'failed to stat "%s"', filename);
+      let err3 = new WError(err2, 'failed to handle request');
+
+      (err3.message: string);
+      (err3.toString(): string);
+      (err3.stack: string);
+    }
+  });
+});

--- a/definitions/npm/verror_v1.10.x/flow_v0.30.x-/verror_v1.10.x.js
+++ b/definitions/npm/verror_v1.10.x/flow_v0.30.x-/verror_v1.10.x.js
@@ -1,0 +1,60 @@
+/**
+ * NOTICE
+ * It's currently not possible? to model the exact exports shape of verror
+ * for both commonjs and ES modules.
+ * So for ES modules use only named exports like so:
+ * `import { VError, SError, WError, MultiError } from 'verror';`
+ */
+
+declare module 'verror' {
+  declare export type Info = {
+    +[string]: mixed,
+  };
+
+  declare export type Options = {|
+    +name?: string,
+    +strict?: boolean,
+    +cause?: Error | null,
+    +constructorOpt?: (...args: Array<mixed>) => void,
+    +info?: Info,
+  |};
+
+  declare class VError extends Error {
+    static info(err: Error): Info;
+    static cause(err: Error): Error | null;
+    static fullStack(err: Error): string;
+    static findCauseByName(err: Error, name: string): Error | null;
+    static hasCauseWithName(err: Error, name: string): boolean;
+    static errorForEach(err: Error, func: (err: Error) => void): void;
+    static errorFromList<T: Error>(errors: Array<T>): null | T | MultiError;
+
+    static (arg?: Options | Error | string, ...params: Array<mixed>): VError;
+
+    constructor(
+      arg?: Options | Error | string,
+      ...params: Array<mixed>
+    ): VError;
+
+    cause(): Error | void;
+  }
+
+  declare class SError extends VError {
+    static (arg?: Options | Error | string, ...params: Array<mixed>): VError;
+  }
+
+  declare class WError extends VError {
+    static (arg?: Options | Error | string, ...params: Array<mixed>): VError;
+  }
+
+  declare class MultiError extends VError {
+    constructor(errors: Array<Error>): MultiError;
+    errors(): Array<Error>;
+  }
+
+  declare module.exports: typeof VError & {
+    VError: typeof VError,
+    MultiError: typeof MultiError,
+    SError: typeof SError,
+    WError: typeof WError,
+  };
+}


### PR DESCRIPTION
- Links to documentation: https://github.com/joyent/node-verror
- Link to GitHub or NPM: https://github.com/joyent/node-verror
- Type of contribution: new definition 

Other notes:

I struggled a bit making it accept commonjs default and named exports as well as constructor and callable signature for classes...

It currently works for commonjs, but named exports for ES modules are not recognized.
`import VError, { WError } from 'verror'; // Error` 

One would need to:
```
import VError from 'verror';
const { WError } = VError;
````
If someone see a better solution.

See https://github.com/joyent/node-verror/blob/master/lib/verror.js#L16-L23

