### PR TITLE
Update react-dnd_v2.x.x.js to avoid $Supertype

### DIFF
--- a/definitions/npm/react-dnd_v2.x.x/flow_v0.104.x-/react-dnd_v2.x.x.js
+++ b/definitions/npm/react-dnd_v2.x.x/flow_v0.104.x-/react-dnd_v2.x.x.js
@@ -116,7 +116,7 @@ declare module "react-dnd" {
     spec: DragSourceSpec<OP>,
     collect: DragSourceCollector<CP>,
     options?: DndOptions<OP>
-  ): Connector<$Supertype<OP & CP>, CP>;
+  ): Connector<$Shape<OP & CP>, CP>;
 
   // Drop Target
   // ----------------------------------------------------------------------
@@ -170,7 +170,7 @@ declare module "react-dnd" {
     spec: DropTargetSpec<OP>,
     collect: DropTargetCollector<CP>,
     options?: DndOptions<OP>
-  ): Connector<$Supertype<OP & CP>, CP>;
+  ): Connector<$Shape<OP & CP>, CP>;
 
   // Drag Layer
   // ----------------------------------------------------------------------
@@ -190,7 +190,7 @@ declare module "react-dnd" {
   declare function DragLayer<OP: {...}, CP: {...}>(
     collect: (monitor: DragLayerMonitor) => CP,
     options?: DndOptions<OP>
-  ): Connector<$Supertype<OP & CP>, CP>;
+  ): Connector<$Shape<OP & CP>, CP>;
 
   // Drag Drop Context
   // ----------------------------------------------------------------------
@@ -210,5 +210,5 @@ declare module "react-dnd" {
 
   declare function DragDropContext<OP: {...}, CP: {...}>(
     backend: mixed
-  ): Connector<$Supertype<OP & CP>, CP>;
+  ): Connector<$Shape<OP & CP>, CP>;
 }


### PR DESCRIPTION
While upgrading flow through 0.98, which turns on deprecated-utility by default I came across this use of the Supertype utility. 

Substituting in $Shape seems to work well

- Links to documentation:
- Link to GitHub or NPM: 
- Type of contribution:  fix 


