### PR TITLE
Added credit-card-type v7 & v8

### DIFF
--- a/definitions/npm/credit-card-type_v7.x.x/flow_v0.25.x-/credit-card-type_v7.x.x.js
+++ b/definitions/npm/credit-card-type_v7.x.x/flow_v0.25.x-/credit-card-type_v7.x.x.js
@@ -1,0 +1,40 @@
+declare module 'credit-card-type' {
+
+  declare export type CardBrand =
+  | "american-express"
+  | "diners-club"
+  | "discover"
+  | "jcb"
+  | "maestro"
+  | "mastercard"
+  | "unionpay"
+  | "visa";
+
+  declare export type CreditCardType = {
+    niceType: string,
+    type: string,
+    prefixPattern: RegExp,
+    exactPattern: RegExp,
+    gaps: number[],
+    lengths: number[],
+    code: {
+        name: string;
+        size: number;
+    },
+  }
+
+  declare type Library = {
+    (cardNumber: string): CreditCardType[];
+    types: {
+      [key: string]: CreditCardType
+    };
+    getTypeInfo: (type: string) => CreditCardType | null;
+    removeCard: (name: string) => void;
+    addCard: (config: CreditCardType) => void;
+    changeOrder: (name: string, position: number) => void;
+    resetModifications: () => void;
+  }
+
+  declare module.exports: Library
+}
+  

--- a/definitions/npm/credit-card-type_v7.x.x/flow_v0.25.x-/test_credit-card-type_v7.x.x.js
+++ b/definitions/npm/credit-card-type_v7.x.x/flow_v0.25.x-/test_credit-card-type_v7.x.x.js
@@ -1,0 +1,55 @@
+// @flow
+
+import creditCardType from 'credit-card-type';
+import type { CreditCardType } from 'credit-card-type';
+
+const {
+  types,
+  getTypeInfo,
+  removeCard,
+  addCard,
+  changeOrder,
+  resetModifications,
+} = creditCardType;
+
+const customCardType: CreditCardType = {
+  niceType: 'NewCard',
+  type: 'new-card',
+  prefixPattern: /^(2|23|234)$/,
+  exactPattern: /^(2345)\d*$/,
+  gaps: [4, 8, 12],
+  lengths: [16],
+  code: {
+    name: 'cvv',
+    size: 3,
+  },
+};
+
+const typesMap: { [key: string]: CreditCardType } = types;
+const visaType: CreditCardType | void = types['VISA'];
+const resolvedTypes: CreditCardType[] = creditCardType('4111111111111111');
+const foundByType: CreditCardType | null = getTypeInfo('VISA');
+const removedCard: void = removeCard('JCB');
+const changedOrder: void = changeOrder('VISA', 3);
+const resetValues: void = resetModifications();
+const addedCard: void = addCard(customCardType);
+
+// $ExpectError
+creditCardType(4111111111111111);
+// $ExpectError
+creditCardType(null);
+// $ExpectError
+getTypeInfo(123);
+// $ExpectError
+getTypeInfo(null);
+// $ExpectError
+removeCard();
+// $ExpectError
+changeOrder(undefined, null);
+// $ExpectError
+changeOrder('VISA');
+// $ExpectError
+addCard({
+  niceType: 'NewCard',
+  type: 'new-card',
+});

--- a/definitions/npm/credit-card-type_v8.x.x/flow_v0.25.x-/credit-card-type_v8.x.x.js
+++ b/definitions/npm/credit-card-type_v8.x.x/flow_v0.25.x-/credit-card-type_v8.x.x.js
@@ -1,0 +1,40 @@
+declare module 'credit-card-type' {
+
+  declare export type CardBrand =
+  | "american-express"
+  | "diners-club"
+  | "discover"
+  | "jcb"
+  | "maestro"
+  | "mastercard"
+  | "unionpay"
+  | "visa";
+
+  declare export type CreditCardType = {
+    niceType: string,
+    type: string,
+    prefixPattern: RegExp,
+    exactPattern: RegExp,
+    gaps: number[],
+    lengths: number[],
+    code: {
+        name: string;
+        size: number;
+    },
+  }
+
+  declare type Library = {
+    (cardNumber: string): CreditCardType[];
+    types: {
+      [key: string]: CreditCardType
+    };
+    getTypeInfo: (type: string) => CreditCardType | null;
+    removeCard: (name: string) => void;
+    addCard: (config: CreditCardType) => void;
+    changeOrder: (name: string, position: number) => void;
+    resetModifications: () => void;
+  }
+
+  declare module.exports: Library
+}
+  

--- a/definitions/npm/credit-card-type_v8.x.x/flow_v0.25.x-/test_credit-card-type_v8.x.x.js
+++ b/definitions/npm/credit-card-type_v8.x.x/flow_v0.25.x-/test_credit-card-type_v8.x.x.js
@@ -1,0 +1,55 @@
+// @flow
+
+import creditCardType from 'credit-card-type';
+import type { CreditCardType } from 'credit-card-type';
+
+const {
+  types,
+  getTypeInfo,
+  removeCard,
+  addCard,
+  changeOrder,
+  resetModifications,
+} = creditCardType;
+
+const customCardType: CreditCardType = {
+  niceType: 'NewCard',
+  type: 'new-card',
+  prefixPattern: /^(2|23|234)$/,
+  exactPattern: /^(2345)\d*$/,
+  gaps: [4, 8, 12],
+  lengths: [16],
+  code: {
+    name: 'cvv',
+    size: 3,
+  },
+};
+
+const typesMap: { [key: string]: CreditCardType } = types;
+const visaType: CreditCardType | void = types['VISA'];
+const resolvedTypes: CreditCardType[] = creditCardType('4111111111111111');
+const foundByType: CreditCardType | null = getTypeInfo('VISA');
+const removedCard: void = removeCard('JCB');
+const changedOrder: void = changeOrder('VISA', 3);
+const resetValues: void = resetModifications();
+const addedCard: void = addCard(customCardType);
+
+// $ExpectError
+creditCardType(4111111111111111);
+// $ExpectError
+creditCardType(null);
+// $ExpectError
+getTypeInfo(123);
+// $ExpectError
+getTypeInfo(null);
+// $ExpectError
+removeCard();
+// $ExpectError
+changeOrder(undefined, null);
+// $ExpectError
+changeOrder('VISA');
+// $ExpectError
+addCard({
+  niceType: 'NewCard',
+  type: 'new-card',
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/braintree/credit-card-type
- Link to GitHub or NPM: https://github.com/braintree/credit-card-type
- Type of contribution: new definition

