### PR TITLE
Export types from winston libdef

### DIFF
--- a/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
@@ -1,93 +1,93 @@
-declare type $winstonLevels = {
-  [string]: number
-};
+declare module 'winston' {
+  declare export type $winstonLevels = {
+    [string]: number
+  };
 
-declare type $winstonNpmLogLevels = {
-  error: number,
-  warn: number,
-  info: number,
-  verbose: number,
-  debug: number,
-  silly: number
-};
+  declare export type $winstonNpmLogLevels = {
+    error: number,
+    warn: number,
+    info: number,
+    verbose: number,
+    debug: number,
+    silly: number
+  };
 
-declare type $winstonInfo<T: $winstonLevels> = {
-  [optionName: string]: any,
-  level: $Keys<T>,
-  message: string
-};
+  declare export type $winstonInfo<T: $winstonLevels> = {
+    [optionName: string]: any,
+    level: $Keys<T>,
+    message: string
+  };
 
-declare type $winstonFormat = Object;
+  declare export type $winstonFormat = Object;
 
-declare type $winstonFileTransportConfig<T: $winstonLevels> = {
-  filename: string,
-  level?: $Keys<T>
-};
+  declare export type $winstonFileTransportConfig<T: $winstonLevels> = {
+    filename: string,
+    level?: $Keys<T>
+  };
 
-declare class $winstonTransport {
-  level?: string;
-  silent?: boolean;
-}
+  declare export class $winstonTransport {
+    level?: string;
+    silent?: boolean;
+  }
 
-declare class $winstonFileTransport<T> extends $winstonTransport {
-  constructor($winstonFileTransportConfig<T>): $winstonFileTransport<T>;
-}
+  declare export class $winstonFileTransport<T> extends $winstonTransport {
+    constructor($winstonFileTransportConfig<T>): $winstonFileTransport<T>;
+  }
 
-declare type $winstonConsoleTransportConfig<T: $winstonLevels> = {
-  level?: $Keys<T>
-};
+  declare export type $winstonConsoleTransportConfig<T: $winstonLevels> = {
+    level?: $Keys<T>
+  };
 
-declare class $winstonConsoleTransport<T> extends $winstonTransport {
-  constructor(
-    config?: $winstonConsoleTransportConfig<T>
-  ): $winstonConsoleTransport<T>;
-}
+  declare export class $winstonConsoleTransport<T> extends $winstonTransport {
+    constructor(config?: $winstonConsoleTransportConfig<T>): $winstonConsoleTransport<T>;
+  }
 
-declare type $winstonLoggerConfig<T: $winstonLevels> = {
-  exitOnError?: boolean,
-  format?: $winstonFormat,
-  level?: $Keys<T>,
-  levels?: T,
-  transports?: Array<$winstonTransport>
-};
+  declare export type $winstonLoggerConfig<T: $winstonLevels> = {
+    exitOnError?: boolean,
+    format?: $winstonFormat,
+    level?: $Keys<T>,
+    levels?: T,
+    transports?: Array<$winstonTransport>
+  };
 
-declare type $winstonLogger<T: $winstonLevels> = {
-  [$Keys<T>]: (message: string, meta?: Object) => void,
-  add: $winstonTransport => void,
-  clear: () => void,
-  configure: ($winstonLoggerConfig<T>) => void,
-  log: (message: $winstonInfo<T>) => void,
-  remove: $winstonTransport => void
-};
+  declare export type $winstonLogger<T: $winstonLevels> = {
+    [$Keys<T>]: (message: string, meta?: Object) => void,
+    add: $winstonTransport => void,
+    clear: () => void,
+    configure: ($winstonLoggerConfig<T>) => void,
+    log: (message: $winstonInfo<T>) => void,
+    remove: $winstonTransport => void
+  };
 
-declare type $winstonConfigSubModule = {
-  npm: () => $winstonNpmLogLevels
-};
+  declare export type $winstonConfigSubModule = {
+    npm: () => $winstonNpmLogLevels
+  };
 
-declare type $winstonFormatSubModule = {
-  combine: (...args: Array<$winstonFormat>) => $winstonFormat,
-  json: () => $winstonFormat,
-  label: (config?: Object) => $winstonFormat,
-  metadata: () => $winstonFormat,
-  prettyPrint: () => $winstonFormat,
-  simple: () => $winstonFormat,
-  splat: () => $winstonFormat,
-  timestamp: (?{ alias?: string, format?: string }) => $winstonFormat,
-  colorize: () => $winstonFormat,
-  logstash: () => $winstonFormat,
-  printf: ((args: $winstonInfo<Object>) => string) => $winstonFormat
-};
+  declare export type $winstonFormatSubModule = {
+    ((info: Object) => Object): $winstonFormat,
+    combine: (...args: Array<$winstonFormat>) => $winstonFormat,
+    json: () => $winstonFormat,
+    label: (config?: Object) => $winstonFormat,
+    metadata: () => $winstonFormat,
+    prettyPrint: () => $winstonFormat,
+    simple: () => $winstonFormat,
+    splat: () => $winstonFormat,
+    timestamp: (?{ alias?: string, format?: string }) => $winstonFormat,
+    colorize: () => $winstonFormat,
+    logstash: () => $winstonFormat,
+    printf: ((args: $winstonInfo<Object>) => string) => $winstonFormat
+  };
 
-declare type $winstonDefaultLogger = $winstonLogger<$winstonNpmLogLevels>;
+  declare export type $winstonDefaultLogger = $winstonLogger<$winstonNpmLogLevels>;
 
-declare class $winstonContainer<T> {
-  constructor(config?: $winstonLoggerConfig<T>): $winstonContainer<T>;
-  add(loggerId: string, config?: $winstonLoggerConfig<T>): $winstonLogger<T>;
-  get(loggerId: string): $winstonLogger<T>;
-}
+  declare export class $winstonContainer<T> {
+    constructor(config?: $winstonLoggerConfig<T>): $winstonContainer<T>;
+    add(loggerId: string, config?: $winstonLoggerConfig<T>): $winstonLogger<T>;
+    get(loggerId: string): $winstonLogger<T>;
+    has(loggerId: string): boolean;
+  }
 
-declare module "winston" {
-  declare module.exports: $winstonDefaultLogger & {
+  declare export default $winstonDefaultLogger & {
     format: $winstonFormatSubModule,
     transports: {
       Console: typeof $winstonConsoleTransport,
@@ -95,6 +95,6 @@ declare module "winston" {
     },
     createLogger: <T>($winstonLoggerConfig<T>) => $winstonLogger<T>,
     Container: typeof $winstonContainer,
-    loggers: $winstonContainer<*>
+    loggers: $winstonContainer<$winstonLevels>
   };
 }

--- a/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
@@ -1,93 +1,111 @@
-declare module 'winston' {
-  declare export type $winstonLevels = {
-    [string]: number
-  };
+declare type $winstonLevels = {
+  [string]: number
+};
 
-  declare export type $winstonNpmLogLevels = {
-    error: number,
-    warn: number,
-    info: number,
-    verbose: number,
-    debug: number,
-    silly: number
-  };
+declare type $winstonNpmLogLevels = {
+  error: number,
+  warn: number,
+  info: number,
+  verbose: number,
+  debug: number,
+  silly: number
+};
 
-  declare export type $winstonInfo<T: $winstonLevels> = {
-    [optionName: string]: any,
-    level: $Keys<T>,
-    message: string
-  };
+declare type $winstonInfo<T: $winstonLevels> = {
+  [optionName: string]: any,
+  level: $Keys<T>,
+  message: string
+};
 
-  declare export type $winstonFormat = Object;
+declare type $winstonFormat = Object;
 
-  declare export type $winstonFileTransportConfig<T: $winstonLevels> = {
-    filename: string,
-    level?: $Keys<T>
-  };
+declare type $winstonFileTransportConfig<T: $winstonLevels> = {
+  filename: string,
+  level?: $Keys<T>
+};
 
-  declare export class $winstonTransport {
-    level?: string;
-    silent?: boolean;
-  }
+declare class $winstonTransport {
+  level?: string;
+  silent?: boolean;
+}
 
-  declare export class $winstonFileTransport<T> extends $winstonTransport {
-    constructor($winstonFileTransportConfig<T>): $winstonFileTransport<T>;
-  }
+declare class $winstonFileTransport<T> extends $winstonTransport {
+  constructor($winstonFileTransportConfig<T>): $winstonFileTransport<T>;
+}
 
-  declare export type $winstonConsoleTransportConfig<T: $winstonLevels> = {
-    level?: $Keys<T>
-  };
+declare type $winstonConsoleTransportConfig<T: $winstonLevels> = {
+  level?: $Keys<T>
+};
 
-  declare export class $winstonConsoleTransport<T> extends $winstonTransport {
-    constructor(config?: $winstonConsoleTransportConfig<T>): $winstonConsoleTransport<T>;
-  }
+declare class $winstonConsoleTransport<T> extends $winstonTransport {
+  constructor(
+    config?: $winstonConsoleTransportConfig<T>
+  ): $winstonConsoleTransport<T>;
+}
 
-  declare export type $winstonLoggerConfig<T: $winstonLevels> = {
-    exitOnError?: boolean,
-    format?: $winstonFormat,
-    level?: $Keys<T>,
-    levels?: T,
-    transports?: Array<$winstonTransport>
-  };
+declare type $winstonLoggerConfig<T: $winstonLevels> = {
+  exitOnError?: boolean,
+  format?: $winstonFormat,
+  level?: $Keys<T>,
+  levels?: T,
+  transports?: Array<$winstonTransport>
+};
 
-  declare export type $winstonLogger<T: $winstonLevels> = {
-    [$Keys<T>]: (message: string, meta?: Object) => void,
-    add: $winstonTransport => void,
-    clear: () => void,
-    configure: ($winstonLoggerConfig<T>) => void,
-    log: (message: $winstonInfo<T>) => void,
-    remove: $winstonTransport => void
-  };
+declare type $winstonLogger<T: $winstonLevels> = {
+  [$Keys<T>]: (message: string, meta?: Object) => void,
+  add: $winstonTransport => void,
+  clear: () => void,
+  configure: ($winstonLoggerConfig<T>) => void,
+  log: (message: $winstonInfo<T>) => void,
+  remove: $winstonTransport => void
+};
 
-  declare export type $winstonConfigSubModule = {
-    npm: () => $winstonNpmLogLevels
-  };
+declare type $winstonConfigSubModule = {
+  npm: () => $winstonNpmLogLevels
+};
 
-  declare export type $winstonFormatSubModule = {
-    ((info: Object) => Object): () => $winstonFormat,
-    combine: (...args: Array<$winstonFormat>) => $winstonFormat,
-    json: () => $winstonFormat,
-    label: (config?: Object) => $winstonFormat,
-    metadata: () => $winstonFormat,
-    prettyPrint: () => $winstonFormat,
-    simple: () => $winstonFormat,
-    splat: () => $winstonFormat,
-    timestamp: (?{ alias?: string, format?: string }) => $winstonFormat,
-    colorize: () => $winstonFormat,
-    logstash: () => $winstonFormat,
-    printf: ((args: $winstonInfo<Object>) => string) => $winstonFormat
-  };
+declare type $winstonFormatSubModule = {
+  ((info: Object) => Object): () => $winstonFormat,
+  combine: (...args: Array<$winstonFormat>) => $winstonFormat,
+  json: () => $winstonFormat,
+  label: (config?: Object) => $winstonFormat,
+  metadata: () => $winstonFormat,
+  prettyPrint: () => $winstonFormat,
+  simple: () => $winstonFormat,
+  splat: () => $winstonFormat,
+  timestamp: (?{ alias?: string, format?: string }) => $winstonFormat,
+  colorize: () => $winstonFormat,
+  logstash: () => $winstonFormat,
+  printf: ((args: $winstonInfo<Object>) => string) => $winstonFormat
+};
 
-  declare export type $winstonDefaultLogger = $winstonLogger<$winstonNpmLogLevels>;
+declare type $winstonDefaultLogger = $winstonLogger<$winstonNpmLogLevels>;
 
-  declare export class $winstonContainer<T> {
-    constructor(config?: $winstonLoggerConfig<T>): $winstonContainer<T>;
-    add(loggerId: string, config?: $winstonLoggerConfig<T>): $winstonLogger<T>;
-    get(loggerId: string): $winstonLogger<T>;
-    has(loggerId: string): boolean;
-  }
+declare class $winstonContainer<T> {
+  constructor(config?: $winstonLoggerConfig<T>): $winstonContainer<T>;
+  add(loggerId: string, config?: $winstonLoggerConfig<T>): $winstonLogger<T>;
+  get(loggerId: string): $winstonLogger<T>;
+  has(loggerId: string): boolean;
+}
 
-  declare export default $winstonDefaultLogger & {
+declare module "winston" {
+  declare export type $WinstonLevels = $winstonLevels;
+  declare export type $WinstonNpmLogLevels = $winstonNpmLogLevels;
+  declare export type $WinstonInfo<T: $WinstonLevels > = $winstonInfo<T>;
+  declare export type $WinstonFormat = $winstonFormat;
+  declare export type $WinstonFileTransportConfig<T: $WinstonLevels> = $winstonFileTransportConfig<T>;
+  declare export type $WinstonTransport = typeof $winstonTransport;
+  declare export type $WinstonFileTransport<T: $WinstonLevels> = $winstonFileTransport<T>;
+  declare export type $WinstonConsoleTransportConfig<T: $WinstonLevels> = $winstonConsoleTransportConfig<T>;
+  declare export type $WinstonConsoleTransport<T: $WinstonLevels> = $winstonConsoleTransport<T>;
+  declare export type $WinstonLoggerConfig<T: $WinstonLevels> = $winstonLoggerConfig<T>;
+  declare export type $WinstonLogger<T: $WinstonLevels> = $winstonLogger<T>;
+  declare export type $WinstonConfigSubModule = $winstonConfigSubModule;
+  declare export type $WinstonFormatSubModule = $winstonFormatSubModule;
+  declare export type $WinstonDefaultLogger = $winstonDefaultLogger;
+  declare export type $WinstonContainer<T: $WinstonLevels> = $winstonContainer<T>;
+
+  declare module.exports: $winstonDefaultLogger & {
     format: $winstonFormatSubModule,
     transports: {
       Console: typeof $winstonConsoleTransport,
@@ -95,6 +113,6 @@ declare module 'winston' {
     },
     createLogger: <T>($winstonLoggerConfig<T>) => $winstonLogger<T>,
     Container: typeof $winstonContainer,
-    loggers: $winstonContainer<$winstonLevels>
+    loggers: $winstonContainer<*>
   };
 }

--- a/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
@@ -64,7 +64,7 @@ declare module 'winston' {
   };
 
   declare export type $winstonFormatSubModule = {
-    ((info: Object) => Object): $winstonFormat,
+    ((info: Object) => Object): () => $winstonFormat,
     combine: (...args: Array<$winstonFormat>) => $winstonFormat,
     json: () => $winstonFormat,
     label: (config?: Object) => $winstonFormat,

--- a/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
@@ -89,21 +89,21 @@ declare class $winstonContainer<T> {
 }
 
 declare module "winston" {
-  declare export type $WinstonLevels = $winstonLevels;
-  declare export type $WinstonNpmLogLevels = $winstonNpmLogLevels;
-  declare export type $WinstonInfo<T: $WinstonLevels > = $winstonInfo<T>;
-  declare export type $WinstonFormat = $winstonFormat;
-  declare export type $WinstonFileTransportConfig<T: $WinstonLevels> = $winstonFileTransportConfig<T>;
-  declare export type $WinstonTransport = typeof $winstonTransport;
-  declare export type $WinstonFileTransport<T: $WinstonLevels> = $winstonFileTransport<T>;
-  declare export type $WinstonConsoleTransportConfig<T: $WinstonLevels> = $winstonConsoleTransportConfig<T>;
-  declare export type $WinstonConsoleTransport<T: $WinstonLevels> = $winstonConsoleTransport<T>;
-  declare export type $WinstonLoggerConfig<T: $WinstonLevels> = $winstonLoggerConfig<T>;
-  declare export type $WinstonLogger<T: $WinstonLevels> = $winstonLogger<T>;
-  declare export type $WinstonConfigSubModule = $winstonConfigSubModule;
-  declare export type $WinstonFormatSubModule = $winstonFormatSubModule;
-  declare export type $WinstonDefaultLogger = $winstonDefaultLogger;
-  declare export type $WinstonContainer<T: $WinstonLevels> = $winstonContainer<T>;
+  declare export type Levels = $winstonLevels;
+  declare export type NpmLogLevels = $winstonNpmLogLevels;
+  declare export type Info<T: Levels > = $winstonInfo<T>;
+  declare export type Format = $winstonFormat;
+  declare export type FileTransportConfig<T: Levels> = $winstonFileTransportConfig<T>;
+  declare export type Transport = typeof $winstonTransport;
+  declare export type FileTransport<T: Levels> = $winstonFileTransport<T>;
+  declare export type ConsoleTransportConfig<T: Levels> = $winstonConsoleTransportConfig<T>;
+  declare export type ConsoleTransport<T: Levels> = $winstonConsoleTransport<T>;
+  declare export type LoggerConfig<T: Levels> = $winstonLoggerConfig<T>;
+  declare export type Logger<T: Levels> = $winstonLogger<T>;
+  declare export type ConfigSubModule = $winstonConfigSubModule;
+  declare export type FormatSubModule = $winstonFormatSubModule;
+  declare export type DefaultLogger = $winstonDefaultLogger;
+  declare export type Container<T: Levels> = $winstonContainer<T>;
 
   declare module.exports: $winstonDefaultLogger & {
     format: $winstonFormatSubModule,

--- a/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
@@ -1,5 +1,5 @@
 import winston from "winston";
-import type { $WinstonLogger, $WinstonLevels, $WinstonFormat, $WinstonConsoleTransport, $WinstonContainer } from "winston";
+import type { Logger, Levels, Format, ConsoleTransport, Container } from "winston";
 
 winston.log({
   level: "info",
@@ -13,11 +13,11 @@ winston.nonExistantLevel("default logger nonExistantLevel message");
 // https://github.com/winstonjs/winston/blob/c868f0ccdc6ddc45e586c9808d99ebae8351113b/README.md#formats
 const customFormat = winston.format(info => info);
 
-const customPrintf: $WinstonFormat = winston.format.printf(info => {
+const customPrintf: Format = winston.format.printf(info => {
   return `${info.level}: ${info.message}`;
 });
 
-let logger: $WinstonLogger<$WinstonLevels> = winston.createLogger({
+let logger: Logger<Levels> = winston.createLogger({
   format: winston.format.combine(
     customFormat(),
     winston.format.json(),
@@ -47,7 +47,7 @@ logger.log({
 
 logger.clear();
 
-const consoleTransport: $WinstonConsoleTransport<$WinstonLevels> = new winston.transports.Console();
+const consoleTransport: ConsoleTransport<Levels> = new winston.transports.Console();
 
 consoleTransport.level = 'debug';
 consoleTransport.silent = true;
@@ -84,7 +84,7 @@ const hasCategoryOneId: boolean = winston.loggers.has("categoryOneId");
 
 logger.debug("categoryOneId debug message");
 
-const container: $WinstonContainer<$WinstonLevels> = new winston.Container({
+const container: Container<Levels> = new winston.Container({
   format: winston.format.json(),
   level: "debug",
   transports: [new winston.transports.File({ filename: "new-container.log" })]

--- a/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
@@ -1,4 +1,5 @@
 import winston from "winston";
+import type { $WinstonLogger, $WinstonLevels, $WinstonFormat, $WinstonConsoleTransport, $WinstonContainer } from "winston";
 
 winston.log({
   level: "info",
@@ -12,11 +13,11 @@ winston.nonExistantLevel("default logger nonExistantLevel message");
 // https://github.com/winstonjs/winston/blob/c868f0ccdc6ddc45e586c9808d99ebae8351113b/README.md#formats
 const customFormat = winston.format(info => info);
 
-const customPrintf = winston.format.printf(info => {
+const customPrintf: $WinstonFormat = winston.format.printf(info => {
   return `${info.level}: ${info.message}`;
 });
 
-let logger = winston.createLogger({
+let logger: $WinstonLogger<$WinstonLevels> = winston.createLogger({
   format: winston.format.combine(
     customFormat(),
     winston.format.json(),
@@ -46,7 +47,7 @@ logger.log({
 
 logger.clear();
 
-const consoleTransport = new winston.transports.Console();
+const consoleTransport: $WinstonConsoleTransport<$WinstonLevels> = new winston.transports.Console();
 
 consoleTransport.level = 'debug';
 consoleTransport.silent = true;
@@ -79,21 +80,21 @@ logger = winston.loggers.add("categoryOneId", {
   level: "debug",
   transports: [new winston.transports.Console()]
 });
-const hasCategoryOneId = winston.loggers.has("categoryOneId");
+const hasCategoryOneId: boolean = winston.loggers.has("categoryOneId");
 
 logger.debug("categoryOneId debug message");
 
-const container = new winston.Container({
+const container: $WinstonContainer<$WinstonLevels> = new winston.Container({
   format: winston.format.json(),
   level: "debug",
   transports: [new winston.transports.File({ filename: "new-container.log" })]
 });
 
 container.add("categoryTwoId");
-const hasCategoryTwoId = container.has("categoryTwoId");
+const hasCategoryTwoId: boolean = container.has("categoryTwoId");
 
 container.add("categoryThreeId");
-const hasCategoryThreeId = container.has("categoryThreeId");
+const hasCategoryThreeId: boolean = container.has("categoryThreeId");
 
 logger = container.get("categoryTwoId");
 

--- a/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
@@ -10,11 +10,15 @@ winston.nonExistantLevel("default logger nonExistantLevel message");
 
 // See example:
 // https://github.com/winstonjs/winston/blob/c868f0ccdc6ddc45e586c9808d99ebae8351113b/README.md#formats
+const customFormat = winston.format(info => info);
+
 const customPrintf = winston.format.printf(info => {
   return `${info.level}: ${info.message}`;
 });
+
 let logger = winston.createLogger({
   format: winston.format.combine(
+    customFormat(),
     winston.format.json(),
     winston.format.label({label: 'label'}),
     winston.format.colorize(),
@@ -75,6 +79,7 @@ logger = winston.loggers.add("categoryOneId", {
   level: "debug",
   transports: [new winston.transports.Console()]
 });
+const hasCategoryOneId = winston.loggers.has("categoryOneId");
 
 logger.debug("categoryOneId debug message");
 
@@ -83,8 +88,12 @@ const container = new winston.Container({
   level: "debug",
   transports: [new winston.transports.File({ filename: "new-container.log" })]
 });
+
 container.add("categoryTwoId");
+const hasCategoryTwoId = container.has("categoryTwoId");
+
 container.add("categoryThreeId");
+const hasCategoryThreeId = container.has("categoryThreeId");
 
 logger = container.get("categoryTwoId");
 


### PR DESCRIPTION
- Links:
https://github.com/winstonjs/logform
https://github.com/winstonjs/winston
- Type of contribution: addition and refactor

Changes:
- All winston types are exported from libdef to make them available in external code
- Callable signature added for winston.format()
- has() method added for winston.Container

