### PR TITLE
[@testing-library/react_v9.x.x] Add act function

### DIFF
--- a/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/react_v9.x.x.js
+++ b/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/react_v9.x.x.js
@@ -1,4 +1,16 @@
 declare module '@testing-library/react' {
+  // This type comes from
+  // https://github.com/facebook/flow/blob/v0.104.0/lib/react-dom.js#L64
+  declare type ReactDOMTestUtilsThenable = {
+    then(resolve: () => mixed, reject?: () => mixed): mixed,
+    ...
+  };
+  // This type comes from
+  // https://github.com/facebook/flow/blob/v0.104.0/lib/react-dom.js#L116
+  declare type ReactDOMTestUtilsAct = (
+    callback: () => void | ReactDOMTestUtilsThenable
+  ) => ReactDOMTestUtilsThenable;
+
   declare type TextMatch =
     | string
     | RegExp
@@ -11,7 +23,10 @@ declare module '@testing-library/react' {
     ...
   };
 
-  declare type SelectorMatchOptions = { selector?: string, ... } & TextMatchOptions;
+  declare type SelectorMatchOptions = {
+    selector?: string,
+    ...
+  } & TextMatchOptions;
 
   declare type GetByText = (
     text: TextMatch,
@@ -100,7 +115,7 @@ declare module '@testing-library/react' {
     eventProperties?: TInit
   ) => boolean;
 
-  declare type Queries = {...};
+  declare type Queries = { ... };
 
   declare type RenderResult<Q: Queries = GetsAndQueries> = {|
     container: HTMLDivElement,
@@ -111,7 +126,7 @@ declare module '@testing-library/react' {
     rerender: (ui: React$Element<*>) => void,
   |} & Q;
 
-  declare export type RenderOptions<Q: Queries = {...}> = {|
+  declare export type RenderOptions<Q: Queries = { ... }> = {|
     container?: HTMLElement,
     baseElement?: HTMLElement,
     hydrate?: boolean,
@@ -122,14 +137,15 @@ declare module '@testing-library/react' {
   declare module.exports: {
     render(
       ui: React.ReactElement<any>,
-      options?: $Diff<RenderOptions<>, {| queries: any |}>,
+      options?: $Diff<RenderOptions<>, {| queries: any |}>
     ): RenderResult<>,
 
     render<Q: Queries>(
       ui: React.ReactElement<any>,
-      options?: RenderOptions<Q>,
+      options?: RenderOptions<Q>
     ): RenderResult<Q>,
 
+    act: ReactDOMTestUtilsAct,
     cleanup: () => void,
     wait: (
       callback?: () => void,

--- a/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/test_react_v9.x.x.js
+++ b/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/test_react_v9.x.x.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import {
+  act,
   render,
   wait,
   fireEvent,
@@ -12,6 +13,41 @@ import {
 } from '@testing-library/react';
 import { describe, it } from 'flow-typed-test';
 import { domainToASCII } from 'url';
+
+describe('act', () => {
+  it('should fail on invalid inputs', () => {
+    // $ExpectError
+    act(1);
+    // $ExpectError
+    act(() => {}, 1);
+    // $ExpectError
+    act(() => 1);
+  });
+
+  it('should pass on correct inputs', () => {
+    act(() => {});
+    act(() => Promise.resolve());
+    act(() => ({
+      then: resolve => {},
+    }));
+  });
+
+  it('should fail on incorrect usage of result', () => {
+    // $ExpectError
+    act(() => {}) + 1;
+    // $ExpectError
+    act(() => {}).doesNotExist();
+    // $ExpectError
+    act(() => {}).then(1);
+    // $ExpectError
+    act(() => {}).then(() => {}, 1);
+  });
+
+  it('should pass on correct usage of result', () => {
+    act(() => {}).then(() => {});
+    act(() => {}).then(() => {}, () => {});
+  });
+});
 
 describe('wait', () => {
   it('should fail on invalid inputs', () => {
@@ -67,7 +103,7 @@ describe('waitForElement', () => {
 });
 
 describe('render', () => {
-  class Component extends React.Component<{...}> {}
+  class Component extends React.Component<{ ... }> {}
   const {
     container,
     unmount,
@@ -383,7 +419,7 @@ describe('cleanup', () => {
 });
 
 describe('within', () => {
-  class Component extends React.Component<{...}> {}
+  class Component extends React.Component<{ ... }> {}
   const { container } = render(<Component />);
 
   it('should has html element as argument', () => {
@@ -647,7 +683,7 @@ describe('fireEvent', () => {
 });
 
 describe('text matching API', () => {
-  class Component extends React.Component<{...}> {}
+  class Component extends React.Component<{ ... }> {}
   const {
     getByAltText,
     getAllByAltText,


### PR DESCRIPTION
- Links to documentation: https://testing-library.com/docs/react-testing-library/api#act
- Link to GitHub or NPM: https://github.com/testing-library/react-testing-library
- Type of contribution: addition

Other notes:
The `act` function should probably be added to the other versions of `@testing-library/react`, too, but I figured I'd start with the latest version first.

I would have liked to import the type of `act` from `react-dom/test-utils`, but that didn't seem to work, so I copied the relevant type information for it instead.