### PR TITLE
use `$ReadOnlyArray` for `omit` and `pick` in `lodash`

### DIFF
--- a/definitions/npm/lodash-es_v4.x.x/flow_v0.104.x-/lodash-es_v4.x.x.js
+++ b/definitions/npm/lodash-es_v4.x.x/flow_v0.104.x-/lodash-es_v4.x.x.js
@@ -1197,8 +1197,8 @@ declare module "lodash-es" {
       source: A | B | C | D
     ) => any | void
   ): Object;
-  declare export function omit(object?: ?Object, ...props: Array<string>): Object;
-  declare export function omit(object?: ?Object, props: Array<string>): Object;
+  declare export function omit(object?: ?Object, ...props: $ReadOnlyArray<string>): Object;
+  declare export function omit(object?: ?Object, props: $ReadOnlyArray<string>): Object;
   declare export function omitBy<A, T: { [id: string]: A, ... }>(
     object: T,
     predicate?: ?OPredicate<A, T>
@@ -1207,8 +1207,8 @@ declare module "lodash-es" {
     object: void | null,
     predicate?: ?OPredicate<A, T>
   ): {...};
-  declare export function pick(object?: ?Object, ...props: Array<string>): Object;
-  declare export function pick(object?: ?Object, props: Array<string>): Object;
+  declare export function pick(object?: ?Object, ...props: $ReadOnlyArray<string>): Object;
+  declare export function pick(object?: ?Object, props: $ReadOnlyArray<string>): Object;
   declare export function pickBy<A, T: { [id: string]: A, ... }>(
     object: T,
     predicate?: ?OPredicate<A, T>

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -1248,14 +1248,14 @@ declare module "lodash" {
         source: A | B | C | D
       ) => any | void
     ): Object;
-    omit(object?: ?Object, ...props: Array<string>): Object;
-    omit(object?: ?Object, props: Array<string>): Object;
+    omit(object?: ?Object, ...props: $ReadOnlyArray<string>): Object;
+    omit(object?: ?Object, props: $ReadOnlyArray<string>): Object;
     omitBy<A, T: { [id: any]: A, ... } | { [id: number]: A, ... }>(
       object: T,
       predicate?: ?OPredicate<A, T>
     ): Object;
     omitBy<A, T>(object: void | null, predicate?: ?OPredicate<A, T>): {...};
-    pick(object?: ?Object, ...props: Array<string>): Object;
+    pick(object?: ?Object, ...props: $ReadOnlyArray<string>): Object;
     pick(object?: ?Object, props: $ReadOnlyArray<string>): Object;
     pickBy<A, T: { [id: any]: A, ... } | { [id: number]: A, ... }>(
       object: T,


### PR DESCRIPTION
`omit` and `pick` doesn't mutate the `path` parameter, should be `$ReadOnlyArray` instead of `Array`

- `lodash` doc: https://lodash.com/docs/4.17.14#omit and https://lodash.com/docs/4.17.14#pick
- Type of contribution: fix 
