### PR TITLE
[npm/express][npm/cookie-parser] remove usages of deprecated $Subtype<>

### DIFF
--- a/definitions/npm/cookie-parser_v1.x.x/flow_v0.93.x-/cookie-parser_v1.x.x.js
+++ b/definitions/npm/cookie-parser_v1.x.x/flow_v0.93.x-/cookie-parser_v1.x.x.js
@@ -159,7 +159,7 @@ declare module 'cookie-parser' {
     param(
       param: string,
       callback: (
-        req: $Subtype<express$Request>,
+        req: express$Request,
         res: express$Response,
         next: express$NextFunction,
         id: string
@@ -254,13 +254,13 @@ declare module 'cookie-parser' {
   declare type express$NextFunction = (err?: ?Error | 'route') => mixed;
   declare type express$Middleware =
     | ((
-        req: $Subtype<express$Request>,
+        req: express$Request,
         res: express$Response,
         next: express$NextFunction
       ) => mixed)
     | ((
         error: Error,
-        req: $Subtype<express$Request>,
+        req: express$Request,
         res: express$Response,
         next: express$NextFunction
       ) => mixed);

--- a/definitions/npm/express_v4.16.x/flow_v0.93.x-/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.93.x-/express_v4.16.x.js
@@ -117,13 +117,13 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 declare type express$NextFunction = (err?: ?Error | "route") => mixed;
 declare type express$Middleware =
   | ((
-      req: $Subtype<express$Request>,
+      req: express$Request,
       res: express$Response,
       next: express$NextFunction
     ) => mixed)
   | ((
       error: Error,
-      req: $Subtype<express$Request>,
+      req: express$Request,
       res: express$Response,
       next: express$NextFunction
     ) => mixed);
@@ -186,7 +186,7 @@ declare class express$Router extends express$Route {
   param(
     param: string,
     callback: (
-      req: $Subtype<express$Request>,
+      req: express$Request,
       res: express$Response,
       next: express$NextFunction,
       id: string

--- a/definitions/npm/express_v4.x.x/flow_v0.93.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.93.x-/express_v4.x.x.js
@@ -101,8 +101,8 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 
 declare type express$NextFunction = (err?: ?Error | 'route') => mixed;
 declare type express$Middleware =
-  ((req: $Subtype<express$Request>, res: express$Response, next: express$NextFunction) => mixed) |
-  ((error: Error, req: $Subtype<express$Request>, res: express$Response, next: express$NextFunction) => mixed);
+  ((req: express$Request, res: express$Response, next: express$NextFunction) => mixed) |
+  ((error: Error, req: express$Request, res: express$Response, next: express$NextFunction) => mixed);
 declare interface express$RouteMethodType<T> {
   (middleware: express$Middleware): T;
   (...middleware: Array<express$Middleware>): T;
@@ -152,7 +152,7 @@ declare class express$Router extends express$Route {
   param(
     param: string,
     callback: (
-      req: $Subtype<express$Request>,
+      req: express$Request,
       res: express$Response,
       next: express$NextFunction,
       id: string


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation:
- Link to GitHub or NPM: https://github.com/expressjs/express and https://github.com/expressjs/cookie-parser
- Type of contribution: fix

