### PR TITLE
react-router correction which fixes #3007

### DIFF
--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-v0.52.x/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-v0.52.x/react-router-dom_v4.x.x.js
@@ -70,7 +70,9 @@ declare module 'react-router-dom' {
     goBack(): void,
     goForward(): void,
     canGo?: (n: number) => bool,
-    block(callback: (location: Location, action: HistoryAction) => boolean): void,
+    block(
+      callback: string | (location: Location, action: HistoryAction) => ?string
+    ): () => void,
     // createMemoryHistory
     index?: number,
     entries?: Array<Location>,

--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-v0.52.x/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-v0.52.x/test_react-router-dom.js
@@ -5,7 +5,8 @@ import {
   Link,
   NavLink,
   matchPath,
-  type Match
+  type Match,
+  type RouterHistory
 } from "react-router-dom";
 
 // BrowserRouter
@@ -85,6 +86,18 @@ import {
 
 // $ExpectError
 <NavLink />;
+
+const IncorrectHistoryBlockUsage = (history: RouterHistory) => {
+  // Wrong arguments here
+  // $ExpectError
+  history.block(false);
+
+  // These are valid
+  history.block('Are you sure you want to leave this page?');
+  history.block((location, action) => {
+    return 'Are you sure you want to leave this page?';
+  });
+};
 
 // matchPath
 const match: null | Match = matchPath("/the/pathname", {

--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.53.x-v0.62.x/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.53.x-v0.62.x/react-router-dom_v4.x.x.js
@@ -66,8 +66,8 @@ declare module "react-router-dom" {
     goForward(): void,
     canGo?: (n: number) => boolean,
     block(
-      callback: (location: Location, action: HistoryAction) => boolean
-    ): void,
+      callback: string | (location: Location, action: HistoryAction) => ?string
+    ): () => void,
     // createMemoryHistory
     index?: number,
     entries?: Array<Location>

--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.53.x-v0.62.x/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.53.x-v0.62.x/test_react-router-dom.js
@@ -8,7 +8,11 @@ import {
   matchPath,
   withRouter
 } from "react-router-dom";
-import type { ContextRouter, Match } from "react-router-dom";
+import type {
+  ContextRouter,
+  Match,
+  RouterHistory
+} from "react-router-dom";
 
 // BrowserRouter
 <BrowserRouter>
@@ -87,6 +91,18 @@ import type { ContextRouter, Match } from "react-router-dom";
 
 // $ExpectError
 <NavLink />;
+
+const IncorrectHistoryBlockUsage = (history: RouterHistory) => {
+  // Wrong arguments here
+  // $ExpectError
+  history.block(false);
+
+  // These are valid
+  history.block('Are you sure you want to leave this page?');
+  history.block((location, action) => {
+    return 'Are you sure you want to leave this page?';
+  });
+};
 
 // matchPath
 const match: null | Match = matchPath("/the/pathname", {

--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/react-router-dom_v4.x.x.js
@@ -66,8 +66,8 @@ declare module "react-router-dom" {
     goForward(): void,
     canGo?: (n: number) => boolean,
     block(
-      callback: (location: Location, action: HistoryAction) => boolean
-    ): void,
+      callback: string | (location: Location, action: HistoryAction) => ?string
+    ): () => void,
     // createMemoryHistory
     index?: number,
     entries?: Array<Location>

--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/test_react-router-dom.js
@@ -230,6 +230,22 @@ describe("react-router-dom", () => {
         );
         const WrappedComp = withRouter(Comp);
       });
+
+      it("errors if using block() incorrectly", () => {
+        const Comp = ({history}: {history: RouterHistory}) => {
+          // $ExpectError - wrong param
+          history.block(false);
+
+          // These are valid
+          history.block('Are you sure you want to leave this page?');
+          history.block((location, action) => {
+            return 'Are you sure you want to leave this page?';
+          });
+
+          return <div />;
+        };
+        const WrappedComp = withRouter(Comp);
+      });
     });
 
     describe("Class Components", () => {

--- a/definitions/npm/react-router-dom_v5.x.x/flow_v0.63.x-/react-router-dom_v5.x.x.js
+++ b/definitions/npm/react-router-dom_v5.x.x/flow_v0.63.x-/react-router-dom_v5.x.x.js
@@ -66,8 +66,8 @@ declare module "react-router-dom" {
     goForward(): void,
     canGo?: (n: number) => boolean,
     block(
-      callback: (location: Location, action: HistoryAction) => boolean
-    ): void,
+      callback: string | (location: Location, action: HistoryAction) => ?string
+    ): () => void,
     // createMemoryHistory
     index?: number,
     entries?: Array<Location>

--- a/definitions/npm/react-router-dom_v5.x.x/flow_v0.63.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v5.x.x/flow_v0.63.x-/test_react-router-dom.js
@@ -230,6 +230,22 @@ describe("react-router-dom", () => {
         );
         const WrappedComp = withRouter(Comp);
       });
+
+      it("errors if using block() incorrectly", () => {
+        const Comp = ({history}: {history: RouterHistory}) => {
+          // $ExpectError - wrong param
+          history.block(false);
+
+          // These are valid
+          history.block('Are you sure you want to leave this page?');
+          history.block((location, action) => {
+            return 'Are you sure you want to leave this page?';
+          });
+
+          return <div />;
+        };
+        const WrappedComp = withRouter(Comp);
+      });
     });
 
     describe("Class Components", () => {

--- a/definitions/npm/react-router_v4.x.x/flow_v0.30.x-v0.52.x/react-router_v4.x.x.js
+++ b/definitions/npm/react-router_v4.x.x/flow_v0.30.x-v0.52.x/react-router_v4.x.x.js
@@ -30,7 +30,9 @@ declare module 'react-router' {
     goBack(): void,
     goForward(): void,
     canGo?: (n: number) => bool,
-    block(callback: (location: Location, action: HistoryAction) => boolean): void,
+    block(
+      callback: string | (location: Location, action: HistoryAction) => ?string
+    ): () => void,
     // createMemoryHistory
     index?: number,
     entries?: Array<Location>,

--- a/definitions/npm/react-router_v4.x.x/flow_v0.30.x-v0.52.x/test_react-router.js
+++ b/definitions/npm/react-router_v4.x.x/flow_v0.30.x-v0.52.x/test_react-router.js
@@ -11,7 +11,12 @@ import {
   withRouter,
   matchPath
 } from "react-router";
-import type { Location, Match, ContextRouter } from "react-router";
+import type {
+  Location,
+  Match,
+  ContextRouter,
+  RouterHistory
+} from "react-router";
 
 // Location
 var locationOK: Location = {
@@ -153,6 +158,18 @@ const IncorrectHistoryUsage = ({ history, name }: Foo2Props) => {
       {name}
     </div>
   );
+};
+
+const IncorrectHistoryBlockUsage = (history: RouterHistory) => {
+  // Wrong arguments here
+  // $ExpectError
+  history.block(false);
+
+  // These are valid
+  history.block('Are you sure you want to leave this page?');
+  history.block((location, action) => {
+    return 'Are you sure you want to leave this page?';
+  });
 };
 
 // matchPath

--- a/definitions/npm/react-router_v4.x.x/flow_v0.53.x-v0.62.x/react-router_v4.x.x.js
+++ b/definitions/npm/react-router_v4.x.x/flow_v0.53.x-v0.62.x/react-router_v4.x.x.js
@@ -33,8 +33,8 @@ declare module "react-router" {
     goForward(): void,
     canGo?: (n: number) => boolean,
     block(
-      callback: (location: Location, action: HistoryAction) => boolean
-    ): void,
+      callback: string | (location: Location, action: HistoryAction) => ?string
+    ): () => void,
     // createMemoryHistory
     index?: number,
     entries?: Array<Location>

--- a/definitions/npm/react-router_v4.x.x/flow_v0.53.x-v0.62.x/test_react-router.js
+++ b/definitions/npm/react-router_v4.x.x/flow_v0.53.x-v0.62.x/test_react-router.js
@@ -155,6 +155,18 @@ const IncorrectHistoryUsage = ({ history, name }: FooProps) => {
   );
 };
 
+const IncorrectHistoryBlockUsage = (history: RouterHistory) => {
+  // Wrong arguments here
+  // $ExpectError
+  history.block(false);
+
+  // These are valid
+  history.block('Are you sure you want to leave this page?');
+  history.block((location, action) => {
+    return 'Are you sure you want to leave this page?';
+  });
+};
+
 // matchPath
 const match: null | Match = matchPath("/the/pathname", {
   path: "/the/:dynamicId",

--- a/definitions/npm/react-router_v4.x.x/flow_v0.63.x-/react-router_v4.x.x.js
+++ b/definitions/npm/react-router_v4.x.x/flow_v0.63.x-/react-router_v4.x.x.js
@@ -33,8 +33,8 @@ declare module "react-router" {
     goForward(): void,
     canGo?: (n: number) => boolean,
     block(
-      callback: (location: Location, action: HistoryAction) => boolean
-    ): void,
+      callback: string | (location: Location, action: HistoryAction) => ?string
+    ): () => void,
     // createMemoryHistory
     index?: number,
     entries?: Array<Location>

--- a/definitions/npm/react-router_v4.x.x/flow_v0.63.x-/test_react-router.js
+++ b/definitions/npm/react-router_v4.x.x/flow_v0.63.x-/test_react-router.js
@@ -160,6 +160,18 @@ describe('withRouter', () => {
     history.push(['bla']);
     return <div>{name}</div>;
   };
+
+  const IncorrectHistoryBlockUsage = (history: RouterHistory) => {
+    // Wrong arguments here
+    // $ExpectError
+    history.block(false);
+
+    // These are valid
+    history.block('Are you sure you want to leave this page?');
+    history.block((location, action) => {
+      return 'Are you sure you want to leave this page?';
+    });
+  };
 });
 
 describe('matchPath', () => {

--- a/definitions/npm/react-router_v5.x.x/flow_v0.63.x-/react-router_v5.x.x.js
+++ b/definitions/npm/react-router_v5.x.x/flow_v0.63.x-/react-router_v5.x.x.js
@@ -33,8 +33,8 @@ declare module "react-router" {
     goForward(): void,
     canGo?: (n: number) => boolean,
     block(
-      callback: (location: Location, action: HistoryAction) => boolean
-    ): void,
+      callback: string | (location: Location, action: HistoryAction) => ?string
+    ): () => void,
     // createMemoryHistory
     index?: number,
     entries?: Array<Location>


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/ReactTraining/history#blocking-transitions
- Link to GitHub or NPM: https://github.com/ReactTraining/history/blob/5f367d8cbdaf91d7f64e2efdbb9196feb0859f3f/modules/__tests__/TestSequences/TransitionHookArgs.js#L21
- Type of contribution: fix

Other notes:

There's a bug in all the `react-router-*` types. The `block()` method never supported returning `void` or `boolean` values, it always expects the return to be a `?string` instead. This PR fixes this, and closes #3007


