### PR TITLE
make ramda ascend and descend return curried functions

### DIFF
--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/ramda_v0.26.x.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/ramda_v0.26.x.js
@@ -874,8 +874,10 @@ declare module ramda {
     fns: Array<(a: V, b: V) => number>,
   ): (xs: T) => T;
 
-  declare function descend<A, B>(A => B): (A => A) => number
-  declare function ascend<A, B>(A => B): (A => A) => number
+  declare type MakeComparator = <A, B>(A => B) => CurriedFunction2<A, A, number>
+
+  declare var descend: MakeComparator
+  declare var ascend: MakeComparator
 
   declare function times<T>(fn: (i: number) => T, n: number): Array<T>;
   declare function times<T>(

--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/ramda_v0.26.x.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/ramda_v0.26.x.js
@@ -874,6 +874,12 @@ declare module ramda {
     fns: Array<(a: V, b: V) => number>,
   ): (xs: T) => T;
 
+  /**
+   * In the examples for ascend and descend, its result is plugged into sort.
+   * In order for this to function properly ascend and descend need to yield a
+   * function that can take two arguments. In our case we'll declare the result
+   * function as curried, which matches the ramda behavior.
+   */
   declare type MakeComparator = <A, B>(A => B) => CurriedFunction2<A, A, number>
 
   declare var descend: MakeComparator

--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/test_ramda_v0.26.x_relation.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/test_ramda_v0.26.x_relation.js
@@ -74,8 +74,8 @@ describe('ascend', () => {
 
 describe('descend', () => {
   /**
-   * In the examples for ascend, its result is plugged into sort. In order
-   * for this to function properly ascend needs to yield a function that can
+   * In the examples for descend, its result is plugged into sort. In order
+   * for this to function properly descend needs to yield a function that can
    * take two arguments.
    */
   it('works as an input to sort', () => {

--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/test_ramda_v0.26.x_relation.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/test_ramda_v0.26.x_relation.js
@@ -2,8 +2,10 @@
 /*eslint-disable no-undef, no-unused-vars, no-console*/
 import { it, describe } from "flow-typed-test";
 import _, {
+  ascend,
   compose,
   curry,
+  descend,
   filter,
   find,
   gt,
@@ -11,7 +13,9 @@ import _, {
   lt,
   lte,
   pipe,
+  prop,
   repeat,
+  sort,
   zipWith,
 } from "ramda";
 
@@ -45,6 +49,50 @@ const diff2 = _.differenceWith(cmp, l1, l2);
 const eqb: boolean = _.eqBy(Math.abs, 5, -5);
 
 const es: boolean = _.equals([1, 2, 3], [1, 2, 3]);
+
+describe('ascend', () => {
+  /**
+   * In the examples for ascend, its result is plugged into sort. In order
+   * for this to function properly ascend needs to yield a function that can
+   * take two arguments.
+   */
+  it('works as an input to sort', () => {
+    const byAge = ascend(prop('age'));
+    const people = [
+      { name: 'Emma', age: 70 },
+      { name: 'Peter', age: 78 },
+      { name: 'Mikhail', age: 62 },
+    ];
+    const peopleByYoungestFirst = sort(byAge, people);
+  })
+
+  it('returns a curried function', () => {
+    const byAge = ascend(prop('age'))
+    byAge({ name: 'Emma', age: 70 })({ name: 'Peter', age: 78 })
+  })
+})
+
+describe('descend', () => {
+  /**
+   * In the examples for ascend, its result is plugged into sort. In order
+   * for this to function properly ascend needs to yield a function that can
+   * take two arguments.
+   */
+  it('works as an input to sort', () => {
+    const byAge = descend(prop('age'));
+    const people = [
+      { name: 'Emma', age: 70 },
+      { name: 'Peter', age: 78 },
+      { name: 'Mikhail', age: 62 },
+    ];
+    const peopleByYoungestFirst = sort(byAge, people);
+  })
+
+  it('returns a curried function', () => {
+    const byAge = descend(prop('age'))
+    byAge({ name: 'Emma', age: 70 })({ name: 'Peter', age: 78 })
+  })
+})
 
 describe('gt', () => {
   it('works with two numbers and produces a bool', () => {
@@ -240,7 +288,7 @@ const ascName = (l, r) => l.name < r.name ? -1 : 1;
 _.sortWith([descAge, ascName], sortWithData);
 _.sortWith([descAge, ascName])(sortWithData);
 
-const eqA = _.eqBy(_.prop("a"));
+const eqA = _.eqBy(prop("a"));
 const ls1: Array<{ [k: string]: number }> = [
   { a: 1 },
   { a: 2 },


### PR DESCRIPTION
- Links to documentation: https://ramdajs.com/docs/#ascend https://ramdajs.com/docs/#descend
- Link to GitHub or NPM: https://github.com/ramda/ramda
- Type of contribution: fix

Other notes:

Returning a curried function makes these functions work with `sort`, which matches usage as well as the documented examples for these functions.