### PR TITLE
[node-fetch_v2.x.x] Copy definition from v1.x.x

### DIFF
--- a/definitions/npm/node-fetch_v2.x.x/flow_v0.100.x-/node-fetch_v2.x.x.js
+++ b/definitions/npm/node-fetch_v2.x.x/flow_v0.100.x-/node-fetch_v2.x.x.js
@@ -1,0 +1,107 @@
+declare module 'node-fetch' {
+  import type http from 'http';
+  import type https from 'https';
+
+  declare export class Request mixins Body {
+    constructor(input: string | { href: string } | Request, init?: RequestInit): this;
+    context: RequestContext;
+    headers: Headers;
+    method: string;
+    redirect: RequestRedirect;
+    referrer: string;
+    url: string;
+
+    // node-fetch extensions
+    agent: http.Agent | https.Agent;
+    compress: boolean;
+    counter: number;
+    follow: number;
+    hostname: string;
+    port: number;
+    protocol: string;
+    size: number;
+    timeout: number;
+  }
+
+  declare type HeaderObject = {
+    [index: string]: string,
+  }
+
+  declare interface RequestInit {
+    body?: BodyInit,
+    headers?: HeaderObject,
+    method?: string,
+    redirect?: RequestRedirect,
+    
+    // node-fetch extensions
+    agent?: http.Agent | https.Agent,
+    compress?: boolean,
+    follow?: number,
+    size?: number,
+    timeout?: number,
+  }
+
+  declare type RequestContext =
+    'audio' | 'beacon' | 'cspreport' | 'download' | 'embed' |
+    'eventsource' | 'favicon' | 'fetch' | 'font' | 'form' | 'frame' |
+    'hyperlink' | 'iframe' | 'image' | 'imageset' | 'import' |
+    'internal' | 'location' | 'manifest' | 'object' | 'ping' | 'plugin' |
+    'prefetch' | 'script' | 'serviceworker' | 'sharedworker' |
+    'subresource' | 'style' | 'track' | 'video' | 'worker' |
+    'xmlhttprequest' | 'xslt';
+  declare type RequestRedirect = 'error' | 'follow' | 'manual';
+
+  declare export class Headers {
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    forEach(callback: (value: string, name: string) => void): void;
+    get(name: string): string;
+    getAll(name: string): Array<string>;
+    has(name: string): boolean;
+    raw(): { [k: string]: string[] };
+    set(name: string, value: string): void;
+  }
+
+  declare export class Body {
+    buffer(): Promise<Buffer>;
+    json(): Promise<any>;
+    json<T>(): Promise<T>;
+    text(): Promise<string>;
+    body: stream$Readable;
+    bodyUsed: boolean;
+  }
+
+  declare export class Response mixins Body {
+    constructor(body?: BodyInit, init?: ResponseInit): this;
+    clone(): Response;
+    error(): Response;
+    redirect(url: string, status: number): Response;
+    headers: Headers;
+    ok: boolean;
+    status: number;
+    statusText: string;
+    size: number;
+    timeout: number;
+    type: ResponseType;
+    url: string;
+  }
+
+  declare type ResponseType =
+    | 'basic'
+    | 'cors'
+    | 'default'
+    | 'error'
+    | 'opaque'
+    | 'opaqueredirect';
+
+  declare interface ResponseInit {
+    headers?: HeaderInit,
+    status: number,
+    statusText?: string,
+  }
+
+  declare type HeaderInit = Headers | Array<string>;
+  declare type BodyInit = string;
+
+  declare export default function fetch(url: string | Request, init?: RequestInit): Promise<Response>
+}

--- a/definitions/npm/node-fetch_v2.x.x/test_node-fetch_v2.x.x.js
+++ b/definitions/npm/node-fetch_v2.x.x/test_node-fetch_v2.x.x.js
@@ -1,0 +1,80 @@
+// @flow
+
+import http from 'http';
+import https from 'https';
+import nodeFetch, { type Headers, type Response } from 'node-fetch';
+import type { Readable } from 'stream';
+
+(nodeFetch('foo'): Promise<Response>);
+(nodeFetch('foo', {}): Promise<Response>);
+
+// $ExpectError url has to be string
+(nodeFetch(123): Promise<Response>);
+
+nodeFetch('foo', {
+    method: 'GET',
+    headers: {
+      Authorization: "Foo",
+    },
+});
+
+nodeFetch('foo', {
+    body: 'bar',
+    agent: new http.Agent({}),
+});
+
+nodeFetch('foo', {
+    // $ExpectError number is not a valid body type
+    body: 5,
+    // $ExpectError number is not a valid agent type
+    agent: 5,
+});
+
+// Response tests
+nodeFetch('foo').then(res => {
+    (res.clone(): Response);
+
+    // Response Headers
+    (res.headers: Headers);
+    (res.headers.append('foo', 'bar'): void);
+    // $ExpectError
+    (res.headers.append(5, 'bar'): void);
+    (res.headers.delete('foo'): void);
+    // $ExpectError
+    (res.headers.delete(5): void);
+    // $ExpectError `entries` not found in Headers
+    (res.headers.entries(): Iterator<*>);
+    (res.headers.get('test'): string);
+    // $ExpectError
+    (res.headers.get(5): string);
+    (res.headers.getAll('test'): Array<string>);
+    (res.headers.has('foo'): boolean);
+    // $ExpectError
+    (res.headers.has(5): boolean);
+    // $ExpectError `keys` not found in Headers
+    (res.headers.keys(): Iterator<string>);
+    // $ExpectError value should be a string
+    (res.headers.set('foo', 5): void);
+    // $ExpectError `values` not found in Headers
+    (res.headers.values(): Iterator<*>);
+
+
+    (res.ok: boolean);
+    (res.status: number);
+    (res.statusText: string);
+
+    // Response type
+    (res.type: ResponseType);
+    res.type = 'basic';
+    // $ExpectError foo is not a valid option
+    res.type = 'foo';
+
+    (res.url: string);
+    (res.size: number);
+    (res.timeout: number);
+
+    (res.bodyUsed: boolean);
+    (res.body: Readable);
+    (res.text(): Promise<string>);
+    (res.buffer(): Promise<Buffer>);
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: [README.md](https://github.com/bitinn/node-fetch/blob/master/README.md) | [CHANGELOG.md](https://github.com/bitinn/node-fetch/blob/master/CHANGELOG.md)
- Link to GitHub or NPM: [GitHub](https://github.com/bitinn/node-fetch) | [NPM](https://www.npmjs.com/package/node-fetch)
- Type of contribution: **new definition** | addition | fix | refactor

Other notes:
**NOTE:** This definition (+ tests) are copied over from the [flow-typed/definitions/npm/node-fetch_v1.x.x](https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/node-fetch_v1.x.x/flow_v0.44.x-/node-fetch_v1.x.x.js).

There are some [breaking changes](https://github.com/bitinn/node-fetch/blob/master/CHANGELOG.md#v200) documented in the v2.0.0 release, but the biggest factor looked to be dropping support for older versions of Node.js.

In theory we can shore up these types to match all of the enhancements and bug fixes.  For now, making this pull request to get the ball rolling since a straight copy+paste gets us a lot of the way there.

