### PR TITLE
[path-to-regexp_v2] fix: Convert module path-to-regexp from ESM to CommonJS

### DIFF
--- a/definitions/npm/path-to-regexp_v2.x.x/flow_v0.25.x-/path-to-regexp_v2.x.x.js
+++ b/definitions/npm/path-to-regexp_v2.x.x/flow_v0.25.x-/path-to-regexp_v2.x.x.js
@@ -1,31 +1,31 @@
-declare module "path-to-regexp" {
+declare module 'path-to-regexp' {
   declare export type Key = {
-    name: string | number;
-    prefix: string;
-    delimiter: string;
-    optional: boolean;
-    repeat: boolean;
-    pattern: string;
-    partial: boolean;
-  }
+    name: string | number,
+    prefix: string,
+    delimiter: string,
+    optional: boolean,
+    repeat: boolean,
+    pattern: string,
+    partial: boolean,
+  };
 
   declare export type RegExpOptions = {
-    sensitive?: boolean;
-    strict?: boolean;
-    end?: boolean;
-    start?: boolean;
-    delimiter?: string;
-    endsWith?: string | string[];
-  }
+    sensitive?: boolean,
+    strict?: boolean,
+    end?: boolean,
+    start?: boolean,
+    delimiter?: string,
+    endsWith?: string | string[],
+  };
 
   declare export type ParseOptions = {
-    delimiter?: string;
-    delimiters?: string | string[];
-  }
+    delimiter?: string,
+    delimiters?: string | string[],
+  };
 
-  declare type PathFunctionOptions = {
-    encode?: (value: string, token: Key) => string;
-  }
+  declare export type PathFunctionOptions = {
+    encode?: (value: string, token: Key) => string,
+  };
 
   declare export type Token = string | Key;
 
@@ -36,21 +36,15 @@ declare module "path-to-regexp" {
     options?: PathFunctionOptions
   ) => string;
 
-  declare export var parse: (path: string, options?: ParseOptions) => Token[];
-
-  declare export var compile: (path: string, options?: {}) => PathFunction;
-
-  declare export var tokensToFunction: (tokens: Token[]) => PathFunction;
-
-  declare export var tokensToRegExp: (
-    tokens: Token[],
-    keys?: Key[],
-    options?: RegExpOptions
-  ) => RegExp;
-
-  declare export default (
-    path: Path,
-    keys?: Key[],
-    options?: RegExpOptions & ParseOptions
-  ) => RegExp;
+  declare module.exports: {
+    (path: Path, keys?: Key[], options?: RegExpOptions & ParseOptions): RegExp,
+    parse: (path: string, options?: ParseOptions) => Token[],
+    compile: (path: string, options?: {}) => PathFunction,
+    tokensToFunction: (tokens: Token[]) => PathFunction,
+    tokensToRegExp: (
+      tokens: Token[],
+      keys?: Key[],
+      options?: RegExpOptions
+    ) => RegExp,
+  };
 }

--- a/definitions/npm/path-to-regexp_v2.x.x/test_path-to-regexp_v2.x.x.js
+++ b/definitions/npm/path-to-regexp_v2.x.x/test_path-to-regexp_v2.x.x.js
@@ -1,43 +1,78 @@
 // @flow
+import { describe, it } from 'flow-typed-test';
+const pathToRegexp = require('path-to-regexp');
 
-import { describe, it } from "flow-typed-test";
+const { parse, compile, tokensToFunction, tokensToRegExp } = pathToRegexp;
 
-import { parse, compile, tokensToFunction, tokensToRegExp } from "path-to-regexp";
-
-describe("path-to-regexp", () => {
-  const url = "/test/url/:with/param";
+describe('path-to-regexp', () => {
+  const url = '/test/url/:with/param';
   const tokens = [
-    "/test",
-    "/url",
-    {name: "with", prefix: "/", delimiter: "/", optional: false, repeat: false, partial: false, pattern: "[^\\/]+?"},
-    "/param"
+    '/test',
+    '/url',
+    {
+      name: 'with',
+      prefix: '/',
+      delimiter: '/',
+      optional: false,
+      repeat: false,
+      partial: false,
+      pattern: '[^\\/]+?',
+    },
+    '/param',
   ];
   const badTokens = [
-    "/test",
-    "/url",
-    {prefix: "/", delimiter: "/", optional: false, repeat: false, partial: false, pattern: "[^\\/]+?"},
-    "/param"
+    '/test',
+    '/url',
+    {
+      prefix: '/',
+      delimiter: '/',
+      optional: false,
+      repeat: false,
+      partial: false,
+      pattern: '[^\\/]+?',
+    },
+    '/param',
   ];
 
-  it("parse", () => {
+  it('parse', () => {
     parse(url);
   });
 
-  it("compile", () => {
+  it('compile', () => {
     compile(url);
   });
 
-  it("tokensToFunction", () => {
+  it('tokensToFunction', () => {
     tokensToFunction(tokens);
 
     // $ExpectError
     tokensToFunction(badTokens);
   });
 
-  it("tokensToRegExp", () => {
+  it('tokensToRegExp', () => {
     tokensToRegExp(tokens);
 
     // $ExpectError
     tokensToRegExp(badTokens);
+  });
+
+  describe('pathToRegexp', () => {
+    it('should return regexp when call with one required argument', () => {
+      const path = 'string';
+
+      (pathToRegexp(path): RegExp);
+    });
+
+    it('should raises an error when call without argument', () => {
+      // $ExpectError: path is required argument
+      pathToRegexp();
+    });
+
+    it('should raises an error when pass path with invalid type', () => {
+      const path = true;
+
+      // $ExpectError: path must be `string` or `RegExp` or `Array<string or RegExp>`
+      pathToRegexp(path);
+    });
   });
 });


### PR DESCRIPTION
- Links to documentation: https://github.com/pillarjs/path-to-regexp
- Link to GitHub or NPM: https://github.com/pillarjs/path-to-regexp
- Type of contribution:  fix

Other notes:
via: https://github.com/flow-typed/flow-typed/issues/3274
