### PR TITLE
[@storybook/react v5.x.x] Use React$Node instead of a bespoke type

### DIFF
--- a/definitions/npm/@storybook/react_v5.x.x/flow_v0.72.x-/react_v5.x.x.js
+++ b/definitions/npm/@storybook/react_v5.x.x/flow_v0.72.x-/react_v5.x.x.js
@@ -9,7 +9,7 @@ declare module '@storybook/react' {
     | Iterable<?Renderable>;
   declare type RenderCallback = (
     context: Context
-  ) => React$Node;
+  ) => Renderable;
   declare type RenderFunction = () => Renderable;
 
   declare type StoryDecorator = (

--- a/definitions/npm/@storybook/react_v5.x.x/flow_v0.72.x-/react_v5.x.x.js
+++ b/definitions/npm/@storybook/react_v5.x.x/flow_v0.72.x-/react_v5.x.x.js
@@ -2,16 +2,15 @@ type NodeModule = typeof module;
 
 declare module '@storybook/react' {
   declare type Context = { kind: string, story: string };
-  declare type Renderable = React$Element<*>;
   declare type RenderCallback = (
     context: Context
-  ) => Renderable | Array<Renderable>;
-  declare type RenderFunction = () => Renderable | Array<Renderable>;
+  ) => React$Node;
+  declare type RenderFunction = () => React$Node;
 
   declare type StoryDecorator = (
     story: RenderFunction,
     context: Context
-  ) => Renderable | null;
+  ) => React$Node;
 
   declare type DecoratorParameters = {
     [key: string]: any,

--- a/definitions/npm/@storybook/react_v5.x.x/flow_v0.72.x-/react_v5.x.x.js
+++ b/definitions/npm/@storybook/react_v5.x.x/flow_v0.72.x-/react_v5.x.x.js
@@ -2,15 +2,20 @@ type NodeModule = typeof module;
 
 declare module '@storybook/react' {
   declare type Context = { kind: string, story: string };
+  declare type Renderable =
+    | string
+    | number
+    | React$Element<any>
+    | Iterable<?Renderable>;
   declare type RenderCallback = (
     context: Context
   ) => React$Node;
-  declare type RenderFunction = () => React$Node;
+  declare type RenderFunction = () => Renderable;
 
   declare type StoryDecorator = (
     story: RenderFunction,
     context: Context
-  ) => React$Node;
+  ) => Renderable;
 
   declare type DecoratorParameters = {
     [key: string]: any,

--- a/definitions/npm/@storybook/react_v5.x.x/flow_v0.72.x-/test_react_v5.x.x.js
+++ b/definitions/npm/@storybook/react_v5.x.x/flow_v0.72.x-/test_react_v5.x.x.js
@@ -64,10 +64,6 @@ describe('The `add` method', () => {
     storiesOf('', module).add('', () => 0);
   });
 
-  it('should validate on default usage (null)', () => {
-    storiesOf('', module).add('', () => null);
-  });
-
   it('should validate on default usage (parameters)', () => {
     storiesOf('', module).add('', () => <Button>test</Button>, {
       param: 'test',
@@ -86,6 +82,8 @@ describe('The `add` method', () => {
     storiesOf('', module).add('', () => () => null);
     // $ExpectError
     storiesOf('', module).add('', () => Button);
+    // $ExpectError
+    storiesOf('', module).add('', () => null);
   });
 
   it('should validate when unwrapping arguments', () => {

--- a/definitions/npm/@storybook/react_v5.x.x/flow_v0.72.x-/test_react_v5.x.x.js
+++ b/definitions/npm/@storybook/react_v5.x.x/flow_v0.72.x-/test_react_v5.x.x.js
@@ -56,6 +56,18 @@ describe('The `add` method', () => {
     ]);
   });
 
+  it('should validate on default usage (string)', () => {
+    storiesOf('', module).add('', () => '');
+  });
+
+  it('should validate on default usage (number)', () => {
+    storiesOf('', module).add('', () => 0);
+  });
+
+  it('should validate on default usage (null)', () => {
+    storiesOf('', module).add('', () => null);
+  });
+
   it('should validate on default usage (parameters)', () => {
     storiesOf('', module).add('', () => <Button>test</Button>, {
       param: 'test',
@@ -71,9 +83,9 @@ describe('The `add` method', () => {
 
   it('should error on invalid default usage', () => {
     // $ExpectError
-    storiesOf('', module).add('', () => '');
+    storiesOf('', module).add('', () => () => null);
     // $ExpectError
-    storiesOf('', module).add('', () => null);
+    storiesOf('', module).add('', () => Button);
   });
 
   it('should validate when unwrapping arguments', () => {


### PR DESCRIPTION
Cleaning this up since the bespoke `Renderable` type isn't accurate (it can be any react element, e.g. a string, or a number would be valid). Also gets rid of the existential type, so thats nice.

- Links to documentation: https://storybook.js.org/docs/basics/introduction/
- Link to GitHub or NPM: https://www.npmjs.com/package/@storybook/react
- Type of contribution: fix

Other notes:

