### PR TITLE
[escape-string-regexp_v2.x.x] Add definition

### DIFF
--- a/definitions/npm/escape-string-regexp_v2.x.x/flow_v0.28.x-/escape-string-regexp_v2.x.x.js
+++ b/definitions/npm/escape-string-regexp_v2.x.x/flow_v0.28.x-/escape-string-regexp_v2.x.x.js
@@ -1,0 +1,3 @@
+declare module 'escape-string-regexp' {
+  declare module.exports: (input: string) => string;
+}

--- a/definitions/npm/escape-string-regexp_v2.x.x/test_escape-string-regexp_v2.x.x.js
+++ b/definitions/npm/escape-string-regexp_v2.x.x/test_escape-string-regexp_v2.x.x.js
@@ -1,0 +1,23 @@
+import escapeStringRegexp from 'escape-string-regexp';
+import { describe, it } from 'flow-typed-test';
+
+describe('escape-string-regexp', () => {
+  it('should pass if used properly', () => {
+    // => 'how much \$ for a unicorn\?'
+    const escapedString: string = escapeStringRegexp(
+      'how much $ for a unicorn?'
+    );
+
+    new RegExp(escapedString);
+  });
+
+  it('should raise an error if input is wrong', () => {
+    // $ExpectError
+    escapeStringRegexp(42);
+  });
+
+  it('should raise an error if output type is wrong', () => {
+    // $ExpectError
+    (escapeStringRegexp('how much $ for a unicorn?'): number);
+  });
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/sindresorhus/escape-string-regexp
- Link to GitHub or NPM: https://www.npmjs.com/package/escape-string-regexp
- Type of contribution: addition

Other notes:

Basically the same as
https://github.com/flow-typed/flow-typed/tree/master/definitions/npm/escape-string-regexp_v1.x.x