### PR TITLE
Update apollo-link-http_v1.2.x.js

### DIFF
--- a/definitions/npm/apollo-link-http_v1.2.x/flow_v0.56.x-/apollo-link-http_v1.2.x.js
+++ b/definitions/npm/apollo-link-http_v1.2.x/flow_v0.56.x-/apollo-link-http_v1.2.x.js
@@ -1,7 +1,7 @@
 // @flow
 
 declare module "apollo-link-http" {
-  declare type $Record<T, U> = {[key: $Enum<T>]: U};
+  declare type $Record<T, U> = {[key: $Keys<T>]: U};
 
   declare type NextLink = (operation: Operation) => any;
 


### PR DESCRIPTION
changed deprecated $Enum to $Keys
