### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,11 @@
+/definitions/npm/sequelize_*/**/* @jedwards1211
+
+/definitions/npm/fuzzaldrin-plus_*/**/* @reyronald
+
+/definitions/npm/ramda_*/**/* @LoganBarnett
+
+/definitions/npm/react-apollo_*/**/* @thymikee @rasmusprentow @bwlt @TLadd @budde377
+
+/definitions/npm/react-navigation_*/**/* @Ashoat
+
+/definitions/npm/papaparse_*/**/* @GAntoine

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,12 @@
-/definitions/npm/sequelize_*/**/* @jedwards1211
-
 /definitions/npm/fuzzaldrin-plus_*/**/* @reyronald
+
+/definitions/npm/papaparse_*/**/* @GAntoine
 
 /definitions/npm/ramda_*/**/* @LoganBarnett
 
-/definitions/npm/react-apollo_*/**/* @thymikee @rasmusprentow @bwlt @TLadd @budde377
+/definitions/npm/react-apollo_*/**/* @jedwards1211 @thymikee @rasmusprentow @bwlt @TLadd @budde377
 
 /definitions/npm/react-navigation_*/**/* @Ashoat
 
-/definitions/npm/papaparse_*/**/* @GAntoine
+/definitions/npm/sequelize_*/**/* @jedwards1211
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,6 +16,7 @@
 
 /definitions/npm/react-apollo_*/**/* @jedwards1211 @thymikee @rasmusprentow @bwlt @budde377
 
+/definitions/npm/@react-navigation @Ashoat
 /definitions/npm/react-navigation_*/**/* @Ashoat
 
 /definitions/npm/redux-oidc_*/**/* @LoganBarnett

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,12 +1,24 @@
+/definitions/npm/angular_v1*/**/* @LoganBarnett
+
+/definitions/npm/antd_*/**/* @reyronald
+
+/definitions/npm/element-ready_*/**/* @reyronald
+
 /definitions/npm/fuzzaldrin-plus_*/**/* @reyronald
+
+/definitions/npm/ignore_*/**/* @reyronald
+
+/definitions/npm/p-cancelable_*/**/* @reyronald
 
 /definitions/npm/papaparse_*/**/* @GAntoine
 
 /definitions/npm/ramda_*/**/* @LoganBarnett
 
-/definitions/npm/react-apollo_*/**/* @jedwards1211 @thymikee @rasmusprentow @bwlt @TLadd @budde377
+/definitions/npm/react-apollo_*/**/* @jedwards1211 @thymikee @rasmusprentow @bwlt @budde377
 
 /definitions/npm/react-navigation_*/**/* @Ashoat
+
+/definitions/npm/redux-oidc_*/**/* @LoganBarnett
 
 /definitions/npm/sequelize_*/**/* @jedwards1211
 


### PR DESCRIPTION
Adds a [CODEOWNERS](https://help.github.com/en/articles/about-code-owners#codeowners-file-location) file. This will ping the listed users for code review when a PR is opened that affects any of targeted files.

@jedwards1211 @reyronald @LoganBarnett @thymikee @rasmusprentow @bwlt @TLadd @budde377 @Ashoat I've pre-added you to the list based on the various CONTRIBUTING.md files, let me know if you'd like to be removed.

Anyone who sees this and would like to take PR review ownership of a libdef, let us know in a comment, or (once this merges) open a PR that adds you to the list!

Pinging @AndrewSouthpaw @villesau so you guys are aware of this change