### PR TITLE
Add type-defs autobind-decorator using typescript defs as a baseline

### DIFF
--- a/definitions/npm/autobind-decorator_v2.x.x/flow_v0.25.x-/autobind-decorator_v2.x.x.js
+++ b/definitions/npm/autobind-decorator_v2.x.x/flow_v0.25.x-/autobind-decorator_v2.x.x.js
@@ -9,7 +9,7 @@ declare module 'autobind-decorator' {
     }
 
     declare export type ClassDecorator = <TFunction: Function>(target: TFunction) => TFunction;
-    declare export type MethodDecorator = <T>(target: Object, propertyKey: string | Symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>;
+    declare export type MethodDecorator = <T>(target: {}, propertyKey: string | Symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>;
 
     declare var autobind: ClassDecorator & MethodDecorator;
 

--- a/definitions/npm/autobind-decorator_v2.x.x/flow_v0.25.x-/autobind-decorator_v2.x.x.js
+++ b/definitions/npm/autobind-decorator_v2.x.x/flow_v0.25.x-/autobind-decorator_v2.x.x.js
@@ -8,7 +8,8 @@ declare module 'autobind-decorator' {
       set?: (value: T) => void;
     }
 
-    declare export type ClassDecorator = <TFunction: Function>(target: TFunction) => TFunction;
+    declare export type ConstructorFunction = () => void;
+    declare export type ClassDecorator = <T: Class<{}> | ConstructorFunction>(target: T) => T;
     declare export type MethodDecorator = <T>(target: {}, propertyKey: string | Symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>;
 
     declare var autobind: ClassDecorator & MethodDecorator;

--- a/definitions/npm/autobind-decorator_v2.x.x/flow_v0.25.x-/autobind-decorator_v2.x.x.js
+++ b/definitions/npm/autobind-decorator_v2.x.x/flow_v0.25.x-/autobind-decorator_v2.x.x.js
@@ -1,7 +1,8 @@
-// types are copied from https://github.com/andreypopp/autobind-decorator
-declare const autobind: ClassDecorator & MethodDecorator;
+declare module 'autobind-decorator' {
+    declare var autobind: ClassDecorator & MethodDecorator;
 
-export declare const boundMethod: MethodDecorator;
-export declare const boundClass: ClassDecorator;
+    declare export var boundMethod: MethodDecorator;
+    declare export var boundClass: ClassDecorator;
 
-export default autobind;
+    declare export default typeof autobind;
+}

--- a/definitions/npm/autobind-decorator_v2.x.x/flow_v0.25.x-/autobind-decorator_v2.x.x.js
+++ b/definitions/npm/autobind-decorator_v2.x.x/flow_v0.25.x-/autobind-decorator_v2.x.x.js
@@ -1,16 +1,16 @@
-interface TypedPropertyDescriptor<T> {
-  enumerable?: boolean;
-  configurable?: boolean;
-  writable?: boolean;
-  value?: T;
-  get?: () => T;
-  set?: (value: T) => void;
-}
-
-declare type ClassDecorator = <TFunction: Function>(target: TFunction) => TFunction;
-declare type MethodDecorator = <T>(target: Object, propertyKey: string | Symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>;
-
 declare module 'autobind-decorator' {
+    declare export interface TypedPropertyDescriptor<T> {
+      enumerable?: boolean;
+      configurable?: boolean;
+      writable?: boolean;
+      value?: T;
+      get?: () => T;
+      set?: (value: T) => void;
+    }
+
+    declare export type ClassDecorator = <TFunction: Function>(target: TFunction) => TFunction;
+    declare export type MethodDecorator = <T>(target: Object, propertyKey: string | Symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>;
+
     declare var autobind: ClassDecorator & MethodDecorator;
 
     declare export var boundMethod: MethodDecorator;

--- a/definitions/npm/autobind-decorator_v2.x.x/flow_v0.25.x-/autobind-decorator_v2.x.x.js
+++ b/definitions/npm/autobind-decorator_v2.x.x/flow_v0.25.x-/autobind-decorator_v2.x.x.js
@@ -1,3 +1,15 @@
+interface TypedPropertyDescriptor<T> {
+  enumerable?: boolean;
+  configurable?: boolean;
+  writable?: boolean;
+  value?: T;
+  get?: () => T;
+  set?: (value: T) => void;
+}
+
+declare type ClassDecorator = <TFunction: Function>(target: TFunction) => TFunction;
+declare type MethodDecorator = <T>(target: Object, propertyKey: string | Symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>;
+
 declare module 'autobind-decorator' {
     declare var autobind: ClassDecorator & MethodDecorator;
 

--- a/definitions/npm/autobind-decorator_v2.x.x/flow_v0.25.x-/autobind-decorator_v2.x.x.js
+++ b/definitions/npm/autobind-decorator_v2.x.x/flow_v0.25.x-/autobind-decorator_v2.x.x.js
@@ -1,0 +1,7 @@
+// types are copied from https://github.com/andreypopp/autobind-decorator
+declare const autobind: ClassDecorator & MethodDecorator;
+
+export declare const boundMethod: MethodDecorator;
+export declare const boundClass: ClassDecorator;
+
+export default autobind;

--- a/definitions/npm/autobind-decorator_v2.x.x/test_autobind-decorator_v2.x.x.js
+++ b/definitions/npm/autobind-decorator_v2.x.x/test_autobind-decorator_v2.x.x.js
@@ -19,7 +19,7 @@ describe('boundClass', () => {
   });
 
   it('errors when types incompatible', () => {
-    //$ExpectError BarCtor is incompatible with Foo
+    // $ExpectError BarCtor is incompatible with Foo
     (boundClass(BarCtor): typeof (Foo));
 
     // $ExpectError Foo is incompatible with string

--- a/definitions/npm/autobind-decorator_v2.x.x/test_autobind-decorator_v2.x.x.js
+++ b/definitions/npm/autobind-decorator_v2.x.x/test_autobind-decorator_v2.x.x.js
@@ -1,15 +1,71 @@
 // @flow
 import { describe, it } from 'flow-typed-test';
 import autobind, { boundMethod, boundClass } from 'autobind-decorator';
+import type { TypedPropertyDescriptor } from 'autobind-decorator';
 
-class Foo { }
+class Foo {
+  method(): void {}
+  get property(): number { return 1; }
+  set property(value: number): void { }
+}
+
+/* boundClass */
+
 (boundClass(Foo): typeof(Foo));
 
 function BarCtor() { }
 (boundClass(BarCtor): typeof(BarCtor));
 
-// $ExpectError
-(boundClass(string): typeof(Foo));
+//$ExpectError BarCtor is incompatible with Foo
+(boundClass(BarCtor): typeof(Foo));
 
-// $ExpectError
+// $ExpectError Foo is incompatible with string
 (boundClass(Foo): string);
+
+
+
+/* boundMethod */
+
+const methodDescriptor = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+};
+(boundMethod(Foo, 'method', methodDescriptor): TypedPropertyDescriptor<any>);
+
+const propertyDescriptor = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+  get: () => 1,
+  set: (value) => {},
+  value: 1,
+};
+(boundMethod(Foo, 'property', propertyDescriptor): TypedPropertyDescriptor<number>);
+
+// $ExpectError number is incompatible with string
+boundMethod(Foo, 123, propertyDescriptor);
+
+const propertyDescriptorString = {
+  enumerable: true,
+  configurable: true,
+  writable: true,
+  get: () => '1',
+  set: (value: string) => {},
+  value: '1',
+};
+// $ExpectError string is incompatible with number
+(boundMethod(Foo, 'property', propertyDescriptorString): TypedPropertyDescriptor<number>);
+
+
+/* autobind */
+
+(autobind(Foo): typeof(Foo));
+
+(autobind(Foo, 'method', methodDescriptor): TypedPropertyDescriptor<any>);
+
+// $ExpectError Foo is incompatible with string
+(autobind(Foo): string);
+
+// $ExpectError number is incompatible with string
+autobind(Foo, 123, propertyDescriptor)

--- a/definitions/npm/autobind-decorator_v2.x.x/test_autobind-decorator_v2.x.x.js
+++ b/definitions/npm/autobind-decorator_v2.x.x/test_autobind-decorator_v2.x.x.js
@@ -1,0 +1,15 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import autobind, { boundMethod, boundClass } from 'autobind-decorator';
+
+class Foo { }
+(boundClass(Foo): typeof(Foo));
+
+function BarCtor() { }
+(boundClass(BarCtor): typeof(BarCtor));
+
+// $ExpectError
+(boundClass(string): typeof(Foo));
+
+// $ExpectError
+(boundClass(Foo): string);

--- a/definitions/npm/autobind-decorator_v2.x.x/test_autobind-decorator_v2.x.x.js
+++ b/definitions/npm/autobind-decorator_v2.x.x/test_autobind-decorator_v2.x.x.js
@@ -4,68 +4,87 @@ import autobind, { boundMethod, boundClass } from 'autobind-decorator';
 import type { TypedPropertyDescriptor } from 'autobind-decorator';
 
 class Foo {
-  method(): void {}
+  method(): void { }
   get property(): number { return 1; }
   set property(value: number): void { }
 }
 
-/* boundClass */
-
-(boundClass(Foo): typeof(Foo));
-
 function BarCtor() { }
-(boundClass(BarCtor): typeof(BarCtor));
 
-//$ExpectError BarCtor is incompatible with Foo
-(boundClass(BarCtor): typeof(Foo));
+describe('boundClass', () => {
+  it('returns result of correct type', () => {
+    (boundClass(Foo): typeof (Foo));
 
-// $ExpectError Foo is incompatible with string
-(boundClass(Foo): string);
+    (boundClass(BarCtor): typeof (BarCtor));
+  });
 
+  it('errors when types incompatible', () => {
+    //$ExpectError BarCtor is incompatible with Foo
+    (boundClass(BarCtor): typeof (Foo));
 
+    // $ExpectError Foo is incompatible with string
+    (boundClass(Foo): string);
+  });
+});
 
-/* boundMethod */
 
 const methodDescriptor = {
   enumerable: true,
   configurable: true,
   writable: true,
 };
-(boundMethod(Foo, 'method', methodDescriptor): TypedPropertyDescriptor<any>);
 
 const propertyDescriptor = {
   enumerable: true,
   configurable: true,
   writable: true,
   get: () => 1,
-  set: (value) => {},
+  set: (value) => { },
   value: 1,
 };
-(boundMethod(Foo, 'property', propertyDescriptor): TypedPropertyDescriptor<number>);
 
-// $ExpectError number is incompatible with string
-boundMethod(Foo, 123, propertyDescriptor);
+describe('boundMethod', () => {
+  it('returns result of correct type', () => {
+    (boundMethod(Foo, 'method', methodDescriptor): TypedPropertyDescriptor<any>);
 
-const propertyDescriptorString = {
-  enumerable: true,
-  configurable: true,
-  writable: true,
-  get: () => '1',
-  set: (value: string) => {},
-  value: '1',
-};
-// $ExpectError string is incompatible with number
-(boundMethod(Foo, 'property', propertyDescriptorString): TypedPropertyDescriptor<number>);
+    (boundMethod(Foo, 'property', propertyDescriptor): TypedPropertyDescriptor<number>);
+  });
+
+  it('errors when types incompatible', () => {
+    // $ExpectError number is incompatible with string
+    boundMethod(Foo, 123, propertyDescriptor);
+
+    const propertyDescriptorString = {
+      enumerable: true,
+      configurable: true,
+      writable: true,
+      get: () => '1',
+      set: (value: string) => { },
+      value: '1',
+    };
+    // $ExpectError string is incompatible with number
+    (boundMethod(Foo, 'property', propertyDescriptorString): TypedPropertyDescriptor<number>);
+  });
+});
 
 
-/* autobind */
 
-(autobind(Foo): typeof(Foo));
+describe('autobind', () => {
+  it('returns result of correct type', () => {
+    (autobind(Foo): typeof (Foo));
 
-(autobind(Foo, 'method', methodDescriptor): TypedPropertyDescriptor<any>);
+    (autobind(Foo, 'method', methodDescriptor): TypedPropertyDescriptor<any>);
+  });
 
-// $ExpectError Foo is incompatible with string
-(autobind(Foo): string);
+  it('errors when types incompatible', () => {
+    // $ExpectError Foo is incompatible with string
+    (autobind(Foo): string);
 
-// $ExpectError number is incompatible with string
-autobind(Foo, 123, propertyDescriptor)
+    // $ExpectError number is incompatible with string
+    autobind(Foo, 123, propertyDescriptor);
+  });
+});
+
+
+
+


### PR DESCRIPTION
- Links to documentation:  https://github.com/andreypopp/autobind-decorator
- Link to GitHub or NPM: https://github.com/andreypopp/autobind-decorator
- Type of contribution: new definition

Other notes:
Typescript typings - https://github.com/andreypopp/autobind-decorator/blob/master/index.d.ts