### PR TITLE
fix Ramda ifElse to work with variadic arguments

### DIFF
--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/ramda_v0.26.x.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/ramda_v0.26.x.js
@@ -1915,20 +1915,20 @@ declare module ramda {
     y: (...args: Array<any>) => *
   ): (...args: Array<any>) => *;
 
-  declare function ifElse<A, B, C>(
-    cond: (...args: Array<A>) => boolean,
+  declare function ifElse<Args, B, C>(
+    cond: (...args: Args) => boolean
   ): ((
-    f1: (...args: Array<A>) => B,
-  ) => (f2: (...args: Array<A>) => C) => (...args: Array<A>) => B | C) &
+    f1: (...args: Args) => B
+  ) => (f2: (...args: Args) => C) => (...args: Args) => B | C) &
     ((
-      f1: (...args: Array<A>) => B,
-      f2: (...args: Array<A>) => C
-    ) => (...args: Array<A>) => B | C);
-  declare function ifElse<A, B, C>(
-    cond: (...args: Array<any>) => boolean,
-    f1: (...args: Array<any>) => B,
-    f2: (...args: Array<any>) => C
-  ): (...args: Array<A>) => B | C;
+      f1: (...args: Args) => B,
+      f2: (...args: Args) => C
+    ) => (...args: Args) => B | C);
+  declare function ifElse<Args, B, C>(
+    cond: (...args: Args) => boolean,
+    f1: (...args: Args) => B,
+    f2: (...args: Args) => C
+  ): (...args: Args) => B | C;
 
   declare function isEmpty(x: ?Array<any> | Object | string): boolean;
 

--- a/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
@@ -2081,20 +2081,20 @@ declare module ramda {
     y: (...args: Array<any>) => *
   ): (...args: Array<any>) => *;
 
-  declare function ifElse<A, B, C>(
-    cond: (...args: Array<A>) => boolean
+  declare function ifElse<Args, B, C>(
+    cond: (...args: Args) => boolean
   ): ((
-    f1: (...args: Array<A>) => B
-  ) => (f2: (...args: Array<A>) => C) => (...args: Array<A>) => B | C) &
+    f1: (...args: Args) => B
+  ) => (f2: (...args: Args) => C) => (...args: Args) => B | C) &
     ((
-      f1: (...args: Array<A>) => B,
-      f2: (...args: Array<A>) => C
-    ) => (...args: Array<A>) => B | C);
-  declare function ifElse<A, B, C>(
-    cond: (...args: Array<any>) => boolean,
-    f1: (...args: Array<any>) => B,
-    f2: (...args: Array<any>) => C
-  ): (...args: Array<A>) => B | C;
+      f1: (...args: Args) => B,
+      f2: (...args: Args) => C
+    ) => (...args: Args) => B | C);
+  declare function ifElse<Args, B, C>(
+    cond: (...args: Args) => boolean,
+    f1: (...args: Args) => B,
+    f2: (...args: Args) => C
+  ): (...args: Args) => B | C;
 
   declare function isEmpty(x: ?Array<any> | Object | string): boolean;
 

