### PR TITLE
[angular_v1.5.x] Fix tests errors

### DIFF
--- a/definitions/npm/angular_v1.5.x/flow_v0.104.x-/test_angular_v1.5.x.js
+++ b/definitions/npm/angular_v1.5.x/flow_v0.104.x-/test_angular_v1.5.x.js
@@ -1,14 +1,14 @@
 // @flow
 import { describe, it } from "flow-typed-test";
-import type {
-  AngularPromise,
-  AngularQ,
-  JqliteElement,
-  AngularHttpService,
-  AngularResourceFactory,
-  AngularResourceResult,
-  AngularResource,
-  AngularCompileService
+import {
+  type AngularPromise,
+  type AngularQ,
+  type JqliteElement,
+  type AngularHttpService,
+  typeof AngularResourceFactory,
+  type AngularResourceResult,
+  type AngularResource,
+  typeof AngularCompileService
 } from "angular";
 
 ("use strict");

--- a/definitions/npm/angular_v1.5.x/flow_v0.47.x-v0.103.x/test_angular_v1.5.x.js
+++ b/definitions/npm/angular_v1.5.x/flow_v0.47.x-v0.103.x/test_angular_v1.5.x.js
@@ -1,14 +1,14 @@
 // @flow
 import { describe, it } from "flow-typed-test";
-import type {
-  AngularPromise,
-  AngularQ,
-  JqliteElement,
-  AngularHttpService,
-  AngularResourceFactory,
-  AngularResourceResult,
-  AngularResource,
-  AngularCompileService
+import {
+  type AngularPromise,
+  type AngularQ,
+  type JqliteElement,
+  type AngularHttpService,
+  typeof AngularResourceFactory,
+  type AngularResourceResult,
+  type AngularResource,
+  typeof AngularCompileService
 } from "angular";
 
 ("use strict");


### PR DESCRIPTION
Problem
```
    Error --------------------------------------------------------------------------------------- test_angular_v1.5.x.js:8:3

    Cannot import the value `AngularResourceFactory` as a type. `import type` only works on type exports like type aliases,
    interfaces, and classes. If you intended to import the type of a value use `import typeof` instead.

       8|   AngularResourceFactory,
            ^^^^^^^^^^^^^^^^^^^^^^
```
