### PR TITLE
Fix types for `source-map`, add null mappings

### DIFF
--- a/definitions/npm/source-map_v0.7.x/flow_v0.104.x-/source-map_v0.7.x.js
+++ b/definitions/npm/source-map_v0.7.x/flow_v0.104.x-/source-map_v0.7.x.js
@@ -47,21 +47,35 @@ declare module 'source-map' {
     +column: number | null,
     +name: string | null,
   |};
-  declare export type MappingItem = {|
-    +source: string,
-    +generatedLine: number,
-    +generatedColumn: number,
-    +lastGeneratedColumn?: number,
-    +originalLine: number,
-    +originalColumn: number,
-    +name: string,
-  |};
-  declare export type Mapping = {|
-    +generated: Position,
-    +original: Position,
-    +source: string,
-    +name?: string,
-  |};
+  declare export type MappingItem =
+    | {|
+        +source: string,
+        +name: string,
+        +generatedLine: number,
+        +generatedColumn: number,
+        +lastGeneratedColumn?: number,
+        +originalLine: number,
+        +originalColumn: number
+      |}
+    | {|
+        +source: null,
+        +name: null,
+        +generatedLine: number,
+        +generatedColumn: number,
+        +lastGeneratedColumn?: number,
+        +originalLine: null,
+        +originalColumn: null
+      |};
+  declare export type Mapping =
+    | {|
+        +generated: Position,
+        +original: Position,
+        +source: string,
+        +name?: string
+      |}
+    | {|
+        +generated: Position
+      |};
   declare export type CodeWithSourceMap = {|
     +code: string,
     +map: SourceMapGenerator,


### PR DESCRIPTION
- Links to documentation: 
- Link to GitHub or NPM: https://github.com/mozilla/source-map
- Type of contribution: fix

Other notes:
When using these typings in Parcel we noticed null mappings aren't allowed in these mappings. Which is pretty important to create correct sourcemaps. This PR adds support for it.
