### PR TITLE
Remove 'unmounted' from react-transition-group

### DIFF
--- a/definitions/npm/react-transition-group_v2.x.x/flow_v0.60.x-/react-transition-group_v2.x.x.js
+++ b/definitions/npm/react-transition-group_v2.x.x/flow_v0.60.x-/react-transition-group_v2.x.x.js
@@ -12,7 +12,7 @@ declare module 'react-transition-group' {
     exitDone?: string,
   };
 
-  declare export type TransitionStatus = 'entering' | 'entered' | 'exiting' | 'exited' | 'unmounted';
+  declare export type TransitionStatus = 'entering' | 'entered' | 'exiting' | 'exited';
 
   declare export type EndHandler = (node: HTMLElement, done: () => void) => void;
   declare export type EnterHandler = (node: HTMLElement, isAppearing: boolean) => void;

--- a/definitions/npm/react-transition-group_v2.x.x/test_react-transition-group.js
+++ b/definitions/npm/react-transition-group_v2.x.x/test_react-transition-group.js
@@ -53,6 +53,35 @@ describe('CSS/Transition', () => {
       <Transition timeout={ 1 } />
     })
 
+    it('should allow examples from the docs', () => {
+      const duration = 300;
+
+      const defaultStyle = {
+        transition: `opacity ${duration}ms ease-in-out`,
+        opacity: 0,
+      }
+
+      const transitionStyles = {
+        entering: { opacity: 1 },
+        entered:  { opacity: 1 },
+        exiting:  { opacity: 0 },
+        exited:  { opacity: 0 },
+      };
+
+      const Fade = ({ in: inProp }) => (
+        <Transition in={inProp} timeout={duration}>
+          {state => (
+            <div style={{
+              ...defaultStyle,
+              ...transitionStyles[state]
+            }}>
+              I'm a fade Transition!
+            </div>
+          )}
+        </Transition>
+      );
+    })
+
     it('props should be compatible with other types with same structure', () => {
       type WithTransitionProps = {
         // props copied from Transition element config


### PR DESCRIPTION
react-transition-group only calls its child-function if the state is one of entering/entered/exiting/exited - not 'unmounted'.  (Transition's render() function bails early if the state is 'unmounted' - https://github.com/reactjs/react-transition-group/blob/65cd9f83309ade93aa9c21d6f6b3c18cbf9e5f27/src/Transition.js#L330-L334)

The documentation example here - http://reactcommunity.org/react-transition-group/transition - would complain with `Cannot get transitionStyles[state] because property unmounted is missing in object literal`.