### PR TITLE
[express] Remove Subtype for recent versions of flow

### DIFF
--- a/definitions/npm/express_v4.16.x/flow_v0.93.x-/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.93.x-/express_v4.16.x.js
@@ -117,13 +117,13 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 declare type express$NextFunction = (err?: ?Error | "route") => mixed;
 declare type express$Middleware =
   | ((
-      req: $Subtype<express$Request>,
+      req: express$Request,
       res: express$Response,
       next: express$NextFunction
     ) => mixed)
   | ((
       error: Error,
-      req: $Subtype<express$Request>,
+      req: express$Request,
       res: express$Response,
       next: express$NextFunction
     ) => mixed);
@@ -186,7 +186,7 @@ declare class express$Router extends express$Route {
   param(
     param: string,
     callback: (
-      req: $Subtype<express$Request>,
+      req: express$Request,
       res: express$Response,
       next: express$NextFunction,
       id: string

--- a/definitions/npm/express_v4.x.x/flow_v0.93.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.93.x-/express_v4.x.x.js
@@ -101,8 +101,8 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 
 declare type express$NextFunction = (err?: ?Error | 'route') => mixed;
 declare type express$Middleware =
-  ((req: $Subtype<express$Request>, res: express$Response, next: express$NextFunction) => mixed) |
-  ((error: Error, req: $Subtype<express$Request>, res: express$Response, next: express$NextFunction) => mixed);
+  ((req: express$Request, res: express$Response, next: express$NextFunction) => mixed) |
+  ((error: Error, req: express$Request, res: express$Response, next: express$NextFunction) => mixed);
 declare interface express$RouteMethodType<T> {
   (middleware: express$Middleware): T;
   (...middleware: Array<express$Middleware>): T;
@@ -152,7 +152,7 @@ declare class express$Router extends express$Route {
   param(
     param: string,
     callback: (
-      req: $Subtype<express$Request>,
+      req: express$Request,
       res: express$Response,
       next: express$NextFunction,
       id: string


### PR DESCRIPTION
Following discussion in #3008 here's a PR to remove `$Subtype` from the recent flow defs for `express`.

Test pass locally, let me know if there's anything else I'm missing.