### PR TITLE
[npm/redux-mock-store] remove usages of deprecated $Subtype<>

### DIFF
--- a/definitions/npm/redux-mock-store_v1.2.x/flow_v0.25.x-/redux-mock-store_v1.2.x.js
+++ b/definitions/npm/redux-mock-store_v1.2.x/flow_v0.25.x-/redux-mock-store_v1.2.x.js
@@ -8,17 +8,19 @@ declare module "redux-mock-store" {
     <S, A>(state: S): mockStoreWithoutMiddleware<S, A>
   };
   declare type DispatchAPI<A> = (action: A) => A;
-  declare type Dispatch<A: { type: $Subtype<string> }> = DispatchAPI<A>;
+  declare type Dispatch<A: { type: string }> = DispatchAPI<A>;
   declare type mockStoreWithoutMiddleware<S, A> = {
     getState(): S,
     getActions(): Array<A>,
     dispatch: Dispatch<A>,
     clearActions(): void,
-    subscribe(callback: Function): () => void,
+    subscribe(callback: () => void): () => void,
     replaceReducer(nextReducer: Function): void
   };
 
-  declare module.exports: (middlewares: ?Array<Function>) => mockStore;
+  declare type Middleware = any => any => any;
+
+  declare module.exports: (middlewares: ?Array<Middleware>) => mockStore;
 }
 
 // Filename aliases

--- a/definitions/npm/redux-mock-store_v1.2.x/test_redux-mock-store_v1.js
+++ b/definitions/npm/redux-mock-store_v1.2.x/test_redux-mock-store_v1.js
@@ -3,7 +3,7 @@
 import configureStore from 'redux-mock-store';
 
 // $ExpectError
-const mockStoreContainingInvalidMiddlware = configureStore(['middlewares']);
+const mockStoreContainingInvalidMiddleware = configureStore(['not a middleware']);
 
 const mockStore = configureStore();
 


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: 
- Link to GitHub or NPM: https://github.com/dmitry-zaets/redux-mock-store
- Type of contribution: fix

