### PR TITLE
expect.toHaveProperty supports Array

### DIFF
--- a/definitions/npm/jest_v24.x.x/flow_v0.39.x-/jest_v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.39.x-/jest_v24.x.x.js
@@ -705,7 +705,7 @@ interface JestExpectType {
   /**
    *
    */
-  toHaveProperty(propPath: string, value?: any): void;
+  toHaveProperty(propPath: string | $ReadOnlyArray<string>, value?: any): void;
   /**
    * Use .toMatch to check that a string matches a regular expression or string.
    */

--- a/definitions/npm/jest_v24.x.x/flow_v0.39.x-/test_jest-v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.39.x-/test_jest-v24.x.x.js
@@ -85,6 +85,7 @@ expect(5).toBeLessThan(8);
 expect('jester').toContain('jest');
 expect({ foo: 'bar' }).toHaveProperty('foo');
 expect({ foo: 'bar' }).toHaveProperty('foo', 'bar');
+expect({ foo: { fizz: 'bar' } }).toHaveProperty(['foo', 'fizz'], 'bar');
 expect('foo').toMatchSnapshot('snapshot name only');
 expect('foo').toMatchSnapshot(undefined, 'snapshot name');
 expect({


### PR DESCRIPTION
See here:
https://github.com/facebook/jest/blob/ccea646e76efd73654468ac32b3cb3a88778f7f4/packages/expect/src/types.ts#L257

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: 
https://jestjs.io/docs/en/expect.html#tohavepropertykeypath-value
https://github.com/facebook/jest/blob/ccea646e76efd73654468ac32b3cb3a88778f7f4/packages/expect/src/types.ts#L257
- Link to GitHub or NPM: https://github.com/facebook/jest
- Type of contribution: fix

Other notes:
