### PR TITLE
[alasql_v0.3.x] Fix tests errors

### DIFF
--- a/definitions/npm/alasql_v0.3.x/flow_v0.25.x-v0.103.x/alasql_v0.3.x.js
+++ b/definitions/npm/alasql_v0.3.x/flow_v0.25.x-v0.103.x/alasql_v0.3.x.js
@@ -1,93 +1,91 @@
-/* @flow */
+declare module 'alasql' {
+  declare export interface _alasql_Callback {
+    (data?: any, err?: Error): void;
+  }
 
-interface _alasql_Callback {
-  (data?: any, err?: Error): void;
-}
+  declare export interface _alasql_Options {
+    errorlog: boolean;
+    valueof: boolean;
+    dropifnotexists: boolean; // drop database in any case
+    datetimeformat: string; // how to handle DATE and DATETIME types
+    casesensitive: boolean; // table and column names are case sensitive and converted to lower-case
+    logtarget: string; // target for log. Values: 'console', 'output', 'id' of html tag
+    logprompt: boolean; // print SQL at log
+    progress: boolean;
+    modifier: any; // values: RECORDSET, VALUE, ROW, COLUMN, MATRIX, TEXTSTRING, INDEX
+    columnlookup: number; // how many rows to lookup to define columns
+    autovertex: boolean; // create vertex if not found
+    usedbo: boolean; // use dbo as current database (for partial T-SQL comaptibility)
+    autocommit: boolean; // the AUTOCOMMIT ON | OFF
+    cache: boolean; // use cache
+    nan: boolean; // check for NaN and convert it to undefined
+    tsql: boolean;
+    mysql: boolean;
+    postgres: boolean;
+    oracle: boolean;
+    sqlite: boolean;
+    orientdb: boolean;
+    autoExtFilenameOnRead: boolean;
+    autoExtFilenameOnWrite: boolean;
+    nocount: boolean; // for SET NOCOUNT OFF
+    joinstar: string;
+  }
 
-interface _alasql_Options {
-  errorlog: boolean;
-  valueof: boolean;
-  dropifnotexists: boolean; // drop database in any case
-  datetimeformat: string; // how to handle DATE and DATETIME types
-  casesensitive: boolean; // table and column names are case sensitive and converted to lower-case
-  logtarget: string; // target for log. Values: 'console', 'output', 'id' of html tag
-  logprompt: boolean; // print SQL at log
-  progress: boolean;
-  modifier: any; // values: RECORDSET, VALUE, ROW, COLUMN, MATRIX, TEXTSTRING, INDEX
-  columnlookup: number; // how many rows to lookup to define columns
-  autovertex: boolean; // create vertex if not found
-  usedbo: boolean; // use dbo as current database (for partial T-SQL comaptibility)
-  autocommit: boolean; // the AUTOCOMMIT ON | OFF
-  cache: boolean; // use cache
-  nan: boolean; // check for NaN and convert it to undefined
-  tsql: boolean;
-  mysql: boolean;
-  postgres: boolean;
-  oracle: boolean;
-  sqlite: boolean;
-  orientdb: boolean;
-  autoExtFilenameOnRead: boolean;
-  autoExtFilenameOnWrite: boolean;
-  nocount: boolean; // for SET NOCOUNT OFF
-  joinstar: string;
-}
+  // compiled Statement
+  declare export interface _alasql_Statement {
+    (params?: any, cb?: _alasql_Callback, scope?: any): any;
+  }
 
-// compiled Statement
-interface _alasql_Statement {
-  (params?: any, cb?: _alasql_Callback, scope?: any): any;
-}
+  // abstract Syntax Tree
+  declare export interface _alasql_AST {
+    compile(databaseid: string): _alasql_Statement;
+  }
 
-// abstract Syntax Tree
-interface _alasql_AST {
-  compile(databaseid: string): _alasql_Statement;
-}
+  // From https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/es6-promise/es6-promise.d.ts
+  declare export interface Thenable<T> {
+    then<U>(
+      onFulfilled?: (value: T) => U | Thenable<U>,
+      onRejected?: (error: any) => U | Thenable<U>
+    ): Thenable<U>;
+    then<U>(
+      onFulfilled?: (value: T) => U | Thenable<U>,
+      onRejected?: (error: any) => void
+    ): Thenable<U>;
+    catch<U>(onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
+  }
 
-// From https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/es6-promise/es6-promise.d.ts
-interface Thenable<T> {
-  then<U>(
-    onFulfilled?: (value: T) => U | Thenable<U>,
-    onRejected?: (error: any) => U | Thenable<U>
-  ): Thenable<U>;
-  then<U>(
-    onFulfilled?: (value: T) => U | Thenable<U>,
-    onRejected?: (error: any) => void
-  ): Thenable<U>;
-  catch<U>(onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
-}
+  // From https://github.com/agershun/_alasql_/wiki/User%20Defined%20Functions
+  declare export interface _alasql_userDefinedFunction {
+    (x: any): any;
+  }
 
-// From https://github.com/agershun/_alasql_/wiki/User%20Defined%20Functions
-interface _alasql_userDefinedFunction {
-  (x: any): any;
-}
+  declare export interface _alasql_userDefinedFunctionLookUp {
+    [x: string]: _alasql_userDefinedFunction;
+  }
 
-interface _alasql_userDefinedFunctionLookUp {
-  [x: string]: _alasql_userDefinedFunction;
-}
+  // From https://github.com/agershun/_alasql_/wiki/User%20Defined%20Functions
+  declare export interface _alasql_userAggregator {
+    (value: any, accumulator: any, stage: number): any;
+  }
 
-// From https://github.com/agershun/_alasql_/wiki/User%20Defined%20Functions
-interface _alasql_userAggregator {
-  (value: any, accumulator: any, stage: number): any;
-}
+  declare export interface _alasql_userAggregatorLookUp {
+    [x: string]: _alasql_userAggregator;
+  }
 
-interface _alasql_userAggregatorLookUp {
-  [x: string]: _alasql_userAggregator;
-}
+  declare export interface AlaSQL {
+    (
+      sql?: string | Array<any> | (() => void),
+      params?: any,
+      cb?: _alasql_Callback
+    ): string | number | {} | Array<any> | Thenable<any>;
+    options: _alasql_Options;
+    error: Error;
+    parse(sql: string): _alasql_AST;
+    promise(sql: string | Array<any>, params?: any): Thenable<any>;
+    fn: _alasql_userDefinedFunctionLookUp;
+    aggr: _alasql_userAggregatorLookUp;
+    autoval(tablename: string, colname: string, getNext?: boolean): number;
+  }
 
-interface AlaSQL {
-  (
-    sql?: string | Array<any> | (() => void),
-    params?: any,
-    cb?: _alasql_Callback
-  ): string | number | {} | Array<any> | Thenable<any>;
-  options: _alasql_Options;
-  error: Error;
-  parse(sql: string): _alasql_AST;
-  promise(sql: string | Array<any>, params?: any): Thenable<any>;
-  fn: _alasql_userDefinedFunctionLookUp;
-  aggr: _alasql_userAggregatorLookUp;
-  autoval(tablename: string, colname: string, getNext?: boolean): number;
-}
-
-declare module "alasql" {
   declare module.exports: AlaSQL;
 }


### PR DESCRIPTION
Fix conflict with react-dom

```
* alasql_v0.3.x/flow_v0.25.x-v0.103.x (flow-v0.101.0): Unexpected Flow errors (2):

    Error ----------------------------------------------------------------------------------- <BUILTINS>/react-dom.js:116:47

    Cannot use `Thenable` [1] without 1 type argument.

       <BUILTINS>/react-dom.js:116:47
       116|   declare function act(callback: () => void | Thenable): Thenable;
                                                          ^^^^^^^^

    References:
       alasql_v0.3.x.js:46:19
        46| interface Thenable<T> {
                              ^^^ [1]
```