--- a/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/test_ramda_v0.x.x_logic.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/test_ramda_v0.x.x_logic.js
@@ -1,7 +1,6 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
 import _, {
-  always,
   compose,
   curry,
   filter,

--- a/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/test_ramda_v0.x.x_logic.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/test_ramda_v0.x.x_logic.js
@@ -87,15 +87,14 @@ describe('ifElse', () => {
 
   it('works with variadic arg inputs', () => {
     const ifElseFn = ifElse(
-      // The original motivation was to work with "test". Future changes could
-      // invalidate the nature of the test, so we need to mimic the form of test
-      // at time of writing. The error will be along the lines of this:
+      // Without this test, variadic argument input functions will produce an
+      // error like this:
       //
       // Cannot call `ifElse` because rest array [1] has an unknown number of
       // elements, so is incompatible with tuple type [2].
       (...args: [string]): boolean => true,
-      always(undefined),
-      always('some error'),
+      (s: string) => s.toUpperCase(),
+      (s: string) => s.toLowerCase(),
     );
     const result: void | string = ifElseFn('input')
   })
@@ -103,8 +102,8 @@ describe('ifElse', () => {
   it('preserves the types used with variadic argument condition functions', () => {
     const ifElseFn = ifElse(
       (...args: [string]): boolean => true,
-      always(undefined),
-      always('some error'),
+      (s: string) => s.toUpperCase(),
+      (s: string) => s.toLowerCase(),
     );
     // $ExpectError
     const result: void | string = ifElseFn(5)

--- a/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/test_ramda_v0.x.x_logic.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/test_ramda_v0.x.x_logic.js
@@ -1,6 +1,17 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from 'ramda';
+import _, {
+  always,
+  compose,
+  curry,
+  filter,
+  find,
+  ifElse,
+  pipe,
+  repeat,
+  zipWith,
+} from 'ramda';
+import { describe, it } from 'flow-typed-test';
 
 const ns: Array<number> = [1, 2, 3, 4, 5];
 const ss: Array<string> = ['one', 'two', 'three', 'four'];
@@ -61,11 +72,58 @@ const def1: number = defaultTo42(undefined);
 const feither = _.either(gt10, even);
 const feitherR: boolean = f(101);
 
-const incCount = _.ifElse(_.is(Number), _.inc, _.toString);
-const ie: number | string = incCount({});
-const ie2: number | string = incCount(1);
+describe('ifElse', () => {
+  it('uses a union of both branches as the return type', () => {
+    const incCount = ifElse(x => x % 2 == 0, x => x + 1, x => x.toString());
+    const ie: number | string = incCount(1);
+  })
 
-const em: boolean = _.isEmpty([1, 2, 3]);
+  it('checks the condition input matches the branch inputs', () => {
+    const incCount = ifElse(x => x % 2 == 0, x => x + 1, x => x.toString());
+    // Because the object literal ({}) isn't a number it
+    // $ExpectError
+    const ie: number | string = incCount({});
+  })
+
+  it('works with variadic arg inputs', () => {
+    const ifElseFn = ifElse(
+      // The original motivation was to work with "test". Future changes could
+      // invalidate the nature of the test, so we need to mimic the form of test
+      // at time of writing. The error will be along the lines of this:
+      //
+      // Cannot call `ifElse` because rest array [1] has an unknown number of
+      // elements, so is incompatible with tuple type [2].
+      (...args: [string]): boolean => true,
+      always(undefined),
+      always('some error'),
+    );
+    const result: void | string = ifElseFn('input')
+  })
+
+  it('preserves the types used with variadic argument condition functions', () => {
+    const ifElseFn = ifElse(
+      (...args: [string]): boolean => true,
+      always(undefined),
+      always('some error'),
+    );
+    // $ExpectError
+    const result: void | string = ifElseFn(5)
+  })
+
+  // This was the original test for ifElse, which depends on the implementation
+  // of "is". "is" in its present form does not perform type refinement, so the
+  // stricter form of ifElse fails the check with this test. This test below
+  // captures the issue, and is left for reference and/or if some brave soul
+  // wishes to expand the definition of ifElse (and possibly also "is") to
+  // refine the predicate correctly. At time of writing, $Pred and $Refine are
+  // considered experimental/internal and abandoned:
+  // https://github.com/facebook/flow/issues/2464#issuecomment-471115953
+  //
+  // it('feeds a predicate-refined type to the branches', () => {
+  //   const incCount = ifElse(is(Number), x => x + 1, x => x.toString());
+  //   const ie: number | string = incCount(1);
+  // })
+})
 
 const n: boolean = _.not(true);
 //$ExpectError


### PR DESCRIPTION
- https://ramdajs.com/docs/#ifElse
- #2411
- Type of contribution: fix

Other notes:

This fixes the issue found in #2411 where `test` could not be used with `ifElse` because `test` is automatically curried, which relies upon variadic arguments.

As another note, I noticed as part of working on this that some of our tests have a lot of cross-dependencies. For example, the `ifElse` test also depended on `is`. I worry that if something happens with `is`, the test for `ifElse` can become invalid. Perhaps instead we can write our tests by only using a single Ramda function at a time, so our test doesn't potentially become a lie built atop another lie. For example, if `is` returns or takes `any` it could invalidate the `ifElse` test entirely. It also conflates what's really being tested. In the case of `test` from #2411, if it dropped variadic argument support while the `ifElse` test I used actually used `test`, then the test would silently become invalid yet pass.

TLDR; Going forward, let's use only one Ramda function at a time during an assertion.

Thoughts?

From the commit message:

This is very typical when working with curried functions, particularly from within Ramda itself. The prior definition of ifElse used to work in type refinement scenarios (although really, it appears to be coercing to any or otherwise losing type information).

The original test for ifElse is broken because it relies upon such refinements or loss of type information.

The tests for ifElse are now expressed in a way that is independent of other Ramda functions.
