### PR TITLE
Add type definitions for @apollo/react-hooks package

### DIFF
--- a/definitions/npm/@apollo/react-hooks_v3.x.x/CONTRIBUTING.md
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# React Apollo
+
+## Common reviewers
+
+Below is a list of common reviewers on Apollo related libraries:
+
+- wzrdzl
+- thymikee
+- rasmusprentow
+- mic
+- bwlt
+- TLadd
+- budde377
+- jedwards1211

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/CONTRIBUTING.md
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/CONTRIBUTING.md
@@ -12,3 +12,4 @@ Below is a list of common reviewers on Apollo related libraries:
 - TLadd
 - budde377
 - jedwards1211
+- ganemone

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
@@ -1,0 +1,1028 @@
+declare module '@apollo/react-hooks' {
+  import type { ComponentType, Element, Node } from 'react';
+
+  /* start graphql types */
+  declare type DocumentNode = any;
+  declare type GraphQLError = any;
+  /* end graphql types */
+
+  
+  /* start @apollo/react-common types */
+  declare export type ApolloProviderProps<TCache> = {
+    client: ApolloClient<TCache>,
+    children: Node | Node[] | null,
+  }
+
+  declare export class ApolloProvider<TCache> extends React$Component<
+    ApolloProviderProps<TCache>
+  > {
+    childContextTypes: {
+      client: ApolloClient<TCache>,
+      operations: Map<string, { query: DocumentNode, variables: any }>
+    };
+
+    getChildContext(): {
+      client: ApolloClient<TCache>,
+      operations: Map<string, { query: DocumentNode, variables: any }>
+    };
+  }
+
+  declare export interface ApolloConsumerProps {
+    children: (client: ApolloClient<any>) => Node;
+  }
+
+  declare export class ApolloConsumer extends React$Component<
+    ApolloConsumerProps
+  > {}
+  
+  declare export function getApolloContext<T>(): T;
+  declare export function resetApolloContext(): void;
+  /* end @apollo/react-common types */
+
+  /* start @apollo/react-hooks types */
+  declare type Record<T, U> = { [key: $Keys<T>]: U };
+
+  declare export function useQuery<TData, TVariables>(
+    query: DocumentNode,
+    options?: QueryHookOptions<TData, TVariables>
+  ): QueryResult<TData, TVariables>;
+
+  declare export function useLazyQuery<TData, TVariables>(
+    query: DocumentNode,
+    options?: LazyQueryHookOptions<TData, TVariables>
+  ): QueryTuple<TData, TVariables>;
+
+  declare export function useSubscription<TData, TVariables>(
+    query: DocumentNode,
+    options?: SubscriptionHookOptions<TData, TVariables>
+  ): QueryResult<TData, TVariables>;
+
+  declare export function useMutation<TData, TVariables>(
+    query: DocumentNode,
+    options?: MutationHookOptions<TData, TVariables>
+  ): MutationTuple<TData, TVariables>;
+  
+  declare export function useApolloClient<T>(): ApolloClient<T>;
+  
+  declare export class RenderPromises {
+    registerSSRObservable<TData, TVariables>(
+      observable: ObservableQuery<any, TVariables>,
+      props: QueryOptions<TData, TVariables>
+    ): void,
+    addQueryPromise<TData, TVariables>(
+      queryInstance: QueryData<TData, TVariables>,
+      finish: () => Node 
+    ): Node,
+    hasPromises(): boolean,
+    consumeAndAwaitPromises(): Promise<void>,
+  }
+  
+  declare export class QueryData<TData, TVariables> {
+    execute(): QueryResult<TData, TVariables>,
+    executeLazy(): QueryTuple<TData, TVariables>,
+    fetchData(): Promise<ApolloQueryResult<any>> | boolean,
+    afterExecute({lazy?: boolean}): any,
+    cleanup(): void,
+    getOptions(): any,
+  }
+
+  /* Common types */
+  declare export type CommonOptions<TOptions> = TOptions & {
+    client?: ApolloClient<Object>,
+  };
+
+  /* Query types */
+  declare export type QueryOptions<TData, TVariables> = QueryFunctionOptions<
+    TData,
+    TVariables
+  > & {
+    children?: (result: QueryResult<TData, TVariables>) => Node,
+    query: DocumentNode,
+  };
+
+  declare export type QueryHookOptions<
+    TData,
+    TVariables
+  > = QueryFunctionOptions<TData, TVariables> & {
+    query?: DocumentNode,
+  };
+
+  declare export type LazyQueryHookOptions<TData, TVariables> = $Diff<
+    QueryFunctionOptions<TData, TVariables>,
+    { skip: * }
+  > & {
+    query?: DocumentNode,
+  };
+
+  declare export type QueryPreviousData<TData, TVariables> = {
+    client?: ApolloClient<Object>,
+    query?: DocumentNode,
+    observableQueryOptions?: {},
+    result?: ApolloQueryResult<TData> | null,
+    loading?: boolean,
+    options?: QueryOptions<TData, TVariables>,
+  };
+
+  declare export type QueryCurrentObservable<TData, TVariables> = {
+    query?: ObservableQuery<TData, TVariables> | null,
+    subscription?: ZenObservableSubscription,
+  };
+
+  declare export type QueryLazyOptions<TVariables> = {
+    variables?: TVariables,
+    context?: Context,
+  };
+
+  declare export type QueryTuple<TData, TVariables> = [
+    (options?: QueryLazyOptions<TVariables>) => void,
+    QueryResult<TData, TVariables>,
+  ];
+
+  /* Mutation types */
+  declare export type MutationHookOptions<
+    TData,
+    TVariables
+  > = BaseMutationOptions<TData, TVariables> & {
+    mutation?: DocumentNode,
+  };
+
+  declare export type MutationOptions<TData, TVariables> = BaseMutationOptions<
+    TData,
+    TVariables
+  > & {
+    mutation: DocumentNode,
+  };
+
+  declare export type MutationTuple<TData, TVariables> = [
+    (
+      options?: MutationFunctionOptions<TData, TVariables>
+    ) => Promise<void | ExecutionResult<TData>>,
+    MutationResult<TData>,
+  ];
+
+  /* Subscription types */
+  declare export type SubscriptionHookOptions<
+    TData,
+    TVariables
+  > = BaseSubscriptionOptions<TData, TVariables> & {
+    subscription?: DocumentNode,
+  };
+
+  declare export type SubscriptionOptions<
+    TData,
+    TVariables
+  > = BaseSubscriptionOptions<TData, TVariables> & {
+    subscription: DocumentNode,
+    children?:
+      | null
+      | ((result: SubscriptionResult<TData>) => Element<*> | null),
+  };
+
+  declare export type SubscriptionCurrentObservable = {
+    query?: Observable<any>,
+    subscription?: ZenObservableSubscription,
+  };
+
+  /* Common types */
+  declare export type OperationVariables = Record<string, any>;
+
+  declare export type Context = Record<string, any>;
+
+  declare export type ExecutionResult<T = Record<string, any>> = {
+    data?: T,
+    extensions?: Record<string, any>,
+    errors?: GraphQLError[],
+  };
+
+  /* Query types */
+  declare export type BaseQueryOptions<TVariables> = {
+    ssr?: boolean,
+    variables?: TVariables,
+    fetchPolicy?: FetchPolicy,
+    errorPolicy?: ErrorPolicy,
+    pollInterval?: number,
+    client?: ApolloClient<any>,
+    notifyOnNetworkStatusChange?: boolean,
+    context?: Context,
+    partialRefetch?: boolean,
+    returnPartialData?: boolean,
+  };
+
+  declare export type QueryFunctionOptions<
+    TData,
+    TVariables
+  > = BaseQueryOptions<TVariables> & {
+    displayName?: string,
+    skip?: boolean,
+    onCompleted?: (data: TData) => void,
+    onError?: (error: ApolloError) => void,
+  };
+
+  declare export type ObservableQueryFields<TData, TVariables> = {
+    startPolling: $PropertyType<
+      ObservableQuery<TData, TVariables>,
+      'startPolling'
+    >,
+    stopPolling: $PropertyType<
+      ObservableQuery<TData, TVariables>,
+      'stopPolling'
+    >,
+    subscribeToMore: $PropertyType<
+      ObservableQuery<TData, TVariables>,
+      'subscribeToMore'
+    >,
+    updateQuery: $PropertyType<
+      ObservableQuery<TData, TVariables>,
+      'updateQuery'
+    >,
+    refetch: $PropertyType<ObservableQuery<TData, TVariables>, 'refetch'>,
+    variables: $PropertyType<ObservableQuery<TData, TVariables>, 'variables'>,
+    fetchMore: (<TVariables>(
+      fetchMoreOptions: FetchMoreQueryOptions<TVariables> &
+        FetchMoreOptions<TData, TVariables>
+    ) => Promise<ApolloQueryResult<TData>>) &
+      (<TData2, TVariables2>(
+        fetchMoreOptions: {
+          query?: DocumentNode,
+        } & FetchMoreQueryOptions<TVariables2> &
+          FetchMoreOptions<TData2, TVariables2>
+      ) => Promise<ApolloQueryResult<TData2>>),
+  };
+
+  declare export type QueryResult<TData, TVariables> = ObservableQueryFields<
+    TData,
+    TVariables
+  > & {
+    client: ApolloClient<any>,
+    data: ?TData,
+    error?: ApolloError,
+    loading: boolean,
+    networkStatus: NetworkStatus,
+    called: boolean,
+  };
+
+  /* Mutation types */
+  declare export type RefetchQueriesFunction = (
+    ...args: any[]
+  ) => Array<string | PureQueryOptions>;
+
+  declare export type BaseMutationOptions<TData, TVariables> = {
+    variables?: TVariables,
+    optimisticResponse?: TData | ((vars: TVariables) => TData),
+    refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction,
+    awaitRefetchQueries?: boolean,
+    errorPolicy?: ErrorPolicy,
+    update?: MutationUpdaterFn<TData>,
+    client?: ApolloClient<Object>,
+    notifyOnNetworkStatusChange?: boolean,
+    context?: Context,
+    onCompleted?: (data: TData) => void,
+    onError?: (error: ApolloError) => void,
+    fetchPolicy?: FetchPolicy,
+    ignoreResults?: boolean,
+  };
+
+  declare export type MutationFunctionOptions<TData, TVariables> = {
+    variables?: TVariables,
+    optimisticResponse?: TData | ((vars: TVariables | {}) => TData),
+    refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction,
+    awaitRefetchQueries?: boolean,
+    update?: MutationUpdaterFn<TData>,
+    context?: Context,
+    fetchPolicy?: FetchPolicy,
+  };
+
+  declare export type MutationResult<TData> = {
+    data?: TData,
+    error?: ApolloError,
+    loading: boolean,
+    called: boolean,
+    client?: ApolloClient<Object>,
+  };
+
+  declare export type MutationFetchResult<
+    TData = Record<string, any>,
+    C = Record<string, any>,
+    E = Record<string, any>
+  > = ExecutionResult<TData> & {
+    extensions?: E,
+    context?: C,
+  };
+
+  declare export type MutationFunction<TData, TVariables> = (
+    options?: MutationFunctionOptions<TData, TVariables>
+  ) => Promise<void | MutationFetchResult<TData>>;
+
+  /* Subscription types */
+  declare export type OnSubscriptionDataOptions<TData> = {
+    client: ApolloClient<Object>,
+    subscriptionData: SubscriptionResult<TData>,
+  };
+
+  declare export type BaseSubscriptionOptions<TData, TVariables> = {
+    variables?: TVariables,
+    fetchPolicy?: FetchPolicy,
+    shouldResubscribe?:
+      | boolean
+      | ((options: BaseSubscriptionOptions<TData, TVariables>) => boolean),
+    client?: ApolloClient<Object>,
+    onSubscriptionData?: (options: OnSubscriptionDataOptions<TData>) => any,
+    onSubscriptionComplete?: () => void,
+  };
+
+  declare export type SubscriptionResult<TData> = {
+    loading: boolean,
+    data?: TData,
+    error?: ApolloError,
+  };
+
+  /* end @apollo/react-hooks types */
+
+  /* start apollo-client types */
+  declare function print(ast: any): string;
+
+  declare class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
+    options: WatchQueryOptions;
+    queryId: string;
+    variables: { [key: string]: any };
+    isCurrentlyPolling: boolean;
+    shouldSubscribe: boolean;
+    isTornDown: boolean;
+    scheduler: QueryScheduler<any>;
+    queryManager: QueryManager<any>;
+    observers: Observer<ApolloQueryResult<T>>[];
+    subscriptionHandles: SubscriptionLINK[];
+    lastResult: ApolloQueryResult<T>;
+    lastError: ApolloError;
+    lastVariables: { [key: string]: any };
+
+    constructor(data: {
+      scheduler: QueryScheduler<any>,
+      options: WatchQueryOptions,
+      shouldSubscribe?: boolean,
+    }): this;
+
+    result(): Promise<ApolloQueryResult<T>>;
+    currentResult(): ApolloCurrentResult<T>;
+    getLastResult(): ApolloQueryResult<T>;
+    getLastError(): ApolloError;
+    resetLastResults(): void;
+    refetch(variables?: any): Promise<ApolloQueryResult<T>>;
+    fetchMore(
+      fetchMoreOptions: FetchMoreQueryOptions<any> & FetchMoreOptions<any, any>
+    ): Promise<ApolloQueryResult<T>>;
+    subscribeToMore(options: SubscribeToMoreOptions<any, any>): () => void;
+    setOptions(
+      opts: ModifiableWatchQueryOptions
+    ): Promise<ApolloQueryResult<T>>;
+    setVariables(
+      variables: any,
+      tryFetch?: boolean,
+      fetchResults?: boolean
+    ): Promise<ApolloQueryResult<T>>;
+    updateQuery(
+      mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => any
+    ): void;
+    stopPolling(): void;
+    startPolling(pollInterval: number): void;
+  }
+
+  declare class QueryManager<TStore> {
+    scheduler: QueryScheduler<TStore>;
+    link: ApolloLink;
+    mutationStore: MutationStore;
+    queryStore: QueryStore;
+    dataStore: DataStore<TStore>;
+
+    constructor({
+      link: ApolloLink,
+      queryDeduplication?: boolean,
+      store: DataStore<TStore>,
+      onBroadcast?: () => void,
+      ssrMode?: boolean,
+    }): this;
+
+    mutate<T>(options: MutationOptions<>): Promise<FetchResult<T>>;
+    fetchQuery<T>(
+      queryId: string,
+      options: WatchQueryOptions,
+      fetchType?: FetchType,
+      fetchMoreForQueryId?: string
+    ): Promise<FetchResult<T>>;
+    queryListenerForObserver<T>(
+      queryId: string,
+      options: WatchQueryOptions,
+      observer: Observer<ApolloQueryResult<T>>
+    ): QueryListener;
+    watchQuery<T>(
+      options: WatchQueryOptions,
+      shouldSubscribe?: boolean
+    ): ObservableQuery<T>;
+    query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
+    generateQueryId(): string;
+    stopQueryInStore(queryId: string): void;
+    addQueryListener(queryId: string, listener: QueryListener): void;
+    updateQueryWatch(
+      queryId: string,
+      document: DocumentNode,
+      options: WatchQueryOptions
+    ): void;
+    addFetchQueryPromise<T>(
+      requestId: number,
+      promise: Promise<ApolloQueryResult<T>>,
+      resolve: (result: ApolloQueryResult<T>) => void,
+      reject: (error: Error) => void
+    ): void;
+    removeFetchQueryPromise(requestId: number): void;
+    addObservableQuery<T>(
+      queryId: string,
+      observableQuery: ObservableQuery<T>
+    ): void;
+    removeObservableQuery(queryId: string): void;
+    clearStore(): Promise<void>;
+    resetStore(): Promise<ApolloQueryResult<any>[]>;
+  }
+
+  declare class QueryStore {
+    getStore(): { [queryId: string]: QueryStoreValue };
+    get(queryId: string): QueryStoreValue;
+    initQuery(query: {
+      queryId: string,
+      document: DocumentNode,
+      storePreviousVariables: boolean,
+      variables: Object,
+      isPoll: boolean,
+      isRefetch: boolean,
+      metadata: any,
+      fetchMoreForQueryId: string | void,
+    }): void;
+    markQueryResult(
+      queryId: string,
+      result: ExecutionResult<>,
+      fetchMoreForQueryId: string | void
+    ): void;
+    markQueryError(
+      queryId: string,
+      error: Error,
+      fetchMoreForQueryId: string | void
+    ): void;
+    markQueryResultClient(queryId: string, complete: boolean): void;
+    stopQuery(queryId: string): void;
+    reset(observableQueryIds: string[]): void;
+  }
+
+  declare class QueryScheduler<TCacheShape> {
+    inFlightQueries: { [queryId: string]: WatchQueryOptions };
+    registeredQueries: { [queryId: string]: WatchQueryOptions };
+    intervalQueries: { [interval: number]: string[] };
+    queryManager: QueryManager<TCacheShape>;
+    constructor({
+      queryManager: QueryManager<TCacheShape>,
+      ssrMode?: boolean,
+    }): this;
+    checkInFlight(queryId: string): ?boolean;
+    fetchQuery<T>(
+      queryId: string,
+      options: WatchQueryOptions,
+      fetchType: FetchType
+    ): Promise<FetchResult<T>>;
+    startPollingQuery<T>(
+      options: WatchQueryOptions,
+      queryId: string,
+      listener?: QueryListener
+    ): string;
+    stopPollingQuery(queryId: string): void;
+    fetchQueriesOnInterval<T>(interval: number): void;
+    addQueryOnInterval<T>(
+      queryId: string,
+      queryOptions: WatchQueryOptions
+    ): void;
+    registerPollingQuery<T>(
+      queryOptions: WatchQueryOptions
+    ): ObservableQuery<T>;
+    markMutationError(mutationId: string, error: Error): void;
+    reset(): void;
+  }
+
+  declare class DataStore<TSerialized> {
+    constructor(initialCache: ApolloCache<TSerialized>): this;
+    getCache(): ApolloCache<TSerialized>;
+    markQueryResult(
+      result: ExecutionResult<>,
+      document: DocumentNode,
+      variables: any,
+      fetchMoreForQueryId: string | void,
+      ignoreErrors?: boolean
+    ): void;
+    markSubscriptionResult(
+      result: ExecutionResult<>,
+      document: DocumentNode,
+      variables: any
+    ): void;
+    markMutationInit(mutation: {
+      mutationId: string,
+      document: DocumentNode,
+      variables: any,
+      updateQueries: { [queryId: string]: QueryWithUpdater },
+      update: ((proxy: DataProxy, mutationResult: Object) => void) | void,
+      optimisticResponse: Object | Function | void,
+    }): void;
+    markMutationResult(mutation: {
+      mutationId: string,
+      result: ExecutionResult<>,
+      document: DocumentNode,
+      variables: any,
+      updateQueries: { [queryId: string]: QueryWithUpdater },
+      update: ((proxy: DataProxy, mutationResult: Object) => void) | void,
+    }): void;
+    markMutationComplete({
+      mutationId: string,
+      optimisticResponse?: any,
+    }): void;
+    markUpdateQueryResult(
+      document: DocumentNode,
+      variables: any,
+      newResult: any
+    ): void;
+    reset(): Promise<void>;
+  }
+
+  declare type QueryWithUpdater = {
+    updater: MutationQueryReducer<Object>,
+    query: QueryStoreValue,
+  };
+
+  declare interface MutationStoreValue {
+    mutationString: string;
+    variables: Object;
+    loading: boolean;
+    error: Error | null;
+  }
+
+  declare class MutationStore {
+    getStore(): { [mutationId: string]: MutationStoreValue };
+    get(mutationId: string): MutationStoreValue;
+    initMutation(
+      mutationId: string,
+      mutationString: string,
+      variables: Object | void
+    ): void;
+  }
+
+  declare interface FetchMoreOptions<TData, TVariables> {
+    updateQuery: (
+      previousQueryResult: TData,
+      options: {
+        fetchMoreResult?: TData,
+        variables: TVariables,
+      }
+    ) => TData;
+  }
+
+  declare interface UpdateQueryOptions {
+    variables?: Object;
+  }
+
+  declare type ApolloCurrentResult<T> = {
+    data: T | {},
+    errors?: Array<GraphQLError>,
+    loading: boolean,
+    networkStatus: NetworkStatus,
+    error?: ApolloError,
+    partial?: boolean,
+  };
+
+  declare type ModifiableWatchQueryOptions = {
+    variables?: { [key: string]: any },
+    pollInterval?: number,
+    fetchPolicy?: FetchPolicy,
+    errorPolicy?: ErrorPolicy,
+    fetchResults?: boolean,
+    notifyOnNetworkStatusChange?: boolean,
+  };
+
+  declare type WatchQueryOptions = {
+    ...$Exact<ModifiableWatchQueryOptions>,
+    query: DocumentNode,
+    metadata?: any,
+    context?: any,
+  };
+
+  declare type RefetchQueryDescription = Array<string | PureQueryOptions>;
+
+  declare interface MutationBaseOptions<T = { [key: string]: any }> {
+    optimisticResponse?: Object | Function;
+    updateQueries?: MutationQueryReducersMap<T>;
+    optimisticResponse?: Object;
+    refetchQueries?:
+      | ((result: ExecutionResult<>) => RefetchQueryDescription)
+      | RefetchQueryDescription;
+    update?: MutationUpdaterFn<T>;
+    errorPolicy?: ErrorPolicy;
+    variables?: any;
+  }
+
+  declare type MutationOperation<T = Object> = (
+    options: MutationBaseOptions<T>
+  ) => Promise<FetchResult<T>>;
+
+  declare type FetchPolicy =
+    | 'cache-first'
+    | 'cache-and-network'
+    | 'network-only'
+    | 'cache-only'
+    | 'no-cache'
+    | 'standby';
+
+  declare type ErrorPolicy = 'none' | 'ignore' | 'all';
+
+  declare interface FetchMoreQueryOptions<TVariables> {
+    variables: $Shape<TVariables>;
+  }
+
+  declare type SubscribeToMoreOptions<
+    TData,
+    TSubscriptionData,
+    TSubscriptionVariables = void
+  > = {
+    document?: DocumentNode,
+    variables?: TSubscriptionVariables,
+    updateQuery?: (
+      previousResult: TData,
+      result: {
+        subscriptionData: { data?: TSubscriptionData },
+        variables: TSubscriptionVariables,
+      }
+    ) => TData,
+    onError?: (error: Error) => void,
+  };
+
+  declare type MutationUpdaterFn<T = OperationVariables> = (
+    proxy: DataProxy,
+    mutationResult: FetchResult<T>
+  ) => void;
+
+  declare type NetworkStatus = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
+  declare type QueryListener = (
+    queryStoreValue: QueryStoreValue,
+    newData?: any
+  ) => void;
+
+  declare type QueryStoreValue = {
+    document: DocumentNode,
+    variables: Object,
+    previousVariables: Object | null,
+    networkStatus: NetworkStatus,
+    networkError: Error | null,
+    graphQLErrors: GraphQLError[],
+    metadata: any,
+  };
+
+  declare type PureQueryOptions = {
+    query: DocumentNode,
+    variables?: { [key: string]: any },
+  };
+
+  declare type ApolloQueryResult<T> = {
+    data: T,
+    errors?: Array<GraphQLError>,
+    loading: boolean,
+    networkStatus: NetworkStatus,
+    stale: boolean,
+  };
+
+  declare type FetchType = 1 | 2 | 3;
+
+  declare type MutationQueryReducer<T> = (
+    previousResult: { [key: string]: any },
+    options: {
+      mutationResult: FetchResult<T>,
+      queryName: string | void,
+      queryVariables: { [key: string]: any },
+    }
+  ) => { [key: string]: any };
+
+  declare type MutationQueryReducersMap<T = { [key: string]: any }> = {
+    [queryName: string]: MutationQueryReducer<T>,
+  };
+
+  declare class ApolloError extends Error {
+    message: string;
+    graphQLErrors: Array<GraphQLError>;
+    networkError: Error | null;
+    extraInfo: any;
+    constructor(info: ErrorConstructor): this;
+  }
+
+  declare interface ErrorConstructor {
+    graphQLErrors?: Array<GraphQLError>;
+    networkError?: Error | null;
+    errorMessage?: string;
+    extraInfo?: any;
+  }
+
+  declare interface DefaultOptions {
+    +watchQuery?: ModifiableWatchQueryOptions;
+    +query?: ModifiableWatchQueryOptions;
+    +mutate?: MutationBaseOptions<>;
+  }
+
+  declare type ApolloClientOptions<TCacheShape> = {
+    link: ApolloLink,
+    cache: ApolloCache<TCacheShape>,
+    ssrMode?: boolean,
+    ssrForceFetchDelay?: number,
+    connectToDevTools?: boolean,
+    queryDeduplication?: boolean,
+    defaultOptions?: DefaultOptions,
+  };
+
+  declare class ApolloClient<TCacheShape> {
+    link: ApolloLink;
+    store: DataStore<TCacheShape>;
+    cache: ApolloCache<TCacheShape>;
+    queryManager: QueryManager<TCacheShape>;
+    disableNetworkFetches: boolean;
+    version: string;
+    queryDeduplication: boolean;
+    defaultOptions: DefaultOptions;
+    devToolsHookCb: Function;
+    proxy: ApolloCache<TCacheShape> | void;
+    ssrMode: boolean;
+    resetStoreCallbacks: Array<() => Promise<any>>;
+
+    constructor(options: ApolloClientOptions<TCacheShape>): this;
+    watchQuery<T>(options: WatchQueryOptions): ObservableQuery<T>;
+    query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
+    mutate<T>(options: MutationOptions<T>): Promise<FetchResult<T>>;
+    subscribe<T, D>(options: SubscriptionOptions<T, D>): Observable<any>;
+    readQuery<T>(options: DataProxyReadQueryOptions): T | null;
+    readFragment<T>(options: DataProxyReadFragmentOptions): T | null;
+    writeQuery(options: DataProxyWriteQueryOptions): void;
+    writeFragment(options: DataProxyWriteFragmentOptions): void;
+    writeData(options: DataProxyWriteDataOptions): void;
+    __actionHookForDevTools(cb: () => any): void;
+    __requestRaw(payload: GraphQLRequest): Observable<ExecutionResult<>>;
+    initQueryManager(): void;
+    resetStore(): Promise<Array<ApolloQueryResult<any>> | null>;
+    onResetStore(cb: () => Promise<any>): () => void;
+    reFetchObservableQueries(
+      includeStandby?: boolean
+    ): Promise<ApolloQueryResult<any>[]> | Promise<null>;
+    extract(optimistic?: boolean): TCacheShape;
+    restore(serializedState: TCacheShape): ApolloCache<TCacheShape>;
+  }
+
+  /* apollo-link types */
+  declare class ApolloLink {
+    constructor(request?: RequestHandler): this;
+
+    static empty(): ApolloLink;
+    static from(links: Array<ApolloLink>): ApolloLink;
+    static split(
+      test: (op: Operation) => boolean,
+      left: ApolloLink | RequestHandler,
+      right: ApolloLink | RequestHandler
+    ): ApolloLink;
+    static execute(
+      link: ApolloLink,
+      operation: GraphQLRequest
+    ): Observable<FetchResult<>>;
+
+    split(
+      test: (op: Operation) => boolean,
+      left: ApolloLink | RequestHandler,
+      right: ApolloLink | RequestHandler
+    ): ApolloLink;
+
+    concat(next: ApolloLink | RequestHandler): ApolloLink;
+
+    request(
+      operation: Operation,
+      forward?: NextLink
+    ): Observable<FetchResult<>> | null;
+  }
+
+  declare interface GraphQLRequest {
+    query: DocumentNode;
+    variables?: { [key: string]: any };
+    operationName?: string;
+    context?: { [key: string]: any };
+    extensions?: { [key: string]: any };
+  }
+
+  declare interface Operation {
+    query: DocumentNode;
+    variables: { [key: string]: any };
+    operationName: string;
+    extensions: { [key: string]: any };
+    setContext: (context: { [key: string]: any }) => { [key: string]: any };
+    getContext: () => { [key: string]: any };
+    toKey: () => string;
+  }
+
+  declare type FetchResult<
+    C = { [key: string]: any },
+    E = { [key: string]: any }
+  > = ExecutionResult<C> & { extension?: E, context?: C };
+
+  declare type NextLink = (operation: Operation) => Observable<FetchResult<>>;
+
+  declare type RequestHandler = (
+    operation: Operation,
+    forward?: NextLink
+  ) => Observable<FetchResult<>> | null;
+
+  declare class Observable<T> {
+    subscribe(
+      observerOrNext: ((value: T) => void) | ZenObservableObserver<T>,
+      error?: (error: any) => void,
+      complete?: () => void
+    ): ZenObservableSubscription;
+
+    forEach(fn: (value: T) => void): Promise<void>;
+
+    map<R>(fn: (value: T) => R): Observable<R>;
+
+    filter(fn: (value: T) => boolean): Observable<T>;
+
+    reduce<R>(
+      fn: (previousValue: R | T, currentValue: T) => R | T,
+      initialValue?: R | T
+    ): Observable<R | T>;
+
+    flatMap<R>(fn: (value: T) => ZenObservableObservableLike<R>): Observable<R>;
+
+    from<R>(
+      observable: Observable<R> | ZenObservableObservableLike<R> | Array<R>
+    ): Observable<R>;
+
+    of<R>(...args: Array<R>): Observable<R>;
+  }
+
+  declare interface Observer<T> {
+    start?: (subscription: SubscriptionLINK) => any;
+    next?: (value: T) => void;
+    error?: (errorValue: any) => void;
+    complete?: () => void;
+  }
+
+  declare interface SubscriptionLINK {
+    closed: boolean;
+    unsubscribe(): void;
+  }
+
+  declare interface ZenObservableSubscriptionObserver<T> {
+    closed: boolean;
+    next(value: T): void;
+    error(errorValue: any): void;
+    complete(): void;
+  }
+
+  declare interface ZenObservableSubscription {
+    closed: boolean;
+    unsubscribe(): void;
+  }
+
+  declare interface ZenObservableObserver<T> {
+    start?: (subscription: ZenObservableSubscription) => any;
+    next?: (value: T) => void;
+    error?: (errorValue: any) => void;
+    complete?: () => void;
+  }
+
+  declare type ZenObservableSubscriber<T> = (
+    observer: ZenObservableSubscriptionObserver<T>
+  ) => void | (() => void) | SubscriptionLINK;
+
+  declare interface ZenObservableObservableLike<T> {
+    subscribe?: ZenObservableSubscriber<T>;
+  }
+  /* apollo-link types */
+
+  /* apollo-cache types */
+  declare class ApolloCache<TSerialized> {
+    read<T>(query: CacheReadOptions): T | null;
+    write(write: CacheWriteOptions): void;
+    diff<T>(query: CacheDiffOptions): CacheDiffResult<T>;
+    watch(watch: CacheWatchOptions): () => void;
+    evict(query: CacheEvictOptions): CacheEvictionResult;
+    reset(): Promise<void>;
+
+    restore(serializedState: TSerialized): ApolloCache<TSerialized>;
+    extract(optimistic?: boolean): TSerialized;
+
+    removeOptimistic(id: string): void;
+
+    performTransaction(transaction: Transaction<TSerialized>): void;
+    recordOptimisticTransaction(
+      transaction: Transaction<TSerialized>,
+      id: string
+    ): void;
+
+    transformDocument(document: DocumentNode): DocumentNode;
+    transformForLink(document: DocumentNode): DocumentNode;
+
+    readQuery<QueryType>(
+      options: DataProxyReadQueryOptions,
+      optimistic?: boolean
+    ): QueryType | null;
+    readFragment<FragmentType>(
+      options: DataProxyReadFragmentOptions,
+      optimistic?: boolean
+    ): FragmentType | null;
+    writeQuery(options: CacheWriteQueryOptions): void;
+    writeFragment(options: CacheWriteFragmentOptions): void;
+    writeData(options: CacheWriteDataOptions): void;
+  }
+
+  declare type Transaction<T> = (c: ApolloCache<T>) => void;
+
+  declare type CacheWatchCallback = (newData: any) => void;
+
+  declare interface CacheEvictionResult {
+    success: boolean;
+  }
+
+  declare interface CacheReadOptions extends DataProxyReadQueryOptions {
+    rootId?: string;
+    previousResult?: any;
+    optimistic: boolean;
+  }
+
+  declare interface CacheWriteOptions extends DataProxyReadQueryOptions {
+    dataId: string;
+    result: any;
+  }
+
+  declare interface CacheDiffOptions extends CacheReadOptions {
+    returnPartialData?: boolean;
+  }
+
+  declare interface CacheWatchOptions extends CacheReadOptions {
+    callback: CacheWatchCallback;
+  }
+
+  declare interface CacheEvictOptions extends DataProxyReadQueryOptions {
+    rootId?: string;
+  }
+
+  declare type CacheDiffResult<T> = DataProxyDiffResult<T>;
+  declare type CacheWriteQueryOptions = DataProxyWriteQueryOptions;
+  declare type CacheWriteFragmentOptions = DataProxyWriteFragmentOptions;
+  declare type CacheWriteDataOptions = DataProxyWriteDataOptions;
+  declare type CacheReadFragmentOptions = DataProxyReadFragmentOptions;
+
+  declare interface DataProxyReadQueryOptions {
+    query: DocumentNode;
+    variables?: any;
+  }
+
+  declare interface DataProxyReadFragmentOptions {
+    id: string;
+    fragment: DocumentNode;
+    fragmentName?: string;
+    variables?: any;
+  }
+
+  declare interface DataProxyWriteQueryOptions {
+    data: any;
+    query: DocumentNode;
+    variables?: any;
+  }
+
+  declare interface DataProxyWriteFragmentOptions {
+    data: any;
+    id: string;
+    fragment: DocumentNode;
+    fragmentName?: string;
+    variables?: any;
+  }
+
+  declare interface DataProxyWriteDataOptions {
+    data: any;
+    id?: string;
+  }
+
+  declare type DataProxyDiffResult<T> = {
+    result?: T,
+    complete?: boolean,
+  };
+
+  declare interface DataProxy {
+    readQuery<QueryType>(
+      options: DataProxyReadQueryOptions,
+      optimistic?: boolean
+    ): QueryType | null;
+    readFragment<FragmentType>(
+      options: DataProxyReadFragmentOptions,
+      optimistic?: boolean
+    ): FragmentType | null;
+    writeQuery(options: DataProxyWriteQueryOptions): void;
+    writeFragment(options: DataProxyWriteFragmentOptions): void;
+    writeData(options: DataProxyWriteDataOptions): void;
+  }
+  /* End apollo-cache types */
+  /* end apollo-client types */
+}

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
@@ -1,29 +1,29 @@
+// @flow
 declare module '@apollo/react-hooks' {
-  import type { ComponentType, Element, Node } from 'react';
+  import type {ComponentType, Element, Node} from 'react';
 
   /* start graphql types */
   declare type DocumentNode = any;
   declare type GraphQLError = any;
   /* end graphql types */
 
-  
   /* start @apollo/react-common types */
   declare export type ApolloProviderProps<TCache> = {
     client: ApolloClient<TCache>,
     children: Node | Node[] | null,
-  }
+  };
 
   declare export class ApolloProvider<TCache> extends React$Component<
     ApolloProviderProps<TCache>
   > {
     childContextTypes: {
       client: ApolloClient<TCache>,
-      operations: Map<string, { query: DocumentNode, variables: any }>
+      operations: Map<string, {query: DocumentNode, variables: any}>,
     };
 
     getChildContext(): {
       client: ApolloClient<TCache>,
-      operations: Map<string, { query: DocumentNode, variables: any }>
+      operations: Map<string, {query: DocumentNode, variables: any}>,
     };
   }
 
