### PR TITLE
Add truncate to knex definition

### DIFF
--- a/definitions/npm/knex_v0.15.x/flow_v0.38.x-v0.74.x/knex_v0.15.x.js
+++ b/definitions/npm/knex_v0.15.x/flow_v0.38.x-v0.74.x/knex_v0.15.x.js
@@ -126,7 +126,7 @@ declare class Knex$QueryBuilder<R> mixins Promise<R> {
     builder: Knex$QueryBuilderFn<R> | Knex$Knex<R> | Knex$QueryBuilder<R>
   ): this;
   into(table: string, options?: Object): this;
-
+  truncate(): this;
   insert(val: Object | Object[]): this;
   del(): this;
   delete(): this;

--- a/definitions/npm/knex_v0.15.x/flow_v0.38.x-v0.74.x/test_knex_v0.15.x.js
+++ b/definitions/npm/knex_v0.15.x/flow_v0.38.x-v0.74.x/test_knex_v0.15.x.js
@@ -41,6 +41,7 @@ knex.crossJoin("bar", function() {
 knex("foo").insert({
   a: 1
 });
+knex('foo').truncate();
 knex("bar").del();
 // $ExpectError
 knex.from();

--- a/definitions/npm/knex_v0.15.x/flow_v0.75.x-/knex_v0.15.x.js
+++ b/definitions/npm/knex_v0.15.x/flow_v0.75.x-/knex_v0.15.x.js
@@ -126,7 +126,7 @@ declare class Knex$QueryBuilder<R> mixins Promise<R> {
     builder: Knex$QueryBuilderFn<R> | Knex$Knex<R> | Knex$QueryBuilder<R>
   ): this;
   into(table: string, options?: Object): this;
-
+  truncate(): this;
   insert(val: Object | Object[]): this;
   del(): this;
   delete(): this;

--- a/definitions/npm/knex_v0.15.x/flow_v0.75.x-/test_knex_v0.15.x.js
+++ b/definitions/npm/knex_v0.15.x/flow_v0.75.x-/test_knex_v0.15.x.js
@@ -41,6 +41,7 @@ knex.crossJoin("bar", function() {
 knex("foo").insert({
   a: 1
 });
+knex('foo').truncate();
 knex("bar").del();
 // $ExpectError
 knex.from();

--- a/definitions/npm/knex_v0.16.x/flow_v0.75.x-/knex_v0.16.x.js
+++ b/definitions/npm/knex_v0.16.x/flow_v0.75.x-/knex_v0.16.x.js
@@ -152,7 +152,7 @@ declare class Knex$QueryBuilder<R> mixins Promise<R> {
     builder: Knex$QueryBuilderFn<R> | Knex$Knex<R> | Knex$QueryBuilder<R>
   ): this;
   into(table: string, options?: Object): this;
-
+  truncate(): this;
   insert(val: Object | Object[]): this;
   del(): this;
   delete(): this;

--- a/definitions/npm/knex_v0.16.x/flow_v0.75.x-/test_knex_v0.16.x.js
+++ b/definitions/npm/knex_v0.16.x/flow_v0.75.x-/test_knex_v0.16.x.js
@@ -42,6 +42,7 @@ knex.crossJoin('bar', function() {
 knex('foo').insert({
   a: 1,
 });
+knex('foo').truncate();
 knex('bar').del();
 // $ExpectError
 knex.from();


### PR DESCRIPTION
- Links to documentation: https://knexjs.org/#Builder-truncate
- Link to GitHub or NPM: https://github.com/tgriesser/knex
- Type of contribution: addition

Other notes:
I added `.truncate()` for both knex 0.15 & knex 0.16. 0.15 is the version I was using when I first noticed the missing method definition, but I figured I might as well update the newer 0.16 while I was at it.