### PR TITLE
[react-intl_v2.x.x] Pass $Exact type to defineMessages (#3243)

### DIFF
--- a/definitions/npm/react-intl_v2.x.x/flow_v0.25.x-v0.52.x/react-intl_v2.x.x.js
+++ b/definitions/npm/react-intl_v2.x.x/flow_v0.25.x-v0.52.x/react-intl_v2.x.x.js
@@ -103,7 +103,7 @@ declare module "react-intl" {
     componentName: string
   ): void;
   declare function addLocaleData(data: LocaleData | Array<LocaleData>): void;
-  declare function defineMessages<T: { [key: string]: MessageDescriptor }>(
+  declare function defineMessages<T: { [key: string]: $Exact<MessageDescriptor> }>(
     messageDescriptors: T
   ): T;
   declare function injectIntl(

--- a/definitions/npm/react-intl_v2.x.x/flow_v0.25.x-v0.52.x/test_react-intl_v2.x.x.js
+++ b/definitions/npm/react-intl_v2.x.x/flow_v0.25.x-v0.52.x/test_react-intl_v2.x.x.js
@@ -55,6 +55,17 @@ const messageDescriptorMap3: Array<string> = defineMessages(messages);
 // $ExpectError string. This type is incompatible with MessageDescriptorMap
 const messageDescriptorMap4: string = defineMessages(messages);
 
+// $ExpectError defineMessages accepts exact $npm$ReactIntl$MessageDescriptor
+const messageDescriptorMap5 = defineMessages({
+  message: {
+    id: "message5",
+    defaultMessage: "Hello",
+    values: {
+      value: 1
+    }
+  }
+});
+
 class TestComponent extends Component {
   render() {
     return React.createElement("div", null, `Hello ppl`);

--- a/definitions/npm/react-intl_v2.x.x/flow_v0.53.x-v0.56.x/react-intl_v2.x.x.js
+++ b/definitions/npm/react-intl_v2.x.x/flow_v0.53.x-v0.56.x/react-intl_v2.x.x.js
@@ -118,7 +118,7 @@ declare module "react-intl" {
     data: $npm$ReactIntl$LocaleData | Array<$npm$ReactIntl$LocaleData>
   ): void;
   declare function defineMessages<
-    T: { [key: string]: $npm$ReactIntl$MessageDescriptor }
+    T: { [key: string]: $Exact<$npm$ReactIntl$MessageDescriptor> }
   >(
     messageDescriptors: T
   ): T;

--- a/definitions/npm/react-intl_v2.x.x/flow_v0.53.x-v0.56.x/test_react-intl_v2.x.x.js
+++ b/definitions/npm/react-intl_v2.x.x/flow_v0.53.x-v0.56.x/test_react-intl_v2.x.x.js
@@ -61,6 +61,17 @@ const msg1:MessageDescriptor = messageDescriptorMap.messagekey1;
 const msg2:MessageDescriptor = messageDescriptorMap.messagekey2_foo;
 const msg3:MessageDescriptor = messageDescriptorMap.messagekey3;
 
+// $ExpectError defineMessages accepts exact $npm$ReactIntl$MessageDescriptor
+const messageDescriptorMap5 = defineMessages({
+  message: {
+    id: "message5",
+    defaultMessage: "Hello",
+    values: {
+      value: 1
+    }
+  }
+});
+
 class TestComponent extends React.Component<{ name: string, intl: IntlShape }> {
   render() {
     return React.createElement("div", {}, `Hello ${this.props.name}`);

--- a/definitions/npm/react-intl_v2.x.x/flow_v0.57.x-v0.62.x/react-intl_v2.x.x.js
+++ b/definitions/npm/react-intl_v2.x.x/flow_v0.57.x-v0.62.x/react-intl_v2.x.x.js
@@ -120,7 +120,7 @@ declare module "react-intl" {
     data: $npm$ReactIntl$LocaleData | Array<$npm$ReactIntl$LocaleData>
   ): void;
   declare function defineMessages<
-    T: { [key: string]: $npm$ReactIntl$MessageDescriptor }
+    T: { [key: string]: $Exact<$npm$ReactIntl$MessageDescriptor> }
   >(
     messageDescriptors: T
   ): T;

--- a/definitions/npm/react-intl_v2.x.x/flow_v0.57.x-v0.62.x/test_react-intl_v2.x.x.js
+++ b/definitions/npm/react-intl_v2.x.x/flow_v0.57.x-v0.62.x/test_react-intl_v2.x.x.js
@@ -61,6 +61,17 @@ const msg1:MessageDescriptor = messageDescriptorMap.messagekey1;
 const msg2:MessageDescriptor = messageDescriptorMap.messagekey2_foo;
 const msg3:MessageDescriptor = messageDescriptorMap.messagekey3;
 
+// $ExpectError defineMessages accepts exact $npm$ReactIntl$MessageDescriptor
+const messageDescriptorMap5 = defineMessages({
+  message: {
+    id: "message5",
+    defaultMessage: "Hello",
+    values: {
+      value: 1
+    }
+  }
+});
+
 class TestComponent extends React.Component<{ name: string, intl: IntlShape }> {
   render() {
     return React.createElement("div", {}, `Hello ${this.props.name}`);

--- a/definitions/npm/react-intl_v2.x.x/flow_v0.63.x-/react-intl_v2.x.x.js
+++ b/definitions/npm/react-intl_v2.x.x/flow_v0.63.x-/react-intl_v2.x.x.js
@@ -118,7 +118,7 @@ declare module "react-intl" {
     data: $npm$ReactIntl$LocaleData | Array<$npm$ReactIntl$LocaleData>
   ): void;
   declare function defineMessages<
-    T: { [key: string]: $npm$ReactIntl$MessageDescriptor }
+    T: { [key: string]: $Exact<$npm$ReactIntl$MessageDescriptor> }
   >(
     messageDescriptors: T
   ): T;
@@ -194,7 +194,7 @@ declare module "react-intl" {
     $npm$ReactIntl$MessageDescriptor & {
       values?: Object,
       tagName?: string,
-      children?: 
+      children?:
         | ((...formattedMessage: Array<React$Node>) => React$Node)
         | (string => React$Node)
     }

--- a/definitions/npm/react-intl_v2.x.x/flow_v0.63.x-/test_react-intl_v2.x.x.js
+++ b/definitions/npm/react-intl_v2.x.x/flow_v0.63.x-/test_react-intl_v2.x.x.js
@@ -62,6 +62,17 @@ const msg1:MessageDescriptor = messageDescriptorMap.messagekey1;
 const msg2:MessageDescriptor = messageDescriptorMap.messagekey2_foo;
 const msg3:MessageDescriptor = messageDescriptorMap.messagekey3;
 
+// $ExpectError defineMessages accepts exact $npm$ReactIntl$MessageDescriptor
+const messageDescriptorMap5 = defineMessages({
+  message: {
+    id: "message5",
+    defaultMessage: "Hello",
+    values: {
+      value: 1
+    }
+  }
+});
+
 
 // Components
 <FormattedMessage
@@ -111,7 +122,7 @@ class TestComponent extends React.Component<{ name: string, intl: IntlShape }> {
     );
   }
 }
-    
+
 class TestComponentWithExactProps extends React.Component<{| name: string, intl: IntlShape, |}> {
   render() {
     const { formatMessage } = this.props.intl;
@@ -161,7 +172,7 @@ describe("react-intl", () => {
   describe("injectIntl", () => {
     describe('Component with single required prop "name"', () => {
       const Component = injectIntl(TestComponent);
-      
+
       it('works', () => {
         <Component name="test" />;
       });
@@ -184,7 +195,7 @@ describe("react-intl", () => {
 
     describe('withRef=true', () => {
       const Component = injectIntl(TestComponent, { withRef: true });
-      
+
       it('works', () => {
         <Component name="test" />;
       });
@@ -207,7 +218,7 @@ describe("react-intl", () => {
 
     describe('Component with exact props', () => {
       const Component = injectIntl(TestComponentWithExactProps);
-      
+
       it('works', () => {
         <Component name="test" />;
       });
@@ -230,7 +241,7 @@ describe("react-intl", () => {
 
     describe('Component with default props', () => {
       const Component = injectIntl(TestComponentWithDefaultProps);
-      
+
       it('works', () => {
         <Component name="test" />;
       });
@@ -251,7 +262,7 @@ describe("react-intl", () => {
 
     describe('Component with with maybe prop', () => {
       const Component = injectIntl(TestComponentWithMaybeProp);
-      
+
       it('works', () => {
         <Component name="test" />;
       });
@@ -283,7 +294,7 @@ describe("react-intl", () => {
           );
         }
       );
-      
+
       it('works', () => {
         <Component name="test" />;
       });
@@ -321,7 +332,7 @@ describe("react-intl", () => {
       };
 
       const Component = injectIntl(FuncComponent);
-      
+
       it('works', () => {
         <Component name="test" />;
       });
@@ -393,7 +404,7 @@ describe("react-intl", () => {
 
         <NumberComponent />;
       });
-      
+
       it('formatNumber', () => {
         const PluralComponent: React.ComponentType<{}> = injectIntl((props: { intl: IntlShape }) => {
           const { formatPlural } = props.intl;


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see  for details. --->

- Links to documentation: https://github.com/yahoo/babel-plugin-react-intl/blob/6d364b01554f80433067202f342d6b516b03daaa/src/index.js#L313-L323
- Link to GitHub or NPM: #3243 
- Type of contribution: fix

Other notes:
As described in #3243 `defineMessages` used along with `babel-plugin-react-intl` will drop all other fields other than `{ id }` and `{ defaultMessage }`. 
In order to avoid missing interpolation in runtime this PR hardens type passed to `defineMessages` to be `$Exact`