### PR TITLE
[jest@24.x.x] add toBeEnabled to dom testing def

### DIFF
--- a/definitions/npm/jest_v24.x.x/flow_v0.39.x-/jest_v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.39.x-/jest_v24.x.x.js
@@ -212,6 +212,7 @@ type EnzymeMatchersType = {
 // DOM testing library extensions https://github.com/kentcdodds/dom-testing-library#custom-jest-matchers
 type DomTestingLibraryType = {
   toBeDisabled(): void,
+  toBeEnabled(): void,
   toBeEmpty(): void,
   toBeInTheDocument(): void,
   toBeVisible(): void,

--- a/definitions/npm/jest_v24.x.x/flow_v0.39.x-/test_jest-v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.39.x-/test_jest-v24.x.x.js
@@ -524,6 +524,7 @@ expect(wrapper).toHaveDisplayName(true);
   const element = document.createElement('div');
 
   expect(element).toBeDisabled();
+  expect(element).toBeEnabled();
   expect(element).toBeEmpty();
   expect(element).toBeInTheDocument();
   expect(element).toBeVisible();


### PR DESCRIPTION
Add toBeEnabled definition to dom testing for jest@24.x.x 
- Links to documentation: https://github.com/testing-library/jest-dom#tobeenabled
- Link to GitHub or NPM: https://github.com/testing-library/jest-dom
- Type of contribution: new definition

Other notes:

