### PR TITLE
[enzyme_v3.x.x] Simplify contains* helpers type

### DIFF
--- a/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/enzyme_v3.x.x.js
+++ b/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/enzyme_v3.x.x.js
@@ -3,7 +3,6 @@ declare module "enzyme" {
     wrapper: T,
     index: number
   ) => boolean;
-  declare type NodeOrNodes = React$Node | Array<React$Node>;
   declare type UntypedSelector = string | {[key: string]: number|string|boolean};
   declare type EnzymeSelector = UntypedSelector | React$ElementType;
 
@@ -19,10 +18,10 @@ declare module "enzyme" {
     filter<T: React$ElementType>(selector: T): ReactWrapper<T>,
     filterWhere(predicate: PredicateFunction<this>): this,
     hostNodes(): this,
-    contains(nodeOrNodes: NodeOrNodes): boolean,
+    contains(nodes: React$Node): boolean,
     containsMatchingElement(node: React$Node): boolean,
-    containsAllMatchingElements(nodes: NodeOrNodes): boolean,
-    containsAnyMatchingElements(nodes: NodeOrNodes): boolean,
+    containsAllMatchingElements(nodes: React$Node): boolean,
+    containsAnyMatchingElements(nodes: React$Node): boolean,
     dive(option?: { context?: Object }): this,
     exists(selector?: EnzymeSelector): boolean,
     isEmptyRender(): boolean,

--- a/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/test_enzyme-v3.x.js
+++ b/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/test_enzyme-v3.x.js
@@ -143,3 +143,12 @@ mount(<div><DeepInstance onChange={() => {}}/></div>).closest(DeepInstance).inst
 mount(<div><DeepInstance onChange={() => {}}/></div>).parents(DeepInstance).instance().props.onChangeX();
 // $ExpectError
 mount(<div><DeepInstance onChange={() => {}}/></div>).children(DeepInstance).instance().props.onChangeX();
+
+
+(mount(<div />).contains(<div />): boolean);
+(mount(<div />).contains([<div />, <div />]): boolean);
+(mount(<div />).containsMatchingElement(<div />): boolean);
+(mount(<div />).containsAllMatchingElements(<div />): boolean);
+(mount(<div />).containsAllMatchingElements([<div />, <div />]): boolean);
+(mount(<div />).containsAnyMatchingElements(<div />): boolean);
+(mount(<div />).containsAnyMatchingElements([<div />, <div />]): boolean);


### PR DESCRIPTION
- Links to documentation: https://airbnb.io/enzyme/
- Link to GitHub or NPM: https://github.com/airbnb/enzyme
- Type of contribution:  fix

Other notes: 
Current typing would require to refine the param type. Whereas `React$Node` already allows Arrays.
See https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoVBLAtgBzgJwBdkwBDAZzACUBTUgY2KnzizAHJ87H2BudACY16MUlzBQArgDtGGONLCEa5QgAoxAcwBc1boQAkAOThCwAHzABBfPlIBPADy0Ghk0IB8ASl0A3OBgC-KjKqmqoYGCOAhi+YMAeqF7BoeoRYADa0bHxHgA0UTFxCQC6SfyRlWDpVahAA




