### PR TITLE
add date support to ramda subtract

### DIFF
--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/ramda_v0.26.x.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/ramda_v0.26.x.js
@@ -483,7 +483,11 @@ declare module ramda {
   declare var multiply: CurriedFunction2<number, number, number>;
   declare var negate: UnaryFn<number, number>;
   declare var product: UnaryFn<Array<number>, number>;
-  declare var subtract: CurriedFunction2<number, number, number>;
+  declare var subtract:
+    & CurriedFunction2<number, number, number>
+    & CurriedFunction2<Date, Date, number>
+    & CurriedFunction2<Date, number, number>
+    & CurriedFunction2<number, Date, number>;
   declare var sum: UnaryFn<Array<number>, number>;
 
   // Filter

--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/test_ramda_v0.26.x_math.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/test_ramda_v0.26.x_math.js
@@ -1,0 +1,32 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+
+import { describe, it } from 'flow-typed-test';
+import {
+  subtract,
+} from 'ramda'
+
+describe('subtract', () => {
+  it('works with two numbers', () => {
+    const result: number = subtract(1, 2)
+  })
+
+  // To see Ramda working with various date combinations, see:
+
+  it('works with dates to produce a number', () => {
+    const result: number = subtract(new Date(), new Date())
+  })
+
+  it('works with a date and a number to produce a number', () => {
+    const result: number = subtract(new Date(), 1000)
+  })
+
+  it('works with a number and a date to produce a number', () => {
+    const result: number = subtract(1000, new Date())
+  })
+
+  it('does not accept strings as inputs', () => {
+    // $ExpectError
+    const result: number = subtract('foo', 'o')
+  })
+})

--- a/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
@@ -650,7 +650,12 @@ declare module ramda {
   declare var multiply: CurriedFunction2<number, number, number>;
   declare var negate: UnaryFn<number, number>;
   declare var product: UnaryFn<Array<number>, number>;
-  declare var subtract: CurriedFunction2<number, number, number>;
+  declare var subtract:
+    & CurriedFunction2<number,  number, number>
+    & CurriedFunction2<Date, Date, number>
+    & CurriedFunction2<Date, number, number>
+    & CurriedFunction2<number, Date, number>
+
   declare var sum: UnaryFn<Array<number>, number>;
 
   // Filter

--- a/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/test_ramda_v0.x.x_math.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/test_ramda_v0.x.x_math.js
@@ -1,0 +1,32 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+
+import { describe, it } from 'flow-typed-test';
+import {
+  subtract,
+} from 'ramda'
+
+describe('subtract', () => {
+  it('works with two numbers', () => {
+    const result: number = subtract(1, 2)
+  })
+
+  // To see Ramda working with various date combinations, see:
+
+  it('works with dates to produce a number', () => {
+    const result: number = subtract(new Date(), new Date())
+  })
+
+  it('works with a date and a number to produce a number', () => {
+    const result: number = subtract(new Date(), 1000)
+  })
+
+  it('works with a number and a date to produce a number', () => {
+    const result: number = subtract(1000, new Date())
+  })
+
+  it('does not accept strings as inputs', () => {
+    // $ExpectError
+    const result: number = subtract('foo', 'o')
+  })
+})


### PR DESCRIPTION
- [repl](https://ramdajs.com/repl/#?const%20later%20%3D%20new%20Date%28%29%0Aconst%20now%20%3D%20new%20Date%28%29%0Alater.setSeconds%28later.getSeconds%28%29%20%2B%201%29%0Asubtract%28later%2C%20now%29%0A%2F%2F%20Uncomment%20to%20see%20variations.%0A%2F%2F%20subtract%28later%2C%202%29%0A%2F%2F%20subtract%282%2C%20later%29) and [subtract documentation](https://ramdajs.com/docs/#subtract)
- Link to GitHub or NPM: https://github.com/ramda/ramda
- Type of contribution: addition

Other notes:

Ramda's `subtract` works with every variation of a `number` and a `Date`, but always returns a `number` (see [this Ramda repl](
https://ramdajs.com/repl/#?const%20later%20%3D%20new%20Date%28%29%0Aconst%20now%20%3D%20new%20Date%28%29%0Alater.setSeconds%28later.getSeconds%28%29%20%2B%201%29%0Asubtract%28later%2C%20now%29%0A%2F%2F%20Uncomment%20to%20see%20variations.%0A%2F%2F%20subtract%28later%2C%202%29%0A%2F%2F%20subtract%282%2C%20later%29)), so this adds the capability plus some tests to cover the variations. 0.x.x and 0.26.x are covered for this change. This isn't strictly documented, but since you can subtract these things in vanilla JavaScript, Ramda is likely deferring to the built in `-` operation.

As an additional note: There wasn't a "math" section, which is one of the divisions that Ramda uses for functions. I added a file for this section with `subtract` being the first test.