### PR TITLE
[express_{v4.x.x,v4.16.x}]: correct `is` method return type on requests

### DIFF
--- a/definitions/npm/express_v4.16.x/flow_v0.32.x-v0.92.x/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.32.x-v0.92.x/express_v4.16.x.js
@@ -42,7 +42,7 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   acceptsEncodings(...encoding: Array<string>): string | false;
   acceptsLanguages(...lang: Array<string>): string | false;
   header(field: string): string | void;
-  is(type: string): boolean;
+  is(type: string): string | false;
   param(name: string, defaultValue?: string): string | void;
 }
 

--- a/definitions/npm/express_v4.16.x/flow_v0.93.x-v0.93.x/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.93.x-v0.93.x/express_v4.16.x.js
@@ -42,7 +42,7 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   acceptsEncodings(...encoding: Array<string>): string | false;
   acceptsLanguages(...lang: Array<string>): string | false;
   header(field: string): string | void;
-  is(type: string): boolean;
+  is(type: string): string | false;
   param(name: string, defaultValue?: string): string | void;
 }
 

--- a/definitions/npm/express_v4.16.x/flow_v0.94.x-/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.94.x-/express_v4.16.x.js
@@ -40,7 +40,7 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   acceptsEncodings(...encoding: Array<string>): string | false;
   acceptsLanguages(...lang: Array<string>): string | false;
   header(field: string): string | void;
-  is(type: string): boolean;
+  is(type: string): string | false;
   param(name: string, defaultValue?: string): string | void;
 }
 

--- a/definitions/npm/express_v4.16.x/test_express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/test_express_v4.16.x.js
@@ -156,6 +156,7 @@ app.use(
     // test req
     req.accepts("accepted/type");
     req.accepts(["json", "text"]);
+    req.is("json");
     if (typeof req.query.foo === "string") console.log((req.query.foo: string));
     else console.log((req.query.foo: Array<string>));
     // test response

--- a/definitions/npm/express_v4.x.x/flow_v0.25.x-v0.27.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.25.x-v0.27.x/express_v4.x.x.js
@@ -37,7 +37,7 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   acceptsEncodings(...encoding: Array<string>): string | false;
   acceptsLanguages(...lang: Array<string>): string | false;
   header(field: string): string | void;
-  is(type: string): boolean;
+  is(type: string): string | false;
   param(name: string, defaultValue?: string): string | void;
 }
 

--- a/definitions/npm/express_v4.x.x/flow_v0.28.x-v0.31.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.28.x-v0.31.x/express_v4.x.x.js
@@ -37,7 +37,7 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   acceptsEncodings(...encoding: Array<string>): string | false;
   acceptsLanguages(...lang: Array<string>): string | false;
   header(field: string): string | void;
-  is(type: string): boolean;
+  is(type: string): string | false;
   param(name: string, defaultValue?: string): string | void;
 }
 

--- a/definitions/npm/express_v4.x.x/flow_v0.32.x-v0.92.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.32.x-v0.92.x/express_v4.x.x.js
@@ -42,7 +42,7 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   acceptsEncodings(...encoding: Array<string>): string | false;
   acceptsLanguages(...lang: Array<string>): string | false;
   header(field: string): string | void;
-  is(type: string): boolean;
+  is(type: string): string | false;
   param(name: string, defaultValue?: string): string | void;
 }
 

--- a/definitions/npm/express_v4.x.x/flow_v0.93.x-v0.93.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.93.x-v0.93.x/express_v4.x.x.js
@@ -42,7 +42,7 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   acceptsEncodings(...encoding: Array<string>): string | false;
   acceptsLanguages(...lang: Array<string>): string | false;
   header(field: string): string | void;
-  is(type: string): boolean;
+  is(type: string): string | false;
   param(name: string, defaultValue?: string): string | void;
 }
 

--- a/definitions/npm/express_v4.x.x/flow_v0.94.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.94.x-/express_v4.x.x.js
@@ -40,7 +40,7 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   acceptsEncodings(...encoding: Array<string>): string | false;
   acceptsLanguages(...lang: Array<string>): string | false;
   header(field: string): string | void;
-  is(type: string): boolean;
+  is(type: string): string | false;
   param(name: string, defaultValue?: string): string | void;
 }
 

--- a/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
@@ -132,6 +132,7 @@ app.use((err: Error, req: express$Request, res: express$Response, next: express$
     // test req
     req.accepts('accepted/type');
     req.accepts(['json', 'text']);
+    req.is('json');
     if (typeof req.query.foo === 'string')
       console.log((req.query.foo: string));
     else


### PR DESCRIPTION
* [Link to documentation][1]
* Link to GitHub or npm: [GitHub][2]
* Type of contribution: fix

Other notes: `req.is` returns a string or `false`, but we were saying that it returned a `boolean`, which wasn't quite right.

[1]: https://expressjs.com/en/4x/api.html#req.is
[2]: https://github.com/expressjs/express

