### PR TITLE
remove deprecated $Enum type in favor of $Keys for ramda

### DIFF
--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/ramda_v0.26.x.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-/ramda_v0.26.x.js
@@ -1709,7 +1709,7 @@ declare module ramda {
 
   declare function invoker<A, B, C, D, O: { [k: string]: Function }>(
     arity: number,
-    name: $Enum<O>
+    name: $Keys<O>
   ): CurriedFunction2<A, O, D> &
     CurriedFunction3<A, B, O, D> &
     CurriedFunction4<A, B, C, O, D>;

--- a/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.82.x-/ramda_v0.x.x.js
@@ -1875,7 +1875,7 @@ declare module ramda {
 
   declare function invoker<A, B, C, D, O: { [k: string]: Function }>(
     arity: number,
-    name: $Enum<O>
+    name: $Keys<O>
   ): CurriedFunction2<A, O, D> &
     CurriedFunction3<A, B, O, D> &
     CurriedFunction4<A, B, C, O, D>;


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/facebook/flow/commit/b95c42f98645183eae26706cd79591474456bf13
- Link to GitHub or NPM: https://www.github.com/ramda/ramda
- Type of contribution: fix

Other notes:
New versions of Flow have been causing build errors for Ramda. Simply switching `$Enum` to `$Keys` fixes the issue. `$Enum` has been deprecated and subsequently removed in favor of `$Keys` per errors that come up in the build and according to [this commit](https://github.com/facebook/flow/commit/b95c42f98645183eae26706cd79591474456bf13).