### PR TITLE
[hoist-non-react-statics v3.x.x] Add defs

### DIFF
--- a/definitions/npm/hoist-non-react-statics_v3.x.x/flow_v0.103.x-/hoist-non-react-statics_v3.x.x.js
+++ b/definitions/npm/hoist-non-react-statics_v3.x.x/flow_v0.103.x-/hoist-non-react-statics_v3.x.x.js
@@ -1,0 +1,86 @@
+declare module 'hoist-non-react-statics' {
+  /**
+   * Inspired by DefinitelyTyped/types/hoist-non-react-statics/index.d.ts
+   *
+   * Unfortunately, unlike in TypeScript, current flow definitions for React does not allow us to tell whether
+   * a React$ComponentType is “clean”, or had been the result of a call to React.memo or React.forwardRef.
+   * Therefore we’ll only be able to precisely filter out statics that are common to all 3 cases, and will
+   * have to live with maybes for everything else. This is not 100% precise, but is better than a blanket
+   * $Shape call on the source component’s statics like what we were doing before in the v2.x.x defs.
+   */
+
+  // declare type REACT_STATICS = {
+  //   childContextTypes: any,
+  //   contextType: any,
+  //   contextTypes: any,
+  //   defaultProps: any,
+  //   displayName: any,
+  //   getDefaultProps: any,
+  //   getDerivedStateFromError: any,
+  //   getDerivedStateFromProps: any,
+  //   mixins: any,
+  //   propTypes: any,
+  //   type: any,
+  //   ...
+  // };
+
+  // declare type MEMO_STATICS = {
+  //   $$typeof: any,
+  //   compare: any,
+  //   defaultProps: any,
+  //   displayName: any,
+  //   propTypes: any,
+  //   type: any,
+  //   ...
+  // };
+
+  // declare type FORWARD_REF_STATICS = {
+  //   $$typeof: any,
+  //   render: any,
+  //   defaultProps: any,
+  //   displayName: any,
+  //   propTypes: any,
+  //   ...
+  // };
+
+  declare type REACT_STATICS = {
+    // “Maybe” React statics
+    $$typeof?: any,
+    childContextTypes?: any,
+    compare?: any,
+    contextType?: any,
+    contextTypes?: any,
+    getDefaultProps?: any,
+    getDerivedStateFromError?: any,
+    getDerivedStateFromProps?: any,
+    mixins?: any,
+    render?: any,
+    type?: any,
+    // Common React statics
+    defaultProps: any,
+    displayName: any,
+    propTypes: any,
+    ...
+  };
+
+  declare type $HoistedStatics<S, C> = $Call<
+    & ((S, empty) => $Diff<S, REACT_STATICS>)
+    & ((S, any) => $Diff<S, $ObjMap<C, any> & REACT_STATICS>),
+    S,
+    C
+  >;
+
+  /*
+    TP - target component props
+    SP - source component props
+    T - target component statics
+    S - source component statics
+  */
+  declare function hoistNonReactStatics<TP, SP, T, S, C: { [key: string]: true, ... }>(
+    TargetComponent: React$ComponentType<TP> & T,
+    SourceComponent: React$ComponentType<SP> & S,
+    customStatics?: C
+  ): React$ComponentType<TP> & $HoistedStatics<S, C> & T;
+
+  declare module.exports: typeof hoistNonReactStatics;
+}

--- a/definitions/npm/hoist-non-react-statics_v3.x.x/flow_v0.103.x-/hoist-non-react-statics_v3.x.x.js
+++ b/definitions/npm/hoist-non-react-statics_v3.x.x/flow_v0.103.x-/hoist-non-react-statics_v3.x.x.js
@@ -80,5 +80,5 @@ declare module 'hoist-non-react-statics' {
     customStatics?: C
   ): React$ComponentType<TP> & $HoistedStatics<S, C> & T;
 
