### PR TITLE
Add react-redux hooks, `useDispatch` & `useSelector`

### DIFF
--- a/definitions/npm/react-redux_v7.x.x/flow_v0.89.x-/react-redux_v7.x.x.js
+++ b/definitions/npm/react-redux_v7.x.x/flow_v0.89.x-/react-redux_v7.x.x.js
@@ -24,6 +24,7 @@ Decrypting the abbreviations:
   RMP = Returned merge props
   CP = Props for returned component
   Com = React Component
+  SS = Selected state
   ST = Static properties of Com
   EFO = Extra factory options (used only in connectAdvanced)
 */
@@ -196,6 +197,19 @@ declare module "react-redux" {
   ): Connector<P, OP, P>;
 
   // ------------------------------------------------------------
+  // Typings for Hooks
+  // ------------------------------------------------------------
+
+  declare export function useDispatch<D>(): D;
+
+  declare export function useSelector<S, SS>(
+    selector: (state: S) => SS,
+    equalityFn?: (a: SS, b: SS) => boolean,
+  ): SS;
+
+  declare export function useStore<Store>(): Store;
+
+  // ------------------------------------------------------------
   // Typings for Provider
   // ------------------------------------------------------------
 
@@ -269,5 +283,8 @@ declare module "react-redux" {
     createProvider: typeof createProvider,
     connect: typeof connect,
     connectAdvanced: typeof connectAdvanced,
+    useDispatch: typeof useDispatch,
+    useSelector: typeof useSelector,
+    useStore: typeof useStore,
   };
 }

--- a/definitions/npm/react-redux_v7.x.x/flow_v0.89.x-/test_useDispatch.js
+++ b/definitions/npm/react-redux_v7.x.x/flow_v0.89.x-/test_useDispatch.js
@@ -1,0 +1,43 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import React from 'react';
+import { useDispatch } from 'react-redux';
+
+type Action = {|
+  type: 'action',
+|};
+type Dispatch = Action => Action;
+
+describe('useDispatch', () => {
+  it('returns type `Dispatch` which accepts only type `Action` as param', () => {
+    function Com() {
+      const dispatch = useDispatch<Dispatch>();
+      return (
+        <button
+          onClick={function() {
+            dispatch({ type: 'action' });
+          }}
+        >
+          Dispatch time
+        </button>
+      );
+    }
+  });
+
+  it('errors if returned type is passed invalid Action', () => {
+    function Com() {
+      const dispatch = useDispatch<Dispatch>();
+      return (
+        <div
+          onClick={() => {
+            // $ExpectError: return value of `useDispatch` should make `Dispatch` and expect an `Action`.
+            dispatch();
+          }}
+        >
+          Dispatch time
+        </div>
+      );
+    }
+  });
+});

--- a/definitions/npm/react-redux_v7.x.x/flow_v0.89.x-/test_useSelector.js
+++ b/definitions/npm/react-redux_v7.x.x/flow_v0.89.x-/test_useSelector.js
@@ -1,0 +1,41 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+type State = {|
+  a: number,
+|};
+
+describe('useSelector', () => {
+  it('passes State as first parameter', () => {
+    function Com() {
+      // $ExpectError: the state has no `b`
+      const count = useSelector<State, number>(state => state.b);
+      return <div>{count}</div>;
+    }
+  });
+
+  it('passes type of second parameter as params to `equalityFn`', () => {
+    function Com2() {
+      // $ExpectError: `equalityFn` is passed params of the second type, do not have `.size`
+      const count = useSelector<State, number>(
+        state => state.a,
+        (a, b) => a.size === b.size
+      );
+      return <div>{count}</div>;
+    }
+  });
+
+  it('returns type of second parameter', () => {
+    function Com3() {
+      const count = useSelector<State, number>(
+        state => state.a,
+        (a, b) => a === b
+      );
+      // `count` is type `number` and allows addition
+      return <div>{count + 5}</div>;
+    }
+  });
+});

--- a/definitions/npm/react-redux_v7.x.x/flow_v0.89.x-/test_useStore.js
+++ b/definitions/npm/react-redux_v7.x.x/flow_v0.89.x-/test_useStore.js
@@ -1,0 +1,41 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import React from 'react';
+import { useStore } from 'react-redux';
+
+describe('useStore', () => {
+  type Action = { type: 'SOME_ACTION' };
+  type State = { state: string };
+
+  // ReduxStore should be imported from 'redux' but we can't do this with this
+  // test environment, so let's copy them once again...
+  declare type Redux$DispatchAPI<A> = (action: A) => A;
+  declare type Redux$Dispatch<A: { type: string }> = Redux$DispatchAPI<A>;
+  declare type Redux$Reducer<S, A> = (state: S | void, action: A) => S;
+  declare type Redux$Store<S, A, D = Redux$Dispatch<A>> = {
+    dispatch: D,
+    getState(): S,
+    subscribe(listener: () => void): () => void,
+    replaceReducer(nextReducer: Redux$Reducer<S, A>): void,
+  };
+
+  type Dispatch = (action: Action) => Action;
+  type GetState = () => State;
+  type Store = Redux$Store<State, Action, Dispatch>;
+
+  it('returns instance of Store', () => {
+    function Com() {
+      const store = useStore<Store>();
+      return <div>{store.getState().state}</div>;
+    }
+  });
+
+  it('returns instance of Store, no extra keys', () => {
+    function Com() {
+      const store = useStore<Store>();
+      // $ExpectError: `foobar` is not a member of the Store instance
+      return <div>{store.getState().foobar}</div>;
+    }
+  });
+});


### PR DESCRIPTION
Resolves #3452

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://react-redux.js.org/api/hooks
- Link to GitHub or NPM: https://github.com/reduxjs/react-redux
- Type of contribution: addition

Other notes:

Adds implementations for the hooks added in [react-redux v7.1.0](https://github.com/reduxjs/react-redux/releases/tag/v7.1.0).