### PR TITLE
Winston: Add correct definition for json format parameter

### DIFF
--- a/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
@@ -63,11 +63,17 @@ declare type $winstonLogger<T: $winstonLevels> = {
 declare type $winstonConfigSubModule = {
   npm: () => $winstonNpmLogLevels
 };
+  
+declare type $winstonFormatJsonOptions = {
+  replacer?: (key: string, value: any) => any,
+  space?: number,
+  stable?: boolean
+};
 
 declare type $winstonFormatSubModule = {
   ((info: Object) => Object): () => $winstonFormat,
   combine: (...args: Array<$winstonFormat>) => $winstonFormat,
-  json: () => $winstonFormat,
+  json: (options?: $winstonFormatJsonOptions) => $winstonFormat,
   label: (config?: Object) => $winstonFormat,
   metadata: () => $winstonFormat,
   prettyPrint: () => $winstonFormat,


### PR DESCRIPTION
The json function have optional parameters: https://github.com/winstonjs/logform#json

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/winstonjs/logform#json
- Link to GitHub or NPM: https://github.com/winstonjs/winston
- Type of contribution: fix 

