### PR TITLE
[phoenix_v1.4.x] update syncState/syncDiff return value

### DIFF
--- a/definitions/npm/phoenix_v1.4.x/flow_v0.104.x-/phoenix_v1.4.x.js
+++ b/definitions/npm/phoenix_v1.4.x/flow_v0.104.x-/phoenix_v1.4.x.js
@@ -109,7 +109,7 @@ declare module 'phoenix' {
       currentState: { [key: string]: any, ... },
       newState: { [key: string]: any, ... },
       onJoin?: PresenceOnJoinCallback,
-      onLeave?: PresenceOnLeaveCallback): any;
+      onLeave?: PresenceOnLeaveCallback): { [key: string]: any, ... };
     static syncDiff(
       currentState: { [key: string]: any, ... },
       diff: {
@@ -118,7 +118,7 @@ declare module 'phoenix' {
         ...
       },
       onJoin?: PresenceOnJoinCallback,
-      onLeave?: PresenceOnLeaveCallback): any;
+      onLeave?: PresenceOnLeaveCallback): { [key: string]: any, ... };
     static list<T>(
       presences: { [key: string]: any, ... },
       chooser?: (key: string, presence: any) => T): T[]

--- a/definitions/npm/phoenix_v1.4.x/flow_v0.25.x-v0.103.x/phoenix_v1.4.x.js
+++ b/definitions/npm/phoenix_v1.4.x/flow_v0.25.x-v0.103.x/phoenix_v1.4.x.js
@@ -111,7 +111,7 @@ declare module 'phoenix' {
       currentState: { [key: string]: any },
       newState: { [key: string]: any },
       onJoin?: PresenceOnJoinCallback,
-      onLeave?: PresenceOnLeaveCallback): any;
+      onLeave?: PresenceOnLeaveCallback): { [key: string]: any };
     static syncDiff(
       currentState: { [key: string]: any },
       diff: {
@@ -119,7 +119,7 @@ declare module 'phoenix' {
         leaves: { [key: string]: any }
       },
       onJoin?: PresenceOnJoinCallback,
-      onLeave?: PresenceOnLeaveCallback): any;
+      onLeave?: PresenceOnLeaveCallback): { [key: string]: any };
     static list<T>(
       presences: { [key: string]: any },
       chooser?: (key: string, presence: any) => T): T[]


### PR DESCRIPTION
- Links to documentation: https://phoenixframework.org/
- Link to GitHub or NPM: https://github.com/phoenixframework/phoenix
- Type of contribution: fix

Other notes:
syncDiff (and syncState via syncDiff) returns `state` which is always a k/v object
https://github.com/phoenixframework/phoenix/blob/master/assets/js/phoenix.js#L1349
