### PR TITLE
Fix addon-knobs array type

### DIFF
--- a/definitions/npm/@storybook/addon-knobs_v3.x.x/flow_all/addon-knobs_v3.x.x.js
+++ b/definitions/npm/@storybook/addon-knobs_v3.x.x/flow_all/addon-knobs_v3.x.x.js
@@ -4,7 +4,7 @@ declare module "@storybook/addon-knobs/react" {
   declare type RenderFunction = () => Renderable | Array<Renderable>;
   declare type GroupId = string;
 
-  declare function array<T>(string, (Array<mixed> | {}), ?string, ?GroupId): Array<string>;
+  declare function array<T>(string, (Array<T> | {[string]: T}), ?string, ?GroupId): Array<T>;
   declare function boolean(string, boolean, ?GroupId): boolean;
   declare function button(string, ((?{}) => void), ?GroupId): void;
   declare function color(string, string, ?GroupId): string;

--- a/definitions/npm/@storybook/addon-knobs_v3.x.x/test_addon-knobs_v3.x.x.js
+++ b/definitions/npm/@storybook/addon-knobs_v3.x.x/test_addon-knobs_v3.x.x.js
@@ -16,14 +16,16 @@ import {
 let arrayVal: Array<string>;
 arrayVal = array("Array", ["one", "two"]);
 arrayVal = array("Array with separator", ["one", "two"], ",");
-arrayVal = array("Array with non-string array default", [1, 2]);
+arrayVal = array("Array with object default", { one: "one", two: "two" });
+let numArrayVal: Array<number> = array("Array assigned to non-string array variable", [1, 2]);
+// $ExpectError
 arrayVal = array("Array with object default", { one: 1, two: 2 });
+// $ExpectError
+arrayVal = array("Array with non-string array default", [1, 2]);
 // $ExpectError
 arrayVal = array("Array with non-array and non-object default", "one");
 // $ExpectError
 arrayVal = array("Array with non-string separator", ["one", "two"], 0);
-// $ExpectError
-let badArrayVal: Array<number> = array("Array assigned to non-string array variable", [1, 2]);
 
 // boolean
 let boolVal: boolean;


### PR DESCRIPTION
Hello!

This pull request makes a fix to the `@storybook/addon-knobs` `array` function to allow non-strings to be returned. The following should not result in an error:
```js
let arrayVal: Array<number> = array("Array assigned to non-string array variable", [1, 2]);
```

The code below is taken from the source code, and it returns `obj` as is if it's `null` or not of type `object`
```js
const escapeStrings = obj => {
  if (typeof obj === 'string') {
    return escape(obj);
  }
  if (obj == null || typeof obj !== 'object') {
    return obj;
  }
  if (Array.isArray(obj)) {
    const newArray = obj.map(escapeStrings);
    const didChange = newArray.some((newValue, key) => newValue !== obj[key]);
    return didChange ? newArray : obj;
  }
  return Object.entries(obj).reduce((acc, [key, oldValue]) => {
    const newValue = escapeStrings(oldValue);
    return newValue === oldValue ? acc : { ...acc, [key]: newValue };
  }, obj);
};
```

```js 
getKnobValue({ value }) {
  return this.options.escapeHTML ? escapeStrings(value) : value;
}
```
[source](https://github.com/storybooks/storybook/blob/master/addons/knobs/src/KnobManager.js)

