### PR TITLE
object-hash: allow "passthrough" as an algorithm option

### DIFF
--- a/definitions/npm/object-hash_v1.x.x/flow_v0.25.x-/object-hash_v1.x.x.js
+++ b/definitions/npm/object-hash_v1.x.x/flow_v0.25.x-/object-hash_v1.x.x.js
@@ -6,7 +6,7 @@
 
 declare module "object-hash" {
   declare type Options = {|
-    algorithm?: "sha1" | "sha256" | "md5",
+    algorithm?: "sha1" | "sha256" | "md5" | "passthrough",
     excludeValues?: boolean,
     encoding?: "buffer" | "hex" | "binary" | "base64",
     ignoreUnknown?: boolean,


### PR DESCRIPTION
This is also an option provided by the library:
https://github.com/puleos/object-hash/blob/c70080cc88b4b54abffe723659bde530474f1d17/index.js#L57-L58