### PR TITLE
[jest_v24.x.x] Update JestMatcher definition

### DIFF
--- a/definitions/npm/jest_v24.x.x/flow_v0.39.x-/jest_v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.39.x-/jest_v24.x.x.js
@@ -124,8 +124,8 @@ type JestMatcherResult = {
 };
 
 type JestMatcher = (
-  actual: any,
-  expected: any
+  received: any,
+  ...actual: Array<any>
 ) => JestMatcherResult | Promise<JestMatcherResult>;
 
 type JestPromiseType = {

--- a/definitions/npm/jest_v24.x.x/flow_v0.39.x-/test_jest-v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.39.x-/test_jest-v24.x.x.js
@@ -245,9 +245,9 @@ expect.extend({
 });
 
 expect.extend({
-  blah(actual, expected) {
+  blah(actual: string, one: string, two: string, three: string) {
     return Promise.resolve({
-      message: () => 'blah fail',
+      message: () => one + two + three,
       pass: false,
     });
   },


### PR DESCRIPTION
### Description
Update the Flow type for Jest's Matcher object. The current definition is a function accepting two argument but it should take an arbitrary number of parameters which are passed to the matcher.

- Links to documentation: https://jestjs.io/docs/en/expect#custom-matchers-api
- Link to GitHub or NPM: https://github.com/facebook/jest/blob/master/packages/expect/src/jestMatchersObject.ts#L84
- Type of contribution: fix

### Other notes
- Renamed parameters to received and actual
- Changed actual to a rest parameter