### PR TITLE
[antd_v3.x.x] Added definitions for Typography, Text, Title and Paragraph

### DIFF
--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
@@ -586,6 +586,37 @@ declare module "antd" {
 
   declare export class TreeSelectTreeNode extends React$Component<{}> {}
 
+  declare export class Typography extends React$Component<{}> {
+    static Title: typeof Title;
+    static Text: typeof Text;
+    static Paragraph: typeof Paragraph;
+  }
+
+  // These props are shared by Paragraph, Title, and Text
+  declare type TypographySharedProps = {
+    code: boolean,
+    copyable: boolean | { text: string, onCopy: Function },
+    delete: boolean,
+    disabled: boolean,
+    editable: boolean | { editing: boolean, onStart: Function, onChange: (string) => void },
+    ellipsis: boolean,
+    mark: boolean,
+    underline: boolean,
+    onChange: (string) => void,
+    strong: boolean,
+    type: 'secondary' |' warning' | 'danger',
+  }
+
+  declare class Paragraph extends React$Component<TypographySharedProps> {}
+
+  declare export type TitleProps = {
+    level: 1 | 2 | 3 | 4,
+  } & TypographySharedProps
+
+  declare class Title extends React$Component<TitleProps> {}
+
+  declare class Text extends React$Component<TypographySharedProps> {}
+
   declare export class Upload extends React$Component<{}> {
     static Dragger: typeof UploadDragger;
   }

--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
@@ -595,10 +595,10 @@ declare module "antd" {
   // These props are shared by Paragraph, Title, and Text
   declare type TypographySharedProps = {
     code: boolean,
-    copyable: boolean | { text: string, onCopy: Function },
+    copyable: boolean | { text: string, onCopy: () => void },
     delete: boolean,
     disabled: boolean,
-    editable: boolean | { editing: boolean, onStart: Function, onChange: (string) => void },
+    editable: boolean | { editing: boolean, onStart: () => void, onChange: (string) => void },
     ellipsis: boolean,
     mark: boolean,
     underline: boolean,

--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
@@ -594,23 +594,23 @@ declare module "antd" {
 
   // These props are shared by Paragraph, Title, and Text
   declare type TypographySharedProps = {
-    code: boolean,
-    copyable: boolean | { text: string, onCopy: () => void },
-    delete: boolean,
-    disabled: boolean,
-    editable: boolean | { editing: boolean, onStart: () => void, onChange: (string) => void },
-    ellipsis: boolean,
-    mark: boolean,
-    underline: boolean,
-    onChange: (string) => void,
-    strong: boolean,
-    type: 'secondary' |' warning' | 'danger',
+    code?: boolean,
+    copyable?: boolean | { text: string, onCopy: () => void },
+    delete?: boolean,
+    disabled?: boolean,
+    editable?: boolean | { editing: boolean, onStart: () => void, onChange: (string) => void },
+    ellipsis?: boolean,
+    mark?: boolean,
+    underline?: boolean,
+    onChange?: (string) => void,
+    strong?: boolean,
+    type?: 'secondary' |' warning' | 'danger',
   }
 
   declare class Paragraph extends React$Component<TypographySharedProps> {}
 
   declare export type TitleProps = {
-    level: 1 | 2 | 3 | 4,
+    level?: 1 | 2 | 3 | 4,
   } & TypographySharedProps
 
   declare class Title extends React$Component<TitleProps> {}

--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/test_antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/test_antd_v3.x.x.js
@@ -35,7 +35,8 @@ import {
   Tabs,
   Tag,
   Tooltip,
-  TreeSelect
+  TreeSelect,
+  Typography,
 } from "antd";
 
 describe("Alert", () => {
@@ -841,5 +842,23 @@ describe("TreeSelect", () => {
 describe("TreeSelect.TreeNode", () => {
   it("is a react component", () => {
     const treeNode = <TreeSelect.TreeNode />;
+  });
+});
+
+describe("Typography.Title", () => {
+  it("is a react component", () => {
+    const titleNode = <Typography.Title />;
+  });
+});
+
+describe("Typography.Text", () => {
+  it("is a react component", () => {
+    const textNode = <Typography.Text />;
+  });
+});
+
+describe("Typography.Paragraph", () => {
+  it("is a react component", () => {
+    const paragraphNode = <Typography.Paragraph />;
   });
 });


### PR DESCRIPTION
From [the docs](https://ant.design/components/typography/)

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation:
- Link to GitHub or NPM: 
- Type of contribution: new definition | addition | fix | refactor

Other notes:

