### PR TITLE
Clone @storybook/react-v4.x.x to @storybook/react-v5.x.x

### DIFF
--- a/definitions/npm/@storybook/react_v5.x.x/flow_v0.25.x-v0.71.x/react_v5.x.x.js
+++ b/definitions/npm/@storybook/react_v5.x.x/flow_v0.25.x-v0.71.x/react_v5.x.x.js
@@ -1,0 +1,51 @@
+type NodeModule = typeof module;
+
+declare module '@storybook/react' {
+  declare type Context = { kind: string, story: string };
+  declare type Renderable = React$Element<*>;
+  declare type RenderCallback = (
+    context: Context
+  ) => Renderable | Array<Renderable>;
+  declare type RenderFunction = () => Renderable | Array<Renderable>;
+
+  declare type StoryDecorator = (
+    story: RenderFunction,
+    context: Context
+  ) => Renderable | null;
+
+  declare type DecoratorParameters = {
+    [key: string]: any,
+  };
+
+  declare interface Story {
+    +kind: string;
+    add(
+      storyName: string,
+      callback: RenderCallback,
+      parameters?: DecoratorParameters
+    ): Story;
+    addDecorator(decorator: StoryDecorator): Story;
+    addParameters(parameters: DecoratorParameters): Story;
+  }
+
+  declare interface StoryObject {
+    name: string;
+    render: RenderFunction;
+  }
+
+  declare interface StoryBucket {
+    kind: string;
+    filename: string;
+    stories: Array<StoryObject>;
+  }
+
+  declare function addDecorator(decorator: StoryDecorator): void;
+  declare function addParameters(parameters: DecoratorParameters): void;
+  declare function clearDecorators(): void;
+  declare function configure(fn: () => void, module: NodeModule): void;
+  declare function setAddon(addon: Object): void;
+  declare function storiesOf(name: string, module: NodeModule): Story;
+  declare function forceReRender(): void;
+
+  declare function getStorybook(): Array<StoryBucket>;
+}

--- a/definitions/npm/@storybook/react_v5.x.x/flow_v0.25.x-v0.71.x/test_react_v5.x.x.js
+++ b/definitions/npm/@storybook/react_v5.x.x/flow_v0.25.x-v0.71.x/test_react_v5.x.x.js
@@ -1,0 +1,159 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import React from 'react';
+import {
+  storiesOf,
+  addDecorator,
+  addParameters,
+  clearDecorators,
+  getStorybook,
+  forceReRender,
+  configure,
+  setAddon,
+  type RenderFunction,
+  type Story,
+} from '@storybook/react';
+
+const Button = props => <button {...props} />;
+
+const Decorator = story => <div>{story()}</div>;
+
+const parameters = { param: 'test' };
+
+describe('The `storiesOf` function', () => {
+  it('should validate on default usage', () => {
+    storiesOf('', module);
+  });
+
+  it('should error on invalid options', () => {
+    // $ExpectError
+    storiesOf([], module);
+    // $ExpectError
+    storiesOf('', 123);
+  });
+
+  it('should error on invalid method call', () => {
+    // $ExpectError
+    storiesOf('', module).foo('', () => <div />);
+  });
+});
+
+describe('The `add` method', () => {
+  it('should validate on default usage (element)', () => {
+    storiesOf('', module).add('', () => <div />);
+  });
+
+  it('should validate on default usage (component)', () => {
+    storiesOf('', module).add('', () => <Button>test</Button>);
+  });
+
+  it('should validate on default usage (array)', () => {
+    storiesOf('', module).add('', () => [
+      <Button>test</Button>,
+      <Button>test</Button>,
+      <Button>test</Button>,
+    ]);
+  });
+
+  it('should validate on default usage (parameters)', () => {
+    storiesOf('', module).add('', () => <Button>test</Button>, {
+      param: 'test',
+    });
+  });
+
+  it('should error on invalid default usage (parameters)', () => {
+    // $ExpectError
+    storiesOf('', module).add('', () => <Button>test</Button>, '');
+    // $ExpectError
+    storiesOf('', module).add('', parameters, () => <Button>test</Button>);
+  });
+
+  it('should error on invalid default usage', () => {
+    // $ExpectError
+    storiesOf('', module).add('', () => '');
+    // $ExpectError
+    storiesOf('', module).add('', () => null);
+  });
+
+  it('should validate when unwrapping arguments', () => {
+    storiesOf('', module).add('', ({ kind, story }) => (
+      <div>
+        {kind} {story}
+      </div>
+    ));
+  });
+
+  it('should error when unwrapping invalid arguments', () => {
+    // $ExpectError
+    storiesOf('', module).add('', ({ kind, story, foo }) => (
+      <div>
+        {kind} {story} {foo}
+      </div>
+    ));
+  });
+});
+
+describe('The `addDecorator` function', () => {
+  it('should validate on default usage (local)', () => {
+    storiesOf('', module)
+      .addDecorator(Decorator)
+      .add('', () => <div />);
+  });
+
+  it('should validate on default usage (global)', () => {
+    addDecorator(Decorator);
+  });
+});
+
+describe('The `addDecorator` function', () => {
+  it('should validate on default usage (local)', () => {
+    storiesOf('', module)
+      .addParameters(parameters)
+      .add('', () => <div />);
+  });
+
+  it('should validate on default usage (global)', () => {
+    addParameters(parameters);
+  });
+
+  it('should error on invalid usage (global)', () => {
+    // $ExpectError
+    addParameters();
+    // $ExpectError
+    addParameters('');
+  });
+});
+
+describe('The `clearDecorators` function', () => {
+  it('should validate on default usage (global)', () => {
+    clearDecorators();
+  });
+
+  it('should error on invalid usage (global)', () => {
+    // $ExpectError
+    clearDecorators(true);
+    // $ExpectError
+    clearDecorators(parameters);
+  });
+});
+
+describe('The `getStorybook` function', () => {
+  it('should validate on default usage', () => {
+    getStorybook().forEach(({ kind, stories }) =>
+      stories.forEach(({ name, render }) => render())
+    );
+  });
+});
+
+describe('The `forceReRender` function', () => {
+  it('should validate on default usage', () => {
+    forceReRender();
+  });
+});
+
+describe('The `configure` function', () => {
+  it('should validate on default usage', () => {
+    configure(() => undefined, module);
+  });
+});

