### PR TITLE
[winston_v3.x.x] Update definition to allow named imports

### DIFF
--- a/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
@@ -111,7 +111,8 @@ declare module "winston" {
   declare export type DefaultLogger = $winstonDefaultLogger;
   declare export type Container<T: Levels> = $winstonContainer<T>;
 
-  declare module.exports: $winstonDefaultLogger & {
+  declare module.exports: {
+    ...$Exact<$winstonDefaultLogger>,
     format: $winstonFormatSubModule,
     transports: {
       Console: typeof $winstonConsoleTransport,

--- a/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
@@ -1,5 +1,5 @@
-import winston from "winston";
-import type { Logger, Levels, Format, ConsoleTransport, Container } from "winston";
+import winston, {format} from "winston";
+import type { Logger, Levels, Format, ConsoleTransport, Container, FormatSubModule } from "winston";
 
 winston.log({
   level: "info",
@@ -99,3 +99,5 @@ const hasCategoryThreeId: boolean = container.has("categoryThreeId");
 logger = container.get("categoryTwoId");
 
 logger.error("categoryTwoId error message");
+
+(format: FormatSubModule);

--- a/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
@@ -1,5 +1,8 @@
-import winston, {format} from "winston";
+import winston, { format } from "winston";
 import type { Logger, Levels, Format, ConsoleTransport, Container, FormatSubModule } from "winston";
+
+const winstonAlternative = require('winston');
+(winstonAlternative: typeof winston);
 
 winston.log({
   level: "info",


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: [README.md](https://github.com/winstonjs/winston/blob/master/README.md)
- Link to GitHub or NPM: [GitHub](https://github.com/winstonjs/winston) | [NPM](https://www.npmjs.com/package/winston)
- Type of contribution: new definition | addition | **fix** | refactor

Other notes:
* Resolves https://github.com/flow-typed/flow-typed/issues/2833
* Opted out of `describe` and `it` since this was an existing definition.  Should the new test use these, or do we grandfather in older tests?

---

The proposed exported type would be equivalent to:

```js
{
  Container: class $winstonContainer<T>, 
  add: ($winstonTransport) => void, 
  clear: () => void, 
  configure: ($winstonLoggerConfig<$winstonNpmLogLevels>) => void, 
  createLogger: <T>($winstonLoggerConfig<T>) => $winstonLogger<T>, 
  format: $winstonFormatSubModule, 
  log: (message: $winstonInfo<$winstonNpmLogLevels>) => void, 
  loggers: $winstonContainer<any>, 
  remove: ($winstonTransport) => void, 
  transports: {
    Console: class $winstonConsoleTransport<T>, 
    File: class $winstonFileTransport<T>
  }, 
  [$Keys<$winstonNpmLogLevels>]: (message: string, meta?: any) => void
}
```

compared to the current type of:

```js
$winstonDefaultLogger & {
  Container: class $winstonContainer<T>, 
  createLogger: <T>($winstonLoggerConfig<T>) => $winstonLogger<T>, 
  format: $winstonFormatSubModule, 
  loggers: $winstonContainer<any>, 
  transports: {
    Console: class $winstonConsoleTransport<T>, 
    File: class $winstonFileTransport<T>
  }
}
```
