### PR TITLE
[cli] Exclude release candidate version

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -127,6 +127,10 @@ async function getOrderedFlowBinVersions(
 
     const flowBins = apiPayload.data
       .filter(rel => {
+        if (rel.tag_name.endsWith('-rc')) {
+          return false;
+        }
+
         if (rel.tag_name === 'v0.67.0') {
           printSkipMessage(
             rel.tag_name,


### PR DESCRIPTION
When I run next command:

```js
 node cli/dist/cli.js run-tests material-ui/core
```

I always have to wait when RC version will be downloaded

```js
Running definition tests against latest 15 flow versions in /home/i/open-source/flow-typed/definitions/npm...

Fetching all Flow binaries...
  Fetching flow-v0.102.0-rc...
    flow-v0.102.0-rc finished downloading.
  Extracting flow-v0.102.0-rc...
  Removing flow-v0.102.0-rc artifacts...
    flow-v0.102.0-rc complete!
Finished fetching Flow binaries.
```