### PR TITLE
[react-native-gesture-handler] Allow to have children

### DIFF
--- a/definitions/npm/react-native-gesture-handler_v1.x.x/flow_v0.104.x-/react-native-gesture-handler_v1.x.x.js
+++ b/definitions/npm/react-native-gesture-handler_v1.x.x/flow_v0.104.x-/react-native-gesture-handler_v1.x.x.js
@@ -381,6 +381,7 @@ declare module 'react-native-gesture-handler/GestureHandler' {
     shouldCancelWhenOutside?: boolean,
     minPointers?: number,
     hitSlop?: HitSlop,
+    children?: React$Node,
   |}>;
 
   /////////////////////////////////////////////////////////////////////////////

--- a/definitions/npm/react-native-gesture-handler_v1.x.x/flow_v0.104.x-/test_all-gesture-handlers.js
+++ b/definitions/npm/react-native-gesture-handler_v1.x.x/flow_v0.104.x-/test_all-gesture-handlers.js
@@ -144,6 +144,14 @@ describe('common part', () => {
         />;
       });
     });
+
+    it('should be able to have children', () => {
+      AllGestureHandlers.forEach(GestureHandler => {
+        <GestureHandler>
+          Hello
+        </GestureHandler>;
+      });
+    });
   });
 });
 

--- a/definitions/npm/react-native-gesture-handler_v1.x.x/flow_v0.88.0-v0.103.x/react-native-gesture-handler_v1.x.x.js
+++ b/definitions/npm/react-native-gesture-handler_v1.x.x/flow_v0.88.0-v0.103.x/react-native-gesture-handler_v1.x.x.js
@@ -373,6 +373,7 @@ declare module 'react-native-gesture-handler/GestureHandler' {
     shouldCancelWhenOutside?: boolean,
     minPointers?: number,
     hitSlop?: HitSlop,
+    children?: React$Node,
   |}>;
 
   /////////////////////////////////////////////////////////////////////////////

--- a/definitions/npm/react-native-gesture-handler_v1.x.x/flow_v0.88.0-v0.103.x/test_all-gesture-handlers.js
+++ b/definitions/npm/react-native-gesture-handler_v1.x.x/flow_v0.88.0-v0.103.x/test_all-gesture-handlers.js
@@ -144,6 +144,14 @@ describe('common part', () => {
         />;
       });
     });
+
+    it('should be able to have children', () => {
+      AllGestureHandlers.forEach(GestureHandler => {
+        <GestureHandler>
+          Hello
+        </GestureHandler>;
+      });
+    });
   });
 });
 


### PR DESCRIPTION
All gesture handlers can have children. [Example 1](https://github.com/kmagiera/react-native-gesture-handler/blob/master/Example/panAndScroll/index.js#L52), [example 2](https://github.com/kmagiera/react-native-reanimated/blob/master/Example/imageViewer/index.js#L390)