### PR TITLE
[antd_v3.x.x] Add definition for Input.Password and Fix definition error for Form.create

### DIFF
--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
@@ -298,6 +298,7 @@ declare module "antd" {
   declare export class Input extends React$Component<InputProps> {
     static Search: typeof InputSearch;
     static TextArea: typeof InputTextArea;
+    static Password: typeof InputPassword;
   }
 
   declare class InputSearch extends React$Component<{}> {
@@ -305,6 +306,13 @@ declare module "antd" {
   }
 
   declare class InputTextArea extends React$Component<{}> {}
+
+  declare type InputPasswordProps = {
+    visibilityToggle?: boolean
+  };
+  
+  // Added in 3.12.0
+  declare class InputPassword extends React$Component<InputPasswordProps> {}
 
   declare export class Layout extends React$Component<{}> {
     static Content: typeof LayoutContent;

--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/antd_v3.x.x.js
@@ -208,7 +208,7 @@ declare module "antd" {
     valuePropName?: string
   };
 
-  declare type WrappedFormUtils = {
+  declare export type WrappedFormUtils = {
     getFieldDecorator(
       id: string,
       options?: GetFieldDecoratorOptions
@@ -247,6 +247,17 @@ declare module "antd" {
     validateFieldsAndScroll(options?: Object, callback?: ValidateCallback): void
   };
 
+  declare interface RcBaseFormProps {
+    wrappedComponentRef?: any;
+  }
+
+  declare interface FormComponentProps extends RcBaseFormProps {
+    form: WrappedFormUtils;
+  }
+
+  declare type FormWrappedProps<T> = <C: React$ComponentType<T>>
+  (component: C) => C;
+
   declare export type FormProps = {
     className?: string,
     form?: WrappedFormUtils,
@@ -269,7 +280,9 @@ declare module "antd" {
 
   declare export class Form extends React$Component<FormProps> {
     static Item: typeof FormItem;
-    static create: <TOwnProps>(options?: FormCreateOption<TOwnProps>) => mixed;
+    static create: <TOwnProps: FormComponentProps>(
+      options?: FormCreateOption<TOwnProps>
+    ) => FormWrappedProps<TOwnProps>;
   }
 
   declare export type FormItemProps = {

--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/test_antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/test_antd_v3.x.x.js
@@ -38,6 +38,8 @@ import {
   TreeSelect
 } from "antd";
 
+import type { WrappedFormUtils } from "antd";
+
 describe("Alert", () => {
   it("is a react component", () => {
     const alert = <Alert />;
@@ -306,6 +308,28 @@ describe("Dropdown", () => {
 describe("Form", () => {
   it("is a react component", () => {
     const form = <Form />;
+  });
+  it("have create method that wrap a component with a form", () => {
+
+    type PropsGoodTest = {a:string, form: WrappedFormUtils};
+    type PropsBadTest = {a:string};
+    class GoodTestComponent extends React.Component<PropsGoodTest> {}
+    class BadTestComponent extends React.Component<PropsBadTest> {}
+
+    // create is a function
+    const GoodWrappedTestForm: typeof GoodTestComponent =
+      Form.create<PropsGoodTest>({name: 'good_test_form'})(GoodTestComponent);
+
+    const BadWrappedTestForm: typeof BadTestComponent =
+      // $ExpectError PropsBadTest. it must contain form attribute
+      Form.create<PropsBadTest>({name: 'bad_test_form'})(BadTestComponent);
+
+    // $ExpectError returned component props {a: string}. It must contain form property
+    const ErrorGoodWrappedTestForm: React$ComponentType<{a: string}> =
+      Form.create<PropsGoodTest>({name: 'bad_test_form'})(GoodTestComponent);
+
+
+
   });
 });
 

--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-/test_antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-/test_antd_v3.x.x.js
@@ -339,6 +339,17 @@ describe("Input.TextArea", () => {
   });
 });
 
+describe("Input.Password", () => {
+  it("is a react component", () => {
+    const inputPassword = <Input.Password />;
+  });
+  it("should accept boolean visibilityToggle", () => {
+    const good = <Input.Password visibilityToggle={false} />;
+    // $ExpectError string. visibilityToggle must be of type boolean
+    const bad = <Input.Password visibilityToggle={"false"} />
+  });
+});
+
 describe("Layout", () => {
   it("is a react component", () => {
     const layout = <Layout />;


### PR DESCRIPTION
1. Add definition for Input.Password added in v3.12.0 

- [Links to documentation](https://ant.design/components/input/#Input.Password-(Added-in-3.12.0)): 
- [Link to GitHub or NPM](https://github.com/ant-design/ant-design/blob/master/components/input/Password.tsx): 
- Type of contribution: addition

2. Fix flow error when using Form.create - mixed is not a function
- [Links to documentation](https://ant.design/components/form/#Form.create(options)): 
- [Link to GitHub or NPM](https://github.com/ant-design/ant-design/blob/2d8396bad79a086ae57b3ef462e681e81786f02d/components/form/Form.tsx#L137): 
- Type of contribution: fix


