### PR TITLE
[lodash_v4.x.x] Fix orderBy types for object case

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -672,7 +672,7 @@ declare module "lodash" {
       iteratees?: ?$ReadOnlyArray<Iteratee<T>> | ?string,
       orders?: ?$ReadOnlyArray<"asc" | "desc"> | ?string
     ): Array<T>;
-    orderBy<V, T: Object>(
+    orderBy<V, T: {}>(
       object: T,
       iteratees?: $ReadOnlyArray<OIteratee<*>> | string,
       orders?: $ReadOnlyArray<"asc" | "desc"> | string

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -25,6 +25,7 @@ import map from "lodash/map";
 import memoize from "lodash/memoize";
 import noop from "lodash/noop";
 import omitBy from "lodash/omitBy";
+import orderBy from 'lodash/orderBy';
 import pickBy from "lodash/pickBy";
 import pullAllBy from "lodash/pullAllBy";
 import range from "lodash/range";
@@ -502,3 +503,12 @@ pairs = toPairsIn({ a: 12, b: 100 });
 (omitBy(null, num => num % 2): {});
 (omitBy(undefined, num => num % 2): {});
 (omitBy({ [1]: 1, [2]: 2 }, num => num === 2): { [prop: number]: number });
+
+/**
+ * _.orderBy
+ */
+(orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], ['a']): Array<{ a: number, b: number }>);
+(orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], [x => x.a]): Array<{ a: number, b: number }>);
+(orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, ['a']): Array<{ a: number, b: number }>);
+(orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, [x => x.a]): Array<{ a: number, b: number }>);
+


### PR DESCRIPTION
That definition conflicted with the definition where an array is passed in the first parameter, because an array is Object too, and flow couldn't deside which case to select.

- Type of contribution: fix
