### PR TITLE
[redux-devtools-extension] Get rid of $Subtype usage

### DIFF
--- a/definitions/npm/redux-devtools-extension_v2.x.x/flow_v0.104.x-/redux-devtools-extension_v2.x.x.js
+++ b/definitions/npm/redux-devtools-extension_v2.x.x/flow_v0.104.x-/redux-devtools-extension_v2.x.x.js
@@ -17,11 +17,11 @@ declare type $npm$ReduxDevtoolsExtension$DevToolsOptions = {
     function?: boolean | Function,
     ...
   },
-  actionSanitizer?: <A: { type: $Subtype<string>, ... }>(action: A, id: number) => A,
+  actionSanitizer?: <A: { type: string, ... }>(action: A, id: number) => A,
   stateSanitizer?: <S>(state: S, index: number) => S,
   actionsBlacklist?: string | string[],
   actionsWhitelist?: string | string[],
-  predicate?: <S, A: { type: $Subtype<string>, ... }>(state: S, action: A) => boolean,
+  predicate?: <S, A: { type: string, ... }>(state: S, action: A) => boolean,
   shouldRecordChanges?: boolean,
   pauseActionType?: string,
   autoPause?: boolean,

--- a/definitions/npm/redux-devtools-extension_v2.x.x/flow_v0.47.x-v0.103.x/redux-devtools-extension_v2.x.x.js
+++ b/definitions/npm/redux-devtools-extension_v2.x.x/flow_v0.47.x-v0.103.x/redux-devtools-extension_v2.x.x.js
@@ -16,11 +16,11 @@ declare type $npm$ReduxDevtoolsExtension$DevToolsOptions = {
     set?: boolean;
     function?: boolean | Function;
   },
-  actionSanitizer?: <A: { type: $Subtype<string> }>(action: A, id: number) => A,
+  actionSanitizer?: <A: { type: string }>(action: A, id: number) => A,
   stateSanitizer?: <S>(state: S, index: number) => S,
   actionsBlacklist?: string | string[],
   actionsWhitelist?: string | string[],
-  predicate?: <S, A: { type: $Subtype<string> }>(state: S, action: A) => boolean,
+  predicate?: <S, A: { type: string }>(state: S, action: A) => boolean,
   shouldRecordChanges?: boolean,
   pauseActionType?: string,
   autoPause?: boolean,


### PR DESCRIPTION
`$Subtype` is deprecated and newer versions of Flow complain if you use it