### PR TITLE
react-apollo ObservableQuery Variables generic

### DIFF
--- a/definitions/npm/@apollo/react-components_v3.x.x/flow_v0.104.x-/react-components_v3.x.x.js
+++ b/definitions/npm/@apollo/react-components_v3.x.x/flow_v0.104.x-/react-components_v3.x.x.js
@@ -14,10 +14,10 @@ declare module '@apollo/react-components' {
    * Copied types from Apollo Client libdef
    * Please update apollo-client libdef as well if updating these types
    */
-  declare class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
+  declare class ObservableQuery<T, V = { [key: string]: any, ... }> extends Observable<ApolloQueryResult<T>> {
     options: WatchQueryOptions;
     queryId: string;
-    variables: Dict;
+    variables: V;
     isCurrentlyPolling: boolean;
     shouldSubscribe: boolean;
     isTornDown: boolean;
@@ -27,7 +27,8 @@ declare module '@apollo/react-components' {
     subscriptionHandles: SubscriptionLINK[];
     lastResult: ApolloQueryResult<T>;
     lastError: ApolloError;
-    lastVariables: Dict;
+    lastVariables: V;
+
     constructor(data: {
       scheduler: QueryScheduler<any>,
       options: WatchQueryOptions,
@@ -39,7 +40,7 @@ declare module '@apollo/react-components' {
     getLastResult(): ApolloQueryResult<T>;
     getLastError(): ApolloError;
     resetLastResults(): void;
-    refetch(variables?: Dict): Promise<ApolloQueryResult<T>>;
+    refetch(variables?: V): Promise<ApolloQueryResult<T>>;
     fetchMore(
       fetchMoreOptions: FetchMoreQueryOptions<any> & FetchMoreOptions<any, any>
     ): Promise<ApolloQueryResult<T>>;
@@ -48,7 +49,7 @@ declare module '@apollo/react-components' {
       opts: ModifiableWatchQueryOptions
     ): Promise<ApolloQueryResult<T>>;
     setVariables(
-      variables: Dict,
+      variables: V,
       tryFetch?: boolean,
       fetchResults?: boolean
     ): Promise<ApolloQueryResult<T>>;

--- a/definitions/npm/@apollo/react-components_v3.x.x/flow_v0.58.x-v0.103.x/react-components_v3.x.x.js
+++ b/definitions/npm/@apollo/react-components_v3.x.x/flow_v0.58.x-v0.103.x/react-components_v3.x.x.js
@@ -13,10 +13,10 @@ declare module '@apollo/react-components' {
    * Copied types from Apollo Client libdef
    * Please update apollo-client libdef as well if updating these types
    */
-  declare class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
+  declare class ObservableQuery<T, V = { [key: string]: any, ... }> extends Observable<ApolloQueryResult<T>> {
     options: WatchQueryOptions;
     queryId: string;
-    variables: Dict;
+    variables: V;
     isCurrentlyPolling: boolean;
     shouldSubscribe: boolean;
     isTornDown: boolean;
@@ -26,20 +26,19 @@ declare module '@apollo/react-components' {
     subscriptionHandles: SubscriptionLINK[];
     lastResult: ApolloQueryResult<T>;
     lastError: ApolloError;
-    lastVariables: Dict;
+    lastVariables: V;
 
     constructor(data: {
       scheduler: QueryScheduler<any>,
       options: WatchQueryOptions,
       shouldSubscribe?: boolean,
     }): this;
-
     result(): Promise<ApolloQueryResult<T>>;
     currentResult(): ApolloCurrentResult<T>;
     getLastResult(): ApolloQueryResult<T>;
     getLastError(): ApolloError;
     resetLastResults(): void;
-    refetch(variables?: Dict): Promise<ApolloQueryResult<T>>;
+    refetch(variables?: V): Promise<ApolloQueryResult<T>>;
     fetchMore(
       fetchMoreOptions: FetchMoreQueryOptions<any> & FetchMoreOptions<any, any>
     ): Promise<ApolloQueryResult<T>>;
@@ -48,7 +47,7 @@ declare module '@apollo/react-components' {
       opts: ModifiableWatchQueryOptions
     ): Promise<ApolloQueryResult<T>>;
     setVariables(
-      variables: Dict,
+      variables: V,
       tryFetch?: boolean,
       fetchResults?: boolean
     ): Promise<ApolloQueryResult<T>>;

--- a/definitions/npm/@apollo/react-hoc_v3.x.x/flow_v0.104.x-/react-hoc_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hoc_v3.x.x/flow_v0.104.x-/react-hoc_v3.x.x.js
@@ -10,10 +10,10 @@ declare module '@apollo/react-hoc' {
    * Copied types from Apollo Client libdef
    * Please update apollo-client libdef as well if updating these types
    */
-  declare class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
+  declare class ObservableQuery<T, V = { [key: string]: any, ... }> extends Observable<ApolloQueryResult<T>> {
     options: WatchQueryOptions;
     queryId: string;
-    variables: { [key: string]: any, ... };
+    variables: V;
     isCurrentlyPolling: boolean;
     shouldSubscribe: boolean;
     isTornDown: boolean;
@@ -23,7 +23,7 @@ declare module '@apollo/react-hoc' {
     subscriptionHandles: SubscriptionLINK[];
     lastResult: ApolloQueryResult<T>;
     lastError: ApolloError;
-    lastVariables: { [key: string]: any, ... };
+    lastVariables: V;
 
     constructor(data: {
       scheduler: QueryScheduler<any>,
@@ -31,13 +31,12 @@ declare module '@apollo/react-hoc' {
       shouldSubscribe?: boolean,
       ...
     }): this;
-
     result(): Promise<ApolloQueryResult<T>>;
     currentResult(): ApolloCurrentResult<T>;
     getLastResult(): ApolloQueryResult<T>;
     getLastError(): ApolloError;
     resetLastResults(): void;
-    refetch(variables?: any): Promise<ApolloQueryResult<T>>;
+    refetch(variables?: V): Promise<ApolloQueryResult<T>>;
     fetchMore(
       fetchMoreOptions: FetchMoreQueryOptions<any> & FetchMoreOptions<any, any>
     ): Promise<ApolloQueryResult<T>>;
@@ -46,7 +45,7 @@ declare module '@apollo/react-hoc' {
       opts: ModifiableWatchQueryOptions
     ): Promise<ApolloQueryResult<T>>;
     setVariables(
-      variables: any,
+      variables: V,
       tryFetch?: boolean,
       fetchResults?: boolean
     ): Promise<ApolloQueryResult<T>>;

--- a/definitions/npm/@apollo/react-hoc_v3.x.x/flow_v0.58.x-v0.103.x/react-hoc_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hoc_v3.x.x/flow_v0.58.x-v0.103.x/react-hoc_v3.x.x.js
@@ -9,10 +9,10 @@ declare module '@apollo/react-hoc' {
    * Copied types from Apollo Client libdef
    * Please update apollo-client libdef as well if updating these types
    */
-  declare class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
+  declare class ObservableQuery<T, V = { [key: string]: any, ... }> extends Observable<ApolloQueryResult<T>> {
     options: WatchQueryOptions;
     queryId: string;
-    variables: { [key: string]: any };
+    variables: V;
     isCurrentlyPolling: boolean;
     shouldSubscribe: boolean;
     isTornDown: boolean;
@@ -22,7 +22,7 @@ declare module '@apollo/react-hoc' {
     subscriptionHandles: SubscriptionLINK[];
     lastResult: ApolloQueryResult<T>;
     lastError: ApolloError;
-    lastVariables: { [key: string]: any };
+    lastVariables: V;
 
     constructor(data: {
       scheduler: QueryScheduler<any>,
@@ -35,7 +35,7 @@ declare module '@apollo/react-hoc' {
     getLastResult(): ApolloQueryResult<T>;
     getLastError(): ApolloError;
     resetLastResults(): void;
-    refetch(variables?: any): Promise<ApolloQueryResult<T>>;
+    refetch(variables?: V): Promise<ApolloQueryResult<T>>;
     fetchMore(
       fetchMoreOptions: FetchMoreQueryOptions<any> & FetchMoreOptions<any, any>
     ): Promise<ApolloQueryResult<T>>;
@@ -44,7 +44,7 @@ declare module '@apollo/react-hoc' {
       opts: ModifiableWatchQueryOptions
     ): Promise<ApolloQueryResult<T>>;
     setVariables(
-      variables: any,
+      variables: V,
       tryFetch?: boolean,
       fetchResults?: boolean
     ): Promise<ApolloQueryResult<T>>;

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
@@ -387,12 +387,10 @@ declare module '@apollo/react-hooks' {
 
   /* start apollo-client types */
 
-  declare class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
+  declare class ObservableQuery<T, V = { [key: string]: any, ... }> extends Observable<ApolloQueryResult<T>> {
     options: WatchQueryOptions;
     queryId: string;
-    variables: {
-      [key: string]: any, ...
-    };
+    variables: V;
     isCurrentlyPolling: boolean;
     shouldSubscribe: boolean;
     isTornDown: boolean;
@@ -402,9 +400,7 @@ declare module '@apollo/react-hooks' {
     subscriptionHandles: SubscriptionLINK[];
     lastResult: ApolloQueryResult<T>;
     lastError: ApolloError;
-    lastVariables: {
-      [key: string]: any, ...
-    };
+    lastVariables: V;
     constructor(data: {
       scheduler: QueryScheduler<any>,
       options: WatchQueryOptions,
@@ -416,7 +412,7 @@ declare module '@apollo/react-hooks' {
     getLastResult(): ApolloQueryResult<T>;
     getLastError(): ApolloError;
     resetLastResults(): void;
-    refetch(variables?: any): Promise<ApolloQueryResult<T>>;
+    refetch(variables?: V): Promise<ApolloQueryResult<T>>;
     fetchMore(
       fetchMoreOptions: FetchMoreQueryOptions<any> & FetchMoreOptions<any, any>
     ): Promise<ApolloQueryResult<T>>;
@@ -425,7 +421,7 @@ declare module '@apollo/react-hooks' {
       opts: ModifiableWatchQueryOptions
     ): Promise<ApolloQueryResult<T>>;
     setVariables(
-      variables: any,
+      variables: V,
       tryFetch?: boolean,
       fetchResults?: boolean
     ): Promise<ApolloQueryResult<T>>;

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
@@ -337,10 +337,10 @@ declare module '@apollo/react-hooks' {
 
   /* start apollo-client types */
 
-  declare class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
+  declare class ObservableQuery<T, V = { [key: string]: any }> extends Observable<ApolloQueryResult<T>> {
     options: WatchQueryOptions;
     queryId: string;
-    variables: { [key: string]: any };
+    variables: V;
     isCurrentlyPolling: boolean;
     shouldSubscribe: boolean;
     isTornDown: boolean;
@@ -350,7 +350,7 @@ declare module '@apollo/react-hooks' {
     subscriptionHandles: SubscriptionLINK[];
     lastResult: ApolloQueryResult<T>;
     lastError: ApolloError;
-    lastVariables: { [key: string]: any };
+    lastVariables: V;
 
     constructor(data: {
       scheduler: QueryScheduler<any>,
@@ -363,7 +363,7 @@ declare module '@apollo/react-hooks' {
     getLastResult(): ApolloQueryResult<T>;
     getLastError(): ApolloError;
     resetLastResults(): void;
-    refetch(variables?: any): Promise<ApolloQueryResult<T>>;
+    refetch(variables?: V): Promise<ApolloQueryResult<T>>;
     fetchMore(
       fetchMoreOptions: FetchMoreQueryOptions<any> & FetchMoreOptions<any, any>
     ): Promise<ApolloQueryResult<T>>;
@@ -372,7 +372,7 @@ declare module '@apollo/react-hooks' {
       opts: ModifiableWatchQueryOptions
     ): Promise<ApolloQueryResult<T>>;
     setVariables(
-      variables: any,
+      variables: V,
       tryFetch?: boolean,
       fetchResults?: boolean
     ): Promise<ApolloQueryResult<T>>;

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.104.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.104.x-/react-apollo_v2.x.x.js
@@ -7,10 +7,10 @@ declare module "react-apollo" {
    * Copied types from Apollo Client libdef
    * Please update apollo-client libdef as well if updating these types
    */
-  declare class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
+  declare class ObservableQuery<T, V = { [key: string]: any, ... }> extends Observable<ApolloQueryResult<T>> {
     options: WatchQueryOptions;
     queryId: string;
-    variables: { [key: string]: any, ... };
+    variables: V;
     isCurrentlyPolling: boolean;
     shouldSubscribe: boolean;
     isTornDown: boolean;
@@ -20,7 +20,7 @@ declare module "react-apollo" {
     subscriptionHandles: SubscriptionLINK[];
     lastResult: ApolloQueryResult<T>;
     lastError: ApolloError;
-    lastVariables: { [key: string]: any, ... };
+    lastVariables: V;
 
     constructor(data: {
       scheduler: QueryScheduler<any>,
@@ -28,13 +28,12 @@ declare module "react-apollo" {
       shouldSubscribe?: boolean,
       ...
     }): this;
-
     result(): Promise<ApolloQueryResult<T>>;
     currentResult(): ApolloCurrentResult<T>;
     getLastResult(): ApolloQueryResult<T>;
     getLastError(): ApolloError;
     resetLastResults(): void;
-    refetch(variables?: any): Promise<ApolloQueryResult<T>>;
+    refetch(variables?: V): Promise<ApolloQueryResult<T>>;
     fetchMore(
       fetchMoreOptions: FetchMoreQueryOptions<any> & FetchMoreOptions<any, any>
     ): Promise<ApolloQueryResult<T>>;
@@ -43,7 +42,7 @@ declare module "react-apollo" {
       opts: ModifiableWatchQueryOptions
     ): Promise<ApolloQueryResult<T>>;
     setVariables(
-      variables: any,
+      variables: V,
       tryFetch?: boolean,
       fetchResults?: boolean
     ): Promise<ApolloQueryResult<T>>;

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-v0.103.x/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-v0.103.x/react-apollo_v2.x.x.js
@@ -7,10 +7,10 @@ declare module "react-apollo" {
    * Copied types from Apollo Client libdef
    * Please update apollo-client libdef as well if updating these types
    */
-  declare class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
+  declare class ObservableQuery<T, V = { [key: string]: any, ... }> extends Observable<ApolloQueryResult<T>> {
     options: WatchQueryOptions;
     queryId: string;
-    variables: { [key: string]: any };
+    variables: V;
     isCurrentlyPolling: boolean;
     shouldSubscribe: boolean;
     isTornDown: boolean;
@@ -20,20 +20,20 @@ declare module "react-apollo" {
     subscriptionHandles: SubscriptionLINK[];
     lastResult: ApolloQueryResult<T>;
     lastError: ApolloError;
-    lastVariables: { [key: string]: any };
+    lastVariables: V;
 
     constructor(data: {
       scheduler: QueryScheduler<any>,
       options: WatchQueryOptions,
-      shouldSubscribe?: boolean
+      shouldSubscribe?: boolean,
     }): this;
-
+    
     result(): Promise<ApolloQueryResult<T>>;
     currentResult(): ApolloCurrentResult<T>;
     getLastResult(): ApolloQueryResult<T>;
     getLastError(): ApolloError;
     resetLastResults(): void;
-    refetch(variables?: any): Promise<ApolloQueryResult<T>>;
+    refetch(variables?: V): Promise<ApolloQueryResult<T>>;
     fetchMore(
       fetchMoreOptions: FetchMoreQueryOptions<any> & FetchMoreOptions<any, any>
     ): Promise<ApolloQueryResult<T>>;
@@ -42,7 +42,7 @@ declare module "react-apollo" {
       opts: ModifiableWatchQueryOptions
     ): Promise<ApolloQueryResult<T>>;
     setVariables(
-      variables: any,
+      variables: V,
       tryFetch?: boolean,
       fetchResults?: boolean
     ): Promise<ApolloQueryResult<T>>;


### PR DESCRIPTION
- Links to documentation:
- Link to GitHub or NPM: 
- Type of contribution: fix

Other notes:
This PR allows for the specification of the `V` generic in `ObservableQuery<T, V>` which describes  the variables in an ObservableQuery in:
- react-apollo@2.x.x
- @apollo/react-hooks@3.x.x
- @apollo/react-hoc@3.x.x
- @apollo/react-components@3.x.x

Not accepting this generic caused:
- Worse type coverage than was possible with the generic
- Flow (0.85) to be unable to correctly resolve the types in apollo@v3.x.x packages which supply the variables generic to `ObservableQuery`

e.g. https://github.com/flow-typed/flow-typed/blob/d18ab9e6cbbed915241f286a110fb3e02692d916/definitions/npm/%40apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js#L235
