### PR TITLE
[archiver_v3.x.x] Add new definition

### DIFF
--- a/definitions/npm/archiver_v3.x.x/flow_v0.88.x-/archiver_v3.x.x.js
+++ b/definitions/npm/archiver_v3.x.x/flow_v0.88.x-/archiver_v3.x.x.js
@@ -1,0 +1,106 @@
+declare module "archiver" {
+  import type { Stats } from "fs";
+
+  declare export type Format = "zip" | "tar";
+
+  declare export type EntryData = {
+    name?: string,
+    prefix?: string,
+    stats?: Stats,
+    date?: Date | string,
+    mode?: number
+  };
+
+  declare export type EntryDataFunction = (entry: EntryData) => false | EntryData;
+
+  declare export type CoreOptions = {|
+    statConcurrency?: number
+  |};
+
+  declare export type TransformOptions = {|
+    allowHalfOpen?: boolean,
+    readableObjectMode?: boolean,
+    writeableObjectMode?: boolean,
+    decodeStrings?: boolean,
+    encoding?: string,
+    highWaterMark?: number,
+    objectmode?: boolean
+  |};
+
+  declare export type ZipOptions = {|
+    comment?: string,
+    forceLocalTime?: boolean,
+    forceZip64?: boolean,
+    store?: boolean,
+    zlib?: zlib$options
+  |};
+
+  declare export type TarOptions = {|
+    gzip?: boolean,
+    gzipOptions?: zlib$options
+  |};
+
+  declare export type GlobOptions = {|
+    cwd?: string,
+    root?: string,
+    dot?: boolean,
+    nomount?: boolean,
+    mark?: boolean,
+    nosort?: boolean,
+    stat?: boolean,
+    silent?: boolean,
+    strict?: boolean,
+    cache?: boolean,
+    statCache?: { [string]: Stats },
+    symlinks?: { [string]: boolean },
+    sync?: boolean,
+    nounique?: boolean,
+    nonull?: boolean,
+    debug?: boolean,
+    nobrace?: boolean,
+    noglobstar?: boolean,
+    noext?: boolean,
+    nocase?: boolean,
+    matchBase?: boolean,
+    nodir?: boolean,
+    ignore?: string | Array<string>,
+    follow?: boolean,
+    realpath?: boolean,
+    nonegate?: boolean,
+    nocomment?: boolean,
+    absolute?: boolean
+  |};
+
+  declare export type ArchiverOptions = {|
+    ...CoreOptions,
+    ...TransformOptions,
+    ...ZipOptions,
+    ...TarOptions
+  |};
+
+  declare class Archiver extends stream$Transform {
+    abort(): this;
+    append(source: stream$Readable | Buffer | string, name?: EntryData): this;
+    directory(
+      dirpath: string,
+      destpath: false | string,
+      data?: EntryData | EntryDataFunction
+    ): this;
+    file(filename: string, data: EntryData): this;
+    glob(pattern: string, options?: GlobOptions, data?: EntryData): this;
+    finalize(): Promise<void>;
+    setFormat(format: string): this;
+    setModule(module: (...a: any) => mixed): this;
+    pointer(): number;
+    use(plugin: (...a: any) => mixed): this;
+    symlink(filepath: string, target: string): this;
+  }
+
+  declare export type Vending = {
+    (format: Format, options?: ArchiverOptions): Archiver,
+    create(format: string, options?: ArchiverOptions): Archiver,
+    registerFormat(format: string, module: (...a: any) => mixed): void
+  };
+
+  declare module.exports: Vending;
+}

--- a/definitions/npm/archiver_v3.x.x/flow_v0.88.x-/test_archiver.js
+++ b/definitions/npm/archiver_v3.x.x/flow_v0.88.x-/test_archiver.js
@@ -1,0 +1,93 @@
+// @flow
+import { it, describe } from 'flow-typed-test';
+const Archiver = require('archiver');
+
+describe('Archiver()', () => {
+  it('should pass when use properly', () => {
+    Archiver('tar');
+    Archiver('tar').abort().abort();
+  });
+
+  it("should raises an error when don't pass a first argument", () => {
+    // $ExpectError (must pass in a format)
+    Archiver();
+  });
+
+  it('should raises an error when a first argument not a valid value of an enum', () => {
+    // $ExpectError (format should be a string)
+    Archiver(10);
+
+    // $ExpectError (format should be 'zip' or 'tar')
+    Archiver('tap');
+  });
+
+  describe('Archiver Options', () => {
+    it('should pass when use properly', () => {
+      const options = {
+        statConcurrency: 1,
+        allowHalfOpen: true,
+        readableObjectMode: true,
+        writeableObjectMode: true,
+        decodeStrings: true,
+        encoding: 'test',
+        highWaterMark: 1,
+        objectmode: true,
+        comment: 'test',
+        forceLocalTime: true,
+        forceZip64: true,
+        store: true,
+        zlib: {},
+        gzip: true,
+        gzipOptions: {},
+      };
+
+      Archiver('zip', options);
+      Archiver('zip', {});
+      Archiver('zip', { gzip: true });
+      Archiver('zip', { statConcurrency: 1 });
+    });
+
+    it("should raises an error when a second argument isn't object", () => {
+      // $ExpectError
+      Archiver('zip', '{}');
+    });
+
+    it('should raises an error when options object has a missing prop', () => {
+      // $ExpectError (must pass in valid options)
+      Archiver('zip', { gzp: true });
+    });
+
+    it('should raises an error when pass an invalid value of options', () => {
+      // $ExpectError (values of options should use correct type)
+      Archiver('zip', { statConcurrency: '1' });
+    });
+  });
+});
+
+describe('Archiver.create()', () => {
+  it('should pass when use properly', () => {
+    Archiver.create('zip');
+    Archiver.create('zip', {});
+  });
+
+  it("should raises an error when don't pass a required argument", () => {
+    // $ExpectError (must pass in a format)
+    Archiver.create();
+  });
+});
+
+describe('Archiver.create()', () => {
+  it('should pass when use properly', () => {
+    Archiver.registerFormat('zip', () => {});
+  });
+
+  it("should raises an error when don't pass a first required argument", () => {
+    // $ExpectError (must pass in a format and module)
+    Archiver.registerFormat();
+  });
+
+  it("should raises an error when don't pass a second required argument", () => {
+    // $ExpectError (must pass in a module)
+    Archiver.registerFormat('zip');
+  });
+});


### PR DESCRIPTION
- Links to documentation: https://www.archiverjs.com/
- Link to GitHub or NPM: https://github.com/archiverjs/node-archiver
- Type of contribution: new definition

Other notes:

This definition based on a previous version [2.x.x](https://github.com/flow-typed/flow-typed/tree/master/definitions/npm/archiver_v2.x.x/flow_v0.54.x-) without changes, because of new [release](https://github.com/archiverjs/node-archiver/releases/tag/3.0.0) 

> remove support for versions under 6