--- a/definitions/npm/@storybook/react_v5.x.x/flow_v0.72.x-/react_v5.x.x.js
+++ b/definitions/npm/@storybook/react_v5.x.x/flow_v0.72.x-/react_v5.x.x.js
@@ -1,0 +1,52 @@
+type NodeModule = typeof module;
+
+declare module '@storybook/react' {
+  declare type Context = { kind: string, story: string };
+  declare type Renderable = React$Element<*>;
+  declare type RenderCallback = (
+    context: Context
+  ) => Renderable | Array<Renderable>;
+  declare type RenderFunction = () => Renderable | Array<Renderable>;
+
+  declare type StoryDecorator = (
+    story: RenderFunction,
+    context: Context
+  ) => Renderable | null;
+
+  declare type DecoratorParameters = {
+    [key: string]: any,
+  };
+
+  declare interface Story {
+    +kind: string;
+    add(
+      storyName: string,
+      callback: RenderCallback,
+      parameters?: DecoratorParameters
+    ): Story;
+    addDecorator(decorator: StoryDecorator): Story;
+    addParameters(parameters: DecoratorParameters): Story;
+  }
+
+  declare interface StoryObject {
+    name: string;
+    render: RenderFunction;
+  }
+
+  declare interface StoryBucket {
+    kind: string;
+    filename: string;
+    stories: Array<StoryObject>;
+  }
+
+  declare function addDecorator(decorator: StoryDecorator): void;
+  declare function addParameters(parameters: DecoratorParameters): void;
+  declare function clearDecorators(): void;
+  declare function configure(fn: () => void, module: NodeModule): void;
+  declare function setAddon(addon: Object): void;
+  declare function storiesOf(name: string, module: NodeModule): Story;
+  declare function storiesOf<T>(name: string, module: NodeModule): Story & T;
+  declare function forceReRender(): void;
+
+  declare function getStorybook(): Array<StoryBucket>;
+}