-  declare module.exports: typeof hoistNonReactStatics;
+  declare export default typeof hoistNonReactStatics;
 }

--- a/definitions/npm/hoist-non-react-statics_v3.x.x/flow_v0.103.x-/hoist-non-react-statics_v3.x.x.js
+++ b/definitions/npm/hoist-non-react-statics_v3.x.x/flow_v0.103.x-/hoist-non-react-statics_v3.x.x.js
@@ -64,21 +64,19 @@ declare module 'hoist-non-react-statics' {
   };
 
   declare type $HoistedStatics<S, C> = $Call<
-    & ((S, empty) => $Diff<S, REACT_STATICS>)
-    & ((S, any) => $Diff<S, $ObjMap<C, any> & REACT_STATICS>),
-    S,
+    & (empty => $Diff<S, REACT_STATICS>)
+    & (any => $Diff<S, $ObjMap<C, any> & REACT_STATICS>),
     C
   >;
 
   /*
     TP - target component props
-    SP - source component props
     T - target component statics
     S - source component statics
   */
-  declare function hoistNonReactStatics<TP, SP, T, S, C: { [key: string]: true, ... }>(
+  declare function hoistNonReactStatics<TP, T, S, C: { [key: string]: true, ... }>(
     TargetComponent: React$ComponentType<TP> & T,
-    SourceComponent: React$ComponentType<SP> & S,
+    SourceComponent: React$ComponentType<any> & S,
     customStatics?: C
   ): React$ComponentType<TP> & $HoistedStatics<S, C> & T;
 

--- a/definitions/npm/hoist-non-react-statics_v3.x.x/flow_v0.103.x-/test_hoist-non-react-statics_v3.x.x.js
+++ b/definitions/npm/hoist-non-react-statics_v3.x.x/flow_v0.103.x-/test_hoist-non-react-statics_v3.x.x.js
@@ -1,0 +1,133 @@
+// @flow
+
+/**
+ * Adapted from DefinitelyTyped/types/hoist-non-react-statics/hoist-non-react-statics-tests.tsx
+ */
+
+import * as React from 'react';
+import hoistNonReactStatics from 'hoist-non-react-statics';
+
+import { it, describe } from 'flow-typed-test';
+
+describe('class components', () => {
+    class A extends React.Component<{|
+        x: number,
+        y?: number | null,
+    |}> {
+        static a = 'a';
+        static c = 'c';
+
+        getA() {
+            return A.a;
+        }
+    }
+
+    class B extends React.Component<{|
+        n: number,
+    |}> {
+        static b = 'b';
+        static c = 42;
+
+        static defaultProps = {
+            n: 42,
+        };
+
+        getB() {
+            return B.b;
+        }
+    }
+
+    // $ExpectError - see † below
+    const C = hoistNonReactStatics(A, B);
+
+    it('does not affect a static on target', () => {
+        const a1: string = C.a;
+        // $ExpectError
+        const a2: number = C.a;
+    });
+
+    it('hoists non-React statics from source', () => {
+        const b1: string = C.b;
+        // $ExpectError
+        const b2: number = C.b;
+    });
+
+    it('overwrites statics of the same name on target', () => {
+        const c1: number = C.c;
+        // $ExpectError
+        const c2: string = C.c;
+    })
+
+    it('does not affect non-statics on target', () => {
+        const a1: string = C.prototype.getA();
+        // $ExpectError
+        const a2: number = C.prototype.getA();
+    });
+
+    it('does not hoist React statics from source', () => {
+        /**
+         * † This does throw an error, but the error is somehow thrown at the function call itself. Seems to
+         *   be a regression introduced in flow v0.103.0.
+         */
+        C.defaultProps;
+    });
+
+    it('does not hoist non-statics from source', () => {
+        // $ExpectError
+        C.prototype.getB();
+    });
+
+    it('does not affect the props type of target', () => {
+        <C x={1} />;
+        <C x={1} y={2} />;
+        // $ExpectError
+        <C x="x" />;
+        // $ExpectError
+        <C n={42} />;
+    });
+
+    // $ExpectError - see † below
+    const D = hoistNonReactStatics(A, B, { a: true, b: true, c: true });
+
+    it('does not affect a static on target even when specified as a custom static', () => {
+        const a1: string = D.a;
+        // $ExpectError
+        const a2: number = D.a;
+    });
+
+    it('does not hoist a static when specified as a custom static', () => {
+        const c1: string = D.c;
+        // $ExpectError
+        const c2: number = D.c;
+        /**
+         * † This does throw an error, but the error is somehow thrown at the function call itself. Seems to
+         *   be a regression introduced in flow v0.103.0.
+         */
+        D.b;
+    });
+});
+
+describe('functional components', () => {
+    const A = ({ x, y }: {| x: number, y?: number |}) => <div>{x + (y || 0)}</div>;
+    A.a = 'a';
+    A.c = 'c';
+
+    const B = ({ n }: {| n: number |}) => <div>{n}</div>;
+    B.b = 'b';
+    B.c = 42;
+    B.defaultProps = {
+        n: 42,
+    };
+
+    const C = hoistNonReactStatics(A, B);
+
+    /**
+     * Nothing really works for functional components, just like how it was with our v2.x.x defs :( Use-cases
+     * defined below are to ensure that we at least don't give false positives.
+     */
+    C.a;
+    C.b;
+    C.c;
+    <C x={1} />;
+    <C x={1} y={2} />;
+});

--- a/definitions/npm/hoist-non-react-statics_v3.x.x/flow_v0.84.x-v0.102.x/hoist-non-react-statics_v3.x.x.js
+++ b/definitions/npm/hoist-non-react-statics_v3.x.x/flow_v0.84.x-v0.102.x/hoist-non-react-statics_v3.x.x.js
@@ -1,0 +1,86 @@
+declare module 'hoist-non-react-statics' {
+  /**
+   * Inspired by DefinitelyTyped/types/hoist-non-react-statics/index.d.ts
+   *
+   * Unfortunately, unlike in TypeScript, current flow definitions for React does not allow us to tell whether
+   * a React$ComponentType is “clean”, or had been the result of a call to React.memo or React.forwardRef.
+   * Therefore we’ll only be able to precisely filter out statics that are common to all 3 cases, and will
+   * have to live with maybes for everything else. This is not 100% precise, but is better than a blanket
+   * $Shape call on the source component’s statics like what we were doing before in the v2.x.x defs.
+   */
+
+  // declare type REACT_STATICS = {
+  //   childContextTypes: any,
+  //   contextType: any,
+  //   contextTypes: any,
+  //   defaultProps: any,
+  //   displayName: any,
+  //   getDefaultProps: any,
+  //   getDerivedStateFromError: any,
+  //   getDerivedStateFromProps: any,
+  //   mixins: any,
+  //   propTypes: any,
+  //   type: any,
+  //   ...
+  // };
+
+  // declare type MEMO_STATICS = {
+  //   $$typeof: any,
+  //   compare: any,
+  //   defaultProps: any,
+  //   displayName: any,
+  //   propTypes: any,
+  //   type: any,
+  //   ...
+  // };
+
+  // declare type FORWARD_REF_STATICS = {
+  //   $$typeof: any,
+  //   render: any,
+  //   defaultProps: any,
+  //   displayName: any,
+  //   propTypes: any,
+  //   ...
+  // };
+
+  declare type REACT_STATICS = {
+    // “Maybe” React statics
+    $$typeof?: any,
+    childContextTypes?: any,
+    compare?: any,
+    contextType?: any,
+    contextTypes?: any,
+    getDefaultProps?: any,
+    getDerivedStateFromError?: any,
+    getDerivedStateFromProps?: any,
+    mixins?: any,
+    render?: any,
+    type?: any,
+    // Common React statics
+    defaultProps: any,
+    displayName: any,
+    propTypes: any,
+    ...
+  };
+
+  declare type $HoistedStatics<S, C> = $Call<
+    & ((S, empty) => $Diff<S, REACT_STATICS>)
+    & ((S, any) => $Diff<S, $ObjMap<C, any> & REACT_STATICS>),
+    S,
+    C
+  >;
+
+  /*
+    TP - target component props
+    SP - source component props
+    T - target component statics
+    S - source component statics
+  */
+  declare function hoistNonReactStatics<TP, SP, T, S, C: { [key: string]: true, ... }>(
+    TargetComponent: React$ComponentType<TP> & T,
+    SourceComponent: React$ComponentType<SP> & S,
+    customStatics?: C
+  ): React$ComponentType<TP> & $HoistedStatics<S, C> & T;
+
+  declare module.exports: typeof hoistNonReactStatics;
+}

--- a/definitions/npm/hoist-non-react-statics_v3.x.x/flow_v0.84.x-v0.102.x/hoist-non-react-statics_v3.x.x.js
+++ b/definitions/npm/hoist-non-react-statics_v3.x.x/flow_v0.84.x-v0.102.x/hoist-non-react-statics_v3.x.x.js
@@ -80,5 +80,5 @@ declare module 'hoist-non-react-statics' {
     customStatics?: C
   ): React$ComponentType<TP> & $HoistedStatics<S, C> & T;
 
-  declare module.exports: typeof hoistNonReactStatics;
+  declare export default typeof hoistNonReactStatics;
 }

