### PR TITLE
antd handler fixes

### DIFF
--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
@@ -398,8 +398,8 @@ declare module "antd" {
     okText?: string,
     okType?: 'primary' | 'dashed' | 'ghost' | 'danger' | 'default',
     title?: 'string' | React$Node,
-    onCancel?: (event: SyntheticEvent<HTMLElement>) => void,
-    onConfirm?: (event: SyntheticEvent<HTMLElement>) => void,
+    onCancel?: (event: SyntheticEvent<>) => void,
+    onConfirm?: (event: SyntheticEvent<>) => void,
     icon?: React$Node
   } & TooltipSharedProps
 

--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
@@ -38,7 +38,7 @@ declare module "antd" {
     size?: 'small' | 'large',
     target?: string,
     type?: 'primary' | 'ghost' | 'dashed' | 'danger' | 'default',
-    onClick?: (event?: SyntheticEvent<HTMLButtonElement>) => void,
+    onClick?: (event: SyntheticEvent<HTMLButtonElement>) => void,
     block?: boolean
   }
 
@@ -377,7 +377,7 @@ declare module "antd" {
     placement?: 'top' | 'left' | 'right' | 'bottom' | 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight' | 'leftTop' | 'leftBottom' | 'rightTop' | 'rightBottom',
     trigger?: 'hover' | 'focus' | 'click' | 'contextMenu',
     visible?: boolean,
-    onVisibleChange?: (visible?: boolean) => void,
+    onVisibleChange?: (visible: boolean) => void,
     align?: AlignConfig
   }
 
@@ -398,8 +398,8 @@ declare module "antd" {
     okText?: string,
     okType?: 'primary' | 'dashed' | 'ghost' | 'danger' | 'default',
     title?: 'string' | React$Node,
-    onCancel?: (event?: SyntheticEvent<HTMLElement>) => void,
-    onConfirm?: (event?: SyntheticEvent<HTMLElement>) => void,
+    onCancel?: (event: SyntheticEvent<HTMLElement>) => void,
+    onConfirm?: (event: SyntheticEvent<HTMLElement>) => void,
     icon?: React$Node
   } & TooltipSharedProps
 

--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/test_antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/test_antd_v3.x.x.js
@@ -68,7 +68,7 @@ describe("Button", () => {
   });
   it("should accept nullary or unary onClick handler", () => {
     const good0 = <Button onClick={() => undefined} />
-    const good1 = <Button onClick={(event) => undefined} />
+    const good1 = <Button onClick={(event: SyntheticEvent<HTMLButtonElement>) => undefined} />
     // $ExpectError
     const bad = <Button onClick='bad' />
   });


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://ant.design/docs/react/introduce
- Link to GitHub or NPM: https://github.com/ant-design/ant-design
- Type of contribution: fix

In #3196, I erroneously made event arguments in a few event handlers optional. They are always provided and so should be required. 

Sorry for the error, I had a misunderstanding about matching function types.