### PR TITLE
[antd] Add Footer static to Layout

### DIFF
--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
@@ -278,11 +278,14 @@ declare module "antd" {
 
   declare export class Layout extends React$Component<{}> {
     static Content: typeof LayoutContent;
+    static Footer: typeof LayoutFooter;
     static Header: typeof LayoutHeader;
     static Sider: typeof LayoutSider;
   }
 
   declare class LayoutContent extends React$Component<{}> {}
+
+  declare class LayoutFooter extends React$Component<{}> {}
 
   declare class LayoutHeader extends React$Component<{}> {}
 

--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/test_antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/test_antd_v3.x.x.js
@@ -244,6 +244,12 @@ describe("Layout.Content", () => {
   });
 });
 
+describe("Layout.Footer", () => {
+  it("is a react component", () => {
+    const layoutFooter = <Layout.Footer />;
+  });
+});
+
 describe("Layout.Header", () => {
   it("is a react component", () => {
     const layoutHeader = <Layout.Header />;


### PR DESCRIPTION
Links to documentation: https://ant.design/components/layout
Link to GitHub or NPM: https://github.com/ant-design/ant-design
Type of contribution: new definition

Adding missing `Layout.Footer`