### PR TITLE
[react-navigation] Fix NavigationScreenProp.getParam type, flow < v0.91.x

### DIFF
--- a/definitions/npm/@react-navigation/core_v3.x.x/flow_v0.60.x-v0.91.x/core_v3.x.x.js
+++ b/definitions/npm/@react-navigation/core_v3.x.x/flow_v0.60.x-v0.91.x/core_v3.x.x.js
@@ -491,7 +491,7 @@ declare module '@react-navigation/core' {
       fallback?: $ElementType<
         $PropertyType<
           {|
-            ...{| params: {| [ParamName]: void |} |},
+            ...{| params: { } |},
             ...$Exact<S>,
           |},
           'params'
@@ -501,7 +501,7 @@ declare module '@react-navigation/core' {
     ) => $ElementType<
       $PropertyType<
         {|
-          ...{| params: {| [ParamName]: void |} |},
+          ...{| params: { } |},
           ...$Exact<S>,
         |},
         'params'

--- a/definitions/npm/react-navigation_v3.x.x/flow_v0.60.x-v0.91.x/react-navigation_v3.x.x.js
+++ b/definitions/npm/react-navigation_v3.x.x/flow_v0.60.x-v0.91.x/react-navigation_v3.x.x.js
@@ -597,7 +597,7 @@ declare module 'react-navigation' {
       fallback?: $ElementType<
         $PropertyType<
           {|
-            ...{| params: {| [ParamName]: void |} |},
+            ...{| params: { } |},
             ...$Exact<S>,
           |},
           'params'
@@ -607,7 +607,7 @@ declare module 'react-navigation' {
     ) => $ElementType<
       $PropertyType<
         {|
-          ...{| params: {| [ParamName]: void |} |},
+          ...{| params: { } |},
           ...$Exact<S>,
         |},
         'params'


### PR DESCRIPTION
This pr applies #3266 to the typedef for flow < 0.91.x
Fixes #3346
 
- Type of contribution: fix

Other notes:

