### PR TITLE
[lodash-es_v4.x.x] Remove use of deprecated `$Supertype` 

### DIFF
--- a/definitions/npm/lodash-es_v4.x.x/flow_v0.104.x-/lodash-es_v4.x.x.js
+++ b/definitions/npm/lodash-es_v4.x.x/flow_v0.104.x-/lodash-es_v4.x.x.js
@@ -1029,7 +1029,7 @@ declare module "lodash-es" {
   ): Object;
   declare export function at(object?: ?Object, ...paths: Array<string>): Array<any>;
   declare export function at(object?: ?Object, paths: Array<string>): Array<any>;
-  declare export function create<T>(prototype: T, properties: Object): $Supertype<T>;
+  declare export function create<T>(prototype: T, properties: Object): T;
   declare export function create(prototype: any, properties: void | null): {...};
   declare export function defaults(object?: ?Object, ...sources?: Array<?Object>): Object;
   declare export function defaultsDeep(object?: ?Object, ...sources?: Array<?Object>): Object;


### PR DESCRIPTION
- Links to documentation: https://lodash.com
- Link to GitHub or NPM: https://github.com/lodash/lodash/tree/es
- Type of contribution: fix

Other notes:

Simply removed the reference to `$Supertype<>`, as in https://github.com/flow-typed/flow-typed/pull/3063.

To do:
- [ ] Fix tests - there seems to be a lot of fails unrelated to this change.