### PR TITLE
Generate stub declarations for directory modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Generate stub declarations for subdirectory modules such as `core-js/stable` and `core-js/es/symbol` in core-js (#3426)
+
 ## [2.5.2] - 2019-05-15
 
 ### Added

--- a/cli/src/lib/stubUtils.js
+++ b/cli/src/lib/stubUtils.js
@@ -239,6 +239,11 @@ async function writeStub(
         if (name === 'index') {
           aliases.push(format(aliasTemplate, moduleName, '', packageName));
           aliases.push(format(aliasTemplate, moduleName, ext, packageName));
+        } else if (path.basename(name) === 'index') {
+          const dirModuleName = packageName + '/' + path.dirname(file);
+          fileDecls.push(format(moduleStubTemplate, dirModuleName));
+          aliases.push(format(aliasTemplate, moduleName, '', dirModuleName));
+          aliases.push(format(aliasTemplate, moduleName, ext, dirModuleName));
         } else {
           fileDecls.push(format(moduleStubTemplate, moduleName));
           aliases.push(format(aliasTemplate, moduleName, ext, moduleName));


### PR DESCRIPTION
This change makes `flow-type install` create stubs for `core-js/stable` and `core-js/es/symbol` rather than just `core-js/stable/index` and `core-js/es/symbol/index`.