### PR TITLE
make ramda comparisons (gt, gte, lt, lte) stricter

### DIFF
--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/ramda_v0.26.x.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/ramda_v0.26.x.js
@@ -1195,11 +1195,16 @@ declare module ramda {
   declare function eqBy<T>(fn: (x: T) => T, x: T): (y: T) => boolean;
   declare function eqBy<T>(fn: (x: T) => T): (x: T) => (y: T) => boolean;
 
-  declare function gt<T>(x: T): (y: T) => boolean;
-  declare function gt<T>(x: T, y: T): boolean;
+  declare type RelationCompare =
+    & ((x: number) => (y: number) => bool)
+    & ((x: number, y: number) => bool)
+    & ((x: string) => (y: string) => bool)
+    & ((x: string, y: string) => bool)
 
-  declare function gte<T>(x: T): (y: T) => boolean;
-  declare function gte<T>(x: T, y: T): boolean;
+  declare var gt: RelationCompare
+  declare var gte: RelationCompare
+  declare var lt: RelationCompare
+  declare var lte: RelationCompare
 
   declare function identical<T>(x: T): (y: T) => boolean;
   declare function identical<T>(x: T, y: T): boolean;
@@ -1221,12 +1226,6 @@ declare module ramda {
 
   declare function intersection<T>(x: Array<T>, y: Array<T>): Array<T>;
   declare function intersection<T>(x: Array<T>): (y: Array<T>) => Array<T>;
-
-  declare function lt<T>(x: T): (y: T) => boolean;
-  declare function lt<T>(x: T, y: T): boolean;
-
-  declare function lte<T>(x: T): (y: T) => boolean;
-  declare function lte<T>(x: T, y: T): boolean;
 
   declare function max<T>(x: T): (y: T) => T;
   declare function max<T>(x: T, y: T): T;

--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/test_ramda_v0.26.x_relation.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/test_ramda_v0.26.x_relation.js
@@ -1,6 +1,19 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from "ramda";
+import { it, describe } from "flow-typed-test";
+import _, {
+  compose,
+  curry,
+  filter,
+  find,
+  gt,
+  gte,
+  lt,
+  lte,
+  pipe,
+  repeat,
+  zipWith,
+} from "ramda";
 
 const ns: Array<number> = [1, 2, 3, 4, 5];
 const ss: Array<string> = ["one", "two", "three", "four"];
@@ -33,11 +46,125 @@ const eqb: boolean = _.eqBy(Math.abs, 5, -5);
 
 const es: boolean = _.equals([1, 2, 3], [1, 2, 3]);
 
-const _gt: boolean = _.gt(2, 1);
-const _lt: boolean = _.lt(2, 1);
+describe('gt', () => {
+  it('works with two numbers and produces a bool', () => {
+    const result: bool = gt(2, 1)
+  })
 
-const _gte: boolean = _.gte(2, 1);
-const _lte: boolean = _.lte(2, 1);
+  it('works with two curried numbers and produces a bool', () => {
+    const result: bool = gt(2)(1)
+  })
+
+  it('works with two strings and produces a bool', () => {
+    const result: bool = gt('a', 'b')
+  })
+
+  it('works with two curried strings and produces a bool', () => {
+    const result: bool = gt('a')('b')
+  })
+
+  it('does not work with mixed numbers and strings', () => {
+    // $ExpectError
+    gt('a', 1)
+    // $ExpectError
+    gt(1, 'a')
+  })
+
+  it('does not work with functions', () => {
+    // $ExpectError
+    gt(() => 1, () => 2)
+  })
+})
+
+describe('gte', () => {
+  it('works with two numbers and produces a bool', () => {
+    const result: bool = gte(2, 1)
+  })
+
+  it('works with two curried numbers and produces a bool', () => {
+    const result: bool = gte(2)(1)
+  })
+
+  it('works with two strings and produces a bool', () => {
+    const result: bool = gte('a', 'b')
+  })
+
+  it('works with two curried strings and produces a bool', () => {
+    const result: bool = gte('a')('b')
+  })
+
+  it('does not work with mixed numbers and strings', () => {
+    // $ExpectError
+    gte('a', 1)
+    // $ExpectError
+    gte(1, 'a')
+  })
+
+  it('does not work with functions', () => {
+    // $ExpectError
+    gte(() => 1, () => 2)
+  })
+})
+
+describe('lt', () => {
+  it('works with two numbers and produces a bool', () => {
+    const result: bool = lt(2, 1)
+  })
+
+  it('works with two curried numbers and produces a bool', () => {
+    const result: bool = lt(2)(1)
+  })
+
+  it('works with two strings and produces a bool', () => {
+    const result: bool = lt('a', 'b')
+  })
+
+  it('works with two curried strings and produces a bool', () => {
+    const result: bool = lt('a')('b')
+  })
+
+  it('does not work with mixed numbers and strings', () => {
+    // $ExpectError
+    lt('a', 1)
+    // $ExpectError
+    lt(1, 'a')
+  })
+
+  it('does not work with functions', () => {
+    // $ExpectError
+    lt(() => 1, () => 2)
+  })
+})
+
+describe('lte', () => {
+  it('works with two numbers and produces a bool', () => {
+    const resulte: bool = lte(2, 1)
+  })
+
+  it('works with two curried numbers and produces a bool', () => {
+    const resulte: bool = lte(2)(1)
+  })
+
+  it('works with two strings and produces a bool', () => {
+    const resulte: bool = lte('a', 'b')
+  })
+
+  it('works with two curried strings and produces a bool', () => {
+    const resulte: bool = lte('a')('b')
+  })
+
+  it('does not work with mixed numbers and strings', () => {
+    // $ExpectError
+    lte('a', 1)
+    // $ExpectError
+    lte(1, 'a')
+  })
+
+  it('does not work with functions', () => {
+    // $ExpectError
+    lte(() => 1, () => 2)
+  })
+})
 
 const _max: number = _.max(2, 1);
 const _min: number = _.min(2, 1);


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: [Ramda gt](https://ramdajs.com/docs/#gt)
- Link to GitHub or NPM: [Ramda github](https://github.com/ramda/ramda)
- Type of contribution: fix

Other notes:

This restrains the comparison functions (`gt`, `gte`, `lt`, `lte`) to require numbers or strings. These all share the same `RelationComparison` type now, since they all do the same thing type-wise.

I did a [test](https://ramdajs.com/repl/#?gt%28%27bb%27%2C%20%27ba%27%29) and found these functions work with strings as well as numbers:

``` javascript
gt('bb', 'ba') // true
gt('ba', 'bb') // false
```

So `string` is also included as a possible type. However mixing and matching `number` and `string` has been disallowed.