### PR TITLE
[koa] fix ctx.cookies.set() options

### DIFF
--- a/definitions/npm/koa_v2.0.x/flow_v0.47.x-v0.92.x/koa_v2.0.x.js
+++ b/definitions/npm/koa_v2.0.x/flow_v0.47.x-v0.92.x/koa_v2.0.x.js
@@ -188,8 +188,8 @@ declare module 'koa' {
   };
   // https://github.com/pillarjs/cookies
   declare type CookiesSetOptions = {
-    domain: string, // domain of the cookie (no default).
-    maxAge: number, // milliseconds from Date.now() for expiry
+    domain?: string, // domain of the cookie (no default).
+    maxAge?: number, // milliseconds from Date.now() for expiry
     expires?: Date, //cookie's expiration date (expires at the end of session by default).
     path?: string, //  the path of the cookie (/ by default).
     secure?: boolean, // false by default for HTTP, true by default for HTTPS

--- a/definitions/npm/koa_v2.0.x/flow_v0.93.x/koa_v2.0.x.js
+++ b/definitions/npm/koa_v2.0.x/flow_v0.93.x/koa_v2.0.x.js
@@ -188,8 +188,8 @@ declare module 'koa' {
   };
   // https://github.com/pillarjs/cookies
   declare type CookiesSetOptions = {
-    domain: string, // domain of the cookie (no default).
-    maxAge: number, // milliseconds from Date.now() for expiry
+    domain?: string, // domain of the cookie (no default).
+    maxAge?: number, // milliseconds from Date.now() for expiry
     expires?: Date, //cookie's expiration date (expires at the end of session by default).
     path?: string, //  the path of the cookie (/ by default).
     secure?: boolean, // false by default for HTTP, true by default for HTTPS

--- a/definitions/npm/koa_v2.0.x/flow_v0.94.x-/koa_v2.0.x.js
+++ b/definitions/npm/koa_v2.0.x/flow_v0.94.x-/koa_v2.0.x.js
@@ -175,8 +175,8 @@ declare module 'koa' {
   };
   // https://github.com/pillarjs/cookies
   declare type CookiesSetOptions = {
-    domain: string, // domain of the cookie (no default).
-    maxAge: number, // milliseconds from Date.now() for expiry
+    domain?: string, // domain of the cookie (no default).
+    maxAge?: number, // milliseconds from Date.now() for expiry
     expires?: Date, //cookie's expiration date (expires at the end of session by default).
     path?: string, //  the path of the cookie (/ by default).
     secure?: boolean, // false by default for HTTP, true by default for HTTPS

--- a/definitions/npm/koa_v2.x.x/flow_v0.47.x-v0.92.x/koa_v2.x.x.js
+++ b/definitions/npm/koa_v2.x.x/flow_v0.47.x-v0.92.x/koa_v2.x.x.js
@@ -193,8 +193,8 @@ declare module 'koa' {
   };
   // https://github.com/pillarjs/cookies
   declare type CookiesSetOptions = {
-    domain: string, // domain of the cookie (no default).
-    maxAge: number, // milliseconds from Date.now() for expiry
+    domain?: string, // domain of the cookie (no default).
+    maxAge?: number, // milliseconds from Date.now() for expiry
     expires?: Date, //cookie's expiration date (expires at the end of session by default).
     path?: string, //  the path of the cookie (/ by default).
     secure?: boolean, // false by default for HTTP, true by default for HTTPS

--- a/definitions/npm/koa_v2.x.x/flow_v0.93.x/koa_v2.x.x.js
+++ b/definitions/npm/koa_v2.x.x/flow_v0.93.x/koa_v2.x.x.js
@@ -193,8 +193,8 @@ declare module 'koa' {
   };
   // https://github.com/pillarjs/cookies
   declare type CookiesSetOptions = {
-    domain: string, // domain of the cookie (no default).
-    maxAge: number, // milliseconds from Date.now() for expiry
+    domain?: string, // domain of the cookie (no default).
+    maxAge?: number, // milliseconds from Date.now() for expiry
     expires?: Date, //cookie's expiration date (expires at the end of session by default).
     path?: string, //  the path of the cookie (/ by default).
     secure?: boolean, // false by default for HTTP, true by default for HTTPS

--- a/definitions/npm/koa_v2.x.x/flow_v0.94.x-/koa_v2.x.x.js
+++ b/definitions/npm/koa_v2.x.x/flow_v0.94.x-/koa_v2.x.x.js
@@ -180,8 +180,8 @@ declare module 'koa' {
   };
   // https://github.com/pillarjs/cookies
   declare type CookiesSetOptions = {
-    domain: string, // domain of the cookie (no default).
-    maxAge: number, // milliseconds from Date.now() for expiry
+    domain?: string, // domain of the cookie (no default).
+    maxAge?: number, // milliseconds from Date.now() for expiry
     expires?: Date, //cookie's expiration date (expires at the end of session by default).
     path?: string, //  the path of the cookie (/ by default).
     secure?: boolean, // false by default for HTTP, true by default for HTTPS


### PR DESCRIPTION
- Links to documentation: https://github.com/pillarjs/cookies#cookiesset-name--value---options--
- Link to GitHub or NPM: https://github.com/koajs/koa
- Type of contribution: fix

Other notes:

Here's the source-code which shows that both maxAge and domain are optional for cookies.
https://github.com/pillarjs/cookies/blob/master/index.js#L150-L175