### PR TITLE
Add missing properties for Subscription

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-v0.103.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-v0.103.x/rxjs_v5.0.x.js
@@ -1523,9 +1523,13 @@ declare class rxjs$ReplaySubject<T> extends rxjs$Subject<T> {
   ): void;
 }
 
-declare class rxjs$Subscription {
+declare class rxjs$Subscription {       
+  static EMPTY: rxjs$Subscription;
+  closed: Object;
+  constructor(unsubscribe?: () => void): void;
   unsubscribe(): void;
   add(teardown: rxjs$TeardownLogic): rxjs$Subscription;
+  remove(subscription: rxjs$Subscription): void;
 }
 
 declare class rxjs$Subscriber<T> extends rxjs$Subscription {

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-v0.103.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-v0.103.x/rxjs_v5.0.x.js
@@ -1525,7 +1525,7 @@ declare class rxjs$ReplaySubject<T> extends rxjs$Subject<T> {
 
 declare class rxjs$Subscription {       
   static EMPTY: rxjs$Subscription;
-  closed: Object;
+  closed: boolean;
   constructor(unsubscribe?: () => void): void;
   unsubscribe(): void;
   add(teardown: rxjs$TeardownLogic): rxjs$Subscription;


### PR DESCRIPTION
Aligned the definition for RxJS v5.

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://rxjs-dev.firebaseapp.com/api/index/class/Subscription
- Link to GitHub or NPM: 
- Type of contribution: fix
