### PR TITLE
[react-navigation] Fix NavigationScreenProp.getParam type

### DIFF
--- a/definitions/npm/@react-navigation/core_v3.x.x/flow_v0.92.x-/core_v3.x.x.js
+++ b/definitions/npm/@react-navigation/core_v3.x.x/flow_v0.92.x-/core_v3.x.x.js
@@ -485,8 +485,8 @@ declare module '@react-navigation/core' {
       fallback?: $ElementType<
         $PropertyType<
           {|
+            ...{| params: { } |},
             ...$Exact<S>,
-            ...{| params: {| [ParamName]: void |} |},
           |},
           'params'
         >,
@@ -495,8 +495,8 @@ declare module '@react-navigation/core' {
     ) => $ElementType<
       $PropertyType<
         {|
+          ...{| params: { } |},
           ...$Exact<S>,
-          ...{| params: {| [ParamName]: void |} |},
         |},
         'params'
       >,

--- a/definitions/npm/react-navigation_v3.x.x/flow_v0.92.x-/react-navigation_v3.x.x.js
+++ b/definitions/npm/react-navigation_v3.x.x/flow_v0.92.x-/react-navigation_v3.x.x.js
@@ -589,8 +589,8 @@ declare module 'react-navigation' {
       fallback?: $ElementType<
         $PropertyType<
           {|
+            ...{| params: { } |},
             ...$Exact<S>,
-            ...{| params: {| [ParamName]: void |} |},
           |},
           'params'
         >,
@@ -599,8 +599,8 @@ declare module 'react-navigation' {
     ) => $ElementType<
       $PropertyType<
         {|
+          ...{| params: { } |},
           ...$Exact<S>,
-          ...{| params: {| [ParamName]: void |} |},
         |},
         'params'
       >,


### PR DESCRIPTION
In my last PR I flipped the order of these around to fix an error, but turns out that was just crippling the type. The correct solution here, to guarantee that the `$PropertyType` won't error if its type parameter don't have the property, is to use an unsealed object type.