### PR TITLE
Add generatePath signature to react router v5

### DIFF
--- a/definitions/npm/react-router_v5.x.x/flow_v0.63.x-/react-router_v5.x.x.js
+++ b/definitions/npm/react-router_v5.x.x/flow_v0.63.x-/react-router_v5.x.x.js
@@ -128,4 +128,6 @@ declare module "react-router" {
     pathname: string,
     options?: MatchPathOptions | string
   ): null | Match;
+  
+  declare export function generatePath(pattern?: string, params?: Object): string;
 }

--- a/definitions/npm/react-router_v5.x.x/flow_v0.63.x-/react-router_v5.x.x.js
+++ b/definitions/npm/react-router_v5.x.x/flow_v0.63.x-/react-router_v5.x.x.js
@@ -129,5 +129,5 @@ declare module "react-router" {
     options?: MatchPathOptions | string
   ): null | Match;
   
-  declare export function generatePath(pattern?: string, params?: Object): string;
+  declare export function generatePath(pattern?: string, params?: {}): string;
 }


### PR DESCRIPTION
Same signature as for v4: https://github.com/flow-typed/flow-typed/pull/2492/files

Here is the doc: https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/generatePath.md