--- a/definitions/npm/hoist-non-react-statics_v3.x.x/flow_v0.84.x-v0.102.x/hoist-non-react-statics_v3.x.x.js
+++ b/definitions/npm/hoist-non-react-statics_v3.x.x/flow_v0.84.x-v0.102.x/hoist-non-react-statics_v3.x.x.js
@@ -64,21 +64,19 @@ declare module 'hoist-non-react-statics' {
   };
 
   declare type $HoistedStatics<S, C> = $Call<
-    & ((S, empty) => $Diff<S, REACT_STATICS>)
-    & ((S, any) => $Diff<S, $ObjMap<C, any> & REACT_STATICS>),
-    S,
+    & (empty => $Diff<S, REACT_STATICS>)
+    & (any => $Diff<S, $ObjMap<C, any> & REACT_STATICS>),
     C
   >;
 
   /*
     TP - target component props
-    SP - source component props
     T - target component statics
     S - source component statics
   */
-  declare function hoistNonReactStatics<TP, SP, T, S, C: { [key: string]: true, ... }>(
+  declare function hoistNonReactStatics<TP, T, S, C: { [key: string]: true, ... }>(
     TargetComponent: React$ComponentType<TP> & T,
-    SourceComponent: React$ComponentType<SP> & S,
+    SourceComponent: React$ComponentType<any> & S,
     customStatics?: C
   ): React$ComponentType<TP> & $HoistedStatics<S, C> & T;
 

--- a/definitions/npm/hoist-non-react-statics_v3.x.x/flow_v0.84.x-v0.102.x/test_hoist-non-react-statics_v3.x.x.js
+++ b/definitions/npm/hoist-non-react-statics_v3.x.x/flow_v0.84.x-v0.102.x/test_hoist-non-react-statics_v3.x.x.js
@@ -1,0 +1,125 @@
+// @flow
+
+/**
+ * Adapted from DefinitelyTyped/types/hoist-non-react-statics/hoist-non-react-statics-tests.tsx
+ */
+
+import * as React from 'react';
+import hoistNonReactStatics from 'hoist-non-react-statics';
+
+import { it, describe } from 'flow-typed-test';
+
+describe('class components', () => {
+    class A extends React.Component<{|
+        x: number,
+        y?: number | null,
+    |}> {
+        static a = 'a';
+        static c = 'c';
+
+        getA() {
+            return A.a;
+        }
+    }
+
+    class B extends React.Component<{|
+        n: number,
+    |}> {
+        static b = 'b';
+        static c = 42;
+
+        static defaultProps = {
+            n: 42,
+        };
+
+        getB() {
+            return B.b;
+        }
+    }
+
+    const C = hoistNonReactStatics(A, B);
+
+    it('does not affect a static on target', () => {
+        const a1: string = C.a;
+        // $ExpectError
+        const a2: number = C.a;
+    });
+
+    it('hoists non-React statics from source', () => {
+        const b1: string = C.b;
+        // $ExpectError
+        const b2: number = C.b;
+    });
+
+    it('overwrites statics of the same name on target', () => {
+        const c1: number = C.c;
+        // $ExpectError
+        const c2: string = C.c;
+    })
+
+    it('does not affect non-statics on target', () => {
+        const a1: string = C.prototype.getA();
+        // $ExpectError
+        const a2: number = C.prototype.getA();
+    });
+
+    it('does not hoist React statics from source', () => {
+        // $ExpectError
+        C.defaultProps;
+    });
+
+    it('does not hoist non-statics from source', () => {
+        // $ExpectError
+        C.prototype.getB();
+    });
+
+    it('does not affect the props type of target', () => {
+        <C x={1} />;
+        <C x={1} y={2} />;
+        // $ExpectError
+        <C x="x" />;
+        // $ExpectError
+        <C n={42} />;
+    });
+
+    const D = hoistNonReactStatics(A, B, { a: true, b: true, c: true });
+
+    it('does not affect a static on target even when specified as a custom static', () => {
+        const a1: string = D.a;
+        // $ExpectError
+        const a2: number = D.a;
+    });
+
+    it('does not hoist a static when specified as a custom static', () => {
+        const c1: string = D.c;
+        // $ExpectError
+        const c2: number = D.c;
+        // $ExpectError
+        D.b;
+    });
+});
+
+describe('functional components', () => {
+    const A = ({ x, y }: {| x: number, y?: number |}) => <div>{x + (y || 0)}</div>;
+    A.a = 'a';
+    A.c = 'c';
+
+    const B = ({ n }: {| n: number |}) => <div>{n}</div>;
+    B.b = 'b';
+    B.c = 42;
+    B.defaultProps = {
+        n: 42,
+    };
+
+    const C = hoistNonReactStatics(A, B);
+
+    /**
+     * Nothing really works for functional components, just like how it was with our v2.x.x defs :( Use-cases
+     * defined below are to ensure that we at least don't give false positives.
+     */
+    C.a;
+    C.b;
+    C.c;
+    <C x={1} />;
+    <C x={1} y={2} />;
+});


### PR DESCRIPTION
- Link to GitHub or NPM: https://github.com/mridgway/hoist-non-react-statics
- Type of contribution: new definition

Other notes:
The `v2.x.x` definitions for this package were very loose and I tried as much as possible to tighten things up in this updated version, taking inspiration from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/hoist-non-react-statics/index.d.ts.

What I was able to do:
- Hoisted statics are no longer just a blanket `$Shape` call over source component statics and are much closer to their actual shape, providing more meaningful typechecks.

What I was not able to do and why:
- React statics that may be present but not always (depending on whether the component has been `memo`'ed or `forwardRef`'ed) are not taken into account with precision like everything else, because we can't actually tell if a component has gone thru `memo` or `forwardRef` calls with our current defs for them. Let me know if you know a way to tell!
- Results from functional components still cannot be typechecked in any meaningful way, just like in `v2.x.x` 😢 I spent some time playing with extracting statics from functions, ran into a lot of quirks. Hopefully I can circle back to this later and find a way (or find things magically fixed), but for now, I don't think this should block everything else. I'm not making anything worse, after all 😆