### PR TITLE
[history_v4.9.x] Update types for history

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ library-definition test runner.
 ***We call this the "flow version directory".***
 
 This specifies that the definition you are contributing is compatible with the
-version range of the directory. You MUST specify a version range with names like
+version range of the directiry. You MUST specify a version range with names like
 `flow_v0.25.x-` ("any version at or after v0.25.x") or
 `flow_-v0.25.x` ("any version at or before v0.25.x") or
 `flow_v0.25.x-v0.28.x` ("any version inclusively between v0.25.x and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ library-definition test runner.
 ***We call this the "flow version directory".***
 
 This specifies that the definition you are contributing is compatible with the
-version range of the directiry. You MUST specify a version range with names like
+version range of the directory. You MUST specify a version range with names like
 `flow_v0.25.x-` ("any version at or after v0.25.x") or
 `flow_-v0.25.x` ("any version at or before v0.25.x") or
 `flow_v0.25.x-v0.28.x` ("any version inclusively between v0.25.x and

--- a/definitions/npm/history_v4.9.x/flow_v0.25.x-/history_v4.9.x.js
+++ b/definitions/npm/history_v4.9.x/flow_v0.25.x-/history_v4.9.x.js
@@ -1,4 +1,3 @@
-// @flow
 declare module 'history' {
   declare function Unblock(): void;
 
@@ -125,15 +124,9 @@ declare module 'history' {
 
   declare function createHashHistory(opts?: HashHistoryOpts): HashHistory;
 
-  declare type LocationType = {
-    pathname?: string,
-    search?: string,
-    hash?: string,
-  };
-
-  declare function parsePath(path: string): LocationType;
+  declare function parsePath(path: string): BrowserLocation | MemoryLocation | HashLocation;
 
   declare function createPath(
-    path: LocationType
+    path: BrowserLocation | MemoryLocation | HashLocation
   ): string;
 }

--- a/definitions/npm/history_v4.9.x/flow_v0.25.x-/history_v4.9.x.js
+++ b/definitions/npm/history_v4.9.x/flow_v0.25.x-/history_v4.9.x.js
@@ -1,8 +1,8 @@
-declare module "history" {
-
+// @flow
+declare module 'history' {
   declare function Unblock(): void;
 
-  declare export type Action = "PUSH" | "REPLACE" | "POP";
+  declare export type Action = 'PUSH' | 'REPLACE' | 'POP';
 
   declare export type BrowserLocation = {
     pathname: string,
@@ -14,19 +14,21 @@ declare module "history" {
   };
 
   declare interface IBrowserHistory {
-    length: number,
-    location: BrowserLocation,
-    action: Action,
-    push(path: string, state?: {}): void,
-    push(location: $Shape<BrowserLocation>): void,
-    replace(path: string, state?: {}): void,
-    replace(location: $Shape<BrowserLocation>): void,
-    go(n: number): void,
-    goBack(): void,
-    goForward(): void,
-    listen((location: BrowserLocation, action: Action) => void): void,
-    block(message: string): typeof Unblock,
-    block((location: BrowserLocation, action: Action) => string): typeof Unblock,
+    length: number;
+    location: BrowserLocation;
+    action: Action;
+    push(path: string, state?: {}): void;
+    push(location: $Shape<BrowserLocation>): void;
+    replace(path: string, state?: {}): void;
+    replace(location: $Shape<BrowserLocation>): void;
+    go(n: number): void;
+    goBack(): void;
+    goForward(): void;
+    listen((location: BrowserLocation, action: Action) => void): void;
+    block(message: string): typeof Unblock;
+    block(
+      (location: BrowserLocation, action: Action) => string
+    ): typeof Unblock;
   }
 
   declare export type BrowserHistory = IBrowserHistory;
@@ -36,11 +38,13 @@ declare module "history" {
     forceRefresh?: boolean,
     getUserConfirmation?: (
       message: string,
-      callback: (willContinue: boolean) => void,
+      callback: (willContinue: boolean) => void
     ) => void,
   };
 
-  declare function createBrowserHistory(opts?: BrowserHistoryOpts): BrowserHistory;
+  declare function createBrowserHistory(
+    opts?: BrowserHistoryOpts
+  ): BrowserHistory;
 
   declare export type MemoryLocation = {
     pathname: string,
@@ -52,23 +56,23 @@ declare module "history" {
   };
 
   declare interface IMemoryHistory {
-    length: number,
-    location: MemoryLocation,
-    action: Action,
-    index: number,
-    entries: Array<string>,
-    push(path: string, state?: {}): void,
-    push(location: $Shape<MemoryLocation>): void,
-    replace(path: string, state?: {}): void,
-    replace(location: $Shape<MemoryLocation>): void,
-    go(n: number): void,
-    goBack(): void,
-    goForward(): void,
+    length: number;
+    location: MemoryLocation;
+    action: Action;
+    index: number;
+    entries: Array<string>;
+    push(path: string, state?: {}): void;
+    push(location: $Shape<MemoryLocation>): void;
+    replace(path: string, state?: {}): void;
+    replace(location: $Shape<MemoryLocation>): void;
+    go(n: number): void;
+    goBack(): void;
+    goForward(): void;
     // Memory only
-    canGo(n: number): boolean,
-    listen((location: MemoryLocation, action: Action) => void): void,
-    block(message: string): typeof Unblock,
-    block((location: MemoryLocation, action: Action) => string): typeof Unblock,
+    canGo(n: number): boolean;
+    listen((location: MemoryLocation, action: Action) => void): void;
+    block(message: string): typeof Unblock;
+    block((location: MemoryLocation, action: Action) => string): typeof Unblock;
   }
 
   declare export type MemoryHistory = IMemoryHistory;
@@ -79,7 +83,7 @@ declare module "history" {
     keyLength?: number,
     getUserConfirmation?: (
       message: string,
-      callback: (willContinue: boolean) => void,
+      callback: (willContinue: boolean) => void
     ) => void,
   };
 
@@ -92,32 +96,44 @@ declare module "history" {
   };
 
   declare interface IHashHistory {
-    length: number,
-    location: HashLocation,
-    action: Action,
-    push(path: string, state?: {}): void,
-    push(location: $Shape<HashLocation>): void,
-    replace(path: string, state?: {}): void,
-    replace(location: $Shape<HashLocation>): void,
-    go(n: number): void,
-    goBack(): void,
-    goForward(): void,
-    listen((location: HashLocation, action: Action) => void): void,
-    block(message: string): typeof Unblock,
-    block((location: HashLocation, action: Action) => string): typeof Unblock,
-    push(path: string): void,
+    length: number;
+    location: HashLocation;
+    action: Action;
+    push(path: string, state?: {}): void;
+    push(location: $Shape<HashLocation>): void;
+    replace(path: string, state?: {}): void;
+    replace(location: $Shape<HashLocation>): void;
+    go(n: number): void;
+    goBack(): void;
+    goForward(): void;
+    listen((location: HashLocation, action: Action) => void): void;
+    block(message: string): typeof Unblock;
+    block((location: HashLocation, action: Action) => string): typeof Unblock;
+    push(path: string): void;
   }
 
   declare export type HashHistory = IHashHistory;
 
   declare type HashHistoryOpts = {
     basename?: string,
-    hashType: "slash" | "noslash" | "hashbang",
+    hashType: 'slash' | 'noslash' | 'hashbang',
     getUserConfirmation?: (
       message: string,
-      callback: (willContinue: boolean) => void,
+      callback: (willContinue: boolean) => void
     ) => void,
   };
 
   declare function createHashHistory(opts?: HashHistoryOpts): HashHistory;
+
+  declare type LocationType = {
+    pathname?: string,
+    search?: string,
+    hash?: string,
+  };
+
+  declare function parsePath(path: string): LocationType;
+
+  declare function createPath(
+    path: LocationType
+  ): string;
 }

--- a/definitions/npm/history_v4.9.x/flow_v0.25.x-/test_history_v4.9.x.js
+++ b/definitions/npm/history_v4.9.x/flow_v0.25.x-/test_history_v4.9.x.js
@@ -269,12 +269,6 @@ describe('create path', () => {
     const state: {} = path
   });
 
-  it('should allow to use empty Location argument', () => {
-    const path = createPath({})
-
-    const key: string = path
-  });
-
   it('should not allow to accept void', () => {
     // $ExpectError
     const path = createPath()

--- a/definitions/npm/history_v4.9.x/flow_v0.25.x-/test_history_v4.9.x.js
+++ b/definitions/npm/history_v4.9.x/flow_v0.25.x-/test_history_v4.9.x.js
@@ -5,6 +5,8 @@ import { describe, it } from 'flow-typed-test';
 import {createBrowserHistory} from 'history';
 import {createMemoryHistory} from 'history';
 import {createHashHistory} from 'history';
+import {createPath} from 'history';
+import {parsePath} from 'history';
 
 // browser history
 
@@ -251,5 +253,49 @@ describe('hash history', () => {
         search: "?a=1",
       })
     });
+  });
+});
+
+describe('create path', () => {
+  it('should allow to use Location argument', () => {
+    const path = createPath({
+      pathname: '/test',
+      search: '?a=1',
+      hash: 'slug',
+    })
+
+    const key: string = path
+    // $ExpectError
+    const state: {} = path
+  });
+
+  it('should allow to use empty Location argument', () => {
+    const path = createPath({})
+
+    const key: string = path
+  });
+
+  it('should not allow to accept void', () => {
+    // $ExpectError
+    const path = createPath()
+
+    const key: string = path
+  });
+});
+
+describe('parse path', () => {
+  it('should allow to use string argument', () => {
+    const location = parsePath('/test?query#hash')
+
+    const state: {} = location
+    // $ExpectError
+    const key: string = location
+  });
+
+  it('should not allow to accept void', () => {
+    // $ExpectError
+    const location = parsePath()
+
+    const state: {} = location
   });
 });


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Link to GitHub or NPM: *Covering [these functions](https://github.com/ReactTraining/history/blob/master/modules/PathUtils.js#L24-L59) from the **history** package*
- Links to documentation: *Unfortunately, these are undocumented*
- Type of contribution: *new definition | **ADDITION** | fix | refactor*

These exported APIs are undocumented and were missed in the previous libdef iteration.

Most of the diff is from prettier (`"` => `'`, `,` => `;`). eslint didn't mind, so I left them in.
