### PR TITLE
[express_v4] Remove import modules

### DIFF
--- a/definitions/npm/express_v4.16.x/flow_v0.32.x-v0.92.x/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.32.x-v0.92.x/express_v4.16.x.js
@@ -1,6 +1,3 @@
-import * as http from "http";
-import type { Socket } from "net";
-
 declare type express$RouterOptions = {
   caseSensitive?: boolean,
   mergeParams?: boolean,
@@ -20,7 +17,7 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   baseUrl: string;
   body: mixed;
   cookies: { [cookie: string]: string };
-  connection: Socket;
+  connection: net$Socket;
   fresh: boolean;
   hostname: string;
   ip: string;
@@ -216,15 +213,15 @@ declare class express$Application extends express$Router mixins events$EventEmit
     hostname?: string,
     backlog?: number,
     callback?: (err?: ?Error) => mixed
-  ): ?http.Server;
+  ): ?http$Server;
   listen(
     port: number,
     hostname?: string,
     callback?: (err?: ?Error) => mixed
-  ): ?http.Server;
-  listen(port: number, callback?: (err?: ?Error) => mixed): ?http.Server;
-  listen(path: string, callback?: (err?: ?Error) => mixed): ?http.Server;
-  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http.Server;
+  ): ?http$Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http$Server;
   disable(name: string): void;
   disabled(name: string): boolean;
   enable(name: string): express$Application;

--- a/definitions/npm/express_v4.16.x/flow_v0.93.x-/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.93.x-/express_v4.16.x.js
@@ -1,6 +1,3 @@
-import * as http from "http";
-import type { Socket } from "net";
-
 declare type express$RouterOptions = {
   caseSensitive?: boolean,
   mergeParams?: boolean,
@@ -20,7 +17,7 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   baseUrl: string;
   body: mixed;
   cookies: { [cookie: string]: string };
-  connection: Socket;
+  connection: net$Socket;
   fresh: boolean;
   hostname: string;
   ip: string;
@@ -216,15 +213,15 @@ declare class express$Application extends express$Router mixins events$EventEmit
     hostname?: string,
     backlog?: number,
     callback?: (err?: ?Error) => mixed
-  ): ?http.Server;
+  ): ?http$Server;
   listen(
     port: number,
     hostname?: string,
     callback?: (err?: ?Error) => mixed
-  ): ?http.Server;
-  listen(port: number, callback?: (err?: ?Error) => mixed): ?http.Server;
-  listen(path: string, callback?: (err?: ?Error) => mixed): ?http.Server;
-  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http.Server;
+  ): ?http$Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http$Server;
   disable(name: string): void;
   disabled(name: string): boolean;
   enable(name: string): express$Application;

--- a/definitions/npm/express_v4.x.x/flow_v0.25.x-v0.27.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.25.x-v0.27.x/express_v4.x.x.js
@@ -1,5 +1,3 @@
-import type { Server } from 'http';
-
 declare type express$RouterOptions = {
   caseSensitive?: boolean,
   mergeParams?: boolean,
@@ -147,11 +145,11 @@ declare class express$Application extends express$Router mixins events$EventEmit
   constructor(): void;
   locals: {[name: string]: mixed};
   mountpath: string;
-  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): Server;
-  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): Server;
-  listen(port: number, callback?: (err?: ?Error) => mixed): Server;
-  listen(path: string, callback?: (err?: ?Error) => mixed): Server;
-  listen(handle: Object, callback?: (err?: ?Error) => mixed): Server;
+  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): http$Server;
+  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): http$Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): http$Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): http$Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): http$Server;
   disable(name: string): void;
   disabled(name: string): boolean;
   enable(name: string): express$Application;

--- a/definitions/npm/express_v4.x.x/flow_v0.28.x-v0.31.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.28.x-v0.31.x/express_v4.x.x.js
@@ -1,5 +1,3 @@
-import type { Server } from 'http';
-
 declare type express$RouterOptions = {
   caseSensitive?: boolean,
   mergeParams?: boolean,
@@ -147,11 +145,11 @@ declare class express$Application extends express$Router mixins events$EventEmit
   constructor(): void;
   locals: {[name: string]: mixed};
   mountpath: string;
-  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): Server;
-  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): Server;
-  listen(port: number, callback?: (err?: ?Error) => mixed): Server;
-  listen(path: string, callback?: (err?: ?Error) => mixed): Server;
-  listen(handle: Object, callback?: (err?: ?Error) => mixed): Server;
+  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): http$Server;
+  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): http$Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): http$Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): http$Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): http$Server;
   disable(name: string): void;
   disabled(name: string): boolean;
   enable(name: string): express$Application;

--- a/definitions/npm/express_v4.x.x/flow_v0.32.x-v0.92.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.32.x-v0.92.x/express_v4.x.x.js
@@ -1,6 +1,3 @@
-import * as http from 'http';
-import type { Socket } from 'net';
-
 declare type express$RouterOptions = {
   caseSensitive?: boolean,
   mergeParams?: boolean,
@@ -20,7 +17,7 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   baseUrl: string;
   body: mixed;
   cookies: {[cookie: string]: string};
-  connection: Socket;
+  connection: net$Socket;
   fresh: boolean;
   hostname: string;
   ip: string;
@@ -165,11 +162,11 @@ declare class express$Application extends express$Router mixins events$EventEmit
   constructor(): void;
   locals: {[name: string]: mixed};
   mountpath: string;
-  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): ?http.Server;
-  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): ?http.Server;
-  listen(port: number, callback?: (err?: ?Error) => mixed): ?http.Server;
-  listen(path: string, callback?: (err?: ?Error) => mixed): ?http.Server;
-  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http.Server;
+  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http$Server;
   disable(name: string): void;
   disabled(name: string): boolean;
   enable(name: string): express$Application;

--- a/definitions/npm/express_v4.x.x/flow_v0.93.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.93.x-/express_v4.x.x.js
@@ -1,6 +1,3 @@
-import * as http from 'http';
-import type { Socket } from 'net';
-
 declare type express$RouterOptions = {
   caseSensitive?: boolean,
   mergeParams?: boolean,
@@ -20,7 +17,7 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   baseUrl: string;
   body: mixed;
   cookies: {[cookie: string]: string};
-  connection: Socket;
+  connection: net$Socket;
   fresh: boolean;
   hostname: string;
   ip: string;
@@ -165,11 +162,11 @@ declare class express$Application extends express$Router mixins events$EventEmit
   constructor(): void;
   locals: {[name: string]: mixed};
   mountpath: string;
-  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): ?http.Server;
-  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): ?http.Server;
-  listen(port: number, callback?: (err?: ?Error) => mixed): ?http.Server;
-  listen(path: string, callback?: (err?: ?Error) => mixed): ?http.Server;
-  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http.Server;
+  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http$Server;
   disable(name: string): void;
   disabled(name: string): boolean;
   enable(name: string): express$Application;


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://expressjs.com/
- Link to GitHub or NPM: https://github.com/expressjs/express
- Type of contribution: Fix

Other notes:

1. This pr will get error with `Deprecated utility. Using '$Subtype' types is not recommended! ('deprecated-utility')`. #3337 will fix this error.

2. If I use `express`, I can not import `net`. I will get error:

```sh
Cannot get net.Socket because property Socket is missing in module net [1].

     packages/configs/src/utils/worker.js
       71│    *
       72│    * @return {client | null} - a client socket or null
       73│    */
       74│   +writeCache = (data: cacheType): ?net.Socket => {
       75│     const { filePath, pid, using } = data;
       76│
       77│     if (this.server) {


/private/tmp/flow/flowlib_20d44069/node.js
 [1] 1617│ declare module "net" {
     1618│
     1619│   declare class Server extends net$Server {}
     1620│   declare class Socket extends net$Socket {}
     1621│
     1622│   declare function isIP(input: string): number;
     1623│   declare function isIPv4(input: string): boolean;
     1624│   declare function isIPv6(input: string): boolean;
     1625│
     1626│
     1627│   declare type connectionListener = (socket: Socket) => any;
     1628│   declare function createServer(
     1629│     options?: {
     1630│       allowHalfOpen?: boolean,
     1631│       pauseOnConnect?: boolean,
     1632│       ...
     1633│     } | connectionListener,
     1634│     connectionListener?: connectionListener,
     1635│   ): Server;
     1636│
     1637│   declare type connectListener = () => any;
     1638│   declare function connect(
     1639│     pathOrPortOrOptions:  string | number | net$connectOptions,
     1640│     hostOrConnectListener?: string | connectListener,
     1641│     connectListener?: connectListener,
     1642│   ): Socket;
     1643│
     1644│   declare function createConnection(
     1645│     pathOrPortOrOptions:  string | number | net$connectOptions,
     1646│     hostOrConnectListener?: string | connectListener,
     1647│     connectListener?: connectListener,
     1648│   ): Socket;
     1649│ }
```
