### PR TITLE
use options argument introduced in indent-string 3.2.0

### DIFF
--- a/definitions/npm/indent-string_v3.2.x/flow_v0.25.x-/indent-string_v3.2.x.js
+++ b/definitions/npm/indent-string_v3.2.x/flow_v0.25.x-/indent-string_v3.2.x.js
@@ -1,0 +1,10 @@
+declare module 'indent-string' {
+  declare module.exports: (
+    input: string,
+    count?: number,
+    opts?: {|
+      +includeEmptyLines?: bool,
+      +indent?: string,
+    |}
+  ) => string;
+}

--- a/definitions/npm/indent-string_v3.2.x/test_indent-string_v3.2.x.js
+++ b/definitions/npm/indent-string_v3.2.x/test_indent-string_v3.2.x.js
@@ -1,0 +1,37 @@
+import indentString from 'indent-string';
+import { describe, it } from 'flow-typed-test';
+
+describe('documented examples', () => {
+  it('allows no options argument', () => {
+    const a: string = indentString('Unicorns\nRainbows', 4);
+    //=> '    Unicorns'
+    //=> '    Rainbows'
+  })
+
+  it('allows an indent character option', () => {
+    const b: string = indentString('Unicorns\nRainbows', 4, { indent: '♥' });
+    //=> '♥♥♥♥Unicorns'
+    //=> '♥♥♥♥Rainbows'
+  })
+
+  it('requires a string input', () => {
+    // $ExpectError
+    indentString(42);
+  })
+
+  it('returns a string', () => {
+    // $ExpectError
+    (indentString('Unicorns\nRainbows', 4): number);
+  })
+})
+
+describe('options', () => {
+  it('accepts an optional includeEmptyLines option', () => {
+    indentString('foo\nbar', 4, { includeEmptyLines: true });
+  })
+
+  it('requires a boolean value for includeEmptyLines', () => {
+    // $ExpectError
+    indentString('foo\nbar', 4, { includeEmptyLines: 'foobar' });
+  })
+})


### PR DESCRIPTION
- Links to documentation: https://github.com/sindresorhus/indent-string
- Link to GitHub or NPM: https://github.com/sindresorhus/indent-string
- Type of contribution: new definition

Other notes:

In 3.2.0 the `indent` argument in the 3rd parameter has been replaced by an options object to accommodate further customization of the function's behavior. This is a breaking change from 3.1.0 and requires a new libdef version for `indent-string`.

See the [README for indent-string](https://github.com/sindresorhus/indent-string) for a quick example.