@@ -31,16 +31,14 @@ declare module '@apollo/react-hooks' {
     children: (client: ApolloClient<any>) => Node;
   }
 
-  declare export class ApolloConsumer extends React$Component<
-    ApolloConsumerProps
-  > {}
-  
+  declare export class ApolloConsumer extends React$Component<ApolloConsumerProps> {}
+
   declare export function getApolloContext<T>(): T;
   declare export function resetApolloContext(): void;
   /* end @apollo/react-common types */
 
   /* start @apollo/react-hooks types */
-  declare type Record<T, U> = { [key: $Keys<T>]: U };
+  declare type Record<T, U> = {[key: $Keys<T>]: U};
 
   declare export function useQuery<TData, TVariables>(
     query: DocumentNode,
@@ -61,29 +59,29 @@ declare module '@apollo/react-hooks' {
     query: DocumentNode,
     options?: MutationHookOptions<TData, TVariables>
   ): MutationTuple<TData, TVariables>;
-  
+
   declare export function useApolloClient<T>(): ApolloClient<T>;
-  
+
   declare export class RenderPromises {
     registerSSRObservable<TData, TVariables>(
       observable: ObservableQuery<any, TVariables>,
       props: QueryOptions<TData, TVariables>
-    ): void,
+    ): void;
     addQueryPromise<TData, TVariables>(
       queryInstance: QueryData<TData, TVariables>,
-      finish: () => Node 
-    ): Node,
-    hasPromises(): boolean,
-    consumeAndAwaitPromises(): Promise<void>,
+      finish: () => Node
+    ): Node;
+    hasPromises(): boolean;
+    consumeAndAwaitPromises(): Promise<void>;
   }
-  
+
   declare export class QueryData<TData, TVariables> {
-    execute(): QueryResult<TData, TVariables>,
-    executeLazy(): QueryTuple<TData, TVariables>,
-    fetchData(): Promise<ApolloQueryResult<any>> | boolean,
-    afterExecute({lazy?: boolean}): any,
-    cleanup(): void,
-    getOptions(): any,
+    execute(): QueryResult<TData, TVariables>;
+    executeLazy(): QueryTuple<TData, TVariables>;
+    fetchData(): Promise<ApolloQueryResult<any>> | boolean;
+    afterExecute({lazy?: boolean}): any;
+    cleanup(): void;
+    getOptions(): any;
   }
 
   /* Common types */
