### PR TITLE
Fix @reach/router `Link` base type

### DIFF
--- a/definitions/npm/@reach/router_v1.1.x/flow_v0.104.x-/router_v1.1.x.js
+++ b/definitions/npm/@reach/router_v1.1.x/flow_v0.104.x-/router_v1.1.x.js
@@ -71,7 +71,7 @@ declare module '@reach/router' {
   |}>;
 
   declare export type LinkProps<State> = {
-    ...$Shape<HTMLAnchorElement>,
+    ...React$ElementProps<string>,
     children: React$Node,
     innerRef?: React$Ref<HTMLAnchorElement>,
     getProps?: (props: {


### PR DESCRIPTION
- Type of contribution: fix

Other notes: This change fixes the problem when `flow@1.106.x` expects all props of `HTMLAnchorElement` to be present in a `Link` instance.