--- a/definitions/npm/@storybook/react_v5.x.x/flow_v0.72.x-/test_react_v5.x.x.js
+++ b/definitions/npm/@storybook/react_v5.x.x/flow_v0.72.x-/test_react_v5.x.x.js
@@ -1,0 +1,183 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import React from 'react';
+import {
+  storiesOf,
+  addDecorator,
+  addParameters,
+  clearDecorators,
+  getStorybook,
+  forceReRender,
+  configure,
+  setAddon,
+  type RenderFunction,
+  type Story,
+} from '@storybook/react';
+
+const Button = props => <button {...props} />;
+
+const Decorator = story => <div>{story()}</div>;
+
+const parameters = { param: 'test' };
+
+describe('The `storiesOf` function', () => {
+  it('should validate on default usage', () => {
+    storiesOf('', module);
+  });
+
+  it('should error on invalid options', () => {
+    // $ExpectError
+    storiesOf([], module);
+    // $ExpectError
+    storiesOf('', 123);
+  });
+
+  it('should error on invalid method call', () => {
+    // $ExpectError
+    storiesOf('', module).foo('', () => <div />);
+  });
+});
+
+describe('The `add` method', () => {
+  it('should validate on default usage (element)', () => {
+    storiesOf('', module).add('', () => <div />);
+  });
+
+  it('should validate on default usage (component)', () => {
+    storiesOf('', module).add('', () => <Button>test</Button>);
+  });
+
+  it('should validate on default usage (array)', () => {
+    storiesOf('', module).add('', () => [
+      <Button>test</Button>,
+      <Button>test</Button>,
+      <Button>test</Button>,
+    ]);
+  });
+
+  it('should validate on default usage (parameters)', () => {
+    storiesOf('', module).add('', () => <Button>test</Button>, {
+      param: 'test',
+    });
+  });
+
+  it('should error on invalid default usage (parameters)', () => {
+    // $ExpectError
+    storiesOf('', module).add('', () => <Button>test</Button>, '');
+    // $ExpectError
+    storiesOf('', module).add('', parameters, () => <Button>test</Button>);
+  });
+
+  it('should error on invalid default usage', () => {
+    // $ExpectError
+    storiesOf('', module).add('', () => '');
+    // $ExpectError
+    storiesOf('', module).add('', () => null);
+  });
+
+  it('should validate when unwrapping arguments', () => {
+    storiesOf('', module).add('', ({ kind, story }) => (
+      <div>
+        {kind} {story}
+      </div>
+    ));
+  });
+
+  it('should error when unwrapping invalid arguments', () => {
+    // $ExpectError
+    storiesOf('', module).add('', ({ kind, story, foo }) => (
+      <div>
+        {kind} {story} {foo}
+      </div>
+    ));
+  });
+});
+
+describe('The `addDecorator` function', () => {
+  it('should validate on default usage (local)', () => {
+    storiesOf('', module)
+      .addDecorator(Decorator)
+      .add('', () => <div />);
+  });
+
+  it('should validate on default usage (global)', () => {
+    addDecorator(Decorator);
+  });
+});
+
+describe('The `addDecorator` function', () => {
+  it('should validate on default usage (local)', () => {
+    storiesOf('', module)
+      .addParameters(parameters)
+      .add('', () => <div />);
+  });
+
+  it('should validate on default usage (global)', () => {
+    addParameters(parameters);
+  });
+
+  it('should error on invalid usage (global)', () => {
+    // $ExpectError
+    addParameters();
+    // $ExpectError
+    addParameters('');
+  });
+});
+
+describe('The `clearDecorators` function', () => {
+  it('should validate on default usage (global)', () => {
+    clearDecorators();
+  });
+
+  it('should error on invalid usage (global)', () => {
+    // $ExpectError
+    clearDecorators(true);
+    // $ExpectError
+    clearDecorators(parameters);
+  });
+});
+
+describe('The `getStorybook` function', () => {
+  it('should validate on default usage', () => {
+    getStorybook().forEach(({ kind, stories }) =>
+      stories.forEach(({ name, render }) => render())
+    );
+  });
+});
+
+describe('The `forceReRender` function', () => {
+  it('should validate on default usage', () => {
+    forceReRender();
+  });
+});
+
+describe('The `configure` function', () => {
+  it('should validate on default usage', () => {
+    configure(() => undefined, module);
+  });
+});
+
+describe('The `setAddon` function', () => {
+  it('should validate on default usage', () => {
+    interface Addon {
+      test<T>(name: string, story: RenderFunction): Story & T;
+    }
+
+    const TestAddon: Addon = {
+      test(name, story) {
+        console.log(this.kind === 'TestAddon');
+        return this.add(name, story);
+      },
+    };
+
+    setAddon(TestAddon);
+
+    storiesOf<Addon>('TestAddon', module)
+      .test('', () => <div />)
+      .test('', () => <div />)
+      .add('', () => <div />)
+      .test('', () => <div />)
+      .add('', () => <div />, parameters);
+  });
+});


### PR DESCRIPTION
The migration from @storybook/react-v4 to @storybook/react-v5 doesn't involve any breaking API changes https://github.com/storybooks/storybook/blob/next/MIGRATION.md#from-version-41x-to-50x so I'm just copying over the existing definitions so they can be used with v5.

- Links to documentation: https://storybook.js.org/docs/basics/introduction/
- Link to GitHub or NPM: https://www.npmjs.com/package/@storybook/react
- Type of contribution: addition

Other notes:

