### PR TITLE
[apollo-client] Fix issue with query/mutate functions and passing variables

### DIFF
--- a/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
+++ b/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
@@ -270,7 +270,7 @@ declare module "apollo-client" {
   };
 
   declare interface ModifiableWatchQueryOptions {
-    variables?: { [key: string]: any };
+    variables?: any;
     pollInterval?: number;
     fetchPolicy?: FetchPolicy;
     errorPolicy?: ErrorPolicy;
@@ -310,7 +310,7 @@ declare module "apollo-client" {
 
   declare export interface SubscriptionOptions {
     query: DocumentNode;
-    variables?: { [key: string]: any };
+    variables?: any;
   }
 
   declare export type FetchPolicy =
@@ -368,7 +368,7 @@ declare module "apollo-client" {
 
   declare export type PureQueryOptions = {
     query: DocumentNode,
-    variables?: { [key: string]: any }
+    variables?: any,
   };
 
   declare export type ApolloQueryResult<T> = {
@@ -495,7 +495,7 @@ declare module "apollo-client" {
 
   declare interface GraphQLRequest {
     query: DocumentNode;
-    variables?: { [key: string]: any };
+    variables?: any;
     operationName?: string;
     context?: { [key: string]: any };
     extensions?: { [key: string]: any };

--- a/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
+++ b/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
@@ -278,7 +278,8 @@ declare module "apollo-client" {
     notifyOnNetworkStatusChange?: boolean;
   }
 
-  declare export type WatchQueryOptions = ModifiableWatchQueryOptions & {
+  declare export type WatchQueryOptions = {
+    ...$Exact<ModifiableWatchQueryOptions>,
     query: DocumentNode;
     metadata?: any;
     context?: any;
@@ -494,7 +495,7 @@ declare module "apollo-client" {
 
   declare interface GraphQLRequest {
     query: DocumentNode;
-    variables?: any;
+    variables?: { [key: string]: any };
     operationName?: string;
     context?: { [key: string]: any };
     extensions?: { [key: string]: any };

--- a/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
+++ b/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
@@ -269,8 +269,8 @@ declare module "apollo-client" {
     partial?: boolean
   };
 
-  declare interface ModifiableWatchQueryOptions {
-    variables?: any;
+  declare export type ModifiableWatchQueryOptions = {
+    variables?: { [key: string]: any };
     pollInterval?: number;
     fetchPolicy?: FetchPolicy;
     errorPolicy?: ErrorPolicy;
@@ -278,8 +278,7 @@ declare module "apollo-client" {
     notifyOnNetworkStatusChange?: boolean;
   }
 
-  declare export interface WatchQueryOptions
-    extends ModifiableWatchQueryOptions {
+  declare export type WatchQueryOptions = ModifiableWatchQueryOptions & {
     query: DocumentNode;
     metadata?: any;
     context?: any;
@@ -308,9 +307,9 @@ declare module "apollo-client" {
     fetchPolicy?: FetchPolicy;
   }
 
-  declare export interface SubscriptionOptions {
+  declare export type SubscriptionOptions = {
     query: DocumentNode;
-    variables?: any;
+    variables?: { [key: string]: any };
   }
 
   declare export type FetchPolicy =
@@ -368,7 +367,7 @@ declare module "apollo-client" {
 
   declare export type PureQueryOptions = {
     query: DocumentNode,
-    variables?: any,
+    variables?: { [key: string ]: any },
   };
 
   declare export type ApolloQueryResult<T> = {

--- a/definitions/npm/apollo-client_v2.x.x/test_apollo-client_v2.x.x.js
+++ b/definitions/npm/apollo-client_v2.x.x/test_apollo-client_v2.x.x.js
@@ -16,6 +16,34 @@ describe("apollo-client", () => {
       });
     });
 
+    it("query function passes", async () => {
+      const client = new ApolloClient({
+        link,
+        cache
+      });
+      const result = await client.query({
+        query: ``,
+        variables: {
+          hello: 'world'
+        }
+      });
+      result.data;
+    });
+
+    it("mutate function passes", async () => {
+      const client = new ApolloClient({
+        link,
+        cache
+      });
+      const result = await client.mutate({
+        mutation: ``,
+        variables: {
+          hello: 'world'
+        }
+      });
+      result.data;
+    });
+
     it("passes with default export", () => {
       new ApolloClientDefault({
         link,


### PR DESCRIPTION
- Links to documentation: https://www.apollographql.com/docs/react/api/apollo-client#ApolloClient.query
- Link to GitHub or NPM: https://github.com/apollographql/apollo-client/
- Type of contribution: fix

This fixes an issue where variables could not be passed to query/mutate functions and adds a regression test.

Fixes #2888 