### PR TITLE
fix flow error for getActiveChildNavigationOptions import

### DIFF
--- a/definitions/npm/@react-navigation/core_v3.x.x/flow_v0.92.x-/core_v3.x.x.js
+++ b/definitions/npm/@react-navigation/core_v3.x.x/flow_v0.92.x-/core_v3.x.x.js
@@ -796,4 +796,12 @@ declare module '@react-navigation/core' {
     getScreenProps: () => {},
     getCurrentNavigation: () => ?NavigationScreenProp<State>
   ): NavigationScreenProp<State>;
+
+  declare export function getActiveChildNavigationOptions<
+    State: NavigationState,
+    Options: {}
+  >(
+    navigation: NavigationScreenProp<State>,
+    screenProps?: {}
+  ): Options;
 }

--- a/definitions/npm/react-navigation_v3.x.x/flow_v0.92.x-/react-navigation_v3.x.x.js
+++ b/definitions/npm/react-navigation_v3.x.x/flow_v0.92.x-/react-navigation_v3.x.x.js
@@ -1275,4 +1275,12 @@ declare module 'react-navigation' {
     getScreenProps: () => {},
     getCurrentNavigation: () => ?NavigationScreenProp<State>
   ): NavigationScreenProp<State>;
+
+  declare export function getActiveChildNavigationOptions<
+    State: NavigationState,
+    Options: {}
+  >(
+    navigation: NavigationScreenProp<State>,
+    screenProps?: {}
+  ): Options;
 }


### PR DESCRIPTION
Try to solve the issue - [#6002 (comment)](https://github.com/react-navigation/react-navigation/issues/6002#issuecomment-502908696)

