### PR TITLE
[react-navigation] Support custom navigators using Transitioner

### DIFF
--- a/definitions/npm/@react-navigation/core_v3.x.x/flow_v0.60.x-/core_v3.x.x.js
+++ b/definitions/npm/@react-navigation/core_v3.x.x/flow_v0.60.x-/core_v3.x.x.js
@@ -216,6 +216,7 @@ declare module '@react-navigation/core' {
      */
     index: number,
     routes: Array<NavigationRoute>,
+    isTransitioning?: bool,
   };
 
   declare export type NavigationRoute =
@@ -615,6 +616,7 @@ declare module '@react-navigation/core' {
     isStale: boolean,
     key: string,
     route: NavigationRoute,
+    descriptor: ?NavigationDescriptor,
   };
 
   declare export type NavigationTransitionProps = $Shape<{
@@ -742,9 +744,9 @@ declare module '@react-navigation/core' {
     }) => NavigationCompleteTransitionAction,
   };
 
-  declare type NavigationDescriptor = {
+  declare export type NavigationDescriptor = {
     key: string,
-    state: NavigationLeafRoute | NavigationStateRoute,
+    state: NavigationRoute,
     navigation: NavigationScreenProp<*>,
     getComponent: () => React$ComponentType<{}>,
   };

--- a/definitions/npm/react-navigation_v3.x.x/flow_v0.60.x-/react-navigation_v3.x.x.js
+++ b/definitions/npm/react-navigation_v3.x.x/flow_v0.60.x-/react-navigation_v3.x.x.js
@@ -238,6 +238,7 @@ declare module 'react-navigation' {
      */
     index: number,
     routes: Array<NavigationRoute>,
+    isTransitioning?: bool,
   };
 
   declare export type NavigationRoute =
@@ -468,10 +469,10 @@ declare module 'react-navigation' {
     disableKeyboardHandling?: boolean,
   |};
 
-  declare export type StackNavigatorConfig = {|
+  declare export type StackNavigatorConfig = $Shape<{|
     ...NavigationStackViewConfig,
     ...NavigationStackRouterConfig,
-  |};
+  |}>;
 
   /**
    * Switch Navigator
@@ -713,6 +714,7 @@ declare module 'react-navigation' {
     isStale: boolean,
     key: string,
     route: NavigationRoute,
+    descriptor: ?NavigationDescriptor,
   };
 
   declare export type NavigationTransitionProps = $Shape<{
@@ -924,9 +926,9 @@ declare module 'react-navigation' {
     router: NavigationRouter<S, O>,
   };
 
-  declare type NavigationDescriptor = {
+  declare export type NavigationDescriptor = {
     key: string,
-    state: NavigationLeafRoute | NavigationStateRoute,
+    state: NavigationRoute,
     navigation: NavigationScreenProp<*>,
     getComponent: () => React$ComponentType<{}>,
   };


### PR DESCRIPTION
This change corresponds to the following changes from the `react-navigation` repo:

1. Add `isTransitioning` property to `NavigationState` so custom navigators can inspect it.
2. Make `StackNavigatorConfig` a `$Shape`, which is correct since none of the properties are required.
3. Add the `descriptor` property to `NavigationScene` and export `NavigationDescriptor`.

This is covered by the following `react-navigation` Flow libdef PRs:

1. https://github.com/react-navigation/react-navigation/pull/5801