### PR TITLE
[redux-reactors_v1.x.x.js] Move types so they don't conflict with other libdefs

### DIFF
--- a/definitions/npm/redux-reactors_v1.x.x/flow_v0.104.x-/redux-reactors_v1.x.x.js
+++ b/definitions/npm/redux-reactors_v1.x.x/flow_v0.104.x-/redux-reactors_v1.x.x.js
@@ -1,45 +1,46 @@
-/* Helper types from 'redux'
- *
- * NOTE THAT THE BELOW TYPES ARE COPIED DIRECTLY FROM THE LIBDEF
- * FOR 'redux'.  CHANGES SHOULD BE MIRRORED BACK HERE TO ENSURE
- * CONSISTENCY ACROSS VERSIONS.
- *
- * Equivalent to:
- *    import type { StoreCreator, Action } from 'redux';
- */
-type Action<T> = { type: T, ... };
-
-type DispatchAPI<A> = (action: A) => A;
-
-type Dispatch<A: { type: *, ... }> = DispatchAPI<A>;
-
-type Reducer<S, A> = (state: S | void, action: A) => S;
-
-type StoreEnhancer<S, A, D = Dispatch<A>> = (
-  next: StoreCreator<S, A, D>
-) => StoreCreator<S, A, D>;
-
-type Store<S, A, D = Dispatch<A>> = {
-  // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
-  dispatch: D,
-  getState(): S,
-  subscribe(listener: () => void): () => void,
-  replaceReducer(nextReducer: Reducer<S, A>): void,
-  ...
-};
-
-type StoreCreator<S, A, D = Dispatch<A>> = {
-  (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>,
-  (
-    reducer: Reducer<S, A>,
-    preloadedState: S,
-    enhancer?: StoreEnhancer<S, A, D>
-  ): Store<S, A, D>,
-  ...
-};
-/* END OF COPIED 'redux' TYPES */
-
 declare module 'redux-reactors' {
+  /* Helper types from 'redux'
+  *
+  * NOTE THAT THE BELOW TYPES ARE COPIED DIRECTLY FROM THE LIBDEF
+  * FOR 'redux'.  CHANGES SHOULD BE MIRRORED BACK HERE TO ENSURE
+  * CONSISTENCY ACROSS VERSIONS.
+  *
+  * Equivalent to:
+  *    import type { StoreCreator, Action } from 'redux';
+  */
+  declare type Action<T> = { type: T, ... };
+
+  declare type DispatchAPI<A> = (action: A) => A;
+
+  declare type Dispatch<A: { type: *, ... }> = DispatchAPI<A>;
+
+  declare type Reducer<S, A> = (state: S | void, action: A) => S;
+
+  declare type StoreEnhancer<S, A, D = Dispatch<A>> = (
+    next: StoreCreator<S, A, D>
+  ) => StoreCreator<S, A, D>;
+
+  declare type Store<S, A, D = Dispatch<A>> = {
+    // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
+    dispatch: D,
+    getState(): S,
+    subscribe(listener: () => void): () => void,
+    replaceReducer(nextReducer: Reducer<S, A>): void,
+    ...
+  };
+
+  declare type StoreCreator<S, A, D = Dispatch<A>> = {
+    (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>,
+    (
+      reducer: Reducer<S, A>,
+      preloadedState: S,
+      enhancer?: StoreEnhancer<S, A, D>
+    ): Store<S, A, D>,
+    ...
+  };
+  /* END OF COPIED 'redux' TYPES */
+
+
   declare export type ReactorAction<S, T> = {|
     type: T,
     payload: mixed,

--- a/definitions/npm/redux-reactors_v1.x.x/flow_v0.104.x-/test_redux-reactors_v1.x.x.js
+++ b/definitions/npm/redux-reactors_v1.x.x/flow_v0.104.x-/test_redux-reactors_v1.x.x.js
@@ -4,6 +4,47 @@ import { describe, it } from 'flow-typed-test';
 import { reactorEnhancer, createReactor } from 'redux-reactors';
 import type { ReactorAction } from 'redux-reactors';
 
+/* Helper types from 'redux'
+*
+* NOTE THAT THE BELOW TYPES ARE COPIED DIRECTLY FROM THE LIBDEF
+* FOR 'redux'.  CHANGES SHOULD BE MIRRORED BACK HERE TO ENSURE
+* CONSISTENCY ACROSS VERSIONS.
+*
+* Equivalent to:
+*    import type { StoreCreator, Action } from 'redux';
+*/
+type Action<T> = { type: T, ... };
+
+type DispatchAPI<A> = (action: A) => A;
+
+type Dispatch<A: { type: *, ... }> = DispatchAPI<A>;
+
+type Reducer<S, A> = (state: S | void, action: A) => S;
+
+type StoreEnhancer<S, A, D = Dispatch<A>> = (
+  next: StoreCreator<S, A, D>
+) => StoreCreator<S, A, D>;
+
+type Store<S, A, D = Dispatch<A>> = {
+  // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
+  dispatch: D,
+  getState(): S,
+  subscribe(listener: () => void): () => void,
+  replaceReducer(nextReducer: Reducer<S, A>): void,
+  ...
+};
+
+type StoreCreator<S, A, D = Dispatch<A>> = {
+  (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>,
+  (
+    reducer: Reducer<S, A>,
+    preloadedState: S,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>,
+  ...
+};
+/* END OF COPIED 'redux' TYPES */
+
 describe('Test reactorEnhancer', () => {
   it('should pass when used properly', () => {
     type State = {|

--- a/definitions/npm/redux-reactors_v1.x.x/flow_v0.95.x-v0.103.x/redux-reactors_v1.x.x.js
+++ b/definitions/npm/redux-reactors_v1.x.x/flow_v0.95.x-v0.103.x/redux-reactors_v1.x.x.js
@@ -1,45 +1,46 @@
-/* Helper types from 'redux'
- *
- * NOTE THAT THE BELOW TYPES ARE COPIED DIRECTLY FROM THE LIBDEF
- * FOR 'redux'.  CHANGES SHOULD BE MIRRORED BACK HERE TO ENSURE
- * CONSISTENCY ACROSS VERSIONS.
- *
- * Equivalent to:
- *    import type { StoreCreator, Action } from 'redux';
- */
-type Action<T> = {
-  type: T
-};
-
-type DispatchAPI<A> = (action: A) => A;
-
-type Dispatch<A: { type: * }> = DispatchAPI<A>;
-
-type Reducer<S, A> = (state: S | void, action: A) => S;
-
-type StoreEnhancer<S, A, D = Dispatch<A>> = (
-  next: StoreCreator<S, A, D>
-) => StoreCreator<S, A, D>;
-
-type Store<S, A, D = Dispatch<A>> = {
-  // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
-  dispatch: D,
-  getState(): S,
-  subscribe(listener: () => void): () => void,
-  replaceReducer(nextReducer: Reducer<S, A>): void,
-};
-
-type StoreCreator<S, A, D = Dispatch<A>> = {
-  (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>,
-  (
-    reducer: Reducer<S, A>,
-    preloadedState: S,
-    enhancer?: StoreEnhancer<S, A, D>
-  ): Store<S, A, D>,
-};
-/* END OF COPIED 'redux' TYPES */
-
 declare module 'redux-reactors' {
+  /* Helper types from 'redux'
+  *
+  * NOTE THAT THE BELOW TYPES ARE COPIED DIRECTLY FROM THE LIBDEF
+  * FOR 'redux'.  CHANGES SHOULD BE MIRRORED BACK HERE TO ENSURE
+  * CONSISTENCY ACROSS VERSIONS.
+  *
+  * Equivalent to:
+  *    import type { StoreCreator, Action } from 'redux';
+  */
+  declare type Action<T> = {
+    type: T
+  };
+
+  declare type DispatchAPI<A> = (action: A) => A;
+
+  declare type Dispatch<A: { type: * }> = DispatchAPI<A>;
+
+  declare type Reducer<S, A> = (state: S | void, action: A) => S;
+
+  declare type StoreEnhancer<S, A, D = Dispatch<A>> = (
+    next: StoreCreator<S, A, D>
+  ) => StoreCreator<S, A, D>;
+
+  declare type Store<S, A, D = Dispatch<A>> = {
+    // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
+    dispatch: D,
+    getState(): S,
+    subscribe(listener: () => void): () => void,
+    replaceReducer(nextReducer: Reducer<S, A>): void,
+  };
+
+  declare type StoreCreator<S, A, D = Dispatch<A>> = {
+    (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>,
+    (
+      reducer: Reducer<S, A>,
+      preloadedState: S,
+      enhancer?: StoreEnhancer<S, A, D>
+    ): Store<S, A, D>,
+  };
+  /* END OF COPIED 'redux' TYPES */
+
+
   declare export type ReactorAction<S, T> = {|
     type: T,
     payload: mixed,

--- a/definitions/npm/redux-reactors_v1.x.x/flow_v0.95.x-v0.103.x/test_redux-reactors_v1.x.x.js
+++ b/definitions/npm/redux-reactors_v1.x.x/flow_v0.95.x-v0.103.x/test_redux-reactors_v1.x.x.js
@@ -4,6 +4,47 @@ import { describe, it } from 'flow-typed-test';
 import { reactorEnhancer, createReactor } from 'redux-reactors';
 import type { ReactorAction } from 'redux-reactors';
 
+/* Helper types from 'redux'
+*
+* NOTE THAT THE BELOW TYPES ARE COPIED DIRECTLY FROM THE LIBDEF
+* FOR 'redux'.  CHANGES SHOULD BE MIRRORED BACK HERE TO ENSURE
+* CONSISTENCY ACROSS VERSIONS.
+*
+* Equivalent to:
+*    import type { StoreCreator, Action } from 'redux';
+*/
+type Action<T> = {
+  type: T
+};
+
+type DispatchAPI<A> = (action: A) => A;
+
+type Dispatch<A: { type: * }> = DispatchAPI<A>;
+
+type Reducer<S, A> = (state: S | void, action: A) => S;
+
+type StoreEnhancer<S, A, D = Dispatch<A>> = (
+  next: StoreCreator<S, A, D>
+) => StoreCreator<S, A, D>;
+
+type Store<S, A, D = Dispatch<A>> = {
+  // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
+  dispatch: D,
+  getState(): S,
+  subscribe(listener: () => void): () => void,
+  replaceReducer(nextReducer: Reducer<S, A>): void,
+};
+
+type StoreCreator<S, A, D = Dispatch<A>> = {
+  (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>,
+  (
+    reducer: Reducer<S, A>,
+    preloadedState: S,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>,
+};
+/* END OF COPIED 'redux' TYPES */
+
 describe('Test reactorEnhancer', () => {
   it('should pass when used properly', () => {
     type State = {|


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation:
- Link to GitHub or NPM: 
- Type of contribution: new definition | addition | **FIX** | refactor

Other notes:
Added in this PR: https://github.com/flow-typed/flow-typed/pull/3457

It seems that since these types were defined outside a `module`, they were essentially global and would conflict with types of the same name from other libdefs. Specifically, I was seeing that the type `Action` was conflicting with a similarly named `Action` type from `history`