### PR TITLE
Change tabbable types from Node to HTMLElement

### DIFF
--- a/definitions/npm/tabbable_v3.x.x/flow_v0.54.x-/tabbable_v3.x.x.js
+++ b/definitions/npm/tabbable_v3.x.x/flow_v0.54.x-/tabbable_v3.x.x.js
@@ -4,13 +4,13 @@ declare module 'tabbable' {
   |};
 
   declare interface UntouchabilityChecker {
-    hasDisplayNone(node: Node, nodeComputedStyle: any): boolean;
-    isUntouchable(node: Node): boolean;
+    hasDisplayNone(node: HTMLElement, nodeComputedStyle: any): boolean;
+    isUntouchable(node: HTMLElement): boolean;
   }
 
   declare module.exports: {
-    (el: Node, options?: ?TabbableOptions): Array<Node>,
-    isTabbable(node: Node, untouchabilityChecker?: ?UntouchabilityChecker): boolean,
-    isFocusable(node: Node, untouchabilityChecker?: ?UntouchabilityChecker): boolean,
+    (el: HTMLElement, options?: ?TabbableOptions): Array<HTMLElement>,
+    isTabbable(node: HTMLElement, untouchabilityChecker?: ?UntouchabilityChecker): boolean,
+    isFocusable(node: HTMLElement, untouchabilityChecker?: ?UntouchabilityChecker): boolean,
   };
 }

--- a/definitions/npm/tabbable_v3.x.x/flow_v0.54.x-/tabbable_v3.x.x.js
+++ b/definitions/npm/tabbable_v3.x.x/flow_v0.54.x-/tabbable_v3.x.x.js
@@ -11,6 +11,6 @@ declare module 'tabbable' {
   declare module.exports: {
     (el: HTMLElement, options?: ?TabbableOptions): Array<HTMLElement>,
     isTabbable(node: HTMLElement, untouchabilityChecker?: ?UntouchabilityChecker): boolean,
-    isFocusable(node: HTMLElement, untouchabilityChecker?: ?UntouchabilityChecker): boolean,
+    isFocusable(node: HTMLElement | Document, untouchabilityChecker?: ?UntouchabilityChecker): boolean,
   };
 }


### PR DESCRIPTION
The tabbable initial query uses querySelectorAll, which returns HTMLElements.
Element is different than Node because it includes methods like .focus().

- https://github.com/davidtheclark/tabbable/blob/master/index.js#L24
- https://github.com/facebook/flow/blob/master/lib/dom.js#L1036
- https://developer.mozilla.org/en-US/docs/Web/API/Element

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Type of contribution: fix

Other notes:

