### PR TITLE
Attempted to fix #3340. Added overwrite option to the install file.

### DIFF
--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -96,6 +96,12 @@ export function setup(yargs: Yargs) {
       describe: 'The relative path of package.json where flow-bin is installed',
       type: 'string',
     },
+    overwrite: {
+      alias: 'o',
+      describe: 'Overwrite an existing libdef',
+      type: 'string',
+      demand: false
+    },
     ignoreDeps: {
       alias: 'i',
       describe: 'Dependency categories to ignore when installing definitions',


### PR DESCRIPTION
- Links to documentation: https://github.com/flow-typed/flow-typed/wiki/CLI-Commands-and-Flags
- Link to GitHub or NPM: https://github.com/flow-typed/flow-typed/issues/3340
- Type of contribution: fix

Other notes:

The following comparison may have the code which accidentally removed the overwrite flag because a colleague claims that it worked in the 2.5.x version, but the 2.6.1 version does not work. I couldn't find the problem, so instead I added the option to the yargs.usage options.

https://github.com/flow-typed/flow-typed/compare/v2.4.0..v2.6.1