### PR TITLE
[enzyme_v3.x.x] Enable static rendering of arbitrary `React$Node`s

### DIFF
--- a/definitions/npm/enzyme_v3.x.x/flow_v0.104.x-/enzyme_v3.x.x.js
+++ b/definitions/npm/enzyme_v3.x.x/flow_v0.104.x-/enzyme_v3.x.x.js
@@ -118,8 +118,8 @@ declare module "enzyme" {
       ...
     }
   ): ReactWrapper<T>;
-  declare function render<T>(
-    node: React$Element<T>,
+  declare function render(
+    node: React$Node,
     options?: { context?: Object, ... }
   ): CheerioWrapper;
 

--- a/definitions/npm/enzyme_v3.x.x/flow_v0.104.x-/test_enzyme-v3.x.js
+++ b/definitions/npm/enzyme_v3.x.x/flow_v0.104.x-/test_enzyme-v3.x.js
@@ -23,6 +23,11 @@ const B: boolean = render(<div />, { context: { foo: true } })
   .filter("bla")
   .equals(<div />);
 
+function opaqueNode(): React$Node {
+  return <span>who knows what I am</span>;
+}
+render(opaqueNode());
+
 // Test against chaining returning `any`
 // $ExpectError
 (shallow(<div />).children(): boolean);


### PR DESCRIPTION
Summary:
The `render` function currently accepts a `React.Component<T>`, but can
actually accept an arbitrary React node, which is sometimes necessary.
This is true of `shallow` and `mount` as well, but the change is easiest
for `render` because there is no component type information to thread
through to the return type.

See discussion:
<https://github.com/flow-typed/flow-typed/pull/3107#issuecomment-523328443>

Test Plan:
Updated tests; the new test fails before this change and passes after
it.

wchargin-branch: enzyme-render-node
