### PR TITLE
Knex: add missing "returning" parameter to update()

### DIFF
--- a/definitions/npm/knex_v0.12.x/flow_v0.38.x-v0.74.x/knex_v0.12.x.js
+++ b/definitions/npm/knex_v0.12.x/flow_v0.38.x-v0.74.x/knex_v0.12.x.js
@@ -131,8 +131,8 @@ declare class Knex$QueryBuilder<R> mixins Promise<R> {
   insert(val: Object | Object[]): this;
   del(): this;
   delete(): this;
-  update(column: string, value: any): this;
-  update(val: Object): this;
+  update(column: string, value: any, returning?: Array<string>): this;
+  update(val: Object, returning?: Array<string>): this;
   returning(columns: string[]): this;
 }
 

--- a/definitions/npm/knex_v0.13.x/flow_v0.38.x-v0.74.x/knex_v0.13.x.js
+++ b/definitions/npm/knex_v0.13.x/flow_v0.38.x-v0.74.x/knex_v0.13.x.js
@@ -130,8 +130,8 @@ declare class Knex$QueryBuilder<R> mixins Promise<R> {
   insert(val: Object | Object[]): this;
   del(): this;
   delete(): this;
-  update(column: string, value: any): this;
-  update(val: Object): this;
+  update(column: string, value: any, returning?: Array<string>): this;
+  update(val: Object, returning?: Array<string>): this;
   returning(columns: string[]): this;
   forUpdate(): this;
   forShare(): this;

--- a/definitions/npm/knex_v0.14.x/flow_v0.38.x-v0.74.x/knex_v0.14.x.js
+++ b/definitions/npm/knex_v0.14.x/flow_v0.38.x-v0.74.x/knex_v0.14.x.js
@@ -130,8 +130,8 @@ declare class Knex$QueryBuilder<R> mixins Promise<R> {
   insert(val: Object | Object[]): this;
   del(): this;
   delete(): this;
-  update(column: string, value: any): this;
-  update(val: Object): this;
+  update(column: string, value: any, returning?: Array<string>): this;
+  update(val: Object, returning?: Array<string>): this;
   returning(columns: string[]): this;
   forUpdate(): this;
   forShare(): this;

--- a/definitions/npm/knex_v0.14.x/flow_v0.75.x-/knex_v0.14.x.js
+++ b/definitions/npm/knex_v0.14.x/flow_v0.75.x-/knex_v0.14.x.js
@@ -130,8 +130,8 @@ declare class Knex$QueryBuilder<R> mixins Promise<R> {
   insert(val: Object | Object[]): this;
   del(): this;
   delete(): this;
-  update(column: string, value: any): this;
-  update(val: Object): this;
+  update(column: string, value: any, returning?: Array<string>): this;
+  update(val: Object, returning?: Array<string>): this;
   returning(columns: string[]): this;
   forUpdate(): this;
   forShare(): this;

--- a/definitions/npm/knex_v0.15.x/flow_v0.38.x-v0.74.x/knex_v0.15.x.js
+++ b/definitions/npm/knex_v0.15.x/flow_v0.38.x-v0.74.x/knex_v0.15.x.js
@@ -130,8 +130,8 @@ declare class Knex$QueryBuilder<R> mixins Promise<R> {
   insert(val: Object | Object[]): this;
   del(): this;
   delete(): this;
-  update(column: string, value: any): this;
-  update(val: Object): this;
+  update(column: string, value: any, returning?: Array<string>): this;
+  update(val: Object, returning?: Array<string>): this;
   returning(columns: string[]): this;
   forUpdate(): this;
   forShare(): this;

--- a/definitions/npm/knex_v0.15.x/flow_v0.75.x-/knex_v0.15.x.js
+++ b/definitions/npm/knex_v0.15.x/flow_v0.75.x-/knex_v0.15.x.js
@@ -130,8 +130,8 @@ declare class Knex$QueryBuilder<R> mixins Promise<R> {
   insert(val: Object | Object[]): this;
   del(): this;
   delete(): this;
-  update(column: string, value: any): this;
-  update(val: Object): this;
+  update(column: string, value: any, returning?: Array<string>): this;
+  update(val: Object, returning?: Array<string>): this;
   returning(columns: string[]): this;
   forUpdate(): this;
   forShare(): this;

--- a/definitions/npm/knex_v0.16.x/flow_v0.75.x-/knex_v0.16.x.js
+++ b/definitions/npm/knex_v0.16.x/flow_v0.75.x-/knex_v0.16.x.js
@@ -156,8 +156,8 @@ declare class Knex$QueryBuilder<R> mixins Promise<R> {
   insert(val: Object | Object[]): this;
   del(): this;
   delete(): this;
-  update(column: string, value: any): this;
-  update(val: Object): this;
+  update(column: string, value: any, returning?: Array<string>): this;
+  update(val: Object, returning?: Array<string>): this;
   returning(columns: string[]): this;
   forUpdate(): this;
   forShare(): this;


### PR DESCRIPTION
- Links to documentation: https://knexjs.org/#Builder-update
- Link to GitHub or NPM: https://github.com/tgriesser/knex
- Type of contribution: addition

Knex's `update()` method supports optional `returning` parameter (array of strings) on many SQL-dialects. see https://knexjs.org/#Builder-update

Flow-typed definition missed this. This pull-request adds it to all knex versions.