### PR TITLE
[lodash_v4.x.x] (Fix) flow, flowRight, pipe, compose should accept multiple functions, not only array

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -1401,7 +1401,9 @@ declare module "lodash" {
     // NaN is a number instead of its own type, otherwise it would behave like null/void
     defaultTo<T1: number, T2>(value: T1, defaultValue: T2): T1 | T2;
     flow: $ComposeReverse & ((funcs: Array<Function>) => Function);
+    flow: $ComposeReverse & ((...funcs: Array<Function>) => Function);
     flowRight: $Compose & ((funcs: Array<Function>) => Function);
+    flowRight: $Compose & ((...funcs: Array<Function>) => Function);
     identity<T>(value: T): T;
     iteratee(func?: any): Function;
     matches(source?: ?Object): Function;
@@ -3169,10 +3171,15 @@ declare module "lodash/fp" {
     defaultTo<T1: number, T2>(defaultValue: T2): (value: T1) => T1 | T2;
     defaultTo<T1: number, T2>(defaultValue: T2, value: T1): T1 | T2;
     flow: $ComposeReverse & ((funcs: Array<Function>) => Function);
+    flow: $ComposeReverse & ((...funcs: Array<Function>) => Function);
     pipe: $ComposeReverse & ((funcs: Array<Function>) => Function);
+    pipe: $ComposeReverse & ((...funcs: Array<Function>) => Function);
     flowRight: $Compose & ((funcs: Array<Function>) => Function);
+    flowRight: $Compose & ((...funcs: Array<Function>) => Function);
     compose: $Compose & ((funcs: Array<Function>) => Function);
+    compose: $Compose & ((...funcs: Array<Function>) => Function);
     compose(funcs: Array<Function>): Function;
+    compose(...funcs: Array<Function>): Function;
     identity<T>(value: T): T;
     iteratee(func: any): Function;
     matches(source: Object): (object: Object) => boolean;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-fp-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-fp-v4.x.x.js
@@ -462,14 +462,21 @@ noop("a", 2, [], null);
 // $ExpectError functions are contravariant in return types
 (noop: string => string);
 
-const ab = (a: number) => `${a}`;
-const bc = (b: string) => ({ b });
-const cd = (c: { b: string }) => [c.b];
+/**
+ * pipe
+ */
+const ab: number => string = a => `${a}`;
+const bc: string => { b: string } = b => ({ b });
+const cd: { b: string } => string[] = c => [c.b];
 const pipedResult: string[] = pipe(
   ab,
   bc,
   cd
 )(1);
+
+/**
+ * compose
+ */
 const composedResult: string[] = compose(
   cd,
   bc,

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -14,6 +14,8 @@ import extend from "lodash/extend";
 import find from "lodash/find";
 import first from "lodash/first";
 import flatMap from "lodash/flatMap";
+import flow from "lodash/flow";
+import flowRight from "lodash/flowRight";
 import forEach from "lodash/forEach";
 import get from "lodash/get";
 import groupBy from "lodash/groupBy";
@@ -533,3 +535,14 @@ pick({ a: 2 }, 1);
 (orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, ['a']): Array<{ a: number, b: number }>);
 (orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, [x => x.a]): Array<{ a: number, b: number }>);
 
+/**
+ * _.flow
+ */
+const f1: number => string = a => `${a}`;
+const f2: string => string[] = b => [b];
+(flow(f1, f2)(1): string[]);
+
+/**
+ * _.flowRight
+ */
+(flowRight(f2, f1)(1): string[]);


### PR DESCRIPTION
The functions `flow`, `flowRight`, `pipe` and `compose` from lodash (and lodash/fp) should all accept multiple functions as arguments, not only a list of functions. This is supported by the documentation for lodash:

`flow`: [https://lodash.com/docs/4.17.14#flow](https://lodash.com/docs/4.17.14#flow)
`flowRight`: [https://lodash.com/docs/4.17.14#flowRight](https://lodash.com/docs/4.17.14#flowRight)

In the [Lodash FP Guide](https://github.com/lodash/lodash/wiki/FP-Guide) it says that:

-  `pipe` is an alias of `flow`
-  `compose` is an alias of `flowRight`

This fixes issue #2125