### PR TITLE
fix(promise-retry): retryNumber is a primitive number

### DIFF
--- a/definitions/npm/promise-retry_v1.1.x/flow_v0.104.x-/promise-retry_v1.1.x.js
+++ b/definitions/npm/promise-retry_v1.1.x/flow_v0.104.x-/promise-retry_v1.1.x.js
@@ -11,7 +11,7 @@ declare module 'promise-retry' {
   declare export type RetryOptions = Options;
 
   declare module.exports: <T>(
-    handler: (retry: RetryFn, retryNumber: Number) => Promise<T>,
+    handler: (retry: RetryFn, retryNumber: number) => Promise<T>,
     options?: Options
   ) => Promise<T>;
 }

--- a/definitions/npm/promise-retry_v1.1.x/flow_v0.104.x-/test_promise-retry.js
+++ b/definitions/npm/promise-retry_v1.1.x/flow_v0.104.x-/test_promise-retry.js
@@ -1,7 +1,7 @@
 // @flow
 import promiseRetry from 'promise-retry';
 
-function promiseFn (retry: (err: Error) => void, attemptNumber: Number): Promise<string> {
+function promiseFn (retry: (err: Error) => void, attemptNumber: number): Promise<string> {
    return Promise.resolve('foo');
 }
 

--- a/definitions/npm/promise-retry_v1.1.x/flow_v0.45.x-v0.103.x/promise-retry_v1.1.x.js
+++ b/definitions/npm/promise-retry_v1.1.x/flow_v0.45.x-v0.103.x/promise-retry_v1.1.x.js
@@ -11,7 +11,7 @@ declare module 'promise-retry' {
   declare export type RetryOptions = Options;
 
   declare module.exports: <T>(
-    handler: (retry: RetryFn, retryNumber: Number) => Promise<T>,
+    handler: (retry: RetryFn, retryNumber: number) => Promise<T>,
     options?: Options
   ) => Promise<T>;
 }

--- a/definitions/npm/promise-retry_v1.1.x/flow_v0.45.x-v0.103.x/test_promise-retry.js
+++ b/definitions/npm/promise-retry_v1.1.x/flow_v0.45.x-v0.103.x/test_promise-retry.js
@@ -1,7 +1,7 @@
 // @flow
 import promiseRetry from 'promise-retry';
 
-function promiseFn (retry: (err: Error) => void, attemptNumber: Number): Promise<string> {
+function promiseFn (retry: (err: Error) => void, attemptNumber: number): Promise<string> {
    return Promise.resolve('foo');
 }
 


### PR DESCRIPTION
It was specified as an instance of the `Number` class, which is not compatible with
primitive number types.

- Links to documentation: https://www.npmjs.com/package/promise-retry
- Link to GitHub or NPM: https://github.com/IndigoUnited/node-promise-retry#readme
- Type of contribution: fix