### PR TITLE
[react-use_v10.x.x] Init with few supported hooks

### DIFF
--- a/definitions/npm/react-use_v10.x.x/flow_v0.101.x-/react-use_v10.x.x.js
+++ b/definitions/npm/react-use_v10.x.x/flow_v0.101.x-/react-use_v10.x.x.js
@@ -1,0 +1,31 @@
+declare module 'react-use' {
+  declare type AsyncState<T> =
+    | {
+        loading: boolean,
+        error?: *,
+        value?: T,
+      }
+    | {
+        loading: false,
+        error: Error,
+        value?: T,
+      }
+    | {
+        loading: false,
+        error?: *,
+        value: T,
+      };
+  declare module.exports: {
+    useAsync<Result>(
+      fn: (...args: Array<any>) => Promise<Result>,
+      deps?: $ReadOnlyArray<any>
+    ): AsyncState<Result>, 
+    useAsyncFn<Result, Args = Array<any>>(
+      fn: (...args: Args) => Promise<Result>,
+      deps?: $ReadOnlyArray<any>
+    ): [AsyncState<Result>, (...args: Args) => Promise<Result>],
+    usePrevious<T>(state: T): ?T,
+    useEffectOnce(effect: () => (() => void) | void): void,
+    useMount(fn: () => void): void,
+  };
+}

--- a/definitions/npm/react-use_v10.x.x/flow_v0.95.x-/react-use_v10.x.x.js
+++ b/definitions/npm/react-use_v10.x.x/flow_v0.95.x-/react-use_v10.x.x.js
@@ -1,0 +1,6 @@
+declare module 'react-use' {
+  declare module.exports: {
+    usePrevious<T>(state: T): ?T,
+    useEffectOnce(effect: () => (() => void) | void): void,
+  };
+}

--- a/definitions/npm/react-use_v10.x.x/flow_v0.95.x-/react-use_v10.x.x.js
+++ b/definitions/npm/react-use_v10.x.x/flow_v0.95.x-/react-use_v10.x.x.js
@@ -1,6 +1,0 @@
-declare module 'react-use' {
-  declare module.exports: {
-    usePrevious<T>(state: T): ?T,
-    useEffectOnce(effect: () => (() => void) | void): void,
-  };
-}

--- a/definitions/npm/react-use_v10.x.x/test_react-use_v10.x.x.js
+++ b/definitions/npm/react-use_v10.x.x/test_react-use_v10.x.x.js
@@ -4,33 +4,71 @@ import { describe, it } from 'flow-typed-test';
 import * as hooks from 'react-use';
 
 describe('react-use', () => {
-  describe('usePrevious', () => {
-    it('should error when casting to another type', () => {
-      let MyComponent = () => {
-        const foo: number = 0;
+  it('useAsync', () => {
+    let MyComponent = () => {
+      // $ExpectError
+      hooks.useAsync(() => console.log('foo'));
+
+      type ResponseT = { data: string };
+      let loading, error, value;
+      [loading, error, value] = hooks.useAsync<ResponseT>(async () =>
+        Promise.resolve({ data: 'foo' })
+      );
+
+      [loading, error, value] = hooks.useAsync<ResponseT>(async () =>
         // $ExpectError
-        const bar: string = hooks.usePrevious(foo);
-      };
-    });
+        Promise.resolve()
+      );
+
+      // $ExpectError
+      hooks.useAsync(async () => Promise.resolve(), { foo: 'bar' });
+    };
   });
 
-  describe('useEffectOnce', () => {
-    it('should error when casting to another type', () => {
-      let MyComponent = () => {
-        hooks.useEffectOnce(() => {
-          console.log('should work');
-        });
+  it('useAsyncFn', () => {
+    let MyComponent = () => {
+      // $ExpectError
+      hooks.useAsync(() => console.log('foo'));
 
-        hooks.useEffectOnce(() => {
-          return () => console.log('should work');
-        });
+      type ResponseT = { data: string };
+      let loading, error, value, fn;
+      [[loading, error, value], fn] = hooks.useAsyncFn<ResponseT>(async () =>
+        Promise.resolve({ data: 'foo' })
+      );
 
+      [[loading, error, value], fn] = hooks.useAsyncFn<ResponseT>(async () =>
         // $ExpectError
-        hooks.useEffectOnce('should not work');
+        Promise.resolve()
+      );
 
-        // $ExpectError
-        hooks.useEffectOnce(() => 'should not work');
-      };
-    });
+      // $ExpectError
+      hooks.useAsync(async () => Promise.resolve(), { foo: 'bar' });
+    };
+  });
+
+  it('usePrevious', () => {
+    let MyComponent = () => {
+      const foo: number = 0;
+      // $ExpectError
+      const bar: string = hooks.usePrevious(foo);
+    };
+  });
+
+  it('useEffectOnce', () => {
+    let MyComponent = () => {
+      hooks.useEffectOnce(() => {
+        console.log('should work');
+      });
+
+      hooks.useEffectOnce(() => {
+        return () => console.log('should work');
+      });
+
+      // $ExpectError
+      hooks.useEffectOnce('should not work');
+
+      // $ExpectError
+      hooks.useEffectOnce(() => 'should not work');
+    };
   });
 });

--- a/definitions/npm/react-use_v10.x.x/test_react-use_v10.x.x.js
+++ b/definitions/npm/react-use_v10.x.x/test_react-use_v10.x.x.js
@@ -1,0 +1,36 @@
+// @flow
+import React from 'react';
+import { describe, it } from 'flow-typed-test';
+import * as hooks from 'react-use';
+
+describe('react-use', () => {
+  describe('usePrevious', () => {
+    it('should error when casting to another type', () => {
+      let MyComponent = () => {
+        const foo: number = 0;
+        // $ExpectError
+        const bar: string = hooks.usePrevious(foo);
+      };
+    });
+  });
+
+  describe('useEffectOnce', () => {
+    it('should error when casting to another type', () => {
+      let MyComponent = () => {
+        hooks.useEffectOnce(() => {
+          console.log('should work');
+        });
+
+        hooks.useEffectOnce(() => {
+          return () => console.log('should work');
+        });
+
+        // $ExpectError
+        hooks.useEffectOnce('should not work');
+
+        // $ExpectError
+        hooks.useEffectOnce(() => 'should not work');
+      };
+    });
+  });
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: http://streamich.github.io/react-use
- Link to GitHub or NPM: https://github.com/streamich/react-use
- Type of contribution: new definition 

Other notes:
Initialized new definition for `react-use` starting with a few hooks:
* usePrevious
* useEffectOnce

**Help on adding more hooks is appreciated!**
