### PR TITLE
Fix add, set, reset and remove methods for backbone collections

### DIFF
--- a/definitions/npm/backbone-collection_v1.x.x/flow_v0.25.x-v0.74.x/backbone-collection_v1.x.x.js
+++ b/definitions/npm/backbone-collection_v1.x.x/flow_v0.25.x-v0.74.x/backbone-collection_v1.x.x.js
@@ -172,10 +172,10 @@ declare module "backbone-collection" {
     countBy: Function;
     indexBy: Function;
     // end underscore methods
-    add(models: Array<TModel>, options?: Object): void;
-    remove(models: Array<TModel>, options?: Object): void;
-    reset(models?: Array<TModel>, options?: Object): void;
-    set(models: Array<TModel>, options?: Object): void;
+    add(models: Array<TModel>, options?: Object): ?TModel | TModel[];
+    remove(models: Array<TModel>, options?: Object): ?TModel | TModel[];
+    reset(models?: Array<TModel>, options?: Object): ?TModel | TModel[];
+    set(models: Array<TModel>, options?: Object): ?TModel | TModel[];
     get(id: string): ?TModel;
     at(index: number): ?TModel;
     push(model: TModel, options?: Object): void;

--- a/definitions/npm/backbone-collection_v1.x.x/flow_v0.75.x-/backbone-collection_v1.x.x.js
+++ b/definitions/npm/backbone-collection_v1.x.x/flow_v0.75.x-/backbone-collection_v1.x.x.js
@@ -173,10 +173,10 @@ declare module "backbone-collection" {
     countBy: Function;
     indexBy: Function;
     // end underscore methods
-    add(models: Array<TModel>, options?: Object): void;
-    remove(models: Array<TModel>, options?: Object): void;
-    reset(models?: Array<TModel>, options?: Object): void;
-    set(models: Array<TModel>, options?: Object): void;
+    add(models: Array<TModel>, options?: Object): ?TModel | TModel[];
+    remove(models: Array<TModel>, options?: Object): ?TModel | TModel[];
+    reset(models?: Array<TModel>, options?: Object): ?TModel | TModel[];
+    set(models: Array<TModel>, options?: Object): ?TModel | TModel[];
     get(id: string): ?TModel;
     at(index: number): ?TModel;
     push(model: TModel, options?: Object): void;

--- a/definitions/npm/backbone-model_v1.x.x/flow_v0.25.x-v0.74.x/backbone-model_v1.x.x.js
+++ b/definitions/npm/backbone-model_v1.x.x/flow_v0.25.x-v0.74.x/backbone-model_v1.x.x.js
@@ -170,10 +170,10 @@ declare module "backbone-model" {
     countBy: Function;
     indexBy: Function;
     // end underscore methods
-    add(models: Array<TModel>, options?: Object): void;
-    remove(models: Array<TModel>, options?: Object): void;
-    reset(models?: Array<TModel>, options?: Object): void;
-    set(models: Array<TModel>, options?: Object): void;
+    add(models: Array<TModel>, options?: Object): ?TModel | TModel[];
+    remove(models: Array<TModel>, options?: Object): ?TModel | TModel[];
+    reset(models?: Array<TModel>, options?: Object): ?TModel | TModel[];
+    set(models: Array<TModel>, options?: Object): ?TModel | TModel[];
     get(id: string): ?TModel;
     at(index: number): ?TModel;
     push(model: TModel, options?: Object): void;

--- a/definitions/npm/backbone-model_v1.x.x/flow_v0.75.x-/backbone-model_v1.x.x.js
+++ b/definitions/npm/backbone-model_v1.x.x/flow_v0.75.x-/backbone-model_v1.x.x.js
@@ -171,10 +171,10 @@ declare module "backbone-model" {
     countBy: Function;
     indexBy: Function;
     // end underscore methods
-    add(models: Array<TModel>, options?: Object): void;
-    remove(models: Array<TModel>, options?: Object): void;
-    reset(models?: Array<TModel>, options?: Object): void;
-    set(models: Array<TModel>, options?: Object): void;
+    add(models: Array<TModel>, options?: Object): ?TModel | TModel[];
+    remove(models: Array<TModel>, options?: Object): ?TModel | TModel[];
+    reset(models?: Array<TModel>, options?: Object): ?TModel | TModel[];
+    set(models: Array<TModel>, options?: Object): ?TModel | TModel[];
     get(id: string): ?TModel;
     at(index: number): ?TModel;
     push(model: TModel, options?: Object): void;

--- a/definitions/npm/backbone_v1.x.x/flow_v0.25.x-v0.41.x/backbone_v1.x.x.js
+++ b/definitions/npm/backbone_v1.x.x/flow_v0.25.x-v0.41.x/backbone_v1.x.x.js
@@ -170,10 +170,10 @@ declare module "backbone" {
     countBy: Function;
     indexBy: Function;
     // end underscore methods
-    add(models: Array<TModel>, options?: Object): void;
-    remove(models: Array<TModel>, options?: Object): void;
-    reset(models?: Array<TModel>, options?: Object): void;
-    set(models: Array<TModel>, options?: Object): void;
+    add(models: Array<TModel>, options?: Object): ?TModel | TModel[];
+    remove(models: Array<TModel>, options?: Object): ?TModel | TModel[];
+    reset(models?: Array<TModel>, options?: Object): ?TModel | TModel[];
+    set(models: Array<TModel>, options?: Object): ?TModel | TModel[];
     get(id: string): ?TModel;
     at(index: number): ?TModel;
     push(model: TModel, options?: Object): void;

--- a/definitions/npm/backbone_v1.x.x/flow_v0.42.x-/backbone_v1.x.x.js
+++ b/definitions/npm/backbone_v1.x.x/flow_v0.42.x-/backbone_v1.x.x.js
@@ -172,10 +172,10 @@ declare module "backbone" {
     countBy: Function;
     indexBy: Function;
     // end underscore methods
-    add(models: Array<TModel>, options?: Object): void;
-    remove(models: Array<TModel>, options?: Object): void;
-    reset(models?: Array<TModel>, options?: Object): void;
-    set(models: Array<TModel>, options?: Object): void;
+    add(models: Array<TModel>, options?: Object): ?TModel | TModel[];
+    remove(models: Array<TModel>, options?: Object): ?TModel | TModel[];
+    reset(models?: Array<TModel>, options?: Object): ?TModel | TModel[];
+    set(models: Array<TModel>, options?: Object): ?TModel | TModel[];
     get(id: string): ?TModel;
     at(index: number): ?TModel;
     push(model: TModel, options?: Object): void;


### PR DESCRIPTION
Links to documentation:

- returns from `set`: https://backbonejs.org/docs/backbone.html#section-123
- `add`: https://backbonejs.org/docs/backbone.html#section-113
- `reset`: https://backbonejs.org/docs/backbone.html#section-123 
- `remove`: https://backbonejs.org/docs/backbone.html#section-114

Link to GitHub: https://github.com/jashkenas/backbone/
Type of contribution: fix