@@ -109,7 +107,7 @@ declare module '@apollo/react-hooks' {
 
   declare export type LazyQueryHookOptions<TData, TVariables> = $Diff<
     QueryFunctionOptions<TData, TVariables>,
-    { skip: * }
+    {skip: *}
   > & {
     query?: DocumentNode,
   };
@@ -135,7 +133,7 @@ declare module '@apollo/react-hooks' {
 
   declare export type QueryTuple<TData, TVariables> = [
     (options?: QueryLazyOptions<TVariables>) => void,
-    QueryResult<TData, TVariables>,
+    QueryResult<TData, TVariables>
   ];
 
   /* Mutation types */
@@ -157,7 +155,7 @@ declare module '@apollo/react-hooks' {
     (
       options?: MutationFunctionOptions<TData, TVariables>
     ) => Promise<void | ExecutionResult<TData>>,
-    MutationResult<TData>,
+    MutationResult<TData>
   ];
 
   /* Subscription types */
@@ -344,7 +342,7 @@ declare module '@apollo/react-hooks' {
   declare class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
     options: WatchQueryOptions;
     queryId: string;
-    variables: { [key: string]: any };
+    variables: {[key: string]: any};
     isCurrentlyPolling: boolean;
     shouldSubscribe: boolean;
     isTornDown: boolean;
@@ -354,7 +352,7 @@ declare module '@apollo/react-hooks' {
     subscriptionHandles: SubscriptionLINK[];
     lastResult: ApolloQueryResult<T>;
     lastError: ApolloError;
-    lastVariables: { [key: string]: any };
+    lastVariables: {[key: string]: any};
 
     constructor(data: {
       scheduler: QueryScheduler<any>,
@@ -444,7 +442,7 @@ declare module '@apollo/react-hooks' {
   }
 
   declare class QueryStore {
-    getStore(): { [queryId: string]: QueryStoreValue };
+    getStore(): {[queryId: string]: QueryStoreValue};
     get(queryId: string): QueryStoreValue;
     initQuery(query: {
       queryId: string,
@@ -472,9 +470,9 @@ declare module '@apollo/react-hooks' {
   }
 
   declare class QueryScheduler<TCacheShape> {
-    inFlightQueries: { [queryId: string]: WatchQueryOptions };
-    registeredQueries: { [queryId: string]: WatchQueryOptions };
-    intervalQueries: { [interval: number]: string[] };
+    inFlightQueries: {[queryId: string]: WatchQueryOptions};
+    registeredQueries: {[queryId: string]: WatchQueryOptions};
+    intervalQueries: {[interval: number]: string[]};
     queryManager: QueryManager<TCacheShape>;
     constructor({
       queryManager: QueryManager<TCacheShape>,
@@ -523,7 +521,7 @@ declare module '@apollo/react-hooks' {
       mutationId: string,
       document: DocumentNode,
       variables: any,
-      updateQueries: { [queryId: string]: QueryWithUpdater },
+      updateQueries: {[queryId: string]: QueryWithUpdater},
       update: ((proxy: DataProxy, mutationResult: Object) => void) | void,
       optimisticResponse: Object | Function | void,
     }): void;
@@ -532,7 +530,7 @@ declare module '@apollo/react-hooks' {
       result: ExecutionResult<>,
       document: DocumentNode,
       variables: any,
-      updateQueries: { [queryId: string]: QueryWithUpdater },
+      updateQueries: {[queryId: string]: QueryWithUpdater},
       update: ((proxy: DataProxy, mutationResult: Object) => void) | void,
     }): void;
     markMutationComplete({
@@ -560,7 +558,7 @@ declare module '@apollo/react-hooks' {
   }
 
   declare class MutationStore {
-    getStore(): { [mutationId: string]: MutationStoreValue };
+    getStore(): {[mutationId: string]: MutationStoreValue};
     get(mutationId: string): MutationStoreValue;
     initMutation(
       mutationId: string,
@@ -593,7 +591,7 @@ declare module '@apollo/react-hooks' {
   };
 
   declare type ModifiableWatchQueryOptions = {
-    variables?: { [key: string]: any },
+    variables?: {[key: string]: any},
     pollInterval?: number,
     fetchPolicy?: FetchPolicy,
     errorPolicy?: ErrorPolicy,
@@ -610,7 +608,7 @@ declare module '@apollo/react-hooks' {
 
   declare type RefetchQueryDescription = Array<string | PureQueryOptions>;
 
-  declare interface MutationBaseOptions<T = { [key: string]: any }> {
+  declare interface MutationBaseOptions<T = {[key: string]: any}> {
     optimisticResponse?: Object | Function;
     updateQueries?: MutationQueryReducersMap<T>;
     optimisticResponse?: Object;
@@ -650,7 +648,7 @@ declare module '@apollo/react-hooks' {
     updateQuery?: (
       previousResult: TData,
       result: {
-        subscriptionData: { data?: TSubscriptionData },
+        subscriptionData: {data?: TSubscriptionData},
         variables: TSubscriptionVariables,
       }
     ) => TData,
@@ -681,7 +679,7 @@ declare module '@apollo/react-hooks' {
 
   declare type PureQueryOptions = {
     query: DocumentNode,
-    variables?: { [key: string]: any },
+    variables?: {[key: string]: any},
   };
 
   declare type ApolloQueryResult<T> = {
@@ -695,15 +693,15 @@ declare module '@apollo/react-hooks' {
   declare type FetchType = 1 | 2 | 3;
 
   declare type MutationQueryReducer<T> = (
-    previousResult: { [key: string]: any },
+    previousResult: {[key: string]: any},
     options: {
       mutationResult: FetchResult<T>,
       queryName: string | void,
-      queryVariables: { [key: string]: any },
+      queryVariables: {[key: string]: any},
     }
-  ) => { [key: string]: any };
+  ) => {[key: string]: any};
 
-  declare type MutationQueryReducersMap<T = { [key: string]: any }> = {
+  declare type MutationQueryReducersMap<T = {[key: string]: any}> = {
     [queryName: string]: MutationQueryReducer<T>,
   };
 
@@ -757,11 +755,17 @@ declare module '@apollo/react-hooks' {
     query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
     mutate<T>(options: MutationOptions<T>): Promise<FetchResult<T>>;
     subscribe<T, D>(options: SubscriptionOptions<T, D>): Observable<any>;
-    readQuery<T>(options: DataProxyReadQueryOptions): T | null;
-    readFragment<T>(options: DataProxyReadFragmentOptions): T | null;
-    writeQuery(options: DataProxyWriteQueryOptions): void;
-    writeFragment(options: DataProxyWriteFragmentOptions): void;
-    writeData(options: DataProxyWriteDataOptions): void;
+    readQuery<T, D>(options: DataProxyReadQueryOptions<D>): T | null;
+    readFragment<TData, TVariables>(
+      options: DataProxyReadFragmentOptions<TVariables>
+    ): TData | null;
+    writeQuery<TData, TVariables>(
+      options: DataProxyWriteQueryOptions<TData, TVariables>
+    ): void;
+    writeFragment<TData, TVariables>(
+      options: DataProxyWriteFragmentOptions<TData, TVariables>
+    ): void;
+    writeData<TData>(options: DataProxyWriteDataOptions<TData>): void;
     __actionHookForDevTools(cb: () => any): void;
     __requestRaw(payload: GraphQLRequest): Observable<ExecutionResult<>>;
     initQueryManager(): void;
@@ -806,26 +810,26 @@ declare module '@apollo/react-hooks' {
 
   declare interface GraphQLRequest {
     query: DocumentNode;
-    variables?: { [key: string]: any };
+    variables?: {[key: string]: any};
     operationName?: string;
-    context?: { [key: string]: any };
-    extensions?: { [key: string]: any };
+    context?: {[key: string]: any};
+    extensions?: {[key: string]: any};
   }
 
   declare interface Operation {
     query: DocumentNode;
-    variables: { [key: string]: any };
+    variables: {[key: string]: any};
     operationName: string;
-    extensions: { [key: string]: any };
-    setContext: (context: { [key: string]: any }) => { [key: string]: any };
-    getContext: () => { [key: string]: any };
+    extensions: {[key: string]: any};
+    setContext: (context: {[key: string]: any}) => {[key: string]: any};
+    getContext: () => {[key: string]: any};
     toKey: () => string;
   }
 
   declare type FetchResult<
-    C = { [key: string]: any },
-    E = { [key: string]: any }
-  > = ExecutionResult<C> & { extension?: E, context?: C };
+    C = {[key: string]: any},
+    E = {[key: string]: any}
+  > = ExecutionResult<C> & {extension?: E, context?: C};
 
   declare type NextLink = (operation: Operation) => Observable<FetchResult<>>;
 
@@ -924,17 +928,21 @@ declare module '@apollo/react-hooks' {
     transformDocument(document: DocumentNode): DocumentNode;
     transformForLink(document: DocumentNode): DocumentNode;
 
-    readQuery<QueryType>(
-      options: DataProxyReadQueryOptions,
+    readQuery<QueryType, TVariables>(
+      options: DataProxyReadQueryOptions<TVariables>,
       optimistic?: boolean
     ): QueryType | null;
-    readFragment<FragmentType>(
-      options: DataProxyReadFragmentOptions,
+    readFragment<FragmentType, TVariables>(
+      options: DataProxyReadFragmentOptions<TVariables>,
       optimistic?: boolean
     ): FragmentType | null;
-    writeQuery(options: CacheWriteQueryOptions): void;
-    writeFragment(options: CacheWriteFragmentOptions): void;
-    writeData(options: CacheWriteDataOptions): void;
+    writeQuery<TData, TVariables>(
+      options: CacheWriteQueryOptions<TData, TVariables>
+    ): void;
+    writeFragment<TData, TVariables>(
+      options: CacheWriteFragmentOptions<TData, TVariables>
+    ): void;
+    writeData<TData>(options: CacheWriteDataOptions<TData>): void;
   }
 
   declare type Transaction<T> = (c: ApolloCache<T>) => void;
@@ -969,39 +977,47 @@ declare module '@apollo/react-hooks' {
   }
 
   declare type CacheDiffResult<T> = DataProxyDiffResult<T>;
-  declare type CacheWriteQueryOptions = DataProxyWriteQueryOptions;
-  declare type CacheWriteFragmentOptions = DataProxyWriteFragmentOptions;
-  declare type CacheWriteDataOptions = DataProxyWriteDataOptions;
-  declare type CacheReadFragmentOptions = DataProxyReadFragmentOptions;
+  declare type CacheWriteQueryOptions<
+    TData,
+    TVariables
+  > = DataProxyWriteQueryOptions<TData, TVariables>;
+  declare type CacheWriteFragmentOptions<
+    TData,
+    TVariables
+  > = DataProxyWriteFragmentOptions<TData, TVariables>;
+  declare type CacheWriteDataOptions<TData> = DataProxyWriteDataOptions<TData>;
+  declare type CacheReadFragmentOptions<
+    TVariables
+  > = DataProxyReadFragmentOptions<TVariables>;
 
   declare interface DataProxyReadQueryOptions {
     query: DocumentNode;
     variables?: any;
   }
 
-  declare interface DataProxyReadFragmentOptions {
+  declare interface DataProxyReadFragmentOptions<TVariables> {
     id: string;
     fragment: DocumentNode;
     fragmentName?: string;
-    variables?: any;
+    variables?: TVariables;
   }
 
-  declare interface DataProxyWriteQueryOptions {
-    data: any;
+  declare interface DataProxyWriteQueryOptions<TData, TVariables> {
+    data: TData;
     query: DocumentNode;
-    variables?: any;
+    variables?: TVariables;
   }
 
-  declare interface DataProxyWriteFragmentOptions {
-    data: any;
+  declare interface DataProxyWriteFragmentOptions<TData, TVariables> {
+    data: TData;
     id: string;
     fragment: DocumentNode;
     fragmentName?: string;
-    variables?: any;
+    variables?: TVariables;
   }
 
-  declare interface DataProxyWriteDataOptions {
-    data: any;
+  declare interface DataProxyWriteDataOptions<TData> {
+    data: TData;
     id?: string;
   }
 
@@ -1011,17 +1027,21 @@ declare module '@apollo/react-hooks' {
   };
 
   declare interface DataProxy {
-    readQuery<QueryType>(
-      options: DataProxyReadQueryOptions,
+    readQuery<QueryType, TVariables>(
+      options: DataProxyReadQueryOptions<TVariables>,
       optimistic?: boolean
     ): QueryType | null;
-    readFragment<FragmentType>(
-      options: DataProxyReadFragmentOptions,
+    readFragment<FragmentType, TVariables>(
+      options: DataProxyReadFragmentOptions<TVariables>,
       optimistic?: boolean
     ): FragmentType | null;
-    writeQuery(options: DataProxyWriteQueryOptions): void;
-    writeFragment(options: DataProxyWriteFragmentOptions): void;
-    writeData(options: DataProxyWriteDataOptions): void;
+    writeQuery<TData, TVariables>(
+      options: DataProxyWriteQueryOptions<TData, TVariables>
+    ): void;
+    writeFragment<TData, TVariables>(
+      options: DataProxyWriteFragmentOptions<TData, TVariables>
+    ): void;
+    writeData<TData>(options: DataProxyWriteDataOptions<TData>): void;
   }
   /* End apollo-cache types */
   /* end apollo-client types */

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
@@ -26,6 +26,7 @@ declare module '@apollo/react-hooks' {
           ...
         }
       >,
+      ...
     };
     getChildContext(): {
       client: ApolloClient<TCache>,
@@ -37,6 +38,7 @@ declare module '@apollo/react-hooks' {
           ...
         }
       >,
+      ...
     };
   }
 
@@ -185,7 +187,7 @@ declare module '@apollo/react-hooks' {
   declare export type MutationTuple<TData, TVariables> = [
     (
       options?: MutationFunctionOptions<TData, TVariables>
-    ) => Promise<void | ExecutionResult<TData>>,
+    ) => Promise<ExecutionResult<TData>>,
     MutationResult<TData>,
   ];
 
@@ -220,7 +222,7 @@ declare module '@apollo/react-hooks' {
 
   declare export type Context = Record<string, any>;
 
-  declare export type ExecutionResult<T = Record<string, any>> = {
+  declare export type ExecutionResult<T> = {
     data?: T,
     extensions?: Record<string, any>,
     errors?: GraphQLError[],
@@ -353,7 +355,7 @@ declare module '@apollo/react-hooks' {
 
   declare export type MutationFunction<TData, TVariables> = (
     options?: MutationFunctionOptions<TData, TVariables>
-  ) => Promise<void | MutationFetchResult<TData>>;
+  ) => Promise<MutationFetchResult<TData>>;
 
   /* Subscription types */
   declare export type OnSubscriptionDataOptions<TData> = {
@@ -390,7 +392,7 @@ declare module '@apollo/react-hooks' {
     options: WatchQueryOptions;
     queryId: string;
     variables: {
-      [key: string]: any,
+      [key: string]: any, ...
     };
     isCurrentlyPolling: boolean;
     shouldSubscribe: boolean;
@@ -402,7 +404,7 @@ declare module '@apollo/react-hooks' {
     lastResult: ApolloQueryResult<T>;
     lastError: ApolloError;
     lastVariables: {
-      [key: string]: any,
+      [key: string]: any, ...
     };
     constructor(data: {
       scheduler: QueryScheduler<any>,
@@ -670,7 +672,7 @@ declare module '@apollo/react-hooks' {
 
   declare type ModifiableWatchQueryOptions = {
     variables?: {
-      [key: string]: any,
+      [key: string]: any, ...
     },
     pollInterval?: number,
     fetchPolicy?: FetchPolicy,
@@ -692,7 +694,7 @@ declare module '@apollo/react-hooks' {
 
   declare interface MutationBaseOptions<
     T = {
-      [key: string]: any,
+      [key: string]: any, ...
     }
   > {
     optimisticResponse?: any;
@@ -772,7 +774,7 @@ declare module '@apollo/react-hooks' {
   declare type PureQueryOptions = {
     query: DocumentNode,
     variables?: {
-      [key: string]: any,
+      [key: string]: any, ...
     },
     ...
   };
@@ -790,23 +792,23 @@ declare module '@apollo/react-hooks' {
 
   declare type MutationQueryReducer<T> = (
     previousResult: {
-      [key: string]: any,
+      [key: string]: any, ...
     },
     options: {
       mutationResult: FetchResult<T>,
       queryName: string | void,
       queryVariables: {
-        [key: string]: any,
+        [key: string]: any, ...
       },
       ...
     }
   ) => {
-    [key: string]: any,
+    [key: string]: any, ...
   };
 
   declare type MutationQueryReducersMap<
     T = {
-      [key: string]: any,
+      [key: string]: any, ...
     }
   > = {
     [queryName: string]: MutationQueryReducer<T>,
@@ -915,43 +917,43 @@ declare module '@apollo/react-hooks' {
   declare interface GraphQLRequest {
     query: DocumentNode;
     variables?: {
-      [key: string]: any,
+      [key: string]: any, ...
     };
     operationName?: string;
     context?: {
-      [key: string]: any,
+      [key: string]: any, ...
     };
     extensions?: {
-      [key: string]: any,
+      [key: string]: any, ...
     };
   }
 
   declare interface Operation {
     query: DocumentNode;
     variables: {
-      [key: string]: any,
+      [key: string]: any, ...
     };
     operationName: string;
     extensions: {
-      [key: string]: any,
+      [key: string]: any, ...
     };
     setContext: (context: {
-      [key: string]: any,
+      [key: string]: any, ...
     }) => {
-      [key: string]: any,
+      [key: string]: any, ...
     };
     getContext: () => {
-      [key: string]: any,
+      [key: string]: any, ...
     };
     toKey: () => string;
   }
 
   declare type FetchResult<
     C = {
-      [key: string]: any,
+      [key: string]: any, ...
     },
     E = {
-      [key: string]: any,
+      [key: string]: any, ...
     }
   > = ExecutionResult<C> & {
     extension?: E,

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
@@ -386,7 +386,6 @@ declare module '@apollo/react-hooks' {
   /* end @apollo/react-hooks types */
 
   /* start apollo-client types */
-  declare function print(ast: any): string;
 
   declare class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
     options: WatchQueryOptions;
@@ -707,10 +706,6 @@ declare module '@apollo/react-hooks' {
     errorPolicy?: ErrorPolicy;
     variables?: any;
   }
-
-  declare type MutationOperation<T> = (
-    options: MutationBaseOptions<T>
-  ) => Promise<FetchResult<T>>;
 
   declare type FetchPolicy =
     | 'cache-first'
@@ -1104,9 +1099,6 @@ declare module '@apollo/react-hooks' {
     TVariables
   > = DataProxyWriteFragmentOptions<TData, TVariables>;
   declare type CacheWriteDataOptions<TData> = DataProxyWriteDataOptions<TData>;
-  declare type CacheReadFragmentOptions<
-    TVariables
-  > = DataProxyReadFragmentOptions<TVariables>;
 
   declare interface DataProxyReadQueryOptions {
     query: DocumentNode;

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
@@ -1,4 +1,3 @@
-// @flow
 declare module '@apollo/react-hooks' {
   import type { ComponentType, Element, Node } from 'react';
 

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
@@ -27,7 +27,6 @@ declare module '@apollo/react-hooks' {
           ...
         }
       >,
-      ...
     };
     getChildContext(): {
       client: ApolloClient<TCache>,
@@ -39,19 +38,14 @@ declare module '@apollo/react-hooks' {
           ...
         }
       >,
-      ...
     };
-    ...
   }
 
   declare export interface ApolloConsumerProps {
     children: (client: ApolloClient<any>) => Node;
-    ...
   }
 
-  declare export class ApolloConsumer extends React$Component<ApolloConsumerProps> {
-    ...
-  }
+  declare export class ApolloConsumer extends React$Component<ApolloConsumerProps> {}
 
   declare export function getApolloContext<T>(): T;
   declare export function resetApolloContext(): void;
@@ -60,7 +54,7 @@ declare module '@apollo/react-hooks' {
   /* start @apollo/react-hooks types */
   declare type Record<T, U> = {
     [key: $Keys<T>]: U,
-    ...
+    ...,
   };
 
   declare export function useQuery<TData, TVariables>(
@@ -96,7 +90,6 @@ declare module '@apollo/react-hooks' {
     ): Node;
     hasPromises(): boolean;
     consumeAndAwaitPromises(): Promise<void>;
-    ...
   }
 
   declare export class QueryData<TData, TVariables> {
@@ -109,12 +102,11 @@ declare module '@apollo/react-hooks' {
     }): any;
     cleanup(): void;
     getOptions(): any;
-    ...
   }
 
   /* Common types */
   declare export type CommonOptions<TOptions> = TOptions & {
-    client?: ApolloClient<Object>,
+    client?: ApolloClient<any>,
     ...
   };
 
@@ -139,7 +131,7 @@ declare module '@apollo/react-hooks' {
   declare export type LazyQueryHookOptions<TData, TVariables> = $Diff<
     QueryFunctionOptions<TData, TVariables>,
     {
-      skip: *,
+      skip: any,
       ...
     }
   > & {
@@ -148,9 +140,9 @@ declare module '@apollo/react-hooks' {
   };
 
   declare export type QueryPreviousData<TData, TVariables> = {
-    client?: ApolloClient<Object>,
+    client?: ApolloClient<any>,
     query?: DocumentNode,
-    observableQueryOptions?: Object,
+    observableQueryOptions?: any,
     result?: ApolloQueryResult<TData> | null,
     loading?: boolean,
     options?: QueryOptions<TData, TVariables>,
@@ -214,7 +206,7 @@ declare module '@apollo/react-hooks' {
     subscription: DocumentNode,
     children?:
       | null
-      | ((result: SubscriptionResult<TData>) => Element<*> | null),
+      | ((result: SubscriptionResult<TData>) => Element<any> | null),
     ...
   };
 
@@ -320,7 +312,7 @@ declare module '@apollo/react-hooks' {
     awaitRefetchQueries?: boolean,
     errorPolicy?: ErrorPolicy,
     update?: MutationUpdaterFn<TData>,
-    client?: ApolloClient<Object>,
+    client?: ApolloClient<any>,
     notifyOnNetworkStatusChange?: boolean,
     context?: Context,
     onCompleted?: (data: TData) => void,
@@ -332,9 +324,7 @@ declare module '@apollo/react-hooks' {
 
   declare export type MutationFunctionOptions<TData, TVariables> = {
     variables?: TVariables,
-    optimisticResponse?:
-      | TData
-      | ((vars: TVariables | {...}) => TData),
+    optimisticResponse?: TData | ((vars: TVariables | { ... }) => TData),
     refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction,
     awaitRefetchQueries?: boolean,
     update?: MutationUpdaterFn<TData>,
@@ -348,7 +338,7 @@ declare module '@apollo/react-hooks' {
     error?: ApolloError,
     loading: boolean,
     called: boolean,
-    client?: ApolloClient<Object>,
+    client?: ApolloClient<any>,
     ...
   };
 
@@ -368,7 +358,7 @@ declare module '@apollo/react-hooks' {
 
   /* Subscription types */
   declare export type OnSubscriptionDataOptions<TData> = {
-    client: ApolloClient<Object>,
+    client: ApolloClient<any>,
     subscriptionData: SubscriptionResult<TData>,
     ...
   };
@@ -379,7 +369,7 @@ declare module '@apollo/react-hooks' {
     shouldResubscribe?:
       | boolean
       | ((options: BaseSubscriptionOptions<TData, TVariables>) => boolean),
-    client?: ApolloClient<Object>,
+    client?: ApolloClient<any>,
     onSubscriptionData?: (options: OnSubscriptionDataOptions<TData>) => any,
     onSubscriptionComplete?: () => void,
     ...
@@ -402,7 +392,6 @@ declare module '@apollo/react-hooks' {
     queryId: string;
     variables: {
       [key: string]: any,
-      ...
     };
     isCurrentlyPolling: boolean;
     shouldSubscribe: boolean;
@@ -415,7 +404,6 @@ declare module '@apollo/react-hooks' {
     lastError: ApolloError;
     lastVariables: {
       [key: string]: any,
-      ...
     };
     constructor(data: {
       scheduler: QueryScheduler<any>,
@@ -446,7 +434,6 @@ declare module '@apollo/react-hooks' {
     ): void;
     stopPolling(): void;
     startPolling(pollInterval: number): void;
-    ...
   }
 
   declare class QueryManager<TStore> {
@@ -502,20 +489,19 @@ declare module '@apollo/react-hooks' {
     removeObservableQuery(queryId: string): void;
     clearStore(): Promise<void>;
     resetStore(): Promise<ApolloQueryResult<any>[]>;
-    ...
   }
 
   declare class QueryStore {
     getStore(): {
       [queryId: string]: QueryStoreValue,
-      ...
+      ...,
     };
     get(queryId: string): QueryStoreValue;
     initQuery(query: {
       queryId: string,
       document: DocumentNode,
       storePreviousVariables: boolean,
-      variables: Object,
+      variables: any,
       isPoll: boolean,
       isRefetch: boolean,
       metadata: any,
@@ -535,21 +521,20 @@ declare module '@apollo/react-hooks' {
     markQueryResultClient(queryId: string, complete: boolean): void;
     stopQuery(queryId: string): void;
     reset(observableQueryIds: string[]): void;
-    ...
   }
 
   declare class QueryScheduler<TCacheShape> {
     inFlightQueries: {
       [queryId: string]: WatchQueryOptions,
-      ...
+      ...,
     };
     registeredQueries: {
       [queryId: string]: WatchQueryOptions,
-      ...
+      ...,
     };
     intervalQueries: {
       [interval: number]: string[],
-      ...
+      ...,
     };
     queryManager: QueryManager<TCacheShape>;
     constructor({
@@ -579,7 +564,6 @@ declare module '@apollo/react-hooks' {
     ): ObservableQuery<T>;
     markMutationError(mutationId: string, error: Error): void;
     reset(): void;
-    ...
   }
 
   declare class DataStore<TSerialized> {
@@ -603,10 +587,10 @@ declare module '@apollo/react-hooks' {
       variables: any,
       updateQueries: {
         [queryId: string]: QueryWithUpdater,
-        ...
+        ...,
       },
-      update: ((proxy: DataProxy, mutationResult: Object) => void) | void,
-      optimisticResponse: Object | Function | void,
+      update: ((proxy: DataProxy, mutationResult: any) => void) | void,
+      optimisticResponse: any,
       ...
     }): void;
     markMutationResult(mutation: {
@@ -616,9 +600,9 @@ declare module '@apollo/react-hooks' {
       variables: any,
       updateQueries: {
         [queryId: string]: QueryWithUpdater,
-        ...
+        ...,
       },
-      update: ((proxy: DataProxy, mutationResult: Object) => void) | void,
+      update: ((proxy: DataProxy, mutationResult: any) => void) | void,
       ...
     }): void;
     markMutationComplete({
@@ -632,35 +616,32 @@ declare module '@apollo/react-hooks' {
       newResult: any
     ): void;
     reset(): Promise<void>;
-    ...
   }
 
   declare type QueryWithUpdater = {
-    updater: MutationQueryReducer<Object>,
+    updater: MutationQueryReducer<any>,
     query: QueryStoreValue,
     ...
   };
 
   declare interface MutationStoreValue {
     mutationString: string;
-    variables: Object;
+    variables: any;
     loading: boolean;
     error: Error | null;
-    ...
   }
 
   declare class MutationStore {
     getStore(): {
       [mutationId: string]: MutationStoreValue,
-      ...
+      ...,
     };
     get(mutationId: string): MutationStoreValue;
     initMutation(
       mutationId: string,
       mutationString: string,
-      variables: Object | void
+      variables: any
     ): void;
-    ...
   }
 
   declare interface FetchMoreOptions<TData, TVariables> {
@@ -672,16 +653,14 @@ declare module '@apollo/react-hooks' {
         ...
       }
     ) => TData;
-    ...
   }
 
   declare interface UpdateQueryOptions {
-    variables?: Object;
-    ...
+    variables?: any;
   }
 
   declare type ApolloCurrentResult<T> = {
-    data: T | {...},
+    data: T | { ... },
     errors?: Array<GraphQLError>,
     loading: boolean,
     networkStatus: NetworkStatus,
@@ -693,7 +672,6 @@ declare module '@apollo/react-hooks' {
   declare type ModifiableWatchQueryOptions = {
     variables?: {
       [key: string]: any,
-      ...
     },
     pollInterval?: number,
     fetchPolicy?: FetchPolicy,
@@ -716,22 +694,20 @@ declare module '@apollo/react-hooks' {
   declare interface MutationBaseOptions<
     T = {
       [key: string]: any,
-      ...
     }
   > {
-    optimisticResponse?: Object | Function;
+    optimisticResponse?: any;
     updateQueries?: MutationQueryReducersMap<T>;
-    optimisticResponse?: Object;
+    optimisticResponse?: any;
     refetchQueries?:
       | ((result: ExecutionResult<>) => RefetchQueryDescription)
       | RefetchQueryDescription;
     update?: MutationUpdaterFn<T>;
     errorPolicy?: ErrorPolicy;
     variables?: any;
-    ...
   }
 
-  declare type MutationOperation<T = Object> = (
+  declare type MutationOperation<T> = (
     options: MutationBaseOptions<T>
   ) => Promise<FetchResult<T>>;
 
@@ -747,7 +723,6 @@ declare module '@apollo/react-hooks' {
 
   declare interface FetchMoreQueryOptions<TVariables> {
     variables: $Shape<TVariables>;
-    ...
   }
 
   declare type SubscribeToMoreOptions<
@@ -786,8 +761,8 @@ declare module '@apollo/react-hooks' {
 
   declare type QueryStoreValue = {
     document: DocumentNode,
-    variables: Object,
-    previousVariables: Object | null,
+    variables: any,
+    previousVariables: any,
     networkStatus: NetworkStatus,
     networkError: Error | null,
     graphQLErrors: GraphQLError[],
@@ -799,7 +774,6 @@ declare module '@apollo/react-hooks' {
     query: DocumentNode,
     variables?: {
       [key: string]: any,
-      ...
     },
     ...
   };
@@ -818,30 +792,26 @@ declare module '@apollo/react-hooks' {
   declare type MutationQueryReducer<T> = (
     previousResult: {
       [key: string]: any,
-      ...
     },
     options: {
       mutationResult: FetchResult<T>,
       queryName: string | void,
       queryVariables: {
         [key: string]: any,
-        ...
       },
       ...
     }
   ) => {
     [key: string]: any,
-    ...
   };
 
   declare type MutationQueryReducersMap<
     T = {
       [key: string]: any,
-      ...
     }
   > = {
     [queryName: string]: MutationQueryReducer<T>,
-    ...
+    ...,
   };
 
   declare class ApolloError extends Error {
@@ -850,7 +820,6 @@ declare module '@apollo/react-hooks' {
     networkError: Error | null;
     extraInfo: any;
     constructor(info: ErrorConstructor): this;
-    ...
   }
 
   declare interface ErrorConstructor {
@@ -858,14 +827,12 @@ declare module '@apollo/react-hooks' {
     networkError?: Error | null;
     errorMessage?: string;
     extraInfo?: any;
-    ...
   }
 
   declare interface DefaultOptions {
     +watchQuery?: ModifiableWatchQueryOptions;
     +query?: ModifiableWatchQueryOptions;
     +mutate?: MutationBaseOptions<>;
-    ...
   }
 
   declare type ApolloClientOptions<TCacheShape> = {
@@ -888,7 +855,7 @@ declare module '@apollo/react-hooks' {
     version: string;
     queryDeduplication: boolean;
     defaultOptions: DefaultOptions;
-    devToolsHookCb: Function;
+    devToolsHookCb: any;
     proxy: ApolloCache<TCacheShape> | void;
     ssrMode: boolean;
     resetStoreCallbacks: Array<() => Promise<any>>;
@@ -918,7 +885,6 @@ declare module '@apollo/react-hooks' {
     ): Promise<ApolloQueryResult<any>[]> | Promise<null>;
     extract(optimistic?: boolean): TCacheShape;
     restore(serializedState: TCacheShape): ApolloCache<TCacheShape>;
-    ...
   }
 
   /* apollo-link types */
@@ -945,61 +911,48 @@ declare module '@apollo/react-hooks' {
       operation: Operation,
       forward?: NextLink
     ): Observable<FetchResult<>> | null;
-    ...
   }
 
   declare interface GraphQLRequest {
     query: DocumentNode;
     variables?: {
       [key: string]: any,
-      ...
     };
     operationName?: string;
     context?: {
       [key: string]: any,
-      ...
     };
     extensions?: {
       [key: string]: any,
-      ...
     };
-    ...
   }
 
   declare interface Operation {
     query: DocumentNode;
     variables: {
       [key: string]: any,
-      ...
     };
     operationName: string;
     extensions: {
       [key: string]: any,
-      ...
     };
     setContext: (context: {
       [key: string]: any,
-      ...
     }) => {
       [key: string]: any,
-      ...
     };
     getContext: () => {
       [key: string]: any,
-      ...
     };
     toKey: () => string;
-    ...
   }
 
   declare type FetchResult<
     C = {
       [key: string]: any,
-      ...
     },
     E = {
       [key: string]: any,
-      ...
     }
   > = ExecutionResult<C> & {
     extension?: E,
@@ -1032,7 +985,6 @@ declare module '@apollo/react-hooks' {
       observable: Observable<R> | ZenObservableObservableLike<R> | Array<R>
     ): Observable<R>;
     of<R>(...args: Array<R>): Observable<R>;
-    ...
   }
 
   declare interface Observer<T> {
@@ -1040,13 +992,11 @@ declare module '@apollo/react-hooks' {
     next?: (value: T) => void;
     error?: (errorValue: any) => void;
     complete?: () => void;
-    ...
   }
 
   declare interface SubscriptionLINK {
     closed: boolean;
     unsubscribe(): void;
-    ...
   }
 
   declare interface ZenObservableSubscriptionObserver<T> {
@@ -1054,13 +1004,11 @@ declare module '@apollo/react-hooks' {
     next(value: T): void;
     error(errorValue: any): void;
     complete(): void;
-    ...
   }
 
   declare interface ZenObservableSubscription {
     closed: boolean;
     unsubscribe(): void;
-    ...
   }
 
   declare interface ZenObservableObserver<T> {
@@ -1068,7 +1016,6 @@ declare module '@apollo/react-hooks' {
     next?: (value: T) => void;
     error?: (errorValue: any) => void;
     complete?: () => void;
-    ...
   }
 
   declare type ZenObservableSubscriber<T> = (
@@ -1077,7 +1024,6 @@ declare module '@apollo/react-hooks' {
 
   declare interface ZenObservableObservableLike<T> {
     subscribe?: ZenObservableSubscriber<T>;
-    ...
   }
   /* apollo-link types */
 
@@ -1114,7 +1060,6 @@ declare module '@apollo/react-hooks' {
       options: CacheWriteFragmentOptions<TData, TVariables>
     ): void;
     writeData<TData>(options: CacheWriteDataOptions<TData>): void;
-    ...
   }
 
   declare type Transaction<T> = (c: ApolloCache<T>) => void;
@@ -1123,35 +1068,29 @@ declare module '@apollo/react-hooks' {
 
   declare interface CacheEvictionResult {
     success: boolean;
-    ...
   }
 
   declare interface CacheReadOptions extends DataProxyReadQueryOptions {
     rootId?: string;
     previousResult?: any;
     optimistic: boolean;
-    ...
   }
 
   declare interface CacheWriteOptions extends DataProxyReadQueryOptions {
     dataId: string;
     result: any;
-    ...
   }
 
   declare interface CacheDiffOptions extends CacheReadOptions {
     returnPartialData?: boolean;
-    ...
   }
 
   declare interface CacheWatchOptions extends CacheReadOptions {
     callback: CacheWatchCallback;
-    ...
   }
 
   declare interface CacheEvictOptions extends DataProxyReadQueryOptions {
     rootId?: string;
-    ...
   }
 
   declare type CacheDiffResult<T> = DataProxyDiffResult<T>;
@@ -1171,7 +1110,6 @@ declare module '@apollo/react-hooks' {
   declare interface DataProxyReadQueryOptions {
     query: DocumentNode;
     variables?: any;
-    ...
   }
 
   declare interface DataProxyReadFragmentOptions<TVariables> {
@@ -1179,14 +1117,12 @@ declare module '@apollo/react-hooks' {
     fragment: DocumentNode;
     fragmentName?: string;
     variables?: TVariables;
-    ...
   }
 
   declare interface DataProxyWriteQueryOptions<TData, TVariables> {
     data: TData;
     query: DocumentNode;
     variables?: TVariables;
-    ...
   }
 
   declare interface DataProxyWriteFragmentOptions<TData, TVariables> {
@@ -1195,13 +1131,11 @@ declare module '@apollo/react-hooks' {
     fragment: DocumentNode;
     fragmentName?: string;
     variables?: TVariables;
-    ...
   }
 
   declare interface DataProxyWriteDataOptions<TData> {
     data: TData;
     id?: string;
-    ...
   }
 
   declare type DataProxyDiffResult<T> = {
@@ -1226,7 +1160,6 @@ declare module '@apollo/react-hooks' {
       options: DataProxyWriteFragmentOptions<TData, TVariables>
     ): void;
     writeData<TData>(options: DataProxyWriteDataOptions<TData>): void;
-    ...
   }
   /* End apollo-cache types */
   /* end apollo-client types */

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
@@ -1,6 +1,6 @@
 // @flow
 declare module '@apollo/react-hooks' {
-  import type {ComponentType, Element, Node} from 'react';
+  import type { ComponentType, Element, Node } from 'react';
 
   /* start graphql types */
   declare type DocumentNode = any;
@@ -11,6 +11,7 @@ declare module '@apollo/react-hooks' {
   declare export type ApolloProviderProps<TCache> = {
     client: ApolloClient<TCache>,
     children: Node | Node[] | null,
+    ...
   };
 
   declare export class ApolloProvider<TCache> extends React$Component<
@@ -18,27 +19,49 @@ declare module '@apollo/react-hooks' {
   > {
     childContextTypes: {
       client: ApolloClient<TCache>,
-      operations: Map<string, {query: DocumentNode, variables: any}>,
+      operations: Map<
+        string,
+        {
+          query: DocumentNode,
+          variables: any,
+          ...
+        }
+      >,
+      ...
     };
-
     getChildContext(): {
       client: ApolloClient<TCache>,
-      operations: Map<string, {query: DocumentNode, variables: any}>,
+      operations: Map<
+        string,
+        {
+          query: DocumentNode,
+          variables: any,
+          ...
+        }
+      >,
+      ...
     };
+    ...
   }
 
   declare export interface ApolloConsumerProps {
     children: (client: ApolloClient<any>) => Node;
+    ...
   }
 
-  declare export class ApolloConsumer extends React$Component<ApolloConsumerProps> {}
+  declare export class ApolloConsumer extends React$Component<ApolloConsumerProps> {
+    ...
+  }
 
   declare export function getApolloContext<T>(): T;
   declare export function resetApolloContext(): void;
   /* end @apollo/react-common types */
 
   /* start @apollo/react-hooks types */
-  declare type Record<T, U> = {[key: $Keys<T>]: U};
+  declare type Record<T, U> = {
+    [key: $Keys<T>]: U,
+    ...
+  };
 
   declare export function useQuery<TData, TVariables>(
     query: DocumentNode,
@@ -73,20 +96,26 @@ declare module '@apollo/react-hooks' {
     ): Node;
     hasPromises(): boolean;
     consumeAndAwaitPromises(): Promise<void>;
+    ...
   }
 
   declare export class QueryData<TData, TVariables> {
     execute(): QueryResult<TData, TVariables>;
     executeLazy(): QueryTuple<TData, TVariables>;
     fetchData(): Promise<ApolloQueryResult<any>> | boolean;
-    afterExecute({lazy?: boolean}): any;
+    afterExecute({
+      lazy?: boolean,
+      ...
+    }): any;
     cleanup(): void;
     getOptions(): any;
+    ...
   }
 
   /* Common types */
   declare export type CommonOptions<TOptions> = TOptions & {
     client?: ApolloClient<Object>,
+    ...
   };
 
   /* Query types */
@@ -96,6 +125,7 @@ declare module '@apollo/react-hooks' {
   > & {
     children?: (result: QueryResult<TData, TVariables>) => Node,
     query: DocumentNode,
+    ...
   };
 
   declare export type QueryHookOptions<
@@ -103,37 +133,45 @@ declare module '@apollo/react-hooks' {
     TVariables
   > = QueryFunctionOptions<TData, TVariables> & {
     query?: DocumentNode,
+    ...
   };
 
   declare export type LazyQueryHookOptions<TData, TVariables> = $Diff<
     QueryFunctionOptions<TData, TVariables>,
-    {skip: *}
+    {
+      skip: *,
+      ...
+    }
   > & {
     query?: DocumentNode,
+    ...
   };
 
   declare export type QueryPreviousData<TData, TVariables> = {
     client?: ApolloClient<Object>,
     query?: DocumentNode,
-    observableQueryOptions?: {},
+    observableQueryOptions?: Object,
     result?: ApolloQueryResult<TData> | null,
     loading?: boolean,
     options?: QueryOptions<TData, TVariables>,
+    ...
   };
 
   declare export type QueryCurrentObservable<TData, TVariables> = {
     query?: ObservableQuery<TData, TVariables> | null,
     subscription?: ZenObservableSubscription,
+    ...
   };
 
   declare export type QueryLazyOptions<TVariables> = {
     variables?: TVariables,
     context?: Context,
+    ...
   };
 
   declare export type QueryTuple<TData, TVariables> = [
     (options?: QueryLazyOptions<TVariables>) => void,
-    QueryResult<TData, TVariables>
+    QueryResult<TData, TVariables>,
   ];
 
   /* Mutation types */
@@ -142,6 +180,7 @@ declare module '@apollo/react-hooks' {
     TVariables
   > = BaseMutationOptions<TData, TVariables> & {
     mutation?: DocumentNode,
+    ...
   };
 
   declare export type MutationOptions<TData, TVariables> = BaseMutationOptions<
@@ -149,13 +188,14 @@ declare module '@apollo/react-hooks' {
     TVariables
   > & {
     mutation: DocumentNode,
+    ...
   };
 
   declare export type MutationTuple<TData, TVariables> = [
     (
       options?: MutationFunctionOptions<TData, TVariables>
     ) => Promise<void | ExecutionResult<TData>>,
-    MutationResult<TData>
+    MutationResult<TData>,
   ];
 
   /* Subscription types */
@@ -164,6 +204,7 @@ declare module '@apollo/react-hooks' {
     TVariables
   > = BaseSubscriptionOptions<TData, TVariables> & {
     subscription?: DocumentNode,
+    ...
   };
 
   declare export type SubscriptionOptions<
@@ -174,11 +215,13 @@ declare module '@apollo/react-hooks' {
     children?:
       | null
       | ((result: SubscriptionResult<TData>) => Element<*> | null),
+    ...
   };
 
   declare export type SubscriptionCurrentObservable = {
     query?: Observable<any>,
     subscription?: ZenObservableSubscription,
+    ...
   };
 
   /* Common types */
@@ -190,6 +233,7 @@ declare module '@apollo/react-hooks' {
     data?: T,
     extensions?: Record<string, any>,
     errors?: GraphQLError[],
+    ...
   };
 
   /* Query types */
@@ -204,6 +248,7 @@ declare module '@apollo/react-hooks' {
     context?: Context,
     partialRefetch?: boolean,
     returnPartialData?: boolean,
+    ...
   };
 
   declare export type QueryFunctionOptions<
@@ -214,6 +259,7 @@ declare module '@apollo/react-hooks' {
     skip?: boolean,
     onCompleted?: (data: TData) => void,
     onError?: (error: ApolloError) => void,
+    ...
   };
 
   declare export type ObservableQueryFields<TData, TVariables> = {
@@ -242,9 +288,11 @@ declare module '@apollo/react-hooks' {
       (<TData2, TVariables2>(
         fetchMoreOptions: {
           query?: DocumentNode,
+          ...
         } & FetchMoreQueryOptions<TVariables2> &
           FetchMoreOptions<TData2, TVariables2>
       ) => Promise<ApolloQueryResult<TData2>>),
+    ...
   };
 
   declare export type QueryResult<TData, TVariables> = ObservableQueryFields<
@@ -257,6 +305,7 @@ declare module '@apollo/react-hooks' {
     loading: boolean,
     networkStatus: NetworkStatus,
     called: boolean,
+    ...
   };
 
   /* Mutation types */
@@ -278,16 +327,20 @@ declare module '@apollo/react-hooks' {
     onError?: (error: ApolloError) => void,
     fetchPolicy?: FetchPolicy,
     ignoreResults?: boolean,
+    ...
   };
 
   declare export type MutationFunctionOptions<TData, TVariables> = {
     variables?: TVariables,
-    optimisticResponse?: TData | ((vars: TVariables | {}) => TData),
+    optimisticResponse?:
+      | TData
+      | ((vars: TVariables | {...}) => TData),
     refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction,
     awaitRefetchQueries?: boolean,
     update?: MutationUpdaterFn<TData>,
     context?: Context,
     fetchPolicy?: FetchPolicy,
+    ...
   };
 
   declare export type MutationResult<TData> = {
@@ -296,6 +349,7 @@ declare module '@apollo/react-hooks' {
     loading: boolean,
     called: boolean,
     client?: ApolloClient<Object>,
+    ...
   };
 
   declare export type MutationFetchResult<
@@ -305,6 +359,7 @@ declare module '@apollo/react-hooks' {
   > = ExecutionResult<TData> & {
     extensions?: E,
     context?: C,
+    ...
   };
 
   declare export type MutationFunction<TData, TVariables> = (
@@ -315,6 +370,7 @@ declare module '@apollo/react-hooks' {
   declare export type OnSubscriptionDataOptions<TData> = {
     client: ApolloClient<Object>,
     subscriptionData: SubscriptionResult<TData>,
+    ...
   };
 
   declare export type BaseSubscriptionOptions<TData, TVariables> = {
@@ -326,12 +382,14 @@ declare module '@apollo/react-hooks' {
     client?: ApolloClient<Object>,
     onSubscriptionData?: (options: OnSubscriptionDataOptions<TData>) => any,
     onSubscriptionComplete?: () => void,
+    ...
   };
 
   declare export type SubscriptionResult<TData> = {
     loading: boolean,
     data?: TData,
     error?: ApolloError,
+    ...
   };
 
   /* end @apollo/react-hooks types */
@@ -342,7 +400,10 @@ declare module '@apollo/react-hooks' {
   declare class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
     options: WatchQueryOptions;
     queryId: string;
-    variables: {[key: string]: any};
+    variables: {
+      [key: string]: any,
+      ...
+    };
     isCurrentlyPolling: boolean;
     shouldSubscribe: boolean;
     isTornDown: boolean;
@@ -352,14 +413,16 @@ declare module '@apollo/react-hooks' {
     subscriptionHandles: SubscriptionLINK[];
     lastResult: ApolloQueryResult<T>;
     lastError: ApolloError;
-    lastVariables: {[key: string]: any};
-
+    lastVariables: {
+      [key: string]: any,
+      ...
+    };
     constructor(data: {
       scheduler: QueryScheduler<any>,
       options: WatchQueryOptions,
       shouldSubscribe?: boolean,
+      ...
     }): this;
-
     result(): Promise<ApolloQueryResult<T>>;
     currentResult(): ApolloCurrentResult<T>;
     getLastResult(): ApolloQueryResult<T>;
@@ -383,6 +446,7 @@ declare module '@apollo/react-hooks' {
     ): void;
     stopPolling(): void;
     startPolling(pollInterval: number): void;
+    ...
   }
 
   declare class QueryManager<TStore> {
@@ -391,15 +455,14 @@ declare module '@apollo/react-hooks' {
     mutationStore: MutationStore;
     queryStore: QueryStore;
     dataStore: DataStore<TStore>;
-
     constructor({
       link: ApolloLink,
       queryDeduplication?: boolean,
       store: DataStore<TStore>,
       onBroadcast?: () => void,
       ssrMode?: boolean,
+      ...
     }): this;
-
     mutate<T>(options: MutationOptions<>): Promise<FetchResult<T>>;
     fetchQuery<T>(
       queryId: string,
@@ -439,10 +502,14 @@ declare module '@apollo/react-hooks' {
     removeObservableQuery(queryId: string): void;
     clearStore(): Promise<void>;
     resetStore(): Promise<ApolloQueryResult<any>[]>;
+    ...
   }
 
   declare class QueryStore {
-    getStore(): {[queryId: string]: QueryStoreValue};
+    getStore(): {
+      [queryId: string]: QueryStoreValue,
+      ...
+    };
     get(queryId: string): QueryStoreValue;
     initQuery(query: {
       queryId: string,
@@ -453,6 +520,7 @@ declare module '@apollo/react-hooks' {
       isRefetch: boolean,
       metadata: any,
       fetchMoreForQueryId: string | void,
+      ...
     }): void;
     markQueryResult(
       queryId: string,
@@ -467,16 +535,27 @@ declare module '@apollo/react-hooks' {
     markQueryResultClient(queryId: string, complete: boolean): void;
     stopQuery(queryId: string): void;
     reset(observableQueryIds: string[]): void;
+    ...
   }
 
   declare class QueryScheduler<TCacheShape> {
-    inFlightQueries: {[queryId: string]: WatchQueryOptions};
-    registeredQueries: {[queryId: string]: WatchQueryOptions};
-    intervalQueries: {[interval: number]: string[]};
+    inFlightQueries: {
+      [queryId: string]: WatchQueryOptions,
+      ...
+    };
+    registeredQueries: {
+      [queryId: string]: WatchQueryOptions,
+      ...
+    };
+    intervalQueries: {
+      [interval: number]: string[],
+      ...
+    };
     queryManager: QueryManager<TCacheShape>;
     constructor({
       queryManager: QueryManager<TCacheShape>,
       ssrMode?: boolean,
+      ...
     }): this;
     checkInFlight(queryId: string): ?boolean;
     fetchQuery<T>(
@@ -500,6 +579,7 @@ declare module '@apollo/react-hooks' {
     ): ObservableQuery<T>;
     markMutationError(mutationId: string, error: Error): void;
     reset(): void;
+    ...
   }
 
   declare class DataStore<TSerialized> {
@@ -521,21 +601,30 @@ declare module '@apollo/react-hooks' {
       mutationId: string,
       document: DocumentNode,
       variables: any,
-      updateQueries: {[queryId: string]: QueryWithUpdater},
+      updateQueries: {
+        [queryId: string]: QueryWithUpdater,
+        ...
+      },
       update: ((proxy: DataProxy, mutationResult: Object) => void) | void,
       optimisticResponse: Object | Function | void,
+      ...
     }): void;
     markMutationResult(mutation: {
       mutationId: string,
       result: ExecutionResult<>,
       document: DocumentNode,
       variables: any,
-      updateQueries: {[queryId: string]: QueryWithUpdater},
+      updateQueries: {
+        [queryId: string]: QueryWithUpdater,
+        ...
+      },
       update: ((proxy: DataProxy, mutationResult: Object) => void) | void,
+      ...
     }): void;
     markMutationComplete({
       mutationId: string,
       optimisticResponse?: any,
+      ...
     }): void;
     markUpdateQueryResult(
       document: DocumentNode,
@@ -543,11 +632,13 @@ declare module '@apollo/react-hooks' {
       newResult: any
     ): void;
     reset(): Promise<void>;
+    ...
   }
 
   declare type QueryWithUpdater = {
     updater: MutationQueryReducer<Object>,
     query: QueryStoreValue,
+    ...
   };
 
   declare interface MutationStoreValue {
@@ -555,16 +646,21 @@ declare module '@apollo/react-hooks' {
     variables: Object;
     loading: boolean;
     error: Error | null;
+    ...
   }
 
   declare class MutationStore {
-    getStore(): {[mutationId: string]: MutationStoreValue};
+    getStore(): {
+      [mutationId: string]: MutationStoreValue,
+      ...
+    };
     get(mutationId: string): MutationStoreValue;
     initMutation(
       mutationId: string,
       mutationString: string,
       variables: Object | void
     ): void;
+    ...
   }
 
   declare interface FetchMoreOptions<TData, TVariables> {
@@ -573,30 +669,38 @@ declare module '@apollo/react-hooks' {
       options: {
         fetchMoreResult?: TData,
         variables: TVariables,
+        ...
       }
     ) => TData;
+    ...
   }
 
   declare interface UpdateQueryOptions {
     variables?: Object;
+    ...
   }
 
   declare type ApolloCurrentResult<T> = {
-    data: T | {},
+    data: T | {...},
     errors?: Array<GraphQLError>,
     loading: boolean,
     networkStatus: NetworkStatus,
     error?: ApolloError,
     partial?: boolean,
+    ...
   };
 
   declare type ModifiableWatchQueryOptions = {
-    variables?: {[key: string]: any},
+    variables?: {
+      [key: string]: any,
+      ...
+    },
     pollInterval?: number,
     fetchPolicy?: FetchPolicy,
     errorPolicy?: ErrorPolicy,
     fetchResults?: boolean,
     notifyOnNetworkStatusChange?: boolean,
+    ...
   };
 
   declare type WatchQueryOptions = {
@@ -604,11 +708,17 @@ declare module '@apollo/react-hooks' {
     query: DocumentNode,
     metadata?: any,
     context?: any,
+    ...
   };
 
   declare type RefetchQueryDescription = Array<string | PureQueryOptions>;
 
-  declare interface MutationBaseOptions<T = {[key: string]: any}> {
+  declare interface MutationBaseOptions<
+    T = {
+      [key: string]: any,
+      ...
+    }
+  > {
     optimisticResponse?: Object | Function;
     updateQueries?: MutationQueryReducersMap<T>;
     optimisticResponse?: Object;
@@ -618,6 +728,7 @@ declare module '@apollo/react-hooks' {
     update?: MutationUpdaterFn<T>;
     errorPolicy?: ErrorPolicy;
     variables?: any;
+    ...
   }
 
   declare type MutationOperation<T = Object> = (
@@ -636,6 +747,7 @@ declare module '@apollo/react-hooks' {
 
   declare interface FetchMoreQueryOptions<TVariables> {
     variables: $Shape<TVariables>;
+    ...
   }
 
   declare type SubscribeToMoreOptions<
@@ -648,11 +760,16 @@ declare module '@apollo/react-hooks' {
     updateQuery?: (
       previousResult: TData,
       result: {
-        subscriptionData: {data?: TSubscriptionData},
+        subscriptionData: {
+          data?: TSubscriptionData,
+          ...
+        },
         variables: TSubscriptionVariables,
+        ...
       }
     ) => TData,
     onError?: (error: Error) => void,
+    ...
   };
 
   declare type MutationUpdaterFn<T = OperationVariables> = (
@@ -675,11 +792,16 @@ declare module '@apollo/react-hooks' {
     networkError: Error | null,
     graphQLErrors: GraphQLError[],
     metadata: any,
+    ...
   };
 
   declare type PureQueryOptions = {
     query: DocumentNode,
-    variables?: {[key: string]: any},
+    variables?: {
+      [key: string]: any,
+      ...
+    },
+    ...
   };
 
   declare type ApolloQueryResult<T> = {
@@ -688,21 +810,38 @@ declare module '@apollo/react-hooks' {
     loading: boolean,
     networkStatus: NetworkStatus,
     stale: boolean,
+    ...
   };
 
   declare type FetchType = 1 | 2 | 3;
 
   declare type MutationQueryReducer<T> = (
-    previousResult: {[key: string]: any},
+    previousResult: {
+      [key: string]: any,
+      ...
+    },
     options: {
       mutationResult: FetchResult<T>,
       queryName: string | void,
-      queryVariables: {[key: string]: any},
+      queryVariables: {
+        [key: string]: any,
+        ...
+      },
+      ...
     }
-  ) => {[key: string]: any};
+  ) => {
+    [key: string]: any,
+    ...
+  };
 
-  declare type MutationQueryReducersMap<T = {[key: string]: any}> = {
+  declare type MutationQueryReducersMap<
+    T = {
+      [key: string]: any,
+      ...
+    }
+  > = {
     [queryName: string]: MutationQueryReducer<T>,
+    ...
   };
 
   declare class ApolloError extends Error {
@@ -711,6 +850,7 @@ declare module '@apollo/react-hooks' {
     networkError: Error | null;
     extraInfo: any;
     constructor(info: ErrorConstructor): this;
+    ...
   }
 
   declare interface ErrorConstructor {
@@ -718,12 +858,14 @@ declare module '@apollo/react-hooks' {
     networkError?: Error | null;
     errorMessage?: string;
     extraInfo?: any;
+    ...
   }
 
   declare interface DefaultOptions {
     +watchQuery?: ModifiableWatchQueryOptions;
     +query?: ModifiableWatchQueryOptions;
     +mutate?: MutationBaseOptions<>;
+    ...
   }
 
   declare type ApolloClientOptions<TCacheShape> = {
@@ -734,6 +876,7 @@ declare module '@apollo/react-hooks' {
     connectToDevTools?: boolean,
     queryDeduplication?: boolean,
     defaultOptions?: DefaultOptions,
+    ...
   };
 
   declare class ApolloClient<TCacheShape> {
@@ -749,7 +892,6 @@ declare module '@apollo/react-hooks' {
     proxy: ApolloCache<TCacheShape> | void;
     ssrMode: boolean;
     resetStoreCallbacks: Array<() => Promise<any>>;
-
     constructor(options: ApolloClientOptions<TCacheShape>): this;
     watchQuery<T>(options: WatchQueryOptions): ObservableQuery<T>;
     query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
@@ -776,12 +918,12 @@ declare module '@apollo/react-hooks' {
     ): Promise<ApolloQueryResult<any>[]> | Promise<null>;
     extract(optimistic?: boolean): TCacheShape;
     restore(serializedState: TCacheShape): ApolloCache<TCacheShape>;
+    ...
   }
 
   /* apollo-link types */
   declare class ApolloLink {
     constructor(request?: RequestHandler): this;
-
     static empty(): ApolloLink;
     static from(links: Array<ApolloLink>): ApolloLink;
     static split(
@@ -793,43 +935,77 @@ declare module '@apollo/react-hooks' {
       link: ApolloLink,
       operation: GraphQLRequest
     ): Observable<FetchResult<>>;
-
     split(
       test: (op: Operation) => boolean,
       left: ApolloLink | RequestHandler,
       right: ApolloLink | RequestHandler
     ): ApolloLink;
-
     concat(next: ApolloLink | RequestHandler): ApolloLink;
-
     request(
       operation: Operation,
       forward?: NextLink
     ): Observable<FetchResult<>> | null;
+    ...
   }
 
   declare interface GraphQLRequest {
     query: DocumentNode;
-    variables?: {[key: string]: any};
+    variables?: {
+      [key: string]: any,
+      ...
+    };
     operationName?: string;
-    context?: {[key: string]: any};
-    extensions?: {[key: string]: any};
+    context?: {
+      [key: string]: any,
+      ...
+    };
+    extensions?: {
+      [key: string]: any,
+      ...
+    };
+    ...
   }
 
   declare interface Operation {
     query: DocumentNode;
-    variables: {[key: string]: any};
+    variables: {
+      [key: string]: any,
+      ...
+    };
     operationName: string;
-    extensions: {[key: string]: any};
-    setContext: (context: {[key: string]: any}) => {[key: string]: any};
-    getContext: () => {[key: string]: any};
+    extensions: {
+      [key: string]: any,
+      ...
+    };
+    setContext: (context: {
+      [key: string]: any,
+      ...
+    }) => {
+      [key: string]: any,
+      ...
+    };
+    getContext: () => {
+      [key: string]: any,
+      ...
+    };
     toKey: () => string;
+    ...
   }
 
   declare type FetchResult<
-    C = {[key: string]: any},
-    E = {[key: string]: any}
-  > = ExecutionResult<C> & {extension?: E, context?: C};
+    C = {
+      [key: string]: any,
+      ...
+    },
+    E = {
+      [key: string]: any,
+      ...
+    }
+  > = ExecutionResult<C> & {
+    extension?: E,
+    context?: C,
+    ...
+  };
 
   declare type NextLink = (operation: Operation) => Observable<FetchResult<>>;
 
@@ -844,25 +1020,19 @@ declare module '@apollo/react-hooks' {
       error?: (error: any) => void,
       complete?: () => void
     ): ZenObservableSubscription;
-
     forEach(fn: (value: T) => void): Promise<void>;
-
     map<R>(fn: (value: T) => R): Observable<R>;
-
     filter(fn: (value: T) => boolean): Observable<T>;
-
     reduce<R>(
       fn: (previousValue: R | T, currentValue: T) => R | T,
       initialValue?: R | T
     ): Observable<R | T>;
-
     flatMap<R>(fn: (value: T) => ZenObservableObservableLike<R>): Observable<R>;
-
     from<R>(
       observable: Observable<R> | ZenObservableObservableLike<R> | Array<R>
     ): Observable<R>;
-
     of<R>(...args: Array<R>): Observable<R>;
+    ...
   }
 
   declare interface Observer<T> {
@@ -870,11 +1040,13 @@ declare module '@apollo/react-hooks' {
     next?: (value: T) => void;
     error?: (errorValue: any) => void;
     complete?: () => void;
+    ...
   }
 
   declare interface SubscriptionLINK {
     closed: boolean;
     unsubscribe(): void;
+    ...
   }
 
   declare interface ZenObservableSubscriptionObserver<T> {
@@ -882,11 +1054,13 @@ declare module '@apollo/react-hooks' {
     next(value: T): void;
     error(errorValue: any): void;
     complete(): void;
+    ...
   }
 
   declare interface ZenObservableSubscription {
     closed: boolean;
     unsubscribe(): void;
+    ...
   }
 
   declare interface ZenObservableObserver<T> {
@@ -894,6 +1068,7 @@ declare module '@apollo/react-hooks' {
     next?: (value: T) => void;
     error?: (errorValue: any) => void;
     complete?: () => void;
+    ...
   }
 
   declare type ZenObservableSubscriber<T> = (
@@ -902,6 +1077,7 @@ declare module '@apollo/react-hooks' {
 
   declare interface ZenObservableObservableLike<T> {
     subscribe?: ZenObservableSubscriber<T>;
+    ...
   }
   /* apollo-link types */
 
@@ -913,21 +1089,16 @@ declare module '@apollo/react-hooks' {
     watch(watch: CacheWatchOptions): () => void;
     evict(query: CacheEvictOptions): CacheEvictionResult;
     reset(): Promise<void>;
-
     restore(serializedState: TSerialized): ApolloCache<TSerialized>;
     extract(optimistic?: boolean): TSerialized;
-
     removeOptimistic(id: string): void;
-
     performTransaction(transaction: Transaction<TSerialized>): void;
     recordOptimisticTransaction(
       transaction: Transaction<TSerialized>,
       id: string
     ): void;
-
     transformDocument(document: DocumentNode): DocumentNode;
     transformForLink(document: DocumentNode): DocumentNode;
-
     readQuery<QueryType, TVariables>(
       options: DataProxyReadQueryOptions<TVariables>,
       optimistic?: boolean
@@ -943,6 +1114,7 @@ declare module '@apollo/react-hooks' {
       options: CacheWriteFragmentOptions<TData, TVariables>
     ): void;
     writeData<TData>(options: CacheWriteDataOptions<TData>): void;
+    ...
   }
 
   declare type Transaction<T> = (c: ApolloCache<T>) => void;
@@ -951,29 +1123,35 @@ declare module '@apollo/react-hooks' {
 
   declare interface CacheEvictionResult {
     success: boolean;
+    ...
   }
 
   declare interface CacheReadOptions extends DataProxyReadQueryOptions {
     rootId?: string;
     previousResult?: any;
     optimistic: boolean;
+    ...
   }
 
   declare interface CacheWriteOptions extends DataProxyReadQueryOptions {
     dataId: string;
     result: any;
+    ...
   }
 
   declare interface CacheDiffOptions extends CacheReadOptions {
     returnPartialData?: boolean;
+    ...
   }
 
   declare interface CacheWatchOptions extends CacheReadOptions {
     callback: CacheWatchCallback;
+    ...
   }
 
   declare interface CacheEvictOptions extends DataProxyReadQueryOptions {
     rootId?: string;
+    ...
   }
 
   declare type CacheDiffResult<T> = DataProxyDiffResult<T>;
@@ -993,6 +1171,7 @@ declare module '@apollo/react-hooks' {
   declare interface DataProxyReadQueryOptions {
     query: DocumentNode;
     variables?: any;
+    ...
   }
 
   declare interface DataProxyReadFragmentOptions<TVariables> {
@@ -1000,12 +1179,14 @@ declare module '@apollo/react-hooks' {
     fragment: DocumentNode;
     fragmentName?: string;
     variables?: TVariables;
+    ...
   }
 
   declare interface DataProxyWriteQueryOptions<TData, TVariables> {
     data: TData;
     query: DocumentNode;
     variables?: TVariables;
+    ...
   }
 
   declare interface DataProxyWriteFragmentOptions<TData, TVariables> {
@@ -1014,16 +1195,19 @@ declare module '@apollo/react-hooks' {
     fragment: DocumentNode;
     fragmentName?: string;
     variables?: TVariables;
+    ...
   }
 
   declare interface DataProxyWriteDataOptions<TData> {
     data: TData;
     id?: string;
+    ...
   }
 
   declare type DataProxyDiffResult<T> = {
     result?: T,
     complete?: boolean,
+    ...
   };
 
   declare interface DataProxy {
@@ -1042,6 +1226,7 @@ declare module '@apollo/react-hooks' {
       options: DataProxyWriteFragmentOptions<TData, TVariables>
     ): void;
     writeData<TData>(options: DataProxyWriteDataOptions<TData>): void;
+    ...
   }
   /* End apollo-cache types */
   /* end apollo-client types */

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/test_react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/test_react-hooks_v3.x.x.js
@@ -1,0 +1,100 @@
+// @flow
+import * as React from "react";
+import { it, describe } from "flow-typed-test";
+import {useQuery, useMutation, useSubscription, useLazyQuery, useApolloClient} from "@apollo/react-hooks";
+
+const gql = (strings, ...args) => {}; // graphql-tag stub
+
+const query = gql`
+  {
+    foo
+  }
+`;
+const mutation = gql`
+  mutation {
+    foo
+  }
+`;
+
+type Hero = {
+  name: string,
+  id: string,
+  appearsIn: string[],
+  friends: Hero[]
+};
+
+type IQuery = {
+  foo: string,
+  bar: string
+};
+
+describe("useQuery hook", () => {
+  type Data = {
+    a: string,
+    b: string,
+  };
+  type Variables = {
+    c: string,
+  };
+  const result = useQuery<Data, Variables>('test');
+  
+  const {data, loading, error} = result;
+  it("handles data correctly", () => {
+    if (data) {
+      const a: string = data.a;
+      // $ExpectError cannot assign `data.b` to `b` because string [2] is incompatible with number
+      const b: number = data.b;
+    }
+  });
+  it("handles loading state correctly", () => {
+    if (error) {
+      (error.message: string);
+      (error.graphQLErrors: Array<any>);
+      // $ExpectError
+      (error.graphQLErrors: string);
+      (error.networkError: Error | null);
+      const extraInfo = error.extraInfo;
+    }
+  });
+  it("handles error state correctly", () => {
+    (loading: boolean);
+    // $ExpectError
+    (loading: string);
+  });
+});
+
+describe("useMutation hook", () => {
+  type Data = {
+    a: string,
+    b: string,
+  };
+  type Variables = {
+    c: string,
+  };
+  const mutation = useMutation<Data, Variables>('test');
+  
+  const {data, loading, error} = result;
+  it("handles data correctly", () => {
+    if (data) {
+      const a: string = data.a;
+      // $ExpectError cannot assign `data.b` to `b` because string [2] is incompatible with number
+      const b: number = data.b;
+    }
+  });
+  it("handles loading state correctly", () => {
+    if (error) {
+      (error.message: string);
+      (error.graphQLErrors: Array<any>);
+      // $ExpectError
+      (error.graphQLErrors: string);
+      (error.networkError: Error | null);
+      const extraInfo = error.extraInfo;
+    }
+  });
+  it("handles error state correctly", () => {
+    (loading: boolean);
+    // $ExpectError
+    (loading: string);
+  });
+});
+

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/test_react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/test_react-hooks_v3.x.x.js
@@ -27,20 +27,24 @@ type Hero = {
   id: string,
   appearsIn: string[],
   friends: Hero[],
+  ...
 };
 
 type IQuery = {
   foo: string,
   bar: string,
+  ...
 };
 
 describe('useQuery hook', () => {
   type Data = {
     a: string,
     b: string,
+    ...
   };
   type Variables = {
     c: string,
+    ...
   };
   const result = useQuery<Data, Variables>('test');
 
@@ -73,9 +77,11 @@ describe('useMutation hook', () => {
   type Data = {
     a: string,
     b: string,
+    ...
   };
   type Variables = {
     c: string,
+    ...
   };
   const mutation = useMutation<Data, Variables>('test');
 

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/test_react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/test_react-hooks_v3.x.x.js
@@ -1,7 +1,13 @@
 // @flow
-import * as React from "react";
-import { it, describe } from "flow-typed-test";
-import {useQuery, useMutation, useSubscription, useLazyQuery, useApolloClient} from "@apollo/react-hooks";
+import * as React from 'react';
+import { it, describe } from 'flow-typed-test';
+import {
+  useQuery,
+  useMutation,
+  useSubscription,
+  useLazyQuery,
+  useApolloClient,
+} from '@apollo/react-hooks';
 
 const gql = (strings, ...args) => {}; // graphql-tag stub
 
@@ -20,15 +26,15 @@ type Hero = {
   name: string,
   id: string,
   appearsIn: string[],
-  friends: Hero[]
+  friends: Hero[],
 };
 
 type IQuery = {
   foo: string,
-  bar: string
+  bar: string,
 };
 
-describe("useQuery hook", () => {
+describe('useQuery hook', () => {
   type Data = {
     a: string,
     b: string,
@@ -37,16 +43,16 @@ describe("useQuery hook", () => {
     c: string,
   };
   const result = useQuery<Data, Variables>('test');
-  
-  const {data, loading, error} = result;
-  it("handles data correctly", () => {
+
+  const { data, loading, error } = result;
+  it('handles data correctly', () => {
     if (data) {
       const a: string = data.a;
       // $ExpectError cannot assign `data.b` to `b` because string [2] is incompatible with number
       const b: number = data.b;
     }
   });
-  it("handles loading state correctly", () => {
+  it('handles loading state correctly', () => {
     if (error) {
       (error.message: string);
       (error.graphQLErrors: Array<any>);
@@ -56,14 +62,14 @@ describe("useQuery hook", () => {
       const extraInfo = error.extraInfo;
     }
   });
-  it("handles error state correctly", () => {
+  it('handles error state correctly', () => {
     (loading: boolean);
     // $ExpectError
     (loading: string);
   });
 });
 
-describe("useMutation hook", () => {
+describe('useMutation hook', () => {
   type Data = {
     a: string,
     b: string,
@@ -72,16 +78,16 @@ describe("useMutation hook", () => {
     c: string,
   };
   const mutation = useMutation<Data, Variables>('test');
-  
-  const {data, loading, error} = result;
-  it("handles data correctly", () => {
+
+  const { data, loading, error } = result;
+  it('handles data correctly', () => {
     if (data) {
       const a: string = data.a;
       // $ExpectError cannot assign `data.b` to `b` because string [2] is incompatible with number
       const b: number = data.b;
     }
   });
-  it("handles loading state correctly", () => {
+  it('handles loading state correctly', () => {
     if (error) {
       (error.message: string);
       (error.graphQLErrors: Array<any>);
@@ -91,10 +97,9 @@ describe("useMutation hook", () => {
       const extraInfo = error.extraInfo;
     }
   });
-  it("handles error state correctly", () => {
+  it('handles error state correctly', () => {
     (loading: boolean);
     // $ExpectError
     (loading: string);
   });
 });
-

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/test_react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/test_react-hooks_v3.x.x.js
@@ -52,7 +52,7 @@ describe('useQuery hook', () => {
   it('handles data correctly', () => {
     if (data) {
       const a: string = data.a;
-      // $ExpectError cannot assign `data.b` to `b` because string [2] is incompatible with number
+      // $ExpectError
       const b: number = data.b;
     }
   });
@@ -74,24 +74,43 @@ describe('useQuery hook', () => {
 });
 
 describe('useMutation hook', () => {
-  type Data = {
+  type TData = {|
     a: string,
     b: string,
-    ...
-  };
-  type Variables = {
+  |};
+  type TVariables = {|
     c: string,
-    ...
-  };
-  const mutation = useMutation<Data, Variables>('test');
+  |};
+  const [mutation, result] = useMutation<TData, TVariables>('test');
 
   const { data, loading, error } = result;
   it('handles data correctly', () => {
     if (data) {
       const a: string = data.a;
-      // $ExpectError cannot assign `data.b` to `b` because string [2] is incompatible with number
+      // $ExpectError
       const b: number = data.b;
     }
+  });
+  it('handles variables correctly', async () => {
+    const mutationResult = await mutation({
+      variables: {
+        c: 'test'
+      }
+    });
+    if (mutationResult.data) {
+      (mutationResult.data.a: string);
+      (mutationResult.data.b: string);
+      // $ExpectError
+      (mutationResult.data.b: number);
+    }
+    // $ExpectError
+    mutation('', {});
+    // $ExpectError
+    mutation('', {
+      variables: {
+        c: 5
+      }
+    });
   });
   it('handles loading state correctly', () => {
     if (error) {

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
@@ -1,0 +1,1028 @@
+declare module '@apollo/react-hooks' {
+  import type { ComponentType, Element, Node } from 'react';
+
+  /* start graphql types */
+  declare type DocumentNode = any;
+  declare type GraphQLError = any;
+  /* end graphql types */
+
+  
+  /* start @apollo/react-common types */
+  declare export type ApolloProviderProps<TCache> = {
+    client: ApolloClient<TCache>,
+    children: Node | Node[] | null,
+  }
+
+  declare export class ApolloProvider<TCache> extends React$Component<
+    ApolloProviderProps<TCache>
+  > {
+    childContextTypes: {
+      client: ApolloClient<TCache>,
+      operations: Map<string, { query: DocumentNode, variables: any }>
+    };
+
+    getChildContext(): {
+      client: ApolloClient<TCache>,
+      operations: Map<string, { query: DocumentNode, variables: any }>
+    };
+  }
+
+  declare export interface ApolloConsumerProps {
+    children: (client: ApolloClient<any>) => Node;
+  }
+
+  declare export class ApolloConsumer extends React$Component<
+    ApolloConsumerProps
+  > {}
+  
+  declare export function getApolloContext<T>(): T;
+  declare export function resetApolloContext(): void;
+  /* end @apollo/react-common types */
+
+  /* start @apollo/react-hooks types */
+  declare type Record<T, U> = { [key: $Keys<T>]: U };
+
+  declare export function useQuery<TData, TVariables>(
+    query: DocumentNode,
+    options?: QueryHookOptions<TData, TVariables>
+  ): QueryResult<TData, TVariables>;
+
+  declare export function useLazyQuery<TData, TVariables>(
+    query: DocumentNode,
+    options?: LazyQueryHookOptions<TData, TVariables>
+  ): QueryTuple<TData, TVariables>;
+
+  declare export function useSubscription<TData, TVariables>(
+    query: DocumentNode,
+    options?: SubscriptionHookOptions<TData, TVariables>
+  ): QueryResult<TData, TVariables>;
+
+  declare export function useMutation<TData, TVariables>(
+    query: DocumentNode,
+    options?: MutationHookOptions<TData, TVariables>
+  ): MutationTuple<TData, TVariables>;
+  
+  declare export function useApolloClient<T>(): ApolloClient<T>;
+  
+  declare export class RenderPromises {
+    registerSSRObservable<TData, TVariables>(
+      observable: ObservableQuery<any, TVariables>,
+      props: QueryOptions<TData, TVariables>
+    ): void,
+    addQueryPromise<TData, TVariables>(
+      queryInstance: QueryData<TData, TVariables>,
+      finish: () => Node 
+    ): Node,
+    hasPromises(): boolean,
+    consumeAndAwaitPromises(): Promise<void>,
+  }
+  
+  declare export class QueryData<TData, TVariables> {
+    execute(): QueryResult<TData, TVariables>,
+    executeLazy(): QueryTuple<TData, TVariables>,
+    fetchData(): Promise<ApolloQueryResult<any>> | boolean,
+    afterExecute({lazy?: boolean}): any,
+    cleanup(): void,
+    getOptions(): any,
+  }
+
+  /* Common types */
+  declare export type CommonOptions<TOptions> = TOptions & {
+    client?: ApolloClient<Object>,
+  };
+
+  /* Query types */
+  declare export type QueryOptions<TData, TVariables> = QueryFunctionOptions<
+    TData,
+    TVariables
+  > & {
+    children?: (result: QueryResult<TData, TVariables>) => Node,
+    query: DocumentNode,
+  };
+
+  declare export type QueryHookOptions<
+    TData,
+    TVariables
+  > = QueryFunctionOptions<TData, TVariables> & {
+    query?: DocumentNode,
+  };
+
+  declare export type LazyQueryHookOptions<TData, TVariables> = $Diff<
+    QueryFunctionOptions<TData, TVariables>,
+    { skip: * }
+  > & {
+    query?: DocumentNode,
+  };
+
+  declare export type QueryPreviousData<TData, TVariables> = {
+    client?: ApolloClient<Object>,
+    query?: DocumentNode,
+    observableQueryOptions?: {},
+    result?: ApolloQueryResult<TData> | null,
+    loading?: boolean,
+    options?: QueryOptions<TData, TVariables>,
+  };
+
+  declare export type QueryCurrentObservable<TData, TVariables> = {
+    query?: ObservableQuery<TData, TVariables> | null,
+    subscription?: ZenObservableSubscription,
+  };
+
+  declare export type QueryLazyOptions<TVariables> = {
+    variables?: TVariables,
+    context?: Context,
+  };
+
+  declare export type QueryTuple<TData, TVariables> = [
+    (options?: QueryLazyOptions<TVariables>) => void,
+    QueryResult<TData, TVariables>,
+  ];
+
+  /* Mutation types */
+  declare export type MutationHookOptions<
+    TData,
+    TVariables
+  > = BaseMutationOptions<TData, TVariables> & {
+    mutation?: DocumentNode,
+  };
+
+  declare export type MutationOptions<TData, TVariables> = BaseMutationOptions<
+    TData,
+    TVariables
+  > & {
+    mutation: DocumentNode,
+  };
+
+  declare export type MutationTuple<TData, TVariables> = [
+    (
+      options?: MutationFunctionOptions<TData, TVariables>
+    ) => Promise<void | ExecutionResult<TData>>,
+    MutationResult<TData>,
+  ];
+
+  /* Subscription types */
+  declare export type SubscriptionHookOptions<
+    TData,
+    TVariables
+  > = BaseSubscriptionOptions<TData, TVariables> & {
+    subscription?: DocumentNode,
+  };
+
+  declare export type SubscriptionOptions<
+    TData,
+    TVariables
+  > = BaseSubscriptionOptions<TData, TVariables> & {
+    subscription: DocumentNode,
+    children?:
+      | null
+      | ((result: SubscriptionResult<TData>) => Element<*> | null),
+  };
+
+  declare export type SubscriptionCurrentObservable = {
+    query?: Observable<any>,
+    subscription?: ZenObservableSubscription,
+  };
+
+  /* Common types */
+  declare export type OperationVariables = Record<string, any>;
+
+  declare export type Context = Record<string, any>;
+
+  declare export type ExecutionResult<T = Record<string, any>> = {
+    data?: T,
+    extensions?: Record<string, any>,
+    errors?: GraphQLError[],
+  };
+
+  /* Query types */
+  declare export type BaseQueryOptions<TVariables> = {
+    ssr?: boolean,
+    variables?: TVariables,
+    fetchPolicy?: FetchPolicy,
+    errorPolicy?: ErrorPolicy,
+    pollInterval?: number,
+    client?: ApolloClient<any>,
+    notifyOnNetworkStatusChange?: boolean,
+    context?: Context,
+    partialRefetch?: boolean,
+    returnPartialData?: boolean,
+  };
+
+  declare export type QueryFunctionOptions<
+    TData,
+    TVariables
+  > = BaseQueryOptions<TVariables> & {
+    displayName?: string,
+    skip?: boolean,
+    onCompleted?: (data: TData) => void,
+    onError?: (error: ApolloError) => void,
+  };
+
+  declare export type ObservableQueryFields<TData, TVariables> = {
+    startPolling: $PropertyType<
+      ObservableQuery<TData, TVariables>,
+      'startPolling'
+    >,
+    stopPolling: $PropertyType<
+      ObservableQuery<TData, TVariables>,
+      'stopPolling'
+    >,
+    subscribeToMore: $PropertyType<
+      ObservableQuery<TData, TVariables>,
+      'subscribeToMore'
+    >,
+    updateQuery: $PropertyType<
+      ObservableQuery<TData, TVariables>,
+      'updateQuery'
+    >,
+    refetch: $PropertyType<ObservableQuery<TData, TVariables>, 'refetch'>,
+    variables: $PropertyType<ObservableQuery<TData, TVariables>, 'variables'>,
+    fetchMore: (<TVariables>(
+      fetchMoreOptions: FetchMoreQueryOptions<TVariables> &
+        FetchMoreOptions<TData, TVariables>
+    ) => Promise<ApolloQueryResult<TData>>) &
+      (<TData2, TVariables2>(
+        fetchMoreOptions: {
+          query?: DocumentNode,
+        } & FetchMoreQueryOptions<TVariables2> &
+          FetchMoreOptions<TData2, TVariables2>
+      ) => Promise<ApolloQueryResult<TData2>>),
+  };
+
+  declare export type QueryResult<TData, TVariables> = ObservableQueryFields<
+    TData,
+    TVariables
+  > & {
+    client: ApolloClient<any>,
+    data: ?TData,
+    error?: ApolloError,
+    loading: boolean,
+    networkStatus: NetworkStatus,
+    called: boolean,
+  };
+
+  /* Mutation types */
+  declare export type RefetchQueriesFunction = (
+    ...args: any[]
+  ) => Array<string | PureQueryOptions>;
+
+  declare export type BaseMutationOptions<TData, TVariables> = {
+    variables?: TVariables,
+    optimisticResponse?: TData | ((vars: TVariables) => TData),
+    refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction,
+    awaitRefetchQueries?: boolean,
+    errorPolicy?: ErrorPolicy,
+    update?: MutationUpdaterFn<TData>,
+    client?: ApolloClient<Object>,
+    notifyOnNetworkStatusChange?: boolean,
+    context?: Context,
+    onCompleted?: (data: TData) => void,
+    onError?: (error: ApolloError) => void,
+    fetchPolicy?: FetchPolicy,
+    ignoreResults?: boolean,
+  };
+
+  declare export type MutationFunctionOptions<TData, TVariables> = {
+    variables?: TVariables,
+    optimisticResponse?: TData | ((vars: TVariables | {}) => TData),
+    refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction,
+    awaitRefetchQueries?: boolean,
+    update?: MutationUpdaterFn<TData>,
+    context?: Context,
+    fetchPolicy?: FetchPolicy,
+  };
+
+  declare export type MutationResult<TData> = {
+    data?: TData,
+    error?: ApolloError,
+    loading: boolean,
+    called: boolean,
+    client?: ApolloClient<Object>,
+  };
+
+  declare export type MutationFetchResult<
+    TData = Record<string, any>,
+    C = Record<string, any>,
+    E = Record<string, any>
+  > = ExecutionResult<TData> & {
+    extensions?: E,
+    context?: C,
+  };
+
+  declare export type MutationFunction<TData, TVariables> = (
+    options?: MutationFunctionOptions<TData, TVariables>
+  ) => Promise<void | MutationFetchResult<TData>>;
+
+  /* Subscription types */
+  declare export type OnSubscriptionDataOptions<TData> = {
+    client: ApolloClient<Object>,
+    subscriptionData: SubscriptionResult<TData>,
+  };
+
+  declare export type BaseSubscriptionOptions<TData, TVariables> = {
+    variables?: TVariables,
+    fetchPolicy?: FetchPolicy,
+    shouldResubscribe?:
+      | boolean
+      | ((options: BaseSubscriptionOptions<TData, TVariables>) => boolean),
+    client?: ApolloClient<Object>,
+    onSubscriptionData?: (options: OnSubscriptionDataOptions<TData>) => any,
+    onSubscriptionComplete?: () => void,
+  };
+
+  declare export type SubscriptionResult<TData> = {
+    loading: boolean,
+    data?: TData,
+    error?: ApolloError,
+  };
+
+  /* end @apollo/react-hooks types */
+
+  /* start apollo-client types */
+  declare function print(ast: any): string;
+
+  declare class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
+    options: WatchQueryOptions;
+    queryId: string;
+    variables: { [key: string]: any };
+    isCurrentlyPolling: boolean;
+    shouldSubscribe: boolean;
+    isTornDown: boolean;
+    scheduler: QueryScheduler<any>;
+    queryManager: QueryManager<any>;
+    observers: Observer<ApolloQueryResult<T>>[];
+    subscriptionHandles: SubscriptionLINK[];
+    lastResult: ApolloQueryResult<T>;
+    lastError: ApolloError;
+    lastVariables: { [key: string]: any };
+
+    constructor(data: {
+      scheduler: QueryScheduler<any>,
+      options: WatchQueryOptions,
+      shouldSubscribe?: boolean,
+    }): this;
+
+    result(): Promise<ApolloQueryResult<T>>;
+    currentResult(): ApolloCurrentResult<T>;
+    getLastResult(): ApolloQueryResult<T>;
+    getLastError(): ApolloError;
+    resetLastResults(): void;
+    refetch(variables?: any): Promise<ApolloQueryResult<T>>;
+    fetchMore(
+      fetchMoreOptions: FetchMoreQueryOptions<any> & FetchMoreOptions<any, any>
+    ): Promise<ApolloQueryResult<T>>;
+    subscribeToMore(options: SubscribeToMoreOptions<any, any>): () => void;
+    setOptions(
+      opts: ModifiableWatchQueryOptions
+    ): Promise<ApolloQueryResult<T>>;
+    setVariables(
+      variables: any,
+      tryFetch?: boolean,
+      fetchResults?: boolean
+    ): Promise<ApolloQueryResult<T>>;
+    updateQuery(
+      mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => any
+    ): void;
+    stopPolling(): void;
+    startPolling(pollInterval: number): void;
+  }
+
+  declare class QueryManager<TStore> {
+    scheduler: QueryScheduler<TStore>;
+    link: ApolloLink;
+    mutationStore: MutationStore;
+    queryStore: QueryStore;
+    dataStore: DataStore<TStore>;
+
+    constructor({
+      link: ApolloLink,
+      queryDeduplication?: boolean,
+      store: DataStore<TStore>,
+      onBroadcast?: () => void,
+      ssrMode?: boolean,
+    }): this;
+
+    mutate<T>(options: MutationOptions<>): Promise<FetchResult<T>>;
+    fetchQuery<T>(
+      queryId: string,
+      options: WatchQueryOptions,
+      fetchType?: FetchType,
+      fetchMoreForQueryId?: string
+    ): Promise<FetchResult<T>>;
+    queryListenerForObserver<T>(
+      queryId: string,
+      options: WatchQueryOptions,
+      observer: Observer<ApolloQueryResult<T>>
+    ): QueryListener;
+    watchQuery<T>(
+      options: WatchQueryOptions,
+      shouldSubscribe?: boolean
+    ): ObservableQuery<T>;
+    query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
+    generateQueryId(): string;
+    stopQueryInStore(queryId: string): void;
+    addQueryListener(queryId: string, listener: QueryListener): void;
+    updateQueryWatch(
+      queryId: string,
+      document: DocumentNode,
+      options: WatchQueryOptions
+    ): void;
+    addFetchQueryPromise<T>(
+      requestId: number,
+      promise: Promise<ApolloQueryResult<T>>,
+      resolve: (result: ApolloQueryResult<T>) => void,
+      reject: (error: Error) => void
+    ): void;
+    removeFetchQueryPromise(requestId: number): void;
+    addObservableQuery<T>(
+      queryId: string,
+      observableQuery: ObservableQuery<T>
+    ): void;
+    removeObservableQuery(queryId: string): void;
+    clearStore(): Promise<void>;
+    resetStore(): Promise<ApolloQueryResult<any>[]>;
+  }
+
+  declare class QueryStore {
+    getStore(): { [queryId: string]: QueryStoreValue };
+    get(queryId: string): QueryStoreValue;
+    initQuery(query: {
+      queryId: string,
+      document: DocumentNode,
+      storePreviousVariables: boolean,
+      variables: Object,
+      isPoll: boolean,
+      isRefetch: boolean,
+      metadata: any,
+      fetchMoreForQueryId: string | void,
+    }): void;
+    markQueryResult(
+      queryId: string,
+      result: ExecutionResult<>,
+      fetchMoreForQueryId: string | void
+    ): void;
+    markQueryError(
+      queryId: string,
+      error: Error,
+      fetchMoreForQueryId: string | void
+    ): void;
+    markQueryResultClient(queryId: string, complete: boolean): void;
+    stopQuery(queryId: string): void;
+    reset(observableQueryIds: string[]): void;
+  }
+
+  declare class QueryScheduler<TCacheShape> {
+    inFlightQueries: { [queryId: string]: WatchQueryOptions };
+    registeredQueries: { [queryId: string]: WatchQueryOptions };
+    intervalQueries: { [interval: number]: string[] };
+    queryManager: QueryManager<TCacheShape>;
+    constructor({
+      queryManager: QueryManager<TCacheShape>,
+      ssrMode?: boolean,
+    }): this;
+    checkInFlight(queryId: string): ?boolean;
+    fetchQuery<T>(
+      queryId: string,
+      options: WatchQueryOptions,
+      fetchType: FetchType
+    ): Promise<FetchResult<T>>;
+    startPollingQuery<T>(
+      options: WatchQueryOptions,
+      queryId: string,
+      listener?: QueryListener
+    ): string;
+    stopPollingQuery(queryId: string): void;
+    fetchQueriesOnInterval<T>(interval: number): void;
+    addQueryOnInterval<T>(
+      queryId: string,
+      queryOptions: WatchQueryOptions
+    ): void;
+    registerPollingQuery<T>(
+      queryOptions: WatchQueryOptions
+    ): ObservableQuery<T>;
+    markMutationError(mutationId: string, error: Error): void;
+    reset(): void;
+  }
+
+  declare class DataStore<TSerialized> {
+    constructor(initialCache: ApolloCache<TSerialized>): this;
+    getCache(): ApolloCache<TSerialized>;
+    markQueryResult(
+      result: ExecutionResult<>,
+      document: DocumentNode,
+      variables: any,
+      fetchMoreForQueryId: string | void,
+      ignoreErrors?: boolean
+    ): void;
+    markSubscriptionResult(
+      result: ExecutionResult<>,
+      document: DocumentNode,
+      variables: any
+    ): void;
+    markMutationInit(mutation: {
+      mutationId: string,
+      document: DocumentNode,
+      variables: any,
+      updateQueries: { [queryId: string]: QueryWithUpdater },
+      update: ((proxy: DataProxy, mutationResult: Object) => void) | void,
+      optimisticResponse: Object | Function | void,
+    }): void;
+    markMutationResult(mutation: {
+      mutationId: string,
+      result: ExecutionResult<>,
+      document: DocumentNode,
+      variables: any,
+      updateQueries: { [queryId: string]: QueryWithUpdater },
+      update: ((proxy: DataProxy, mutationResult: Object) => void) | void,
+    }): void;
+    markMutationComplete({
+      mutationId: string,
+      optimisticResponse?: any,
+    }): void;
+    markUpdateQueryResult(
+      document: DocumentNode,
+      variables: any,
+      newResult: any
+    ): void;
+    reset(): Promise<void>;
+  }
+
+  declare type QueryWithUpdater = {
+    updater: MutationQueryReducer<Object>,
+    query: QueryStoreValue,
+  };
+
+  declare interface MutationStoreValue {
+    mutationString: string;
+    variables: Object;
+    loading: boolean;
+    error: Error | null;
+  }
+
+  declare class MutationStore {
+    getStore(): { [mutationId: string]: MutationStoreValue };
+    get(mutationId: string): MutationStoreValue;
+    initMutation(
+      mutationId: string,
+      mutationString: string,
+      variables: Object | void
+    ): void;
+  }
+
+  declare interface FetchMoreOptions<TData, TVariables> {
+    updateQuery: (
+      previousQueryResult: TData,
+      options: {
+        fetchMoreResult?: TData,
+        variables: TVariables,
+      }
+    ) => TData;
+  }
+
+  declare interface UpdateQueryOptions {
+    variables?: Object;
+  }
+
+  declare type ApolloCurrentResult<T> = {
+    data: T | {},
+    errors?: Array<GraphQLError>,
+    loading: boolean,
+    networkStatus: NetworkStatus,
+    error?: ApolloError,
+    partial?: boolean,
+  };
+
+  declare type ModifiableWatchQueryOptions = {
+    variables?: { [key: string]: any },
+    pollInterval?: number,
+    fetchPolicy?: FetchPolicy,
+    errorPolicy?: ErrorPolicy,
+    fetchResults?: boolean,
+    notifyOnNetworkStatusChange?: boolean,
+  };
+
+  declare type WatchQueryOptions = {
+    ...$Exact<ModifiableWatchQueryOptions>,
+    query: DocumentNode,
+    metadata?: any,
+    context?: any,
+  };
+
+  declare type RefetchQueryDescription = Array<string | PureQueryOptions>;
+
+  declare interface MutationBaseOptions<T = { [key: string]: any }> {
+    optimisticResponse?: Object | Function;
+    updateQueries?: MutationQueryReducersMap<T>;
+    optimisticResponse?: Object;
+    refetchQueries?:
+      | ((result: ExecutionResult<>) => RefetchQueryDescription)
+      | RefetchQueryDescription;
+    update?: MutationUpdaterFn<T>;
+    errorPolicy?: ErrorPolicy;
+    variables?: any;
+  }
+
+  declare type MutationOperation<T = Object> = (
+    options: MutationBaseOptions<T>
+  ) => Promise<FetchResult<T>>;
+
+  declare type FetchPolicy =
+    | 'cache-first'
+    | 'cache-and-network'
+    | 'network-only'
+    | 'cache-only'
+    | 'no-cache'
+    | 'standby';
+
+  declare type ErrorPolicy = 'none' | 'ignore' | 'all';
+
+  declare interface FetchMoreQueryOptions<TVariables> {
+    variables: $Shape<TVariables>;
+  }
+
+  declare type SubscribeToMoreOptions<
+    TData,
+    TSubscriptionData,
+    TSubscriptionVariables = void
+  > = {
+    document?: DocumentNode,
+    variables?: TSubscriptionVariables,
+    updateQuery?: (
+      previousResult: TData,
+      result: {
+        subscriptionData: { data?: TSubscriptionData },
+        variables: TSubscriptionVariables,
+      }
+    ) => TData,
+    onError?: (error: Error) => void,
+  };
+
+  declare type MutationUpdaterFn<T = OperationVariables> = (
+    proxy: DataProxy,
+    mutationResult: FetchResult<T>
+  ) => void;
+
+  declare type NetworkStatus = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
+  declare type QueryListener = (
+    queryStoreValue: QueryStoreValue,
+    newData?: any
+  ) => void;
+
+  declare type QueryStoreValue = {
+    document: DocumentNode,
+    variables: Object,
+    previousVariables: Object | null,
+    networkStatus: NetworkStatus,
+    networkError: Error | null,
+    graphQLErrors: GraphQLError[],
+    metadata: any,
+  };
+
+  declare type PureQueryOptions = {
+    query: DocumentNode,
+    variables?: { [key: string]: any },
+  };
+
+  declare type ApolloQueryResult<T> = {
+    data: T,
+    errors?: Array<GraphQLError>,
+    loading: boolean,
+    networkStatus: NetworkStatus,
+    stale: boolean,
+  };
+
+  declare type FetchType = 1 | 2 | 3;
+
+  declare type MutationQueryReducer<T> = (
+    previousResult: { [key: string]: any },
+    options: {
+      mutationResult: FetchResult<T>,
+      queryName: string | void,
+      queryVariables: { [key: string]: any },
+    }
+  ) => { [key: string]: any };
+
+  declare type MutationQueryReducersMap<T = { [key: string]: any }> = {
+    [queryName: string]: MutationQueryReducer<T>,
+  };
+
+  declare class ApolloError extends Error {
+    message: string;
+    graphQLErrors: Array<GraphQLError>;
+    networkError: Error | null;
+    extraInfo: any;
+    constructor(info: ErrorConstructor): this;
+  }
+
+  declare interface ErrorConstructor {
+    graphQLErrors?: Array<GraphQLError>;
+    networkError?: Error | null;
+    errorMessage?: string;
+    extraInfo?: any;
+  }
+
+  declare interface DefaultOptions {
+    +watchQuery?: ModifiableWatchQueryOptions;
+    +query?: ModifiableWatchQueryOptions;
+    +mutate?: MutationBaseOptions<>;
+  }
+
+  declare type ApolloClientOptions<TCacheShape> = {
+    link: ApolloLink,
+    cache: ApolloCache<TCacheShape>,
+    ssrMode?: boolean,
+    ssrForceFetchDelay?: number,
+    connectToDevTools?: boolean,
+    queryDeduplication?: boolean,
+    defaultOptions?: DefaultOptions,
+  };
+
+  declare class ApolloClient<TCacheShape> {
+    link: ApolloLink;
+    store: DataStore<TCacheShape>;
+    cache: ApolloCache<TCacheShape>;
+    queryManager: QueryManager<TCacheShape>;
+    disableNetworkFetches: boolean;
+    version: string;
+    queryDeduplication: boolean;
+    defaultOptions: DefaultOptions;
+    devToolsHookCb: Function;
+    proxy: ApolloCache<TCacheShape> | void;
+    ssrMode: boolean;
+    resetStoreCallbacks: Array<() => Promise<any>>;
+
+    constructor(options: ApolloClientOptions<TCacheShape>): this;
+    watchQuery<T>(options: WatchQueryOptions): ObservableQuery<T>;
+    query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
+    mutate<T>(options: MutationOptions<T>): Promise<FetchResult<T>>;
+    subscribe<T, D>(options: SubscriptionOptions<T, D>): Observable<any>;
+    readQuery<T>(options: DataProxyReadQueryOptions): T | null;
+    readFragment<T>(options: DataProxyReadFragmentOptions): T | null;
+    writeQuery(options: DataProxyWriteQueryOptions): void;
+    writeFragment(options: DataProxyWriteFragmentOptions): void;
+    writeData(options: DataProxyWriteDataOptions): void;
+    __actionHookForDevTools(cb: () => any): void;
+    __requestRaw(payload: GraphQLRequest): Observable<ExecutionResult<>>;
+    initQueryManager(): void;
+    resetStore(): Promise<Array<ApolloQueryResult<any>> | null>;
+    onResetStore(cb: () => Promise<any>): () => void;
+    reFetchObservableQueries(
+      includeStandby?: boolean
+    ): Promise<ApolloQueryResult<any>[]> | Promise<null>;
+    extract(optimistic?: boolean): TCacheShape;
+    restore(serializedState: TCacheShape): ApolloCache<TCacheShape>;
+  }
+
+  /* apollo-link types */
+  declare class ApolloLink {
+    constructor(request?: RequestHandler): this;
+
+    static empty(): ApolloLink;
+    static from(links: Array<ApolloLink>): ApolloLink;
+    static split(
+      test: (op: Operation) => boolean,
+      left: ApolloLink | RequestHandler,
+      right: ApolloLink | RequestHandler
+    ): ApolloLink;
+    static execute(
+      link: ApolloLink,
+      operation: GraphQLRequest
+    ): Observable<FetchResult<>>;
+
+    split(
+      test: (op: Operation) => boolean,
+      left: ApolloLink | RequestHandler,
+      right: ApolloLink | RequestHandler
+    ): ApolloLink;
+
+    concat(next: ApolloLink | RequestHandler): ApolloLink;
+
+    request(
+      operation: Operation,
+      forward?: NextLink
+    ): Observable<FetchResult<>> | null;
+  }
+
+  declare interface GraphQLRequest {
+    query: DocumentNode;
+    variables?: { [key: string]: any };
+    operationName?: string;
+    context?: { [key: string]: any };
+    extensions?: { [key: string]: any };
+  }
+
+  declare interface Operation {
+    query: DocumentNode;
+    variables: { [key: string]: any };
+    operationName: string;
+    extensions: { [key: string]: any };
+    setContext: (context: { [key: string]: any }) => { [key: string]: any };
+    getContext: () => { [key: string]: any };
+    toKey: () => string;
+  }
+
+  declare type FetchResult<
+    C = { [key: string]: any },
+    E = { [key: string]: any }
+  > = ExecutionResult<C> & { extension?: E, context?: C };
+
+  declare type NextLink = (operation: Operation) => Observable<FetchResult<>>;
+
+  declare type RequestHandler = (
+    operation: Operation,
+    forward?: NextLink
+  ) => Observable<FetchResult<>> | null;
+
+  declare class Observable<T> {
+    subscribe(
+      observerOrNext: ((value: T) => void) | ZenObservableObserver<T>,
+      error?: (error: any) => void,
+      complete?: () => void
+    ): ZenObservableSubscription;
+
+    forEach(fn: (value: T) => void): Promise<void>;
+
+    map<R>(fn: (value: T) => R): Observable<R>;
+
+    filter(fn: (value: T) => boolean): Observable<T>;
+
+    reduce<R>(
+      fn: (previousValue: R | T, currentValue: T) => R | T,
+      initialValue?: R | T
+    ): Observable<R | T>;
+
+    flatMap<R>(fn: (value: T) => ZenObservableObservableLike<R>): Observable<R>;
+
+    from<R>(
+      observable: Observable<R> | ZenObservableObservableLike<R> | Array<R>
+    ): Observable<R>;
+
+    of<R>(...args: Array<R>): Observable<R>;
+  }
+
+  declare interface Observer<T> {
+    start?: (subscription: SubscriptionLINK) => any;
+    next?: (value: T) => void;
+    error?: (errorValue: any) => void;
+    complete?: () => void;
+  }
+
+  declare interface SubscriptionLINK {
+    closed: boolean;
+    unsubscribe(): void;
+  }
+
+  declare interface ZenObservableSubscriptionObserver<T> {
+    closed: boolean;
+    next(value: T): void;
+    error(errorValue: any): void;
+    complete(): void;
+  }
+
+  declare interface ZenObservableSubscription {
+    closed: boolean;
+    unsubscribe(): void;
+  }
+
+  declare interface ZenObservableObserver<T> {
+    start?: (subscription: ZenObservableSubscription) => any;
+    next?: (value: T) => void;
+    error?: (errorValue: any) => void;
+    complete?: () => void;
+  }
+
+  declare type ZenObservableSubscriber<T> = (
+    observer: ZenObservableSubscriptionObserver<T>
+  ) => void | (() => void) | SubscriptionLINK;
+
+  declare interface ZenObservableObservableLike<T> {
+    subscribe?: ZenObservableSubscriber<T>;
+  }
+  /* apollo-link types */
+
+  /* apollo-cache types */
+  declare class ApolloCache<TSerialized> {
+    read<T>(query: CacheReadOptions): T | null;
+    write(write: CacheWriteOptions): void;
+    diff<T>(query: CacheDiffOptions): CacheDiffResult<T>;
+    watch(watch: CacheWatchOptions): () => void;
+    evict(query: CacheEvictOptions): CacheEvictionResult;
+    reset(): Promise<void>;
+
+    restore(serializedState: TSerialized): ApolloCache<TSerialized>;
+    extract(optimistic?: boolean): TSerialized;
+
+    removeOptimistic(id: string): void;
+
+    performTransaction(transaction: Transaction<TSerialized>): void;
+    recordOptimisticTransaction(
+      transaction: Transaction<TSerialized>,
+      id: string
+    ): void;
+
+    transformDocument(document: DocumentNode): DocumentNode;
+    transformForLink(document: DocumentNode): DocumentNode;
+
+    readQuery<QueryType>(
+      options: DataProxyReadQueryOptions,
+      optimistic?: boolean
+    ): QueryType | null;
+    readFragment<FragmentType>(
+      options: DataProxyReadFragmentOptions,
+      optimistic?: boolean
+    ): FragmentType | null;
+    writeQuery(options: CacheWriteQueryOptions): void;
+    writeFragment(options: CacheWriteFragmentOptions): void;
+    writeData(options: CacheWriteDataOptions): void;
+  }
+
+  declare type Transaction<T> = (c: ApolloCache<T>) => void;
+
+  declare type CacheWatchCallback = (newData: any) => void;
+
+  declare interface CacheEvictionResult {
+    success: boolean;
+  }
+
+  declare interface CacheReadOptions extends DataProxyReadQueryOptions {
+    rootId?: string;
+    previousResult?: any;
+    optimistic: boolean;
+  }
+
+  declare interface CacheWriteOptions extends DataProxyReadQueryOptions {
+    dataId: string;
+    result: any;
+  }
+
+  declare interface CacheDiffOptions extends CacheReadOptions {
+    returnPartialData?: boolean;
+  }
+
+  declare interface CacheWatchOptions extends CacheReadOptions {
+    callback: CacheWatchCallback;
+  }
+
+  declare interface CacheEvictOptions extends DataProxyReadQueryOptions {
+    rootId?: string;
+  }
+
+  declare type CacheDiffResult<T> = DataProxyDiffResult<T>;
+  declare type CacheWriteQueryOptions = DataProxyWriteQueryOptions;
+  declare type CacheWriteFragmentOptions = DataProxyWriteFragmentOptions;
+  declare type CacheWriteDataOptions = DataProxyWriteDataOptions;
+  declare type CacheReadFragmentOptions = DataProxyReadFragmentOptions;
+
+  declare interface DataProxyReadQueryOptions {
+    query: DocumentNode;
+    variables?: any;
+  }
+
+  declare interface DataProxyReadFragmentOptions {
+    id: string;
+    fragment: DocumentNode;
+    fragmentName?: string;
+    variables?: any;
+  }
+
+  declare interface DataProxyWriteQueryOptions {
+    data: any;
+    query: DocumentNode;
+    variables?: any;
+  }
+
+  declare interface DataProxyWriteFragmentOptions {
+    data: any;
+    id: string;
+    fragment: DocumentNode;
+    fragmentName?: string;
+    variables?: any;
+  }
+
+  declare interface DataProxyWriteDataOptions {
+    data: any;
+    id?: string;
+  }
+
+  declare type DataProxyDiffResult<T> = {
+    result?: T,
+    complete?: boolean,
+  };
+
+  declare interface DataProxy {
+    readQuery<QueryType>(
+      options: DataProxyReadQueryOptions,
+      optimistic?: boolean
+    ): QueryType | null;
+    readFragment<FragmentType>(
+      options: DataProxyReadFragmentOptions,
+      optimistic?: boolean
+    ): FragmentType | null;
+    writeQuery(options: DataProxyWriteQueryOptions): void;
+    writeFragment(options: DataProxyWriteFragmentOptions): void;
+    writeData(options: DataProxyWriteDataOptions): void;
+  }
+  /* End apollo-cache types */
+  /* end apollo-client types */
+}

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
@@ -86,7 +86,7 @@ declare module '@apollo/react-hooks' {
 
   /* Common types */
   declare export type CommonOptions<TOptions> = TOptions & {
-    client?: ApolloClient<Object>,
+    client?: ApolloClient<any>,
   };
 
   /* Query types */
@@ -107,13 +107,13 @@ declare module '@apollo/react-hooks' {
 
   declare export type LazyQueryHookOptions<TData, TVariables> = $Diff<
     QueryFunctionOptions<TData, TVariables>,
-    { skip: * }
+    { skip: any }
   > & {
     query?: DocumentNode,
   };
 
   declare export type QueryPreviousData<TData, TVariables> = {
-    client?: ApolloClient<Object>,
+    client?: ApolloClient<any>,
     query?: DocumentNode,
     observableQueryOptions?: {},
     result?: ApolloQueryResult<TData> | null,
@@ -173,7 +173,7 @@ declare module '@apollo/react-hooks' {
     subscription: DocumentNode,
     children?:
       | null
-      | ((result: SubscriptionResult<TData>) => Element<*> | null),
+      | ((result: SubscriptionResult<TData>) => Element<any> | null),
   };
 
   declare export type SubscriptionCurrentObservable = {
@@ -271,7 +271,7 @@ declare module '@apollo/react-hooks' {
     awaitRefetchQueries?: boolean,
     errorPolicy?: ErrorPolicy,
     update?: MutationUpdaterFn<TData>,
-    client?: ApolloClient<Object>,
+    client?: ApolloClient<any>,
     notifyOnNetworkStatusChange?: boolean,
     context?: Context,
     onCompleted?: (data: TData) => void,
@@ -295,7 +295,7 @@ declare module '@apollo/react-hooks' {
     error?: ApolloError,
     loading: boolean,
     called: boolean,
-    client?: ApolloClient<Object>,
+    client?: ApolloClient<any>,
   };
 
   declare export type MutationFetchResult<
@@ -313,7 +313,7 @@ declare module '@apollo/react-hooks' {
 
   /* Subscription types */
   declare export type OnSubscriptionDataOptions<TData> = {
-    client: ApolloClient<Object>,
+    client: ApolloClient<any>,
     subscriptionData: SubscriptionResult<TData>,
   };
 
@@ -323,7 +323,7 @@ declare module '@apollo/react-hooks' {
     shouldResubscribe?:
       | boolean
       | ((options: BaseSubscriptionOptions<TData, TVariables>) => boolean),
-    client?: ApolloClient<Object>,
+    client?: ApolloClient<any>,
     onSubscriptionData?: (options: OnSubscriptionDataOptions<TData>) => any,
     onSubscriptionComplete?: () => void,
   };
@@ -448,7 +448,7 @@ declare module '@apollo/react-hooks' {
       queryId: string,
       document: DocumentNode,
       storePreviousVariables: boolean,
-      variables: Object,
+      variables: any,
       isPoll: boolean,
       isRefetch: boolean,
       metadata: any,
@@ -522,8 +522,8 @@ declare module '@apollo/react-hooks' {
       document: DocumentNode,
       variables: any,
       updateQueries: { [queryId: string]: QueryWithUpdater },
-      update: ((proxy: DataProxy, mutationResult: Object) => void) | void,
-      optimisticResponse: Object | Function | void,
+      update: ((proxy: DataProxy, mutationResult: any) => void) | void,
+      optimisticResponse: any,
     }): void;
     markMutationResult(mutation: {
       mutationId: string,
@@ -531,7 +531,7 @@ declare module '@apollo/react-hooks' {
       document: DocumentNode,
       variables: any,
       updateQueries: { [queryId: string]: QueryWithUpdater },
-      update: ((proxy: DataProxy, mutationResult: Object) => void) | void,
+      update: ((proxy: DataProxy, mutationResult: any) => void) | void,
     }): void;
     markMutationComplete({
       mutationId: string,
@@ -546,13 +546,13 @@ declare module '@apollo/react-hooks' {
   }
 
   declare type QueryWithUpdater = {
-    updater: MutationQueryReducer<Object>,
+    updater: MutationQueryReducer<any>,
     query: QueryStoreValue,
   };
 
   declare interface MutationStoreValue {
     mutationString: string;
-    variables: Object;
+    variables: any;
     loading: boolean;
     error: Error | null;
   }
@@ -563,7 +563,7 @@ declare module '@apollo/react-hooks' {
     initMutation(
       mutationId: string,
       mutationString: string,
-      variables: Object | void
+      variables: any
     ): void;
   }
 
@@ -578,7 +578,7 @@ declare module '@apollo/react-hooks' {
   }
 
   declare interface UpdateQueryOptions {
-    variables?: Object;
+    variables?: any;
   }
 
   declare type ApolloCurrentResult<T> = {
@@ -609,9 +609,9 @@ declare module '@apollo/react-hooks' {
   declare type RefetchQueryDescription = Array<string | PureQueryOptions>;
 
   declare interface MutationBaseOptions<T = { [key: string]: any }> {
-    optimisticResponse?: Object | Function;
+    optimisticResponse?: any;
     updateQueries?: MutationQueryReducersMap<T>;
-    optimisticResponse?: Object;
+    optimisticResponse?: any;
     refetchQueries?:
       | ((result: ExecutionResult<>) => RefetchQueryDescription)
       | RefetchQueryDescription;
@@ -620,7 +620,7 @@ declare module '@apollo/react-hooks' {
     variables?: any;
   }
 
-  declare type MutationOperation<T = Object> = (
+  declare type MutationOperation<T> = (
     options: MutationBaseOptions<T>
   ) => Promise<FetchResult<T>>;
 
@@ -669,8 +669,8 @@ declare module '@apollo/react-hooks' {
 
   declare type QueryStoreValue = {
     document: DocumentNode,
-    variables: Object,
-    previousVariables: Object | null,
+    variables: any,
+    previousVariables: any,
     networkStatus: NetworkStatus,
     networkError: Error | null,
     graphQLErrors: GraphQLError[],
@@ -745,7 +745,7 @@ declare module '@apollo/react-hooks' {
     version: string;
     queryDeduplication: boolean;
     defaultOptions: DefaultOptions;
-    devToolsHookCb: Function;
+    devToolsHookCb: any;
     proxy: ApolloCache<TCacheShape> | void;
     ssrMode: boolean;
     resetStoreCallbacks: Array<() => Promise<any>>;

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
@@ -1,4 +1,3 @@
-// @flow
 declare module '@apollo/react-hooks' {
   import type { ComponentType, Element, Node } from 'react';
 

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
@@ -1,3 +1,4 @@
+// @flow
 declare module '@apollo/react-hooks' {
   import type { ComponentType, Element, Node } from 'react';
 
@@ -6,24 +7,23 @@ declare module '@apollo/react-hooks' {
   declare type GraphQLError = any;
   /* end graphql types */
 
-  
   /* start @apollo/react-common types */
   declare export type ApolloProviderProps<TCache> = {
     client: ApolloClient<TCache>,
     children: Node | Node[] | null,
-  }
+  };
 
   declare export class ApolloProvider<TCache> extends React$Component<
     ApolloProviderProps<TCache>
   > {
     childContextTypes: {
       client: ApolloClient<TCache>,
-      operations: Map<string, { query: DocumentNode, variables: any }>
+      operations: Map<string, { query: DocumentNode, variables: any }>,
     };
 
     getChildContext(): {
       client: ApolloClient<TCache>,
-      operations: Map<string, { query: DocumentNode, variables: any }>
+      operations: Map<string, { query: DocumentNode, variables: any }>,
     };
   }
 
@@ -31,10 +31,8 @@ declare module '@apollo/react-hooks' {
     children: (client: ApolloClient<any>) => Node;
   }
 
-  declare export class ApolloConsumer extends React$Component<
-    ApolloConsumerProps
-  > {}
-  
+  declare export class ApolloConsumer extends React$Component<ApolloConsumerProps> {}
+
   declare export function getApolloContext<T>(): T;
   declare export function resetApolloContext(): void;
   /* end @apollo/react-common types */
@@ -61,29 +59,29 @@ declare module '@apollo/react-hooks' {
     query: DocumentNode,
     options?: MutationHookOptions<TData, TVariables>
   ): MutationTuple<TData, TVariables>;
-  
+
   declare export function useApolloClient<T>(): ApolloClient<T>;
-  
+
   declare export class RenderPromises {
     registerSSRObservable<TData, TVariables>(
       observable: ObservableQuery<any, TVariables>,
       props: QueryOptions<TData, TVariables>
-    ): void,
+    ): void;
     addQueryPromise<TData, TVariables>(
       queryInstance: QueryData<TData, TVariables>,
-      finish: () => Node 
-    ): Node,
-    hasPromises(): boolean,
-    consumeAndAwaitPromises(): Promise<void>,
+      finish: () => Node
+    ): Node;
+    hasPromises(): boolean;
+    consumeAndAwaitPromises(): Promise<void>;
   }
-  
+
   declare export class QueryData<TData, TVariables> {
-    execute(): QueryResult<TData, TVariables>,
-    executeLazy(): QueryTuple<TData, TVariables>,
-    fetchData(): Promise<ApolloQueryResult<any>> | boolean,
-    afterExecute({lazy?: boolean}): any,
-    cleanup(): void,
-    getOptions(): any,
+    execute(): QueryResult<TData, TVariables>;
+    executeLazy(): QueryTuple<TData, TVariables>;
+    fetchData(): Promise<ApolloQueryResult<any>> | boolean;
+    afterExecute({ lazy?: boolean }): any;
+    cleanup(): void;
+    getOptions(): any;
   }
 
   /* Common types */
@@ -757,11 +755,17 @@ declare module '@apollo/react-hooks' {
     query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
     mutate<T>(options: MutationOptions<T>): Promise<FetchResult<T>>;
     subscribe<T, D>(options: SubscriptionOptions<T, D>): Observable<any>;
-    readQuery<T>(options: DataProxyReadQueryOptions): T | null;
-    readFragment<T>(options: DataProxyReadFragmentOptions): T | null;
-    writeQuery(options: DataProxyWriteQueryOptions): void;
-    writeFragment(options: DataProxyWriteFragmentOptions): void;
-    writeData(options: DataProxyWriteDataOptions): void;
+    readQuery<T, D>(options: DataProxyReadQueryOptions<D>): T | null;
+    readFragment<TData, TVariables>(
+      options: DataProxyReadFragmentOptions<TVariables>
+    ): TData | null;
+    writeQuery<TData, TVariables>(
+      options: DataProxyWriteQueryOptions<TData, TVariables>
+    ): void;
+    writeFragment<TData, TVariables>(
+      options: DataProxyWriteFragmentOptions<TData, TVariables>
+    ): void;
+    writeData<TData>(options: DataProxyWriteDataOptions<TData>): void;
     __actionHookForDevTools(cb: () => any): void;
     __requestRaw(payload: GraphQLRequest): Observable<ExecutionResult<>>;
     initQueryManager(): void;
@@ -924,17 +928,21 @@ declare module '@apollo/react-hooks' {
     transformDocument(document: DocumentNode): DocumentNode;
     transformForLink(document: DocumentNode): DocumentNode;
 
-    readQuery<QueryType>(
-      options: DataProxyReadQueryOptions,
+    readQuery<QueryType, TVariables>(
+      options: DataProxyReadQueryOptions<TVariables>,
       optimistic?: boolean
     ): QueryType | null;
-    readFragment<FragmentType>(
-      options: DataProxyReadFragmentOptions,
+    readFragment<FragmentType, TVariables>(
+      options: DataProxyReadFragmentOptions<TVariables>,
       optimistic?: boolean
     ): FragmentType | null;
-    writeQuery(options: CacheWriteQueryOptions): void;
-    writeFragment(options: CacheWriteFragmentOptions): void;
-    writeData(options: CacheWriteDataOptions): void;
+    writeQuery<TData, TVariables>(
+      options: CacheWriteQueryOptions<TData, TVariables>
+    ): void;
+    writeFragment<TData, TVariables>(
+      options: CacheWriteFragmentOptions<TData, TVariables>
+    ): void;
+    writeData<TData>(options: CacheWriteDataOptions<TData>): void;
   }
 
   declare type Transaction<T> = (c: ApolloCache<T>) => void;
@@ -969,39 +977,47 @@ declare module '@apollo/react-hooks' {
   }
 
   declare type CacheDiffResult<T> = DataProxyDiffResult<T>;
-  declare type CacheWriteQueryOptions = DataProxyWriteQueryOptions;
-  declare type CacheWriteFragmentOptions = DataProxyWriteFragmentOptions;
-  declare type CacheWriteDataOptions = DataProxyWriteDataOptions;
-  declare type CacheReadFragmentOptions = DataProxyReadFragmentOptions;
+  declare type CacheWriteQueryOptions<
+    TData,
+    TVariables
+  > = DataProxyWriteQueryOptions<TData, TVariables>;
+  declare type CacheWriteFragmentOptions<
+    TData,
+    TVariables
+  > = DataProxyWriteFragmentOptions<TData, TVariables>;
+  declare type CacheWriteDataOptions<TData> = DataProxyWriteDataOptions<TData>;
+  declare type CacheReadFragmentOptions<
+    TVariables
+  > = DataProxyReadFragmentOptions<TVariables>;
 
   declare interface DataProxyReadQueryOptions {
     query: DocumentNode;
     variables?: any;
   }
 
-  declare interface DataProxyReadFragmentOptions {
+  declare interface DataProxyReadFragmentOptions<TVariables> {
     id: string;
     fragment: DocumentNode;
     fragmentName?: string;
-    variables?: any;
+    variables?: TVariables;
   }
 
-  declare interface DataProxyWriteQueryOptions {
-    data: any;
+  declare interface DataProxyWriteQueryOptions<TData, TVariables> {
+    data: TData;
     query: DocumentNode;
-    variables?: any;
+    variables?: TVariables;
   }
 
-  declare interface DataProxyWriteFragmentOptions {
-    data: any;
+  declare interface DataProxyWriteFragmentOptions<TData, TVariables> {
+    data: TData;
     id: string;
     fragment: DocumentNode;
     fragmentName?: string;
-    variables?: any;
+    variables?: TVariables;
   }
 
-  declare interface DataProxyWriteDataOptions {
-    data: any;
+  declare interface DataProxyWriteDataOptions<TData> {
+    data: TData;
     id?: string;
   }
 
@@ -1011,17 +1027,21 @@ declare module '@apollo/react-hooks' {
   };
 
   declare interface DataProxy {
-    readQuery<QueryType>(
-      options: DataProxyReadQueryOptions,
+    readQuery<QueryType, TVariables>(
+      options: DataProxyReadQueryOptions<TVariables>,
       optimistic?: boolean
     ): QueryType | null;
-    readFragment<FragmentType>(
-      options: DataProxyReadFragmentOptions,
+    readFragment<FragmentType, TVariables>(
+      options: DataProxyReadFragmentOptions<TVariables>,
       optimistic?: boolean
     ): FragmentType | null;
-    writeQuery(options: DataProxyWriteQueryOptions): void;
-    writeFragment(options: DataProxyWriteFragmentOptions): void;
-    writeData(options: DataProxyWriteDataOptions): void;
+    writeQuery<TData, TVariables>(
+      options: DataProxyWriteQueryOptions<TData, TVariables>
+    ): void;
+    writeFragment<TData, TVariables>(
+      options: DataProxyWriteFragmentOptions<TData, TVariables>
+    ): void;
+    writeData<TData>(options: DataProxyWriteDataOptions<TData>): void;
   }
   /* End apollo-cache types */
   /* end apollo-client types */

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
@@ -336,7 +336,6 @@ declare module '@apollo/react-hooks' {
   /* end @apollo/react-hooks types */
 
   /* start apollo-client types */
-  declare function print(ast: any): string;
 
   declare class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
     options: WatchQueryOptions;
@@ -618,10 +617,6 @@ declare module '@apollo/react-hooks' {
     errorPolicy?: ErrorPolicy;
     variables?: any;
   }
-
-  declare type MutationOperation<T> = (
-    options: MutationBaseOptions<T>
-  ) => Promise<FetchResult<T>>;
 
   declare type FetchPolicy =
     | 'cache-first'
@@ -985,9 +980,6 @@ declare module '@apollo/react-hooks' {
     TVariables
   > = DataProxyWriteFragmentOptions<TData, TVariables>;
   declare type CacheWriteDataOptions<TData> = DataProxyWriteDataOptions<TData>;
-  declare type CacheReadFragmentOptions<
-    TVariables
-  > = DataProxyReadFragmentOptions<TVariables>;
 
   declare interface DataProxyReadQueryOptions {
     query: DocumentNode;

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
@@ -153,7 +153,7 @@ declare module '@apollo/react-hooks' {
   declare export type MutationTuple<TData, TVariables> = [
     (
       options?: MutationFunctionOptions<TData, TVariables>
-    ) => Promise<void | ExecutionResult<TData>>,
+    ) => Promise<ExecutionResult<TData>>,
     MutationResult<TData>,
   ];
 
@@ -308,7 +308,7 @@ declare module '@apollo/react-hooks' {
 
   declare export type MutationFunction<TData, TVariables> = (
     options?: MutationFunctionOptions<TData, TVariables>
-  ) => Promise<void | MutationFetchResult<TData>>;
+  ) => Promise<MutationFetchResult<TData>>;
 
   /* Subscription types */
   declare export type OnSubscriptionDataOptions<TData> = {

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/test_react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/test_react-hooks_v3.x.x.js
@@ -1,0 +1,100 @@
+// @flow
+import * as React from "react";
+import { it, describe } from "flow-typed-test";
+import {useQuery, useMutation, useSubscription, useLazyQuery, useApolloClient} from "@apollo/react-hooks";
+
+const gql = (strings, ...args) => {}; // graphql-tag stub
+
+const query = gql`
+  {
+    foo
+  }
+`;
+const mutation = gql`
+  mutation {
+    foo
+  }
+`;
+
+type Hero = {
+  name: string,
+  id: string,
+  appearsIn: string[],
+  friends: Hero[]
+};
+
+type IQuery = {
+  foo: string,
+  bar: string
+};
+
+describe("useQuery hook", () => {
+  type Data = {
+    a: string,
+    b: string,
+  };
+  type Variables = {
+    c: string,
+  };
+  const result = useQuery<Data, Variables>('test');
+  
+  const {data, loading, error} = result;
+  it("handles data correctly", () => {
+    if (data) {
+      const a: string = data.a;
+      // $ExpectError cannot assign `data.b` to `b` because string [2] is incompatible with number
+      const b: number = data.b;
+    }
+  });
+  it("handles loading state correctly", () => {
+    if (error) {
+      (error.message: string);
+      (error.graphQLErrors: Array<any>);
+      // $ExpectError
+      (error.graphQLErrors: string);
+      (error.networkError: Error | null);
+      const extraInfo = error.extraInfo;
+    }
+  });
+  it("handles error state correctly", () => {
+    (loading: boolean);
+    // $ExpectError
+    (loading: string);
+  });
+});
+
+describe("useMutation hook", () => {
+  type Data = {
+    a: string,
+    b: string,
+  };
+  type Variables = {
+    c: string,
+  };
+  const mutation = useMutation<Data, Variables>('test');
+  
+  const {data, loading, error} = result;
+  it("handles data correctly", () => {
+    if (data) {
+      const a: string = data.a;
+      // $ExpectError cannot assign `data.b` to `b` because string [2] is incompatible with number
+      const b: number = data.b;
+    }
+  });
+  it("handles loading state correctly", () => {
+    if (error) {
+      (error.message: string);
+      (error.graphQLErrors: Array<any>);
+      // $ExpectError
+      (error.graphQLErrors: string);
+      (error.networkError: Error | null);
+      const extraInfo = error.extraInfo;
+    }
+  });
+  it("handles error state correctly", () => {
+    (loading: boolean);
+    // $ExpectError
+    (loading: string);
+  });
+});
+

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/test_react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/test_react-hooks_v3.x.x.js
@@ -1,7 +1,13 @@
 // @flow
-import * as React from "react";
-import { it, describe } from "flow-typed-test";
-import {useQuery, useMutation, useSubscription, useLazyQuery, useApolloClient} from "@apollo/react-hooks";
+import * as React from 'react';
+import { it, describe } from 'flow-typed-test';
+import {
+  useQuery,
+  useMutation,
+  useSubscription,
+  useLazyQuery,
+  useApolloClient,
+} from '@apollo/react-hooks';
 
 const gql = (strings, ...args) => {}; // graphql-tag stub
 
@@ -20,15 +26,15 @@ type Hero = {
   name: string,
   id: string,
   appearsIn: string[],
-  friends: Hero[]
+  friends: Hero[],
 };
 
 type IQuery = {
   foo: string,
-  bar: string
+  bar: string,
 };
 
-describe("useQuery hook", () => {
+describe('useQuery hook', () => {
   type Data = {
     a: string,
     b: string,
@@ -37,16 +43,16 @@ describe("useQuery hook", () => {
     c: string,
   };
   const result = useQuery<Data, Variables>('test');
-  
-  const {data, loading, error} = result;
-  it("handles data correctly", () => {
+
+  const { data, loading, error } = result;
+  it('handles data correctly', () => {
     if (data) {
       const a: string = data.a;
       // $ExpectError cannot assign `data.b` to `b` because string [2] is incompatible with number
       const b: number = data.b;
     }
   });
-  it("handles loading state correctly", () => {
+  it('handles loading state correctly', () => {
     if (error) {
       (error.message: string);
       (error.graphQLErrors: Array<any>);
@@ -56,14 +62,14 @@ describe("useQuery hook", () => {
       const extraInfo = error.extraInfo;
     }
   });
-  it("handles error state correctly", () => {
+  it('handles error state correctly', () => {
     (loading: boolean);
     // $ExpectError
     (loading: string);
   });
 });
 
-describe("useMutation hook", () => {
+describe('useMutation hook', () => {
   type Data = {
     a: string,
     b: string,
@@ -72,16 +78,16 @@ describe("useMutation hook", () => {
     c: string,
   };
   const mutation = useMutation<Data, Variables>('test');
-  
-  const {data, loading, error} = result;
-  it("handles data correctly", () => {
+
+  const { data, loading, error } = result;
+  it('handles data correctly', () => {
     if (data) {
       const a: string = data.a;
       // $ExpectError cannot assign `data.b` to `b` because string [2] is incompatible with number
       const b: number = data.b;
     }
   });
-  it("handles loading state correctly", () => {
+  it('handles loading state correctly', () => {
     if (error) {
       (error.message: string);
       (error.graphQLErrors: Array<any>);
@@ -91,10 +97,9 @@ describe("useMutation hook", () => {
       const extraInfo = error.extraInfo;
     }
   });
-  it("handles error state correctly", () => {
+  it('handles error state correctly', () => {
     (loading: boolean);
     // $ExpectError
     (loading: string);
   });
 });
-

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/test_react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/test_react-hooks_v3.x.x.js
@@ -27,20 +27,24 @@ type Hero = {
   id: string,
   appearsIn: string[],
   friends: Hero[],
+  ...
 };
 
 type IQuery = {
   foo: string,
   bar: string,
+  ...
 };
 
 describe('useQuery hook', () => {
   type Data = {
     a: string,
     b: string,
+    ...
   };
   type Variables = {
     c: string,
+    ...
   };
   const result = useQuery<Data, Variables>('test');
 
@@ -48,7 +52,7 @@ describe('useQuery hook', () => {
   it('handles data correctly', () => {
     if (data) {
       const a: string = data.a;
-      // $ExpectError cannot assign `data.b` to `b` because string [2] is incompatible with number
+      // $ExpectError
       const b: number = data.b;
     }
   });
@@ -70,22 +74,43 @@ describe('useQuery hook', () => {
 });
 
 describe('useMutation hook', () => {
-  type Data = {
+  type TData = {|
     a: string,
     b: string,
-  };
-  type Variables = {
+  |};
+  type TVariables = {|
     c: string,
-  };
-  const mutation = useMutation<Data, Variables>('test');
+  |};
+  const [mutation, result] = useMutation<TData, TVariables>('test');
 
   const { data, loading, error } = result;
   it('handles data correctly', () => {
     if (data) {
       const a: string = data.a;
-      // $ExpectError cannot assign `data.b` to `b` because string [2] is incompatible with number
+      // $ExpectError
       const b: number = data.b;
     }
+  });
+  it('handles variables correctly', async () => {
+    const mutationResult = await mutation({
+      variables: {
+        c: 'test'
+      }
+    });
+    if (mutationResult.data) {
+      (mutationResult.data.a: string);
+      (mutationResult.data.b: string);
+      // $ExpectError
+      (mutationResult.data.b: number);
+    }
+    // $ExpectError
+    mutation('', {});
+    // $ExpectError
+    mutation('', {
+      variables: {
+        c: 5
+      }
+    });
   });
   it('handles loading state correctly', () => {
     if (error) {


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation:https://www.apollographql.com/docs/react/api/react-hooks/
- Link to GitHub or NPM: https://www.npmjs.com/package/@apollo/react-hooks
- Type of contribution: new definition

Other notes: I did my best to adapt the typescript definitions into flow types. There is some usage of any, however I did my best to keep `any` out of all the APIs generally consumed directly.