### PR TITLE
[React-Navigation] Fix NavigationNavigator to allow class-based custom navigator, flow < v0.91.x 

### DIFF
--- a/definitions/npm/@react-navigation/core_v3.x.x/flow_v0.60.x-v0.91.x/core_v3.x.x.js
+++ b/definitions/npm/@react-navigation/core_v3.x.x/flow_v0.60.x-v0.91.x/core_v3.x.x.js
@@ -346,7 +346,7 @@ declare module '@react-navigation/core' {
     State: NavigationState,
     Options: {},
     Props: {}
-  > = React$StatelessFunctionalComponent<{
+  > = React$ComponentType<{
     ...Props,
     ...NavigationNavigatorProps<Options, State>,
   }> &


### PR DESCRIPTION
Fixes #3348 

React-Native: 0.58.6
React-Navigation: 3.9.1
Flow: 0.86.0 (using `flow_v.60.x-v0.91.x/react-navigation_v3.x.x.js`)

`NavigationNavigator` should be able to be a class-based custom navigator, not just a `StatelessFunctionalComponent`.