### PR TITLE
[history@4.9.x] Update definitions to match new bundling

### DIFF
--- a/definitions/npm/history_v4.9.x/flow_v0.25.x-/history_v4.9.x.js
+++ b/definitions/npm/history_v4.9.x/flow_v0.25.x-/history_v4.9.x.js
@@ -24,7 +24,7 @@ declare module "history" {
     go(n: number): void,
     goBack(): void,
     goForward(): void,
-    listen: Function,
+    listen((location: BrowserLocation, action: Action) => void): void,
     block(message: string): typeof Unblock,
     block((location: BrowserLocation, action: Action) => string): typeof Unblock,
   }
@@ -66,7 +66,7 @@ declare module "history" {
     goForward(): void,
     // Memory only
     canGo(n: number): boolean,
-    listen: Function,
+    listen((location: MemoryLocation, action: Action) => void): void,
     block(message: string): typeof Unblock,
     block((location: MemoryLocation, action: Action) => string): typeof Unblock,
   }
@@ -102,7 +102,7 @@ declare module "history" {
     go(n: number): void,
     goBack(): void,
     goForward(): void,
-    listen: Function,
+    listen((location: HashLocation, action: Action) => void): void,
     block(message: string): typeof Unblock,
     block((location: HashLocation, action: Action) => string): typeof Unblock,
     push(path: string): void,

--- a/definitions/npm/history_v4.9.x/flow_v0.25.x-/history_v4.9.x.js
+++ b/definitions/npm/history_v4.9.x/flow_v0.25.x-/history_v4.9.x.js
@@ -1,0 +1,123 @@
+declare module "history" {
+
+  declare function Unblock(): void;
+
+  declare export type Action = "PUSH" | "REPLACE" | "POP";
+
+  declare export type BrowserLocation = {
+    pathname: string,
+    search: string,
+    hash: string,
+    // Browser and Memory specific
+    state: {},
+    key: string,
+  };
+
+  declare interface IBrowserHistory {
+    length: number,
+    location: BrowserLocation,
+    action: Action,
+    push(path: string, state?: {}): void,
+    push(location: $Shape<BrowserLocation>): void,
+    replace(path: string, state?: {}): void,
+    replace(location: $Shape<BrowserLocation>): void,
+    go(n: number): void,
+    goBack(): void,
+    goForward(): void,
+    listen: Function,
+    block(message: string): typeof Unblock,
+    block((location: BrowserLocation, action: Action) => string): typeof Unblock,
+  }
+
+  declare export type BrowserHistory = IBrowserHistory;
+
+  declare type BrowserHistoryOpts = {
+    basename?: string,
+    forceRefresh?: boolean,
+    getUserConfirmation?: (
+      message: string,
+      callback: (willContinue: boolean) => void,
+    ) => void,
+  };
+
+  declare function createBrowserHistory(opts?: BrowserHistoryOpts): BrowserHistory;
+
+  declare export type MemoryLocation = {
+    pathname: string,
+    search: string,
+    hash: string,
+    // Browser and Memory specific
+    state: {},
+    key: string,
+  };
+
+  declare interface IMemoryHistory {
+    length: number,
+    location: MemoryLocation,
+    action: Action,
+    index: number,
+    entries: Array<string>,
+    push(path: string, state?: {}): void,
+    push(location: $Shape<MemoryLocation>): void,
+    replace(path: string, state?: {}): void,
+    replace(location: $Shape<MemoryLocation>): void,
+    go(n: number): void,
+    goBack(): void,
+    goForward(): void,
+    // Memory only
+    canGo(n: number): boolean,
+    listen: Function,
+    block(message: string): typeof Unblock,
+    block((location: MemoryLocation, action: Action) => string): typeof Unblock,
+  }
+
+  declare export type MemoryHistory = IMemoryHistory;
+
+  declare type MemoryHistoryOpts = {
+    initialEntries?: Array<string>,
+    initialIndex?: number,
+    keyLength?: number,
+    getUserConfirmation?: (
+      message: string,
+      callback: (willContinue: boolean) => void,
+    ) => void,
+  };
+
+  declare function createMemoryHistory(opts?: MemoryHistoryOpts): MemoryHistory;
+
+  declare export type HashLocation = {
+    pathname: string,
+    search: string,
+    hash: string,
+  };
+
+  declare interface IHashHistory {
+    length: number,
+    location: HashLocation,
+    action: Action,
+    push(path: string, state?: {}): void,
+    push(location: $Shape<HashLocation>): void,
+    replace(path: string, state?: {}): void,
+    replace(location: $Shape<HashLocation>): void,
+    go(n: number): void,
+    goBack(): void,
+    goForward(): void,
+    listen: Function,
+    block(message: string): typeof Unblock,
+    block((location: HashLocation, action: Action) => string): typeof Unblock,
+    push(path: string): void,
+  }
+
+  declare export type HashHistory = IHashHistory;
+
+  declare type HashHistoryOpts = {
+    basename?: string,
+    hashType: "slash" | "noslash" | "hashbang",
+    getUserConfirmation?: (
+      message: string,
+      callback: (willContinue: boolean) => void,
+    ) => void,
+  };
+
+  declare function createHashHistory(opts?: HashHistoryOpts): HashHistory;
+}

--- a/definitions/npm/history_v4.9.x/flow_v0.25.x-/test_history_v4.9.x.js
+++ b/definitions/npm/history_v4.9.x/flow_v0.25.x-/test_history_v4.9.x.js
@@ -1,0 +1,255 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+
+import {createBrowserHistory} from 'history';
+import {createMemoryHistory} from 'history';
+import {createHashHistory} from 'history';
+
+// browser history
+
+describe('browser history', () => {
+  it('should allow to get location fields', () => {
+    const history = createBrowserHistory({
+      basename: "",
+      forceRefresh: false,
+      keyLength: 6,
+    })
+
+    const pathname: string = history.location.pathname
+  });
+
+  it('should allow to get browser and memory specific location fields', () => {
+    const history = createBrowserHistory({
+      basename: "",
+      forceRefresh: false,
+      keyLength: 6,
+    })
+
+    const key: string = history.location.key
+    const state: {} = history.location.state
+  });
+
+  it('should not allow to get field which is absent in the history', () => {
+    const history = createBrowserHistory({
+      basename: "",
+      forceRefresh: false,
+      keyLength: 6,
+    })
+
+    // $ExpectError
+    history.foo
+  });
+
+  describe('#push', () => {
+    it('should allow to use string as first argument', () => {
+      const history = createBrowserHistory({
+        basename: "",
+        forceRefresh: false,
+        keyLength: 6,
+      })
+
+      history.push("/")
+    });
+
+    it('should allow to use partial location as first argument', () => {
+      const history = createBrowserHistory({
+        basename: "",
+        forceRefresh: false,
+        keyLength: 6,
+      })
+
+      history.push({
+        pathname: "/",
+        state: { a: 1 },
+      })
+    });
+  });
+
+  describe('#replace', () => {
+    it('should allow to use string as first argument', () => {
+      const history = createBrowserHistory({
+        basename: "",
+        forceRefresh: false,
+        keyLength: 6,
+      })
+
+      history.replace("/")
+    });
+
+    it('should allow to use partial location as first argument', () => {
+      const history = createBrowserHistory({
+        basename: "",
+        forceRefresh: false,
+        keyLength: 6,
+      })
+
+      history.replace({
+        pathname: "/",
+        state: { a: 1 },
+      })
+    });
+  });
+});
+
+describe('memory history', () => {
+  it('should allow to get location fields', () => {
+    const history = createMemoryHistory({
+      initialEntries: ["/"],
+      initialIndex: 0,
+      keyLength: 6,
+    })
+
+    const pathname: string = history.location.pathname
+  });
+
+  it('should allow to get browser and memory specific location fields', () => {
+    const history = createMemoryHistory({
+      initialEntries: ["/"],
+      initialIndex: 0,
+      keyLength: 6,
+    })
+
+    const key: string = history.location.key
+    const state: {} = history.location.state
+  });
+
+  it('should not allow to get field which is absent in the history', () => {
+    const history = createMemoryHistory({
+      initialEntries: ["/"],
+      initialIndex: 0,
+      keyLength: 6,
+    })
+
+    // $ExpectError
+    history.foo
+  });
+
+  describe('#push', () => {
+    it('should allow to use string as first argument', () => {
+      const history = createMemoryHistory({
+        initialEntries: ["/"],
+        initialIndex: 0,
+        keyLength: 6,
+      })
+
+      history.push("/")
+    });
+
+    it('should allow to use partial location as first argument', () => {
+      const history = createMemoryHistory({
+        initialEntries: ["/"],
+        initialIndex: 0,
+        keyLength: 6,
+      })
+
+      history.push({
+        pathname: "/",
+        state: { a: 1 },
+      })
+    });
+  });
+
+  describe('#replace', () => {
+    it('should allow to use string as first argument', () => {
+      const history = createMemoryHistory({
+        initialEntries: ["/"],
+        initialIndex: 0,
+        keyLength: 6,
+      })
+
+      history.replace("/")
+    });
+
+    it('should allow to use partial location as first argument', () => {
+      const history = createMemoryHistory({
+        initialEntries: ["/"],
+        initialIndex: 0,
+        keyLength: 6,
+      })
+
+      history.replace({
+        pathname: "/",
+        state: { a: 1 },
+      })
+    });
+  });
+});
+
+describe('hash history', () => {
+  it('should allow to get location fields', () => {
+    const history = createHashHistory({
+      basename: "",
+      hashType: "slash",
+    })
+
+    const pathname: string = history.location.pathname
+  });
+
+  it('should not allow to get browser and memory specific location fields', () => {
+    const history = createHashHistory({
+      basename: "",
+      hashType: "slash",
+    })
+
+    // $ExpectError
+    const key: string = history.location.key
+    // $ExpectError
+    const state: {} = history.location.state
+  });
+
+  it('should not allow to get field which is absent in the history', () => {
+    const history = createHashHistory({
+      basename: "",
+      hashType: "slash",
+    })
+
+    // $ExpectError
+    history.foo
+  });
+
+
+  describe('#push', () => {
+    it('should allow to use string as first argument', () => {
+      const history = createHashHistory({
+        basename: "",
+        hashType: "slash",
+      })
+
+      history.push("/")
+    });
+
+    it('should allow to use partial location as first argument', () => {
+      const history = createHashHistory({
+        basename: "",
+        hashType: "slash",
+      })
+
+      history.push({
+        search: "?a=1",
+      })
+    });
+  });
+
+  describe('#replace', () => {
+    it('should allow to use string as first argument', () => {
+      const history = createHashHistory({
+        basename: "",
+        hashType: "slash",
+      })
+
+      history.replace("/")
+    });
+
+    it('should allow to use partial location as first argument', () => {
+      const history = createHashHistory({
+        basename: "",
+        hashType: "slash",
+      })
+
+      history.push({
+        search: "?a=1",
+      })
+    });
+  });
+});


### PR DESCRIPTION
Update types to work with the new bundling and export format of the history module.

- Links to documentation: https://github.com/ReactTraining/history/releases/tag/v4.9.0
- Link to GitHub or NPM: https://github.com/ReactTraining/history/
- Type of contribution: new definition for 4.9.x version
