### PR TITLE
[koa_v2.x.x] cookies.set() options are optional

### DIFF
--- a/definitions/npm/koa_v2.0.x/flow_v0.38.x/koa_v2.0.x.js
+++ b/definitions/npm/koa_v2.0.x/flow_v0.38.x/koa_v2.0.x.js
@@ -187,15 +187,15 @@ declare module 'koa' {
   };
   // https://github.com/pillarjs/cookies
   declare type CookiesSetOptions = {
-    maxAge: number, // milliseconds from Date.now() for expiry
-    expires: Date, //cookie's expiration date (expires at the end of session by default).
-    path: string, //  the path of the cookie (/ by default).
-    domain: string, // domain of the cookie (no default).
-    secure: boolean, // false by default for HTTP, true by default for HTTPS
-    httpOnly: boolean, //  a boolean indicating whether the cookie is only to be sent over HTTP(S),
+    maxAge?: number, // milliseconds from Date.now() for expiry
+    expires?: Date, //cookie's expiration date (expires at the end of session by default).
+    path?: string, //  the path of the cookie (/ by default).
+    domain?: string, // domain of the cookie (no default).
+    secure?: boolean, // false by default for HTTP, true by default for HTTPS
+    httpOnly?: boolean, //  a boolean indicating whether the cookie is only to be sent over HTTP(S),
     // and not made available to client JavaScript (true by default).
-    signed: boolean, // whether the cookie is to be signed (false by default)
-    overwrite: boolean, //  whether to overwrite previously set cookies of the same name (false by default).
+    signed?: boolean, // whether the cookie is to be signed (false by default)
+    overwrite?: boolean, //  whether to overwrite previously set cookies of the same name (false by default).
   };
   declare type Cookies = {
     get: (name: string, options: {signed: boolean}) => string|void,


### PR DESCRIPTION
- Links to documentation: https://koajs.com/#ctx-cookies-set-name-value-options-
- Link to GitHub or NPM: https://github.com/koajs/koa
- Type of contribution: fix

Other notes:

Looks like this has already been fixed on the [Koa definitions for newer Flow versions](https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/koa_v2.0.x/flow_v0.93.x/koa_v2.0.x.js#L190-L200), but the defintion for old Flow versions (pre-0.93) is still wrong. This PR fixes it.