### PR TITLE
[redux] Extract the action type in a separate public definition

### DIFF
--- a/definitions/npm/redux_v3.x.x/flow_v0.104.x-/redux_v3.x.x.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.104.x-/redux_v3.x.x.js
@@ -7,9 +7,11 @@ declare module 'redux' {
 
   */
 
+  declare export type Action = { type: *, ... };
+
   declare export type DispatchAPI<A> = (action: A) => A;
 
-  declare export type Dispatch<A: { type: *, ... }> = DispatchAPI<A>;
+  declare export type Dispatch<A: Action> = DispatchAPI<A>;
 
   declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
     dispatch: D,

--- a/definitions/npm/redux_v3.x.x/flow_v0.28.x-v0.32.x/redux_v3.x.x.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.28.x-v0.32.x/redux_v3.x.x.js
@@ -7,7 +7,8 @@ declare module 'redux' {
 
   */
 
-  declare type Dispatch<A: { type: $Subtype<string> }> = (action: A) => A;
+  declare type Action = { type: $Subtype<string> };
+  declare type Dispatch<A: Action> = (action: A) => A;
 
   declare type MiddlewareAPI<S, A> = {
     dispatch: Dispatch<A>;

--- a/definitions/npm/redux_v3.x.x/flow_v0.33.x-v0.54.x/redux_v3.x.x.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.33.x-v0.54.x/redux_v3.x.x.js
@@ -8,8 +8,9 @@ declare module 'redux' {
 
   */
 
+  declare export type Action = { type: $Subtype<string> };
   declare export type DispatchAPI<A> = (action: A) => A;
-  declare export type Dispatch<A: { type: $Subtype<string> }> = DispatchAPI<A>;
+  declare export type Dispatch<A: Action> = DispatchAPI<A>;
 
   declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
     dispatch: D;

--- a/definitions/npm/redux_v3.x.x/flow_v0.55.x-v0.88.x/redux_v3.x.x.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.55.x-v0.88.x/redux_v3.x.x.js
@@ -8,8 +8,9 @@ declare module 'redux' {
 
   */
 
+  declare export type Action = { type: $Subtype<string> };
   declare export type DispatchAPI<A> = (action: A) => A;
-  declare export type Dispatch<A: { type: $Subtype<string> }> = DispatchAPI<A>;
+  declare export type Dispatch<A: Action> = DispatchAPI<A>;
 
   declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
     dispatch: D;

--- a/definitions/npm/redux_v3.x.x/flow_v0.89.x-v0.103.x/redux_v3.x.x.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.89.x-v0.103.x/redux_v3.x.x.js
@@ -7,9 +7,11 @@ declare module 'redux' {
 
   */
 
+  declare export type Action = { type: * };
+
   declare export type DispatchAPI<A> = (action: A) => A;
 
-  declare export type Dispatch<A: { type: * }> = DispatchAPI<A>;
+  declare export type Dispatch<A: Action> = DispatchAPI<A>;
 
   declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
     dispatch: D,

--- a/definitions/npm/redux_v4.x.x/flow_v0.55.x-v0.88.x/redux_v4.x.x.js
+++ b/definitions/npm/redux_v4.x.x/flow_v0.55.x-v0.88.x/redux_v4.x.x.js
@@ -8,8 +8,9 @@ declare module 'redux' {
 
   */
 
+  declare export type Action = { type: $Subtype<string> };
   declare export type DispatchAPI<A> = (action: A) => A;
-  declare export type Dispatch<A: { type: $Subtype<string> }> = DispatchAPI<A>;
+  declare export type Dispatch<A: Action> = DispatchAPI<A>;
 
   declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
     dispatch: D;


### PR DESCRIPTION
- Links to documentation: https://github.com/reduxjs/redux
- Link to GitHub or NPM: https://redux.js.org/
- Type of contribution: refactor

Other notes:
It is often useful in Redux project to have an action type definition. 
Alack, the older library definitions do not provide it. 
I fixed the inconvenience by extracting an existing type in a separate exported declaration
