### PR TITLE
[express] Remove $Subtype usage in express and cookie-parser

### DIFF
--- a/definitions/npm/cookie-parser_v1.x.x/flow_v0.104.x-/cookie-parser_v1.x.x.js
+++ b/definitions/npm/cookie-parser_v1.x.x/flow_v0.104.x-/cookie-parser_v1.x.x.js
@@ -10,28 +10,10 @@ import type { Socket } from 'net';
 declare module 'cookie-parser' {
   /**
    * NOTE:
-   * The following block has all been copied from
-   * https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/express_v4.x.x/flow_v0.93.x-/express_v4.x.x.js#L103-L105
+   * The following block has all been copied from the express libdef
    */
 
   /* -------------------------- 8< ------------------------------------------------------------------ */
-
-  declare type express$RenderCallback = (
-    err: Error | null,
-    html?: string
-  ) => mixed;
-
-  declare type express$CookieOptions = {
-    domain?: string,
-    encode?: (value: string) => string,
-    expires?: Date,
-    httpOnly?: boolean,
-    maxAge?: number,
-    path?: string,
-    secure?: boolean,
-    signed?: boolean,
-    ...
-  };
 
   declare type express$RouterOptions = {
     caseSensitive?: boolean,
@@ -40,150 +22,18 @@ declare module 'cookie-parser' {
     ...
   };
 
-  declare interface express$RouteMethodType<T> {
-    (middleware: express$Middleware): T;
-    (...middleware: Array<express$Middleware>): T;
-    (
-      path: express$Path | express$Path[],
-      ...middleware: Array<express$Middleware>
-    ): T;
+  declare class express$RequestResponseBase {
+    app: express$Application<any, any>;
+    get(field: string): string | void;
   }
 
   declare type express$RequestParams = { [param: string]: string, ... };
 
-  declare type express$SendFileOptions = {
-    maxAge?: number,
-    root?: string,
-    lastModified?: boolean,
-    headers?: { [name: string]: string, ... },
-    dotfiles?: 'allow' | 'deny' | 'ignore',
-    ...
-  };
-
-  declare class express$Application extends express$Router
-    mixins events$EventEmitter {
-    constructor(): void;
-    locals: { [name: string]: mixed, ... };
-    mountpath: string;
-    listen(
-      port: number,
-      hostname?: string,
-      backlog?: number,
-      callback?: (err?: ?Error) => mixed
-    ): ?http.Server;
-    listen(
-      port: number,
-      hostname?: string,
-      callback?: (err?: ?Error) => mixed
-    ): ?http.Server;
-    listen(port: number, callback?: (err?: ?Error) => mixed): ?http.Server;
-    listen(path: string, callback?: (err?: ?Error) => mixed): ?http.Server;
-    listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http.Server;
-    disable(name: string): void;
-    disabled(name: string): boolean;
-    enable(name: string): express$Application;
-    enabled(name: string): boolean;
-    engine(name: string, callback: Function): void;
-    /**
-     * Mixed will not be taken as a value option. Issue around using the GET http method name and the get for settings.
-     */
-    //   get(name: string): mixed;
-    set(name: string, value: mixed): mixed;
-    render(
-      name: string,
-      optionsOrFunction: { [name: string]: mixed, ... },
-      callback: express$RenderCallback
-    ): void;
-    handle(
-      req: http$IncomingMessage<>,
-      res: http$ServerResponse,
-      next?: ?express$NextFunction
-    ): void;
-    // callable signature is not inherited
-    (
-      req: http$IncomingMessage<>,
-      res: http$ServerResponse,
-      next?: ?express$NextFunction
-    ): void;
-  }
-
-  declare type express$Path = string | RegExp;
-
-  declare class express$Route {
-    all: express$RouteMethodType<this>;
-    get: express$RouteMethodType<this>;
-    post: express$RouteMethodType<this>;
-    put: express$RouteMethodType<this>;
-    head: express$RouteMethodType<this>;
-    delete: express$RouteMethodType<this>;
-    options: express$RouteMethodType<this>;
-    trace: express$RouteMethodType<this>;
-    copy: express$RouteMethodType<this>;
-    lock: express$RouteMethodType<this>;
-    mkcol: express$RouteMethodType<this>;
-    move: express$RouteMethodType<this>;
-    purge: express$RouteMethodType<this>;
-    propfind: express$RouteMethodType<this>;
-    proppatch: express$RouteMethodType<this>;
-    unlock: express$RouteMethodType<this>;
-    report: express$RouteMethodType<this>;
-    mkactivity: express$RouteMethodType<this>;
-    checkout: express$RouteMethodType<this>;
-    merge: express$RouteMethodType<this>;
-
-    // @TODO Missing 'm-search' but get flow illegal name error.
-
-    notify: express$RouteMethodType<this>;
-    subscribe: express$RouteMethodType<this>;
-    unsubscribe: express$RouteMethodType<this>;
-    patch: express$RouteMethodType<this>;
-    search: express$RouteMethodType<this>;
-    connect: express$RouteMethodType<this>;
-  }
-
-  declare class express$Router extends express$Route {
-    constructor(options?: express$RouterOptions): void;
-    route(path: string): express$Route;
-    static (options?: express$RouterOptions): express$Router;
-    use(middleware: express$Middleware): this;
-    use(...middleware: Array<express$Middleware>): this;
-    use(
-      path: express$Path | express$Path[],
-      ...middleware: Array<express$Middleware>
-    ): this;
-    use(path: string, router: express$Router): this;
-    handle(
-      req: http$IncomingMessage<>,
-      res: http$ServerResponse,
-      next: express$NextFunction
-    ): void;
-    param(
-      param: string,
-      callback: (
-        req: express$Request,
-        res: express$Response,
-        next: express$NextFunction,
-        id: string
-      ) => mixed
-    ): void;
-    (
-      req: http$IncomingMessage<>,
-      res: http$ServerResponse,
-      next?: ?express$NextFunction
-    ): void;
-  }
-
-  declare class express$RequestResponseBase {
-    app: express$Application;
-    get(field: string): string | void;
-  }
-
-  declare class express$Request extends http$IncomingMessage
-    mixins express$RequestResponseBase {
+  declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
     baseUrl: string;
     body: mixed;
     cookies: { [cookie: string]: string, ... };
-    connection: Socket;
+    connection: net$Socket;
     fresh: boolean;
     hostname: string;
     ip: string;
@@ -192,7 +42,7 @@ declare module 'cookie-parser' {
     originalUrl: string;
     params: express$RequestParams;
     path: string;
-    protocol: 'https' | 'http';
+    protocol: "https" | "http";
     query: { [name: string]: string | Array<string>, ... };
     route: string;
     secure: boolean;
@@ -206,12 +56,39 @@ declare module 'cookie-parser' {
     acceptsEncodings(...encoding: Array<string>): string | false;
     acceptsLanguages(...lang: Array<string>): string | false;
     header(field: string): string | void;
-    is(type: string): boolean;
+    is(type: string): string | false;
     param(name: string, defaultValue?: string): string | void;
   }
 
-  declare class express$Response extends http$ServerResponse
-    mixins express$RequestResponseBase {
+  declare type express$CookieOptions = {
+    domain?: string,
+    encode?: (value: string) => string,
+    expires?: Date,
+    httpOnly?: boolean,
+    maxAge?: number,
+    path?: string,
+    secure?: boolean,
+    signed?: boolean,
+    ...
+  };
+
+  declare type express$Path = string | RegExp;
+
+  declare type express$RenderCallback = (
+    err: Error | null,
+    html?: string
+  ) => mixed;
+
+  declare type express$SendFileOptions = {
+    maxAge?: number,
+    root?: string,
+    lastModified?: boolean,
+    headers?: { [name: string]: string, ... },
+    dotfiles?: "allow" | "deny" | "ignore",
+    ...
+  };
+
+  declare class express$Response extends http$ServerResponse mixins express$RequestResponseBase {
     headersSent: boolean;
     locals: { [name: string]: mixed, ... };
     append(field: string, value?: string): this;
@@ -252,28 +129,159 @@ declare module 'cookie-parser' {
     req: express$Request;
   }
 
-  declare type express$NextFunction = (err?: ?Error | 'route') => mixed;
-  declare type express$Middleware =
-    | ((
-        req: express$Request,
-        res: express$Response,
-        next: express$NextFunction
-      ) => mixed)
-    | ((
-        error: Error,
-        req: express$Request,
-        res: express$Response,
-        next: express$NextFunction
-      ) => mixed);
+  declare type express$NextFunction = (err?: ?Error | "route") => mixed;
+  declare type express$Middleware<Req: express$Request, Res: express$Response> =
+    ((req: Req, res: Res, next: express$NextFunction) => mixed) |
+    ((error: Error, req: Req, res: Res, next: express$NextFunction) => mixed);
+
+  declare interface express$RouteMethodType<
+    T,
+    Req: express$Request,
+    Res: express$Response,
+  > {
+    (middleware: express$Middleware<Req, Res>): T;
+    (...middleware: Array<express$Middleware<Req, Res>>): T;
+    (
+      path: express$Path | $ReadOnlyArray<express$Path>,
+      ...middleware: Array<express$Middleware<Req, Res>>
+    ): T;
+  }
+
+  declare class express$Route<Req: express$Request, Res: express$Response> {
+    all: express$RouteMethodType<this, Req, Res>;
+    get: express$RouteMethodType<this, Req, Res>;
+    post: express$RouteMethodType<this, Req, Res>;
+    put: express$RouteMethodType<this, Req, Res>;
+    head: express$RouteMethodType<this, Req, Res>;
+    delete: express$RouteMethodType<this, Req, Res>;
+    options: express$RouteMethodType<this, Req, Res>;
+    trace: express$RouteMethodType<this, Req, Res>;
+    copy: express$RouteMethodType<this, Req, Res>;
+    lock: express$RouteMethodType<this, Req, Res>;
+    mkcol: express$RouteMethodType<this, Req, Res>;
+    move: express$RouteMethodType<this, Req, Res>;
+    purge: express$RouteMethodType<this, Req, Res>;
+    propfind: express$RouteMethodType<this, Req, Res>;
+    proppatch: express$RouteMethodType<this, Req, Res>;
+    unlock: express$RouteMethodType<this, Req, Res>;
+    report: express$RouteMethodType<this, Req, Res>;
+    mkactivity: express$RouteMethodType<this, Req, Res>;
+    checkout: express$RouteMethodType<this, Req, Res>;
+    merge: express$RouteMethodType<this, Req, Res>;
+
+    // @TODO Missing 'm-search' but get flow illegal name error.
+
+    notify: express$RouteMethodType<this, Req, Res>;
+    subscribe: express$RouteMethodType<this, Req, Res>;
+    unsubscribe: express$RouteMethodType<this, Req, Res>;
+    patch: express$RouteMethodType<this, Req, Res>;
+    search: express$RouteMethodType<this, Req, Res>;
+    connect: express$RouteMethodType<this, Req, Res>;
+  }
+
+  declare class express$Router<
+    Req: express$Request,
+    Res: express$Response,
+  > extends express$Route<Req, Res> {
+    constructor(options?: express$RouterOptions): void;
+    route(path: string): express$Route<Req, Res>;
+    static <Req2: express$Request, Res2: express$Response>(
+      options?: express$RouterOptions,
+    ): express$Router<Req2, Res2>;
+    use(middleware: express$Middleware<Req, Res>): this;
+    use(...middleware: Array<express$Middleware<Req, Res>>): this;
+    use(
+      path: express$Path | $ReadOnlyArray<express$Path>,
+      ...middleware: Array<express$Middleware<Req, Res>>
+    ): this;
+    use(path: string, router: express$Router<Req, Res>): this;
+    handle(
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse,
+      next: express$NextFunction
+    ): void;
+    param(
+      param: string,
+      callback: (
+        req: Req,
+        res: Res,
+        next: express$NextFunction,
+        value: string,
+        paramName: string,
+      ) => mixed
+    ): void;
+    (
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse,
+      next?: ?express$NextFunction
+    ): void;
+  }
+
+  /*
+  With flow-bin ^0.59, express app.listen() is deemed to return any and fails flow type coverage.
+  Which is ironic because https://github.com/facebook/flow/blob/master/Changelog.md#misc-2 (release notes for 0.59)
+  says "Improves typings for Node.js HTTP server listen() function."  See that?  IMPROVES!
+  To work around this issue, we changed Server to ?Server here, so that our invocations of express.listen() will
+  not be deemed to lack type coverage.
+  */
+
+  declare class express$Application<
+    Req: express$Request,
+    Res: express$Response,
+  > extends express$Router<Req, Res> mixins events$EventEmitter {
+    constructor(): void;
+    locals: { [name: string]: mixed, ... };
+    mountpath: string;
+    listen(
+      port: number,
+      hostname?: string,
+      backlog?: number,
+      callback?: (err?: ?Error) => mixed
+    ): ?http$Server;
+    listen(
+      port: number,
+      hostname?: string,
+      callback?: (err?: ?Error) => mixed
+    ): ?http$Server;
+    listen(port: number, callback?: (err?: ?Error) => mixed): ?http$Server;
+    listen(path: string, callback?: (err?: ?Error) => mixed): ?http$Server;
+    listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http$Server;
+    disable(name: string): void;
+    disabled(name: string): boolean;
+    enable(name: string): this;
+    enabled(name: string): boolean;
+    engine(name: string, callback: Function): void;
+    /**
+     * Mixed will not be taken as a value option. Issue around using the GET http method name and the get for settings.
+     */
+    //   get(name: string): mixed;
+    set(name: string, value: mixed): mixed;
+    render(
+      name: string,
+      optionsOrFunction: { [name: string]: mixed, ... },
+      callback: express$RenderCallback
+    ): void;
+    handle(
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse,
+      next?: ?express$NextFunction
+    ): void;
+    // callable signature is not inherited
+    (
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse,
+      next?: ?express$NextFunction
+    ): void;
+  }
 
   /* -------------------------- 8< ------------------------------------------------------------------ */
 
-  declare export type Middleware = express$Middleware;
+  declare export type Middleware = express$Middleware<express$Request, express$Response>;
 
   declare function cookieParser(
     secret?: string | Array<string>,
     options?: mixed
-  ): express$Middleware;
+  ): Middleware;
 
   declare export default typeof cookieParser;
 }

--- a/definitions/npm/cookie-parser_v1.x.x/flow_v0.104.x-/cookie-parser_v1.x.x.js
+++ b/definitions/npm/cookie-parser_v1.x.x/flow_v0.104.x-/cookie-parser_v1.x.x.js
@@ -160,7 +160,7 @@ declare module 'cookie-parser' {
     param(
       param: string,
       callback: (
-        req: $Subtype<express$Request>,
+        req: express$Request,
         res: express$Response,
         next: express$NextFunction,
         id: string
@@ -255,13 +255,13 @@ declare module 'cookie-parser' {
   declare type express$NextFunction = (err?: ?Error | 'route') => mixed;
   declare type express$Middleware =
     | ((
-        req: $Subtype<express$Request>,
+        req: express$Request,
         res: express$Response,
         next: express$NextFunction
       ) => mixed)
     | ((
         error: Error,
-        req: $Subtype<express$Request>,
+        req: express$Request,
         res: express$Response,
         next: express$NextFunction
       ) => mixed);

--- a/definitions/npm/cookie-parser_v1.x.x/flow_v0.93.x-v0.103.x/cookie-parser_v1.x.x.js
+++ b/definitions/npm/cookie-parser_v1.x.x/flow_v0.93.x-v0.103.x/cookie-parser_v1.x.x.js
@@ -10,179 +10,31 @@ import type { Socket } from 'net';
 declare module 'cookie-parser' {
   /**
    * NOTE:
-   * The following block has all been copied from
-   * https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/express_v4.x.x/flow_v0.93.x-/express_v4.x.x.js#L103-L105
+   * The following block has all been copied from the express libdef
    */
 
   /* -------------------------- 8< ------------------------------------------------------------------ */
 
-  declare type express$RenderCallback = (
-    err: Error | null,
-    html?: string
-  ) => mixed;
-
-  declare type express$CookieOptions = {
-    domain?: string,
-    encode?: (value: string) => string,
-    expires?: Date,
-    httpOnly?: boolean,
-    maxAge?: number,
-    path?: string,
-    secure?: boolean,
-    signed?: boolean,
-  };
-
   declare type express$RouterOptions = {
     caseSensitive?: boolean,
     mergeParams?: boolean,
-    strict?: boolean,
+    strict?: boolean
   };
-
-  declare interface express$RouteMethodType<T> {
-    (middleware: express$Middleware): T;
-    (...middleware: Array<express$Middleware>): T;
-    (
-      path: express$Path | express$Path[],
-      ...middleware: Array<express$Middleware>
-    ): T;
-  }
-
-  declare type express$RequestParams = {
-    [param: string]: string,
-  };
-
-  declare type express$SendFileOptions = {
-    maxAge?: number,
-    root?: string,
-    lastModified?: boolean,
-    headers?: { [name: string]: string },
-    dotfiles?: 'allow' | 'deny' | 'ignore',
-  };
-
-  declare class express$Application extends express$Router
-    mixins events$EventEmitter {
-    constructor(): void;
-    locals: { [name: string]: mixed };
-    mountpath: string;
-    listen(
-      port: number,
-      hostname?: string,
-      backlog?: number,
-      callback?: (err?: ?Error) => mixed
-    ): ?http.Server;
-    listen(
-      port: number,
-      hostname?: string,
-      callback?: (err?: ?Error) => mixed
-    ): ?http.Server;
-    listen(port: number, callback?: (err?: ?Error) => mixed): ?http.Server;
-    listen(path: string, callback?: (err?: ?Error) => mixed): ?http.Server;
-    listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http.Server;
-    disable(name: string): void;
-    disabled(name: string): boolean;
-    enable(name: string): express$Application;
-    enabled(name: string): boolean;
-    engine(name: string, callback: Function): void;
-    /**
-     * Mixed will not be taken as a value option. Issue around using the GET http method name and the get for settings.
-     */
-    //   get(name: string): mixed;
-    set(name: string, value: mixed): mixed;
-    render(
-      name: string,
-      optionsOrFunction: { [name: string]: mixed },
-      callback: express$RenderCallback
-    ): void;
-    handle(
-      req: http$IncomingMessage<>,
-      res: http$ServerResponse,
-      next?: ?express$NextFunction
-    ): void;
-    // callable signature is not inherited
-    (
-      req: http$IncomingMessage<>,
-      res: http$ServerResponse,
-      next?: ?express$NextFunction
-    ): void;
-  }
-
-  declare type express$Path = string | RegExp;
-
-  declare class express$Route {
-    all: express$RouteMethodType<this>;
-    get: express$RouteMethodType<this>;
-    post: express$RouteMethodType<this>;
-    put: express$RouteMethodType<this>;
-    head: express$RouteMethodType<this>;
-    delete: express$RouteMethodType<this>;
-    options: express$RouteMethodType<this>;
-    trace: express$RouteMethodType<this>;
-    copy: express$RouteMethodType<this>;
-    lock: express$RouteMethodType<this>;
-    mkcol: express$RouteMethodType<this>;
-    move: express$RouteMethodType<this>;
-    purge: express$RouteMethodType<this>;
-    propfind: express$RouteMethodType<this>;
-    proppatch: express$RouteMethodType<this>;
-    unlock: express$RouteMethodType<this>;
-    report: express$RouteMethodType<this>;
-    mkactivity: express$RouteMethodType<this>;
-    checkout: express$RouteMethodType<this>;
-    merge: express$RouteMethodType<this>;
-
-    // @TODO Missing 'm-search' but get flow illegal name error.
-
-    notify: express$RouteMethodType<this>;
-    subscribe: express$RouteMethodType<this>;
-    unsubscribe: express$RouteMethodType<this>;
-    patch: express$RouteMethodType<this>;
-    search: express$RouteMethodType<this>;
-    connect: express$RouteMethodType<this>;
-  }
-
-  declare class express$Router extends express$Route {
-    constructor(options?: express$RouterOptions): void;
-    route(path: string): express$Route;
-    static (options?: express$RouterOptions): express$Router;
-    use(middleware: express$Middleware): this;
-    use(...middleware: Array<express$Middleware>): this;
-    use(
-      path: express$Path | express$Path[],
-      ...middleware: Array<express$Middleware>
-    ): this;
-    use(path: string, router: express$Router): this;
-    handle(
-      req: http$IncomingMessage<>,
-      res: http$ServerResponse,
-      next: express$NextFunction
-    ): void;
-    param(
-      param: string,
-      callback: (
-        req: express$Request,
-        res: express$Response,
-        next: express$NextFunction,
-        id: string
-      ) => mixed
-    ): void;
-    (
-      req: http$IncomingMessage<>,
-      res: http$ServerResponse,
-      next?: ?express$NextFunction
-    ): void;
-  }
 
   declare class express$RequestResponseBase {
-    app: express$Application;
+    app: express$Application<any, any>;
     get(field: string): string | void;
   }
 
-  declare class express$Request extends http$IncomingMessage
-    mixins express$RequestResponseBase {
+  declare type express$RequestParams = {
+    [param: string]: string
+  };
+
+  declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
     baseUrl: string;
     body: mixed;
     cookies: { [cookie: string]: string };
-    connection: Socket;
+    connection: net$Socket;
     fresh: boolean;
     hostname: string;
     ip: string;
@@ -191,7 +43,7 @@ declare module 'cookie-parser' {
     originalUrl: string;
     params: express$RequestParams;
     path: string;
-    protocol: 'https' | 'http';
+    protocol: "https" | "http";
     query: { [name: string]: string | Array<string> };
     route: string;
     secure: boolean;
@@ -205,12 +57,37 @@ declare module 'cookie-parser' {
     acceptsEncodings(...encoding: Array<string>): string | false;
     acceptsLanguages(...lang: Array<string>): string | false;
     header(field: string): string | void;
-    is(type: string): boolean;
+    is(type: string): string | false;
     param(name: string, defaultValue?: string): string | void;
   }
 
-  declare class express$Response extends http$ServerResponse
-    mixins express$RequestResponseBase {
+  declare type express$CookieOptions = {
+    domain?: string,
+    encode?: (value: string) => string,
+    expires?: Date,
+    httpOnly?: boolean,
+    maxAge?: number,
+    path?: string,
+    secure?: boolean,
+    signed?: boolean
+  };
+
+  declare type express$Path = string | RegExp;
+
+  declare type express$RenderCallback = (
+    err: Error | null,
+    html?: string
+  ) => mixed;
+
+  declare type express$SendFileOptions = {
+    maxAge?: number,
+    root?: string,
+    lastModified?: boolean,
+    headers?: { [name: string]: string },
+    dotfiles?: "allow" | "deny" | "ignore"
+  };
+
+  declare class express$Response extends http$ServerResponse mixins express$RequestResponseBase {
     headersSent: boolean;
     locals: { [name: string]: mixed };
     append(field: string, value?: string): this;
@@ -251,28 +128,159 @@ declare module 'cookie-parser' {
     req: express$Request;
   }
 
-  declare type express$NextFunction = (err?: ?Error | 'route') => mixed;
-  declare type express$Middleware =
-    | ((
-        req: express$Request,
-        res: express$Response,
-        next: express$NextFunction
-      ) => mixed)
-    | ((
-        error: Error,
-        req: express$Request,
-        res: express$Response,
-        next: express$NextFunction
-      ) => mixed);
+  declare type express$NextFunction = (err?: ?Error | "route") => mixed;
+  declare type express$Middleware<Req: express$Request, Res: express$Response> =
+    ((req: Req, res: Res, next: express$NextFunction) => mixed) |
+    ((error: Error, req: Req, res: Res, next: express$NextFunction) => mixed);
+
+  declare interface express$RouteMethodType<
+    T,
+    Req: express$Request,
+    Res: express$Response,
+  > {
+    (middleware: express$Middleware<Req, Res>): T;
+    (...middleware: Array<express$Middleware<Req, Res>>): T;
+    (
+      path: express$Path | $ReadOnlyArray<express$Path>,
+      ...middleware: Array<express$Middleware<Req, Res>>
+    ): T;
+  }
+
+  declare class express$Route<Req: express$Request, Res: express$Response> {
+    all: express$RouteMethodType<this, Req, Res>;
+    get: express$RouteMethodType<this, Req, Res>;
+    post: express$RouteMethodType<this, Req, Res>;
+    put: express$RouteMethodType<this, Req, Res>;
+    head: express$RouteMethodType<this, Req, Res>;
+    delete: express$RouteMethodType<this, Req, Res>;
+    options: express$RouteMethodType<this, Req, Res>;
+    trace: express$RouteMethodType<this, Req, Res>;
+    copy: express$RouteMethodType<this, Req, Res>;
+    lock: express$RouteMethodType<this, Req, Res>;
+    mkcol: express$RouteMethodType<this, Req, Res>;
+    move: express$RouteMethodType<this, Req, Res>;
+    purge: express$RouteMethodType<this, Req, Res>;
+    propfind: express$RouteMethodType<this, Req, Res>;
+    proppatch: express$RouteMethodType<this, Req, Res>;
+    unlock: express$RouteMethodType<this, Req, Res>;
+    report: express$RouteMethodType<this, Req, Res>;
+    mkactivity: express$RouteMethodType<this, Req, Res>;
+    checkout: express$RouteMethodType<this, Req, Res>;
+    merge: express$RouteMethodType<this, Req, Res>;
+
+    // @TODO Missing 'm-search' but get flow illegal name error.
+
+    notify: express$RouteMethodType<this, Req, Res>;
+    subscribe: express$RouteMethodType<this, Req, Res>;
+    unsubscribe: express$RouteMethodType<this, Req, Res>;
+    patch: express$RouteMethodType<this, Req, Res>;
+    search: express$RouteMethodType<this, Req, Res>;
+    connect: express$RouteMethodType<this, Req, Res>;
+  }
+
+  declare class express$Router<
+    Req: express$Request,
+    Res: express$Response,
+  > extends express$Route<Req, Res> {
+    constructor(options?: express$RouterOptions): void;
+    route(path: string): express$Route<Req, Res>;
+    static <Req2: express$Request, Res2: express$Response>(
+      options?: express$RouterOptions,
+    ): express$Router<Req2, Res2>;
+    use(middleware: express$Middleware<Req, Res>): this;
+    use(...middleware: Array<express$Middleware<Req, Res>>): this;
+    use(
+      path: express$Path | $ReadOnlyArray<express$Path>,
+      ...middleware: Array<express$Middleware<Req, Res>>
+    ): this;
+    use(path: string, router: express$Router<Req, Res>): this;
+    handle(
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse,
+      next: express$NextFunction
+    ): void;
+    param(
+      param: string,
+      callback: (
+        req: Req,
+        res: Res,
+        next: express$NextFunction,
+        value: string,
+        paramName: string,
+      ) => mixed
+    ): void;
+    (
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse,
+      next?: ?express$NextFunction
+    ): void;
+  }
+
+  /*
+  With flow-bin ^0.59, express app.listen() is deemed to return any and fails flow type coverage.
+  Which is ironic because https://github.com/facebook/flow/blob/master/Changelog.md#misc-2 (release notes for 0.59)
+  says "Improves typings for Node.js HTTP server listen() function."  See that?  IMPROVES!
+  To work around this issue, we changed Server to ?Server here, so that our invocations of express.listen() will
+  not be deemed to lack type coverage.
+  */
+
+  declare class express$Application<
+    Req: express$Request,
+    Res: express$Response,
+  > extends express$Router<Req, Res> mixins events$EventEmitter {
+    constructor(): void;
+    locals: { [name: string]: mixed };
+    mountpath: string;
+    listen(
+      port: number,
+      hostname?: string,
+      backlog?: number,
+      callback?: (err?: ?Error) => mixed
+    ): ?http$Server;
+    listen(
+      port: number,
+      hostname?: string,
+      callback?: (err?: ?Error) => mixed
+    ): ?http$Server;
+    listen(port: number, callback?: (err?: ?Error) => mixed): ?http$Server;
+    listen(path: string, callback?: (err?: ?Error) => mixed): ?http$Server;
+    listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http$Server;
+    disable(name: string): void;
+    disabled(name: string): boolean;
+    enable(name: string): this;
+    enabled(name: string): boolean;
+    engine(name: string, callback: Function): void;
+    /**
+     * Mixed will not be taken as a value option. Issue around using the GET http method name and the get for settings.
+     */
+    //   get(name: string): mixed;
+    set(name: string, value: mixed): mixed;
+    render(
+      name: string,
+      optionsOrFunction: { [name: string]: mixed },
+      callback: express$RenderCallback
+    ): void;
+    handle(
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse,
+      next?: ?express$NextFunction
+    ): void;
+    // callable signature is not inherited
+    (
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse,
+      next?: ?express$NextFunction
+    ): void;
+  }
 
   /* -------------------------- 8< ------------------------------------------------------------------ */
 
-  declare export type Middleware = express$Middleware;
+  declare export type Middleware = express$Middleware<express$Request, express$Response>;
 
   declare function cookieParser(
     secret?: string | Array<string>,
     options?: mixed
-  ): express$Middleware;
+  ): Middleware;
 
   declare export default typeof cookieParser;
 }

--- a/definitions/npm/cookie-parser_v1.x.x/flow_v0.93.x-v0.103.x/cookie-parser_v1.x.x.js
+++ b/definitions/npm/cookie-parser_v1.x.x/flow_v0.93.x-v0.103.x/cookie-parser_v1.x.x.js
@@ -159,7 +159,7 @@ declare module 'cookie-parser' {
     param(
       param: string,
       callback: (
-        req: $Subtype<express$Request>,
+        req: express$Request,
         res: express$Response,
         next: express$NextFunction,
         id: string
@@ -254,13 +254,13 @@ declare module 'cookie-parser' {
   declare type express$NextFunction = (err?: ?Error | 'route') => mixed;
   declare type express$Middleware =
     | ((
-        req: $Subtype<express$Request>,
+        req: express$Request,
         res: express$Response,
         next: express$NextFunction
       ) => mixed)
     | ((
         error: Error,
-        req: $Subtype<express$Request>,
+        req: express$Request,
         res: express$Response,
         next: express$NextFunction
       ) => mixed);

--- a/definitions/npm/express_v4.16.x/flow_v0.104.x-/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.104.x-/express_v4.16.x.js
@@ -183,11 +183,11 @@ declare class express$Router<
     res: http$ServerResponse,
     next: express$NextFunction
   ): void;
-  param<Req: express$Request>(
+  param(
     param: string,
     callback: (
       req: Req,
-      res: express$Response,
+      res: Res,
       next: express$NextFunction,
       value: string,
       paramName: string,

--- a/definitions/npm/express_v4.16.x/flow_v0.104.x-/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.104.x-/express_v4.16.x.js
@@ -6,7 +6,7 @@ declare type express$RouterOptions = {
 };
 
 declare class express$RequestResponseBase {
-  app: express$Application;
+  app: express$Application<any, any>;
   get(field: string): string | void;
 }
 
@@ -113,81 +113,84 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 }
 
 declare type express$NextFunction = (err?: ?Error | "route") => mixed;
-declare type express$Middleware =
-  | ((
-      req: express$Request,
-      res: express$Response,
-      next: express$NextFunction
-    ) => mixed)
-  | ((
-      error: Error,
-      req: express$Request,
-      res: express$Response,
-      next: express$NextFunction
-    ) => mixed);
-declare interface express$RouteMethodType<T> {
-  (middleware: express$Middleware): T;
-  (...middleware: Array<express$Middleware>): T;
+declare type express$Middleware<Req: express$Request, Res: express$Response> =
+  ((req: Req, res: Res, next: express$NextFunction) => mixed) |
+  ((error: Error, req: Req, res: Res, next: express$NextFunction) => mixed);
+
+declare interface express$RouteMethodType<
+  T,
+  Req: express$Request,
+  Res: express$Response,
+> {
+  (middleware: express$Middleware<Req, Res>): T;
+  (...middleware: Array<express$Middleware<Req, Res>>): T;
   (
-    path: express$Path | express$Path[],
-    ...middleware: Array<express$Middleware>
+    path: express$Path | $ReadOnlyArray<express$Path>,
+    ...middleware: Array<express$Middleware<Req, Res>>
   ): T;
 }
-declare class express$Route {
-  all: express$RouteMethodType<this>;
-  get: express$RouteMethodType<this>;
-  post: express$RouteMethodType<this>;
-  put: express$RouteMethodType<this>;
-  head: express$RouteMethodType<this>;
-  delete: express$RouteMethodType<this>;
-  options: express$RouteMethodType<this>;
-  trace: express$RouteMethodType<this>;
-  copy: express$RouteMethodType<this>;
-  lock: express$RouteMethodType<this>;
-  mkcol: express$RouteMethodType<this>;
-  move: express$RouteMethodType<this>;
-  purge: express$RouteMethodType<this>;
-  propfind: express$RouteMethodType<this>;
-  proppatch: express$RouteMethodType<this>;
-  unlock: express$RouteMethodType<this>;
-  report: express$RouteMethodType<this>;
-  mkactivity: express$RouteMethodType<this>;
-  checkout: express$RouteMethodType<this>;
-  merge: express$RouteMethodType<this>;
+
+declare class express$Route<Req: express$Request, Res: express$Response> {
+  all: express$RouteMethodType<this, Req, Res>;
+  get: express$RouteMethodType<this, Req, Res>;
+  post: express$RouteMethodType<this, Req, Res>;
+  put: express$RouteMethodType<this, Req, Res>;
+  head: express$RouteMethodType<this, Req, Res>;
+  delete: express$RouteMethodType<this, Req, Res>;
+  options: express$RouteMethodType<this, Req, Res>;
+  trace: express$RouteMethodType<this, Req, Res>;
+  copy: express$RouteMethodType<this, Req, Res>;
+  lock: express$RouteMethodType<this, Req, Res>;
+  mkcol: express$RouteMethodType<this, Req, Res>;
+  move: express$RouteMethodType<this, Req, Res>;
+  purge: express$RouteMethodType<this, Req, Res>;
+  propfind: express$RouteMethodType<this, Req, Res>;
+  proppatch: express$RouteMethodType<this, Req, Res>;
+  unlock: express$RouteMethodType<this, Req, Res>;
+  report: express$RouteMethodType<this, Req, Res>;
+  mkactivity: express$RouteMethodType<this, Req, Res>;
+  checkout: express$RouteMethodType<this, Req, Res>;
+  merge: express$RouteMethodType<this, Req, Res>;
 
   // @TODO Missing 'm-search' but get flow illegal name error.
 
-  notify: express$RouteMethodType<this>;
-  subscribe: express$RouteMethodType<this>;
-  unsubscribe: express$RouteMethodType<this>;
-  patch: express$RouteMethodType<this>;
-  search: express$RouteMethodType<this>;
-  connect: express$RouteMethodType<this>;
+  notify: express$RouteMethodType<this, Req, Res>;
+  subscribe: express$RouteMethodType<this, Req, Res>;
+  unsubscribe: express$RouteMethodType<this, Req, Res>;
+  patch: express$RouteMethodType<this, Req, Res>;
+  search: express$RouteMethodType<this, Req, Res>;
+  connect: express$RouteMethodType<this, Req, Res>;
 }
 
-declare class express$Router extends express$Route {
+declare class express$Router<
+  Req: express$Request,
+  Res: express$Response,
+> extends express$Route<Req, Res> {
   constructor(options?: express$RouterOptions): void;
-  route(path: string): express$Route;
-  static (options?: express$RouterOptions): express$Router;
-  use(middleware: express$Middleware): this;
-  use(...middleware: Array<express$Middleware>): this;
+  route(path: string): express$Route<Req, Res>;
+  static <Req2: express$Request, Res2: express$Response>(
+    options?: express$RouterOptions,
+  ): express$Router<Req2, Res2>;
+  use(middleware: express$Middleware<Req, Res>): this;
+  use(...middleware: Array<express$Middleware<Req, Res>>): this;
   use(
-    path: express$Path | express$Path[],
-    ...middleware: Array<express$Middleware>
+    path: express$Path | $ReadOnlyArray<express$Path>,
+    ...middleware: Array<express$Middleware<Req, Res>>
   ): this;
-  use(path: string, router: express$Router): this;
+  use(path: string, router: express$Router<Req, Res>): this;
   handle(
     req: http$IncomingMessage<>,
     res: http$ServerResponse,
     next: express$NextFunction
   ): void;
-  param(
+  param<Req: express$Request>(
     param: string,
     callback: (
-      req: express$Request,
+      req: Req,
       res: express$Response,
       next: express$NextFunction,
-      id: string
+      value: string,
+      paramName: string,
     ) => mixed
   ): void;
   (
@@ -205,7 +208,10 @@ To work around this issue, we changed Server to ?Server here, so that our invoca
 not be deemed to lack type coverage.
 */
 
-declare class express$Application extends express$Router mixins events$EventEmitter {
+declare class express$Application<
+  Req: express$Request,
+  Res: express$Response,
+> extends express$Router<Req, Res> mixins events$EventEmitter {
   constructor(): void;
   locals: { [name: string]: mixed, ... };
   mountpath: string;
@@ -225,7 +231,7 @@ declare class express$Application extends express$Router mixins events$EventEmit
   listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http$Server;
   disable(name: string): void;
   disabled(name: string): boolean;
-  enable(name: string): express$Application;
+  enable(name: string): this;
   enabled(name: string): boolean;
   engine(name: string, callback: Function): void;
   /**
@@ -284,22 +290,28 @@ declare type express$UrlEncodedOptions = {
 declare module "express" {
   declare export type RouterOptions = express$RouterOptions;
   declare export type CookieOptions = express$CookieOptions;
-  declare export type Middleware = express$Middleware;
+  declare export type Middleware<
+    Req: express$Request,
+    Res: express$Response,
+  > = express$Middleware<Req, Res>;
   declare export type NextFunction = express$NextFunction;
   declare export type RequestParams = express$RequestParams;
   declare export type $Response = express$Response;
   declare export type $Request = express$Request;
-  declare export type $Application = express$Application;
+  declare export type $Application<
+    Req: express$Request,
+    Res: express$Response,
+  > = express$Application<Req, Res>;
 
   declare module.exports: {
     // If you try to call like a function, it will use this signature
-    (): express$Application,
-    json: (opts: ?JsonOptions) => express$Middleware,
+    <Req: express$Request, Res: express$Response>(): express$Application<Req, Res>,
+    json: (opts: ?JsonOptions) => express$Middleware<express$Request, express$Response>,
     // `static` property on the function
-    static: (root: string, options?: Object) => express$Middleware,
+    static: <Req: express$Request, Res: express$Response>(root: string, options?: Object) => express$Middleware<Req, Res>,
     // `Router` property on the function
     Router: typeof express$Router,
-    urlencoded: (opts: ?express$UrlEncodedOptions) => express$Middleware,
+    urlencoded: (opts: ?express$UrlEncodedOptions) => express$Middleware<express$Request, express$Response>,
     ...
   };
 }

--- a/definitions/npm/express_v4.16.x/flow_v0.104.x-/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.104.x-/express_v4.16.x.js
@@ -115,13 +115,13 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 declare type express$NextFunction = (err?: ?Error | "route") => mixed;
 declare type express$Middleware =
   | ((
-      req: $Subtype<express$Request>,
+      req: express$Request,
       res: express$Response,
       next: express$NextFunction
     ) => mixed)
   | ((
       error: Error,
-      req: $Subtype<express$Request>,
+      req: express$Request,
       res: express$Response,
       next: express$NextFunction
     ) => mixed);
@@ -184,7 +184,7 @@ declare class express$Router extends express$Route {
   param(
     param: string,
     callback: (
-      req: $Subtype<express$Request>,
+      req: express$Request,
       res: express$Response,
       next: express$NextFunction,
       id: string

--- a/definitions/npm/express_v4.16.x/flow_v0.104.x-/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.104.x-/express_v4.16.x.js
@@ -113,14 +113,17 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 }
 
 declare type express$NextFunction = (err?: ?Error | "route") => mixed;
-declare type express$Middleware<Req: express$Request, Res: express$Response> =
+declare type express$Middleware<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> =
   ((req: Req, res: Res, next: express$NextFunction) => mixed) |
   ((error: Error, req: Req, res: Res, next: express$NextFunction) => mixed);
 
 declare interface express$RouteMethodType<
   T,
-  Req: express$Request,
-  Res: express$Response,
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
 > {
   (middleware: express$Middleware<Req, Res>): T;
   (...middleware: Array<express$Middleware<Req, Res>>): T;
@@ -130,7 +133,10 @@ declare interface express$RouteMethodType<
   ): T;
 }
 
-declare class express$Route<Req: express$Request, Res: express$Response> {
+declare class express$Route<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> {
   all: express$RouteMethodType<this, Req, Res>;
   get: express$RouteMethodType<this, Req, Res>;
   post: express$RouteMethodType<this, Req, Res>;
@@ -163,8 +169,8 @@ declare class express$Route<Req: express$Request, Res: express$Response> {
 }
 
 declare class express$Router<
-  Req: express$Request,
-  Res: express$Response,
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
 > extends express$Route<Req, Res> {
   constructor(options?: express$RouterOptions): void;
   route(path: string): express$Route<Req, Res>;
@@ -209,8 +215,8 @@ not be deemed to lack type coverage.
 */
 
 declare class express$Application<
-  Req: express$Request,
-  Res: express$Response,
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
 > extends express$Router<Req, Res> mixins events$EventEmitter {
   constructor(): void;
   locals: { [name: string]: mixed, ... };
@@ -291,27 +297,27 @@ declare module "express" {
   declare export type RouterOptions = express$RouterOptions;
   declare export type CookieOptions = express$CookieOptions;
   declare export type Middleware<
-    Req: express$Request,
-    Res: express$Response,
+    Req: express$Request = express$Request,
+    Res: express$Response = express$Response,
   > = express$Middleware<Req, Res>;
   declare export type NextFunction = express$NextFunction;
   declare export type RequestParams = express$RequestParams;
   declare export type $Response = express$Response;
   declare export type $Request = express$Request;
   declare export type $Application<
-    Req: express$Request,
-    Res: express$Response,
+    Req: express$Request = express$Request,
+    Res: express$Response = express$Response,
   > = express$Application<Req, Res>;
 
   declare module.exports: {
     // If you try to call like a function, it will use this signature
     <Req: express$Request, Res: express$Response>(): express$Application<Req, Res>,
-    json: (opts: ?JsonOptions) => express$Middleware<express$Request, express$Response>,
+    json: (opts: ?JsonOptions) => express$Middleware<>,
     // `static` property on the function
     static: <Req: express$Request, Res: express$Response>(root: string, options?: Object) => express$Middleware<Req, Res>,
     // `Router` property on the function
     Router: typeof express$Router,
-    urlencoded: (opts: ?express$UrlEncodedOptions) => express$Middleware<express$Request, express$Response>,
+    urlencoded: (opts: ?express$UrlEncodedOptions) => express$Middleware<>,
     ...
   };
 }

--- a/definitions/npm/express_v4.16.x/flow_v0.104.x-/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.104.x-/express_v4.16.x.js
@@ -12,6 +12,33 @@ declare class express$RequestResponseBase {
 
 declare type express$RequestParams = { [param: string]: string, ... };
 
+/*
+  NOTE: Use caution when extending `express$Request` or `express$Response`. When
+  a request first hits the server, its `req` and `res` will not have any
+  additional properties, even if you explicitly type them with your custom
+  subclass. Subsequent middleware may assign these properties, but you must be
+  cognizant of this ordering. One way to handle this is marking all properties
+  as optional to force refinement every time a property is accessed. Therefore,
+  we advise that you always mark properties as _optional_ in `express$Request`
+  and `express$Response` subclasses.
+
+  You may decide not to do this, in which case the typings will be unsound and
+  the behavior will be similar to how arrays work in Flow. See here for more
+  information: https://flow.org/en/docs/types/arrays/#toc-array-access-is-unsafe
+
+  See #3578 and #3337 for additional discussion. If you have ideas on how to
+  improve these typings, please share them in #3578 or open a new issue.
+
+  **BAD**
+  declare class test_express$CustomRequest extends express$Request {
+    foo: string;
+  }
+
+  **GOOD**
+  declare class test_express$CustomRequest extends express$Request {
+    foo: string | void;
+  }
+*/
 declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
   baseUrl: string;
   body: mixed;

--- a/definitions/npm/express_v4.16.x/flow_v0.104.x-/test_overrideUseMethodClassExtension.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.104.x-/test_overrideUseMethodClassExtension.js
@@ -10,40 +10,26 @@ declare class test_express$CustomResponse extends express$Response {
   bar: string;
 }
 
-declare type test_express$CustomPath = string | RegExp;
+declare type expressConstructor =
+  <Req: express$Request, Res: express$Response>() => express$Application<Req, Res>;
 
-declare type test_express$CustomNextFunction = express$NextFunction;
-
-declare type test_express$CustomMiddleware =
-  | ((
-      req: test_express$CustomRequest,
-      res: test_express$CustomResponse,
-      next: test_express$CustomNextFunction
-    ) => mixed)
-  | ((
-      error: Error,
-      req: test_express$CustomRequest,
-      res: test_express$CustomResponse,
-      next: test_express$CustomNextFunction
-    ) => mixed);
-
-declare class test_express$CustomApplication extends express$Application {
-  constructor(expressConstructor: () => express$Application): this;
-  use(middleware: test_express$CustomMiddleware): this;
-  use(...middleware: Array<test_express$CustomMiddleware>): this;
-  use(
-    path: test_express$CustomPath | test_express$CustomPath[],
-    ...middleware: Array<test_express$CustomMiddleware>
-  ): this;
-  use(path: string, router: express$Router): this;
+declare class test_express$CustomApplication extends express$Application<
+  test_express$CustomRequest,
+  test_express$CustomResponse,
+> {
+  constructor(expressConstructor: expressConstructor): this;
 }
 
 // Class Extensions: Test Functions
 function test_express$CustomApplication(
-  expressConstructor: () => express$Application
+  expressConstructor: expressConstructor,
 ) {
   const express = expressConstructor();
-  express.use((req: any, res: any, next: express$NextFunction) => {
+  express.use((
+    req: test_express$CustomRequest,
+    res: test_express$CustomResponse,
+    next: express$NextFunction,
+  ) => {
     // Private Constructor Mutation: Add new properties
     req.foo = "hello";
     res.bar = "goodbye";
@@ -73,7 +59,7 @@ customApp.use(
   (
     req: test_express$CustomRequest,
     res: test_express$CustomResponse,
-    next: test_express$CustomNextFunction
+    next: express$NextFunction
   ) => {
     req.foo;
     res.bar;

--- a/definitions/npm/express_v4.16.x/flow_v0.104.x-/test_response.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.104.x-/test_response.js
@@ -27,6 +27,18 @@ app.use(
 );
 app.post("/post-router-callable", router);
 
+// Can set a custom param on request
+app.param('test', (
+  req: express$Request & { testValue: string, ... },
+  res: express$Response,
+  next: express$NextFunction,
+  id: string,
+  paramName: string,
+) => {
+  req.testValue = id;
+  next();
+});
+
 // Can use an express app directly as a server listener
 const httpServer = http.createServer(app);
 httpServer.listen(9000);

--- a/definitions/npm/express_v4.16.x/flow_v0.94.x-v0.103.x/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.94.x-v0.103.x/express_v4.16.x.js
@@ -114,13 +114,13 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 declare type express$NextFunction = (err?: ?Error | "route") => mixed;
 declare type express$Middleware =
   | ((
-      req: $Subtype<express$Request>,
+      req: express$Request,
       res: express$Response,
       next: express$NextFunction
     ) => mixed)
   | ((
       error: Error,
-      req: $Subtype<express$Request>,
+      req: express$Request,
       res: express$Response,
       next: express$NextFunction
     ) => mixed);
@@ -183,7 +183,7 @@ declare class express$Router extends express$Route {
   param(
     param: string,
     callback: (
-      req: $Subtype<express$Request>,
+      req: express$Request,
       res: express$Response,
       next: express$NextFunction,
       id: string

--- a/definitions/npm/express_v4.16.x/flow_v0.94.x-v0.103.x/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.94.x-v0.103.x/express_v4.16.x.js
@@ -182,11 +182,11 @@ declare class express$Router<
     res: http$ServerResponse,
     next: express$NextFunction
   ): void;
-  param<Req: express$Request>(
+  param(
     param: string,
     callback: (
       req: Req,
-      res: express$Response,
+      res: Res,
       next: express$NextFunction,
       value: string,
       paramName: string,

--- a/definitions/npm/express_v4.16.x/flow_v0.94.x-v0.103.x/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.94.x-v0.103.x/express_v4.16.x.js
@@ -112,14 +112,17 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 }
 
 declare type express$NextFunction = (err?: ?Error | "route") => mixed;
-declare type express$Middleware<Req: express$Request, Res: express$Response> =
+declare type express$Middleware<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> =
   ((req: Req, res: Res, next: express$NextFunction) => mixed) |
   ((error: Error, req: Req, res: Res, next: express$NextFunction) => mixed);
 
 declare interface express$RouteMethodType<
   T,
-  Req: express$Request,
-  Res: express$Response,
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
 > {
   (middleware: express$Middleware<Req, Res>): T;
   (...middleware: Array<express$Middleware<Req, Res>>): T;
@@ -129,7 +132,10 @@ declare interface express$RouteMethodType<
   ): T;
 }
 
-declare class express$Route<Req: express$Request, Res: express$Response> {
+declare class express$Route<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> {
   all: express$RouteMethodType<this, Req, Res>;
   get: express$RouteMethodType<this, Req, Res>;
   post: express$RouteMethodType<this, Req, Res>;
@@ -162,8 +168,8 @@ declare class express$Route<Req: express$Request, Res: express$Response> {
 }
 
 declare class express$Router<
-  Req: express$Request,
-  Res: express$Response,
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
 > extends express$Route<Req, Res> {
   constructor(options?: express$RouterOptions): void;
   route(path: string): express$Route<Req, Res>;
@@ -208,8 +214,8 @@ not be deemed to lack type coverage.
 */
 
 declare class express$Application<
-  Req: express$Request,
-  Res: express$Response,
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
 > extends express$Router<Req, Res> mixins events$EventEmitter {
   constructor(): void;
   locals: { [name: string]: mixed };
@@ -288,26 +294,26 @@ declare module "express" {
   declare export type RouterOptions = express$RouterOptions;
   declare export type CookieOptions = express$CookieOptions;
   declare export type Middleware<
-    Req: express$Request,
-    Res: express$Response,
+    Req: express$Request = express$Request,
+    Res: express$Response = express$Response,
   > = express$Middleware<Req, Res>;
   declare export type NextFunction = express$NextFunction;
   declare export type RequestParams = express$RequestParams;
   declare export type $Response = express$Response;
   declare export type $Request = express$Request;
   declare export type $Application<
-    Req: express$Request,
-    Res: express$Response,
+    Req: express$Request = express$Request,
+    Res: express$Response = express$Response,
   > = express$Application<Req, Res>;
 
   declare module.exports: {
     // If you try to call like a function, it will use this signature
     <Req: express$Request, Res: express$Response>(): express$Application<Req, Res>,
-    json: (opts: ?JsonOptions) => express$Middleware<express$Request, express$Response>,
+    json: (opts: ?JsonOptions) => express$Middleware<>,
     // `static` property on the function
     static: <Req: express$Request, Res: express$Response>(root: string, options?: Object) => express$Middleware<Req, Res>,
     // `Router` property on the function
     Router: typeof express$Router,
-    urlencoded: (opts: ?express$UrlEncodedOptions) => express$Middleware<express$Request, express$Response>,
+    urlencoded: (opts: ?express$UrlEncodedOptions) => express$Middleware<>,
   };
 }

--- a/definitions/npm/express_v4.16.x/flow_v0.94.x-v0.103.x/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.94.x-v0.103.x/express_v4.16.x.js
@@ -5,7 +5,7 @@ declare type express$RouterOptions = {
 };
 
 declare class express$RequestResponseBase {
-  app: express$Application;
+  app: express$Application<any, any>;
   get(field: string): string | void;
 }
 
@@ -112,81 +112,84 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 }
 
 declare type express$NextFunction = (err?: ?Error | "route") => mixed;
-declare type express$Middleware =
-  | ((
-      req: express$Request,
-      res: express$Response,
-      next: express$NextFunction
-    ) => mixed)
-  | ((
-      error: Error,
-      req: express$Request,
-      res: express$Response,
-      next: express$NextFunction
-    ) => mixed);
-declare interface express$RouteMethodType<T> {
-  (middleware: express$Middleware): T;
-  (...middleware: Array<express$Middleware>): T;
+declare type express$Middleware<Req: express$Request, Res: express$Response> =
+  ((req: Req, res: Res, next: express$NextFunction) => mixed) |
+  ((error: Error, req: Req, res: Res, next: express$NextFunction) => mixed);
+
+declare interface express$RouteMethodType<
+  T,
+  Req: express$Request,
+  Res: express$Response,
+> {
+  (middleware: express$Middleware<Req, Res>): T;
+  (...middleware: Array<express$Middleware<Req, Res>>): T;
   (
-    path: express$Path | express$Path[],
-    ...middleware: Array<express$Middleware>
+    path: express$Path | $ReadOnlyArray<express$Path>,
+    ...middleware: Array<express$Middleware<Req, Res>>
   ): T;
 }
-declare class express$Route {
-  all: express$RouteMethodType<this>;
-  get: express$RouteMethodType<this>;
-  post: express$RouteMethodType<this>;
-  put: express$RouteMethodType<this>;
-  head: express$RouteMethodType<this>;
-  delete: express$RouteMethodType<this>;
-  options: express$RouteMethodType<this>;
-  trace: express$RouteMethodType<this>;
-  copy: express$RouteMethodType<this>;
-  lock: express$RouteMethodType<this>;
-  mkcol: express$RouteMethodType<this>;
-  move: express$RouteMethodType<this>;
-  purge: express$RouteMethodType<this>;
-  propfind: express$RouteMethodType<this>;
-  proppatch: express$RouteMethodType<this>;
-  unlock: express$RouteMethodType<this>;
-  report: express$RouteMethodType<this>;
-  mkactivity: express$RouteMethodType<this>;
-  checkout: express$RouteMethodType<this>;
-  merge: express$RouteMethodType<this>;
+
+declare class express$Route<Req: express$Request, Res: express$Response> {
+  all: express$RouteMethodType<this, Req, Res>;
+  get: express$RouteMethodType<this, Req, Res>;
+  post: express$RouteMethodType<this, Req, Res>;
+  put: express$RouteMethodType<this, Req, Res>;
+  head: express$RouteMethodType<this, Req, Res>;
+  delete: express$RouteMethodType<this, Req, Res>;
+  options: express$RouteMethodType<this, Req, Res>;
+  trace: express$RouteMethodType<this, Req, Res>;
+  copy: express$RouteMethodType<this, Req, Res>;
+  lock: express$RouteMethodType<this, Req, Res>;
+  mkcol: express$RouteMethodType<this, Req, Res>;
+  move: express$RouteMethodType<this, Req, Res>;
+  purge: express$RouteMethodType<this, Req, Res>;
+  propfind: express$RouteMethodType<this, Req, Res>;
+  proppatch: express$RouteMethodType<this, Req, Res>;
+  unlock: express$RouteMethodType<this, Req, Res>;
+  report: express$RouteMethodType<this, Req, Res>;
+  mkactivity: express$RouteMethodType<this, Req, Res>;
+  checkout: express$RouteMethodType<this, Req, Res>;
+  merge: express$RouteMethodType<this, Req, Res>;
 
   // @TODO Missing 'm-search' but get flow illegal name error.
 
-  notify: express$RouteMethodType<this>;
-  subscribe: express$RouteMethodType<this>;
-  unsubscribe: express$RouteMethodType<this>;
-  patch: express$RouteMethodType<this>;
-  search: express$RouteMethodType<this>;
-  connect: express$RouteMethodType<this>;
+  notify: express$RouteMethodType<this, Req, Res>;
+  subscribe: express$RouteMethodType<this, Req, Res>;
+  unsubscribe: express$RouteMethodType<this, Req, Res>;
+  patch: express$RouteMethodType<this, Req, Res>;
+  search: express$RouteMethodType<this, Req, Res>;
+  connect: express$RouteMethodType<this, Req, Res>;
 }
 
-declare class express$Router extends express$Route {
+declare class express$Router<
+  Req: express$Request,
+  Res: express$Response,
+> extends express$Route<Req, Res> {
   constructor(options?: express$RouterOptions): void;
-  route(path: string): express$Route;
-  static (options?: express$RouterOptions): express$Router;
-  use(middleware: express$Middleware): this;
-  use(...middleware: Array<express$Middleware>): this;
+  route(path: string): express$Route<Req, Res>;
+  static <Req2: express$Request, Res2: express$Response>(
+    options?: express$RouterOptions,
+  ): express$Router<Req2, Res2>;
+  use(middleware: express$Middleware<Req, Res>): this;
+  use(...middleware: Array<express$Middleware<Req, Res>>): this;
   use(
-    path: express$Path | express$Path[],
-    ...middleware: Array<express$Middleware>
+    path: express$Path | $ReadOnlyArray<express$Path>,
+    ...middleware: Array<express$Middleware<Req, Res>>
   ): this;
-  use(path: string, router: express$Router): this;
+  use(path: string, router: express$Router<Req, Res>): this;
   handle(
     req: http$IncomingMessage<>,
     res: http$ServerResponse,
     next: express$NextFunction
   ): void;
-  param(
+  param<Req: express$Request>(
     param: string,
     callback: (
-      req: express$Request,
+      req: Req,
       res: express$Response,
       next: express$NextFunction,
-      id: string
+      value: string,
+      paramName: string,
     ) => mixed
   ): void;
   (
@@ -204,7 +207,10 @@ To work around this issue, we changed Server to ?Server here, so that our invoca
 not be deemed to lack type coverage.
 */
 
-declare class express$Application extends express$Router mixins events$EventEmitter {
+declare class express$Application<
+  Req: express$Request,
+  Res: express$Response,
+> extends express$Router<Req, Res> mixins events$EventEmitter {
   constructor(): void;
   locals: { [name: string]: mixed };
   mountpath: string;
@@ -224,7 +230,7 @@ declare class express$Application extends express$Router mixins events$EventEmit
   listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http$Server;
   disable(name: string): void;
   disabled(name: string): boolean;
-  enable(name: string): express$Application;
+  enable(name: string): this;
   enabled(name: string): boolean;
   engine(name: string, callback: Function): void;
   /**
@@ -281,18 +287,27 @@ declare type express$UrlEncodedOptions = {
 declare module "express" {
   declare export type RouterOptions = express$RouterOptions;
   declare export type CookieOptions = express$CookieOptions;
-  declare export type Middleware = express$Middleware;
+  declare export type Middleware<
+    Req: express$Request,
+    Res: express$Response,
+  > = express$Middleware<Req, Res>;
   declare export type NextFunction = express$NextFunction;
   declare export type RequestParams = express$RequestParams;
   declare export type $Response = express$Response;
   declare export type $Request = express$Request;
-  declare export type $Application = express$Application;
+  declare export type $Application<
+    Req: express$Request,
+    Res: express$Response,
+  > = express$Application<Req, Res>;
 
   declare module.exports: {
-    (): express$Application, // If you try to call like a function, it will use this signature
-    json: (opts: ?JsonOptions) => express$Middleware,
-    static: (root: string, options?: Object) => express$Middleware, // `static` property on the function
-    Router: typeof express$Router, // `Router` property on the function
-    urlencoded: (opts: ?express$UrlEncodedOptions) => express$Middleware,
+    // If you try to call like a function, it will use this signature
+    <Req: express$Request, Res: express$Response>(): express$Application<Req, Res>,
+    json: (opts: ?JsonOptions) => express$Middleware<express$Request, express$Response>,
+    // `static` property on the function
+    static: <Req: express$Request, Res: express$Response>(root: string, options?: Object) => express$Middleware<Req, Res>,
+    // `Router` property on the function
+    Router: typeof express$Router,
+    urlencoded: (opts: ?express$UrlEncodedOptions) => express$Middleware<express$Request, express$Response>,
   };
 }

--- a/definitions/npm/express_v4.16.x/flow_v0.94.x-v0.103.x/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.94.x-v0.103.x/express_v4.16.x.js
@@ -13,6 +13,33 @@ declare type express$RequestParams = {
   [param: string]: string
 };
 
+/*
+  NOTE: Use caution when extending `express$Request` or `express$Response`. When
+  a request first hits the server, its `req` and `res` will not have any
+  additional properties, even if you explicitly type them with your custom
+  subclass. Subsequent middleware may assign these properties, but you must be
+  cognizant of this ordering. One way to handle this is marking all properties
+  as optional to force refinement every time a property is accessed. Therefore,
+  we advise that you always mark properties as _optional_ in `express$Request`
+  and `express$Response` subclasses.
+
+  You may decide not to do this, in which case the typings will be unsound and
+  the behavior will be similar to how arrays work in Flow. See here for more
+  information: https://flow.org/en/docs/types/arrays/#toc-array-access-is-unsafe
+
+  See #3578 and #3337 for additional discussion. If you have ideas on how to
+  improve these typings, please share them in #3578 or open a new issue.
+
+  **BAD**
+  declare class test_express$CustomRequest extends express$Request {
+    foo: string;
+  }
+
+  **GOOD**
+  declare class test_express$CustomRequest extends express$Request {
+    foo: string | void;
+  }
+*/
 declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
   baseUrl: string;
   body: mixed;

--- a/definitions/npm/express_v4.16.x/flow_v0.94.x-v0.103.x/test_overrideUseMethodClassExtension.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.94.x-v0.103.x/test_overrideUseMethodClassExtension.js
@@ -10,40 +10,26 @@ declare class test_express$CustomResponse extends express$Response {
   bar: string;
 }
 
-declare type test_express$CustomPath = string | RegExp;
+declare type expressConstructor =
+  <Req: express$Request, Res: express$Response>() => express$Application<Req, Res>;
 
-declare type test_express$CustomNextFunction = express$NextFunction;
-
-declare type test_express$CustomMiddleware =
-  | ((
-      req: test_express$CustomRequest,
-      res: test_express$CustomResponse,
-      next: test_express$CustomNextFunction
-    ) => mixed)
-  | ((
-      error: Error,
-      req: test_express$CustomRequest,
-      res: test_express$CustomResponse,
-      next: test_express$CustomNextFunction
-    ) => mixed);
-
-declare class test_express$CustomApplication extends express$Application {
-  constructor(expressConstructor: () => express$Application): this;
-  use(middleware: test_express$CustomMiddleware): this;
-  use(...middleware: Array<test_express$CustomMiddleware>): this;
-  use(
-    path: test_express$CustomPath | test_express$CustomPath[],
-    ...middleware: Array<test_express$CustomMiddleware>
-  ): this;
-  use(path: string, router: express$Router): this;
+declare class test_express$CustomApplication extends express$Application<
+  test_express$CustomRequest,
+  test_express$CustomResponse,
+> {
+  constructor(expressConstructor: expressConstructor): this;
 }
 
 // Class Extensions: Test Functions
 function test_express$CustomApplication(
-  expressConstructor: () => express$Application
+  expressConstructor: expressConstructor,
 ) {
   const express = expressConstructor();
-  express.use((req: any, res: any, next: express$NextFunction) => {
+  express.use((
+    req: test_express$CustomRequest,
+    res: test_express$CustomResponse,
+    next: express$NextFunction,
+  ) => {
     // Private Constructor Mutation: Add new properties
     req.foo = "hello";
     res.bar = "goodbye";
@@ -73,7 +59,7 @@ customApp.use(
   (
     req: test_express$CustomRequest,
     res: test_express$CustomResponse,
-    next: test_express$CustomNextFunction
+    next: express$NextFunction
   ) => {
     req.foo;
     res.bar;

--- a/definitions/npm/express_v4.16.x/flow_v0.94.x-v0.103.x/test_response.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.94.x-v0.103.x/test_response.js
@@ -27,6 +27,18 @@ app.use(
 );
 app.post("/post-router-callable", router);
 
+// Can set a custom param on request
+app.param('test', (
+  req: express$Request & { testValue: string },
+  res: express$Response,
+  next: express$NextFunction,
+  id: string,
+  paramName: string,
+) => {
+  req.testValue = id;
+  next();
+});
+
 // Can use an express app directly as a server listener
 const httpServer = http.createServer(app);
 httpServer.listen(9000);

--- a/definitions/npm/express_v4.16.x/test_express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/test_express_v4.16.x.js
@@ -65,7 +65,7 @@ myRouter.use(
   }
 );
 
-app.on('mount', (parent: express$Application<express$Request, express$Response>) => {
+app.on('mount', (parent: express$Application<>) => {
   console.log("Parent Loaded", parent);
   // $ExpectError
   parent.fail();
@@ -77,7 +77,7 @@ app.use("/foo", (req: express$Request, res: express$Response, next) => {
   res.send("should work").status(300);
 });
 
-const bar: express$Router<express$Request, express$Response> = new Router();
+const bar: express$Router<> = new Router();
 
 bar.get("/", (req: express$Request, res: express$Response): void => {
   // $ExpectError should be of type object
@@ -117,7 +117,7 @@ app.enable(100);
 // $ExpectError
 const f: number = app.enabled("100");
 
-const g: express$Application<express$Request, express$Response> = app.enable('foo');
+const g: express$Application<> = app.enable('foo');
 
 app.render(
   "view",

--- a/definitions/npm/express_v4.16.x/test_express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/test_express_v4.16.x.js
@@ -65,7 +65,7 @@ myRouter.use(
   }
 );
 
-app.on("mount", (parent: express$Application) => {
+app.on('mount', (parent: express$Application<express$Request, express$Response>) => {
   console.log("Parent Loaded", parent);
   // $ExpectError
   parent.fail();
@@ -77,7 +77,7 @@ app.use("/foo", (req: express$Request, res: express$Response, next) => {
   res.send("should work").status(300);
 });
 
-const bar: express$Router = new Router();
+const bar: express$Router<express$Request, express$Response> = new Router();
 
 bar.get("/", (req: express$Request, res: express$Response): void => {
   // $ExpectError should be of type object
@@ -117,7 +117,7 @@ app.enable(100);
 // $ExpectError
 const f: number = app.enabled("100");
 
-const g: express$Application = app.enable("foo");
+const g: express$Application<express$Request, express$Response> = app.enable('foo');
 
 app.render(
   "view",

--- a/definitions/npm/express_v4.17.x/flow_v0.104.x-/express_v4.17.x.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.104.x-/express_v4.17.x.js
@@ -1,0 +1,323 @@
+declare type express$RouterOptions = {
+  caseSensitive?: boolean,
+  mergeParams?: boolean,
+  strict?: boolean,
+  ...
+};
+
+declare class express$RequestResponseBase {
+  app: express$Application<any, any>;
+  get(field: string): string | void;
+}
+
+declare type express$RequestParams = { [param: string]: string, ... };
+
+declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
+  baseUrl: string;
+  body: mixed;
+  cookies: { [cookie: string]: string, ... };
+  connection: net$Socket;
+  fresh: boolean;
+  hostname: string;
+  ip: string;
+  ips: Array<string>;
+  method: string;
+  originalUrl: string;
+  params: express$RequestParams;
+  path: string;
+  protocol: "https" | "http";
+  query: { [name: string]: string | Array<string>, ... };
+  route: string;
+  secure: boolean;
+  signedCookies: { [signedCookie: string]: string, ... };
+  stale: boolean;
+  subdomains: Array<string>;
+  xhr: boolean;
+  accepts(types: string): string | false;
+  accepts(types: Array<string>): string | false;
+  acceptsCharsets(...charsets: Array<string>): string | false;
+  acceptsEncodings(...encoding: Array<string>): string | false;
+  acceptsLanguages(...lang: Array<string>): string | false;
+  header(field: string): string | void;
+  is(type: string): string | false;
+  param(name: string, defaultValue?: string): string | void;
+}
+
+declare type express$CookieOptions = {
+  domain?: string,
+  encode?: (value: string) => string,
+  expires?: Date,
+  httpOnly?: boolean,
+  maxAge?: number,
+  path?: string,
+  secure?: boolean,
+  signed?: boolean,
+  ...
+};
+
+declare type express$Path = string | RegExp;
+
+declare type express$RenderCallback = (
+  err: Error | null,
+  html?: string
+) => mixed;
+
+declare type express$SendFileOptions = {
+  maxAge?: number,
+  root?: string,
+  lastModified?: boolean,
+  headers?: { [name: string]: string, ... },
+  dotfiles?: "allow" | "deny" | "ignore",
+  ...
+};
+
+declare class express$Response extends http$ServerResponse mixins express$RequestResponseBase {
+  headersSent: boolean;
+  locals: { [name: string]: mixed, ... };
+  append(field: string, value?: string): this;
+  attachment(filename?: string): this;
+  cookie(name: string, value: string, options?: express$CookieOptions): this;
+  clearCookie(name: string, options?: express$CookieOptions): this;
+  download(
+    path: string,
+    filename?: string,
+    callback?: (err?: ?Error) => void
+  ): this;
+  format(typesObject: { [type: string]: Function, ... }): this;
+  json(body?: mixed): this;
+  jsonp(body?: mixed): this;
+  links(links: { [name: string]: string, ... }): this;
+  location(path: string): this;
+  redirect(url: string, ...args: Array<void>): this;
+  redirect(status: number, url: string, ...args: Array<void>): this;
+  render(
+    view: string,
+    locals?: { [name: string]: mixed, ... },
+    callback?: express$RenderCallback
+  ): this;
+  send(body?: mixed): this;
+  sendFile(
+    path: string,
+    options?: express$SendFileOptions,
+    callback?: (err?: ?Error) => mixed
+  ): this;
+  sendStatus(statusCode: number): this;
+  header(field: string, value?: string): this;
+  header(headers: { [name: string]: string, ... }): this;
+  set(field: string, value?: string | string[]): this;
+  set(headers: { [name: string]: string, ... }): this;
+  status(statusCode: number): this;
+  type(type: string): this;
+  vary(field: string): this;
+  req: express$Request;
+}
+
+declare type express$NextFunction = (err?: ?Error | "route") => mixed;
+declare type express$Middleware<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> =
+  ((req: Req, res: Res, next: express$NextFunction) => mixed) |
+  ((error: Error, req: Req, res: Res, next: express$NextFunction) => mixed);
+
+declare interface express$RouteMethodType<
+  T,
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> {
+  (middleware: express$Middleware<Req, Res>): T;
+  (...middleware: Array<express$Middleware<Req, Res>>): T;
+  (
+    path: express$Path | $ReadOnlyArray<express$Path>,
+    ...middleware: Array<express$Middleware<Req, Res>>
+  ): T;
+}
+
+declare class express$Route<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> {
+  all: express$RouteMethodType<this, Req, Res>;
+  get: express$RouteMethodType<this, Req, Res>;
+  post: express$RouteMethodType<this, Req, Res>;
+  put: express$RouteMethodType<this, Req, Res>;
+  head: express$RouteMethodType<this, Req, Res>;
+  delete: express$RouteMethodType<this, Req, Res>;
+  options: express$RouteMethodType<this, Req, Res>;
+  trace: express$RouteMethodType<this, Req, Res>;
+  copy: express$RouteMethodType<this, Req, Res>;
+  lock: express$RouteMethodType<this, Req, Res>;
+  mkcol: express$RouteMethodType<this, Req, Res>;
+  move: express$RouteMethodType<this, Req, Res>;
+  purge: express$RouteMethodType<this, Req, Res>;
+  propfind: express$RouteMethodType<this, Req, Res>;
+  proppatch: express$RouteMethodType<this, Req, Res>;
+  unlock: express$RouteMethodType<this, Req, Res>;
+  report: express$RouteMethodType<this, Req, Res>;
+  mkactivity: express$RouteMethodType<this, Req, Res>;
+  checkout: express$RouteMethodType<this, Req, Res>;
+  merge: express$RouteMethodType<this, Req, Res>;
+
+  // @TODO Missing 'm-search' but get flow illegal name error.
+
+  notify: express$RouteMethodType<this, Req, Res>;
+  subscribe: express$RouteMethodType<this, Req, Res>;
+  unsubscribe: express$RouteMethodType<this, Req, Res>;
+  patch: express$RouteMethodType<this, Req, Res>;
+  search: express$RouteMethodType<this, Req, Res>;
+  connect: express$RouteMethodType<this, Req, Res>;
+}
+
+declare class express$Router<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> extends express$Route<Req, Res> {
+  constructor(options?: express$RouterOptions): void;
+  route(path: string): express$Route<Req, Res>;
+  static <Req2: express$Request, Res2: express$Response>(
+    options?: express$RouterOptions,
+  ): express$Router<Req2, Res2>;
+  use(middleware: express$Middleware<Req, Res>): this;
+  use(...middleware: Array<express$Middleware<Req, Res>>): this;
+  use(
+    path: express$Path | $ReadOnlyArray<express$Path>,
+    ...middleware: Array<express$Middleware<Req, Res>>
+  ): this;
+  use(path: string, router: express$Router<Req, Res>): this;
+  handle(
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    next: express$NextFunction
+  ): void;
+  param(
+    param: string,
+    callback: (
+      req: Req,
+      res: Res,
+      next: express$NextFunction,
+      value: string,
+      paramName: string,
+    ) => mixed
+  ): void;
+  (
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+}
+
+/*
+With flow-bin ^0.59, express app.listen() is deemed to return any and fails flow type coverage.
+Which is ironic because https://github.com/facebook/flow/blob/master/Changelog.md#misc-2 (release notes for 0.59)
+says "Improves typings for Node.js HTTP server listen() function."  See that?  IMPROVES!
+To work around this issue, we changed Server to ?Server here, so that our invocations of express.listen() will
+not be deemed to lack type coverage.
+*/
+
+declare class express$Application<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> extends express$Router<Req, Res> mixins events$EventEmitter {
+  constructor(): void;
+  locals: { [name: string]: mixed, ... };
+  mountpath: string;
+  listen(
+    port: number,
+    hostname?: string,
+    backlog?: number,
+    callback?: (err?: ?Error) => mixed
+  ): ?http$Server;
+  listen(
+    port: number,
+    hostname?: string,
+    callback?: (err?: ?Error) => mixed
+  ): ?http$Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http$Server;
+  disable(name: string): void;
+  disabled(name: string): boolean;
+  enable(name: string): this;
+  enabled(name: string): boolean;
+  engine(name: string, callback: Function): void;
+  /**
+   * Mixed will not be taken as a value option. Issue around using the GET http method name and the get for settings.
+   */
+  //   get(name: string): mixed;
+  set(name: string, value: mixed): mixed;
+  render(
+    name: string,
+    optionsOrFunction: { [name: string]: mixed, ... },
+    callback: express$RenderCallback
+  ): void;
+  handle(
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+  // callable signature is not inherited
+  (
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+}
+
+declare type JsonOptions = {
+  inflate?: boolean,
+  limit?: string | number,
+  reviver?: (key: string, value: mixed) => mixed,
+  strict?: boolean,
+  type?: string | Array<string> | ((req: express$Request) => boolean),
+  verify?: (
+    req: express$Request,
+    res: express$Response,
+    buf: Buffer,
+    encoding: string
+  ) => mixed,
+  ...
+};
+
+declare type express$UrlEncodedOptions = {
+  extended?: boolean,
+  inflate?: boolean,
+  limit?: string | number,
+  parameterLimit?: number,
+  type?: string | Array<string> | ((req: express$Request) => boolean),
+  verify?: (
+    req: express$Request,
+    res: express$Response,
+    buf: Buffer,
+    encoding: string
+  ) => mixed,
+  ...
+}
+
+declare module "express" {
+  declare export type RouterOptions = express$RouterOptions;
+  declare export type CookieOptions = express$CookieOptions;
+  declare export type Middleware<
+    Req: express$Request = express$Request,
+    Res: express$Response = express$Response,
+  > = express$Middleware<Req, Res>;
+  declare export type NextFunction = express$NextFunction;
+  declare export type RequestParams = express$RequestParams;
+  declare export type $Response = express$Response;
+  declare export type $Request = express$Request;
+  declare export type $Application<
+    Req: express$Request = express$Request,
+    Res: express$Response = express$Response,
+  > = express$Application<Req, Res>;
+
+  declare module.exports: {
+    // If you try to call like a function, it will use this signature
+    <Req: express$Request, Res: express$Response>(): express$Application<Req, Res>,
+    json: (opts: ?JsonOptions) => express$Middleware<>,
+    // `static` property on the function
+    static: <Req: express$Request, Res: express$Response>(root: string, options?: Object) => express$Middleware<Req, Res>,
+    // `Router` property on the function
+    Router: typeof express$Router,
+    urlencoded: (opts: ?express$UrlEncodedOptions) => express$Middleware<>,
+    ...
+  };
+}

--- a/definitions/npm/express_v4.17.x/flow_v0.104.x-/express_v4.17.x.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.104.x-/express_v4.17.x.js
@@ -12,6 +12,33 @@ declare class express$RequestResponseBase {
 
 declare type express$RequestParams = { [param: string]: string, ... };
 
+/*
+  NOTE: Use caution when extending `express$Request` or `express$Response`. When
+  a request first hits the server, its `req` and `res` will not have any
+  additional properties, even if you explicitly type them with your custom
+  subclass. Subsequent middleware may assign these properties, but you must be
+  cognizant of this ordering. One way to handle this is marking all properties
+  as optional to force refinement every time a property is accessed. Therefore,
+  we advise that you always mark properties as _optional_ in `express$Request`
+  and `express$Response` subclasses.
+
+  You may decide not to do this, in which case the typings will be unsound and
+  the behavior will be similar to how arrays work in Flow. See here for more
+  information: https://flow.org/en/docs/types/arrays/#toc-array-access-is-unsafe
+
+  See #3578 and #3337 for additional discussion. If you have ideas on how to
+  improve these typings, please share them in #3578 or open a new issue.
+
+  **BAD**
+  declare class test_express$CustomRequest extends express$Request {
+    foo: string;
+  }
+
+  **GOOD**
+  declare class test_express$CustomRequest extends express$Request {
+    foo: string | void;
+  }
+*/
 declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
   baseUrl: string;
   body: mixed;

--- a/definitions/npm/express_v4.17.x/flow_v0.104.x-/test_overrideUseMethodClassExtension.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.104.x-/test_overrideUseMethodClassExtension.js
@@ -1,0 +1,76 @@
+// @flow
+import express from "express";
+
+// Class Extensions: Global Class/Type Declarations (prefixed to prevent name clashes)
+// Use method needs to be covarient: https://github.com/facebook/flow/issues/2770#issuecomment-258955097
+declare class test_express$CustomRequest extends express$Request {
+  foo: string;
+}
+declare class test_express$CustomResponse extends express$Response {
+  bar: string;
+}
+
+declare type expressConstructor =
+  <Req: express$Request, Res: express$Response>() => express$Application<Req, Res>;
+
+declare class test_express$CustomApplication extends express$Application<
+  test_express$CustomRequest,
+  test_express$CustomResponse,
+> {
+  constructor(expressConstructor: expressConstructor): this;
+}
+
+// Class Extensions: Test Functions
+function test_express$CustomApplication(
+  expressConstructor: expressConstructor,
+) {
+  const express = expressConstructor();
+  express.use((
+    req: test_express$CustomRequest,
+    res: test_express$CustomResponse,
+    next: express$NextFunction,
+  ) => {
+    // Private Constructor Mutation: Add new properties
+    req.foo = "hello";
+    res.bar = "goodbye";
+    next();
+  });
+  return express;
+}
+
+// Class Extensions: Test
+const customApp = new test_express$CustomApplication(express);
+
+// $ExpectError
+const customApp_error = new test_express$CustomApplication();
+
+customApp.use(
+  "/something",
+  (req: express$Request, res: express$Response, next: express$NextFunction) => {
+    // $ExpectError
+    req.foo;
+    // $ExpectError
+    res.bar;
+    next();
+  }
+);
+customApp.use(
+  "/something",
+  (
+    req: test_express$CustomRequest,
+    res: test_express$CustomResponse,
+    next: express$NextFunction
+  ) => {
+    req.foo;
+    res.bar;
+    // $ExpectError
+    req.notHere;
+    // $ExpectError
+    res.notHere;
+  }
+);
+
+// $ExpectError
+customApp.use("/something", (req: string, res: string, next: Function) => {
+  next();
+});

--- a/definitions/npm/express_v4.17.x/flow_v0.104.x-/test_response.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.104.x-/test_response.js
@@ -1,0 +1,52 @@
+// @flow
+
+import express, { Router } from "express";
+import http from "http";
+
+const app = express();
+
+app.use("/response_api", (req: express$Request, res: express$Response) => {
+  const contentLength = String(2);
+  res.set("Content-Length", contentLength);
+  res.set("Content-Type", "application/json");
+  res.writeHead(200, {
+    "Content-Length": contentLength,
+    "Content-Type": "application/json"
+  });
+  res.end("{}");
+  res.req;
+});
+
+// Can manually invoke router.handle() to handle a request.
+const router = new Router();
+app.use(
+  "/router",
+  (req: express$Request, res: express$Response, next: express$NextFunction) => {
+    router.handle(req, res, next);
+  }
+);
+app.post("/post-router-callable", router);
+
+// Can set a custom param on request
+app.param('test', (
+  req: express$Request & { testValue: string, ... },
+  res: express$Response,
+  next: express$NextFunction,
+  id: string,
+  paramName: string,
+) => {
+  req.testValue = id;
+  next();
+});
+
+// Can use an express app directly as a server listener
+const httpServer = http.createServer(app);
+httpServer.listen(9000);
+
+const badHttpServer = null;
+// $ExpectError
+badHttpServer.listen();
+
+// Can manually invoke app.handle() to handle a request
+const httpServer2 = http.createServer((req, res) => app.handle(req, res));
+httpServer.listen(9000);

--- a/definitions/npm/express_v4.17.x/flow_v0.32.x-v0.92.x/express_v4.17.x.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.32.x-v0.92.x/express_v4.17.x.js
@@ -1,0 +1,300 @@
+import * as http from "http";
+
+declare type express$RouterOptions = {
+  caseSensitive?: boolean,
+  mergeParams?: boolean,
+  strict?: boolean
+};
+
+declare class express$RequestResponseBase {
+  app: express$Application;
+  get(field: string): string | void;
+}
+
+declare type express$RequestParams = {
+  [param: string]: string
+};
+
+declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
+  baseUrl: string;
+  body: mixed;
+  cookies: { [cookie: string]: string };
+  connection: net$Socket;
+  fresh: boolean;
+  hostname: string;
+  ip: string;
+  ips: Array<string>;
+  method: string;
+  originalUrl: string;
+  params: express$RequestParams;
+  path: string;
+  protocol: "https" | "http";
+  query: { [name: string]: string | Array<string> };
+  route: string;
+  secure: boolean;
+  signedCookies: { [signedCookie: string]: string };
+  stale: boolean;
+  subdomains: Array<string>;
+  xhr: boolean;
+  accepts(types: string): string | false;
+  accepts(types: Array<string>): string | false;
+  acceptsCharsets(...charsets: Array<string>): string | false;
+  acceptsEncodings(...encoding: Array<string>): string | false;
+  acceptsLanguages(...lang: Array<string>): string | false;
+  header(field: string): string | void;
+  is(type: string): string | false;
+  param(name: string, defaultValue?: string): string | void;
+}
+
+declare type express$CookieOptions = {
+  domain?: string,
+  encode?: (value: string) => string,
+  expires?: Date,
+  httpOnly?: boolean,
+  maxAge?: number,
+  path?: string,
+  secure?: boolean,
+  signed?: boolean
+};
+
+declare type express$Path = string | RegExp;
+
+declare type express$RenderCallback = (
+  err: Error | null,
+  html?: string
+) => mixed;
+
+declare type express$SendFileOptions = {
+  maxAge?: number,
+  root?: string,
+  lastModified?: boolean,
+  headers?: { [name: string]: string },
+  dotfiles?: "allow" | "deny" | "ignore"
+};
+
+declare class express$Response extends http$ServerResponse mixins express$RequestResponseBase {
+  headersSent: boolean;
+  locals: { [name: string]: mixed };
+  append(field: string, value?: string): this;
+  attachment(filename?: string): this;
+  cookie(name: string, value: string, options?: express$CookieOptions): this;
+  clearCookie(name: string, options?: express$CookieOptions): this;
+  download(
+    path: string,
+    filename?: string,
+    callback?: (err?: ?Error) => void
+  ): this;
+  format(typesObject: { [type: string]: Function }): this;
+  json(body?: mixed): this;
+  jsonp(body?: mixed): this;
+  links(links: { [name: string]: string }): this;
+  location(path: string): this;
+  redirect(url: string, ...args: Array<void>): this;
+  redirect(status: number, url: string, ...args: Array<void>): this;
+  render(
+    view: string,
+    locals?: { [name: string]: mixed },
+    callback?: express$RenderCallback
+  ): this;
+  send(body?: mixed): this;
+  sendFile(
+    path: string,
+    options?: express$SendFileOptions,
+    callback?: (err?: ?Error) => mixed
+  ): this;
+  sendStatus(statusCode: number): this;
+  header(field: string, value?: string): this;
+  header(headers: { [name: string]: string }): this;
+  set(field: string, value?: string | string[]): this;
+  set(headers: { [name: string]: string }): this;
+  status(statusCode: number): this;
+  type(type: string): this;
+  vary(field: string): this;
+  req: express$Request;
+}
+
+declare type express$NextFunction = (err?: ?Error | "route") => mixed;
+declare type express$Middleware =
+  | ((
+      req: $Subtype<express$Request>,
+      res: express$Response,
+      next: express$NextFunction
+    ) => mixed)
+  | ((
+      error: Error,
+      req: $Subtype<express$Request>,
+      res: express$Response,
+      next: express$NextFunction
+    ) => mixed);
+declare interface express$RouteMethodType<T> {
+  (middleware: express$Middleware): T;
+  (...middleware: Array<express$Middleware>): T;
+  (
+    path: express$Path | express$Path[],
+    ...middleware: Array<express$Middleware>
+  ): T;
+}
+declare class express$Route {
+  all: express$RouteMethodType<this>;
+  get: express$RouteMethodType<this>;
+  post: express$RouteMethodType<this>;
+  put: express$RouteMethodType<this>;
+  head: express$RouteMethodType<this>;
+  delete: express$RouteMethodType<this>;
+  options: express$RouteMethodType<this>;
+  trace: express$RouteMethodType<this>;
+  copy: express$RouteMethodType<this>;
+  lock: express$RouteMethodType<this>;
+  mkcol: express$RouteMethodType<this>;
+  move: express$RouteMethodType<this>;
+  purge: express$RouteMethodType<this>;
+  propfind: express$RouteMethodType<this>;
+  proppatch: express$RouteMethodType<this>;
+  unlock: express$RouteMethodType<this>;
+  report: express$RouteMethodType<this>;
+  mkactivity: express$RouteMethodType<this>;
+  checkout: express$RouteMethodType<this>;
+  merge: express$RouteMethodType<this>;
+
+  // @TODO Missing 'm-search' but get flow illegal name error.
+
+  notify: express$RouteMethodType<this>;
+  subscribe: express$RouteMethodType<this>;
+  unsubscribe: express$RouteMethodType<this>;
+  patch: express$RouteMethodType<this>;
+  search: express$RouteMethodType<this>;
+  connect: express$RouteMethodType<this>;
+}
+
+declare class express$Router extends express$Route {
+  constructor(options?: express$RouterOptions): void;
+  route(path: string): express$Route;
+  static (options?: express$RouterOptions): express$Router;
+  use(middleware: express$Middleware): this;
+  use(...middleware: Array<express$Middleware>): this;
+  use(
+    path: express$Path | express$Path[],
+    ...middleware: Array<express$Middleware>
+  ): this;
+  use(path: string, router: express$Router): this;
+  handle(
+    req: http$IncomingMessage,
+    res: http$ServerResponse,
+    next: express$NextFunction
+  ): void;
+  param(
+    param: string,
+    callback: (
+      req: $Subtype<express$Request>,
+      res: express$Response,
+      next: express$NextFunction,
+      id: string
+    ) => mixed
+  ): void;
+  (
+    req: http$IncomingMessage,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+}
+
+/*
+With flow-bin ^0.59, express app.listen() is deemed to return any and fails flow type coverage.
+Which is ironic because https://github.com/facebook/flow/blob/master/Changelog.md#misc-2 (release notes for 0.59)
+says "Improves typings for Node.js HTTP server listen() function."  See that?  IMPROVES!
+To work around this issue, we changed Server to ?Server here, so that our invocations of express.listen() will
+not be deemed to lack type coverage.
+*/
+
+declare class express$Application extends express$Router mixins events$EventEmitter {
+  constructor(): void;
+  locals: { [name: string]: mixed };
+  mountpath: string;
+  listen(
+    port: number,
+    hostname?: string,
+    backlog?: number,
+    callback?: (err?: ?Error) => mixed
+  ): ?http.Server;
+  listen(
+    port: number,
+    hostname?: string,
+    callback?: (err?: ?Error) => mixed
+  ): ?http.Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): ?http.Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): ?http.Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http.Server;
+  disable(name: string): void;
+  disabled(name: string): boolean;
+  enable(name: string): express$Application;
+  enabled(name: string): boolean;
+  engine(name: string, callback: Function): void;
+  /**
+   * Mixed will not be taken as a value option. Issue around using the GET http method name and the get for settings.
+   */
+  //   get(name: string): mixed;
+  set(name: string, value: mixed): mixed;
+  render(
+    name: string,
+    optionsOrFunction: { [name: string]: mixed },
+    callback: express$RenderCallback
+  ): void;
+  handle(
+    req: http$IncomingMessage,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+  // callable signature is not inherited
+  (
+    req: http$IncomingMessage,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+}
+
+declare type JsonOptions = {
+  inflate?: boolean,
+  limit?: string | number,
+  reviver?: (key: string, value: mixed) => mixed,
+  strict?: boolean,
+  type?: string | Array<string> | ((req: express$Request) => boolean),
+  verify?: (
+    req: express$Request,
+    res: express$Response,
+    buf: Buffer,
+    encoding: string
+  ) => mixed
+};
+
+declare type express$UrlEncodedOptions = {
+  extended?: boolean,
+  inflate?: boolean,
+  limit?: string | number,
+  parameterLimit?: number,
+  type?: string | Array<string> | ((req: express$Request) => boolean),
+  verify?: (
+    req: express$Request,
+    res: express$Response,
+    buf: Buffer,
+    encoding: string
+  ) => mixed,
+}
+
+declare module "express" {
+  declare export type RouterOptions = express$RouterOptions;
+  declare export type CookieOptions = express$CookieOptions;
+  declare export type Middleware = express$Middleware;
+  declare export type NextFunction = express$NextFunction;
+  declare export type RequestParams = express$RequestParams;
+  declare export type $Response = express$Response;
+  declare export type $Request = express$Request;
+  declare export type $Application = express$Application;
+
+  declare module.exports: {
+    (): express$Application, // If you try to call like a function, it will use this signature
+    json: (opts: ?JsonOptions) => express$Middleware,
+    static: (root: string, options?: Object) => express$Middleware, // `static` property on the function
+    Router: typeof express$Router, // `Router` property on the function
+    urlencoded: (opts: ?express$UrlEncodedOptions) => express$Middleware,
+  };
+}

--- a/definitions/npm/express_v4.17.x/flow_v0.32.x-v0.92.x/test_overrideUseMethodClassExtension.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.32.x-v0.92.x/test_overrideUseMethodClassExtension.js
@@ -1,0 +1,90 @@
+// @flow
+import express from "express";
+
+// Class Extensions: Global Class/Type Declarations (prefixed to prevent name clashes)
+// Use method needs to be covarient: https://github.com/facebook/flow/issues/2770#issuecomment-258955097
+declare class test_express$CustomRequest extends express$Request {
+  foo: string;
+}
+declare class test_express$CustomResponse extends express$Response {
+  bar: string;
+}
+
+declare type test_express$CustomPath = string | RegExp;
+
+declare type test_express$CustomNextFunction = express$NextFunction;
+
+declare type test_express$CustomMiddleware =
+  | ((
+      req: test_express$CustomRequest,
+      res: test_express$CustomResponse,
+      next: test_express$CustomNextFunction
+    ) => mixed)
+  | ((
+      error: Error,
+      req: test_express$CustomRequest,
+      res: test_express$CustomResponse,
+      next: test_express$CustomNextFunction
+    ) => mixed);
+
+declare class test_express$CustomApplication extends express$Application {
+  constructor(expressConstructor: () => express$Application): this;
+  use(middleware: test_express$CustomMiddleware): this;
+  use(...middleware: Array<test_express$CustomMiddleware>): this;
+  use(
+    path: test_express$CustomPath | test_express$CustomPath[],
+    ...middleware: Array<test_express$CustomMiddleware>
+  ): this;
+  use(path: string, router: express$Router): this;
+}
+
+// Class Extensions: Test Functions
+function test_express$CustomApplication(
+  expressConstructor: () => express$Application
+) {
+  const express = expressConstructor();
+  express.use((req: any, res: any, next: express$NextFunction) => {
+    // Private Constructor Mutation: Add new properties
+    req.foo = "hello";
+    res.bar = "goodbye";
+    next();
+  });
+  return express;
+}
+
+// Class Extensions: Test
+const customApp = new test_express$CustomApplication(express);
+
+// $ExpectError
+const customApp_error = new test_express$CustomApplication();
+
+customApp.use(
+  "/something",
+  (req: express$Request, res: express$Response, next: express$NextFunction) => {
+    // $ExpectError
+    req.foo;
+    // $ExpectError
+    res.bar;
+    next();
+  }
+);
+customApp.use(
+  "/something",
+  (
+    req: test_express$CustomRequest,
+    res: test_express$CustomResponse,
+    next: test_express$CustomNextFunction
+  ) => {
+    req.foo;
+    res.bar;
+    // $ExpectError
+    req.notHere;
+    // $ExpectError
+    res.notHere;
+  }
+);
+
+// $ExpectError
+customApp.use("/something", (req: string, res: string, next: Function) => {
+  next();
+});

--- a/definitions/npm/express_v4.17.x/flow_v0.32.x-v0.92.x/test_response.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.32.x-v0.92.x/test_response.js
@@ -1,0 +1,40 @@
+// @flow
+
+import express, { Router } from "express";
+import http from "http";
+
+const app = express();
+
+app.use("/response_api", (req: express$Request, res: express$Response) => {
+  const contentLength = String(2);
+  res.set("Content-Length", contentLength);
+  res.set("Content-Type", "application/json");
+  res.writeHead(200, {
+    "Content-Length": contentLength,
+    "Content-Type": "application/json"
+  });
+  res.end("{}");
+  res.req;
+});
+
+// Can manually invoke router.handle() to handle a request.
+const router = new Router();
+app.use(
+  "/router",
+  (req: express$Request, res: express$Response, next: express$NextFunction) => {
+    router.handle(req, res, next);
+  }
+);
+app.post("/post-router-callable", router);
+
+// Can use an express app directly as a server listener
+const httpServer = http.createServer(app);
+httpServer.listen(9000);
+
+const badHttpServer = null;
+// $ExpectError
+badHttpServer.listen();
+
+// Can manually invoke app.handle() to handle a request
+const httpServer2 = http.createServer((req, res) => app.handle(req, res));
+httpServer.listen(9000);

--- a/definitions/npm/express_v4.17.x/flow_v0.93.x-v0.93.x/express_v4.17.x.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.93.x-v0.93.x/express_v4.17.x.js
@@ -1,0 +1,300 @@
+import * as http from "http";
+
+declare type express$RouterOptions = {
+  caseSensitive?: boolean,
+  mergeParams?: boolean,
+  strict?: boolean
+};
+
+declare class express$RequestResponseBase {
+  app: express$Application;
+  get(field: string): string | void;
+}
+
+declare type express$RequestParams = {
+  [param: string]: string
+};
+
+declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
+  baseUrl: string;
+  body: mixed;
+  cookies: { [cookie: string]: string };
+  connection: net$Socket;
+  fresh: boolean;
+  hostname: string;
+  ip: string;
+  ips: Array<string>;
+  method: string;
+  originalUrl: string;
+  params: express$RequestParams;
+  path: string;
+  protocol: "https" | "http";
+  query: { [name: string]: string | Array<string> };
+  route: string;
+  secure: boolean;
+  signedCookies: { [signedCookie: string]: string };
+  stale: boolean;
+  subdomains: Array<string>;
+  xhr: boolean;
+  accepts(types: string): string | false;
+  accepts(types: Array<string>): string | false;
+  acceptsCharsets(...charsets: Array<string>): string | false;
+  acceptsEncodings(...encoding: Array<string>): string | false;
+  acceptsLanguages(...lang: Array<string>): string | false;
+  header(field: string): string | void;
+  is(type: string): string | false;
+  param(name: string, defaultValue?: string): string | void;
+}
+
+declare type express$CookieOptions = {
+  domain?: string,
+  encode?: (value: string) => string,
+  expires?: Date,
+  httpOnly?: boolean,
+  maxAge?: number,
+  path?: string,
+  secure?: boolean,
+  signed?: boolean
+};
+
+declare type express$Path = string | RegExp;
+
+declare type express$RenderCallback = (
+  err: Error | null,
+  html?: string
+) => mixed;
+
+declare type express$SendFileOptions = {
+  maxAge?: number,
+  root?: string,
+  lastModified?: boolean,
+  headers?: { [name: string]: string },
+  dotfiles?: "allow" | "deny" | "ignore"
+};
+
+declare class express$Response extends http$ServerResponse mixins express$RequestResponseBase {
+  headersSent: boolean;
+  locals: { [name: string]: mixed };
+  append(field: string, value?: string): this;
+  attachment(filename?: string): this;
+  cookie(name: string, value: string, options?: express$CookieOptions): this;
+  clearCookie(name: string, options?: express$CookieOptions): this;
+  download(
+    path: string,
+    filename?: string,
+    callback?: (err?: ?Error) => void
+  ): this;
+  format(typesObject: { [type: string]: Function }): this;
+  json(body?: mixed): this;
+  jsonp(body?: mixed): this;
+  links(links: { [name: string]: string }): this;
+  location(path: string): this;
+  redirect(url: string, ...args: Array<void>): this;
+  redirect(status: number, url: string, ...args: Array<void>): this;
+  render(
+    view: string,
+    locals?: { [name: string]: mixed },
+    callback?: express$RenderCallback
+  ): this;
+  send(body?: mixed): this;
+  sendFile(
+    path: string,
+    options?: express$SendFileOptions,
+    callback?: (err?: ?Error) => mixed
+  ): this;
+  sendStatus(statusCode: number): this;
+  header(field: string, value?: string): this;
+  header(headers: { [name: string]: string }): this;
+  set(field: string, value?: string | string[]): this;
+  set(headers: { [name: string]: string }): this;
+  status(statusCode: number): this;
+  type(type: string): this;
+  vary(field: string): this;
+  req: express$Request;
+}
+
+declare type express$NextFunction = (err?: ?Error | "route") => mixed;
+declare type express$Middleware =
+  | ((
+      req: $Subtype<express$Request>,
+      res: express$Response,
+      next: express$NextFunction
+    ) => mixed)
+  | ((
+      error: Error,
+      req: $Subtype<express$Request>,
+      res: express$Response,
+      next: express$NextFunction
+    ) => mixed);
+declare interface express$RouteMethodType<T> {
+  (middleware: express$Middleware): T;
+  (...middleware: Array<express$Middleware>): T;
+  (
+    path: express$Path | express$Path[],
+    ...middleware: Array<express$Middleware>
+  ): T;
+}
+declare class express$Route {
+  all: express$RouteMethodType<this>;
+  get: express$RouteMethodType<this>;
+  post: express$RouteMethodType<this>;
+  put: express$RouteMethodType<this>;
+  head: express$RouteMethodType<this>;
+  delete: express$RouteMethodType<this>;
+  options: express$RouteMethodType<this>;
+  trace: express$RouteMethodType<this>;
+  copy: express$RouteMethodType<this>;
+  lock: express$RouteMethodType<this>;
+  mkcol: express$RouteMethodType<this>;
+  move: express$RouteMethodType<this>;
+  purge: express$RouteMethodType<this>;
+  propfind: express$RouteMethodType<this>;
+  proppatch: express$RouteMethodType<this>;
+  unlock: express$RouteMethodType<this>;
+  report: express$RouteMethodType<this>;
+  mkactivity: express$RouteMethodType<this>;
+  checkout: express$RouteMethodType<this>;
+  merge: express$RouteMethodType<this>;
+
+  // @TODO Missing 'm-search' but get flow illegal name error.
+
+  notify: express$RouteMethodType<this>;
+  subscribe: express$RouteMethodType<this>;
+  unsubscribe: express$RouteMethodType<this>;
+  patch: express$RouteMethodType<this>;
+  search: express$RouteMethodType<this>;
+  connect: express$RouteMethodType<this>;
+}
+
+declare class express$Router extends express$Route {
+  constructor(options?: express$RouterOptions): void;
+  route(path: string): express$Route;
+  static (options?: express$RouterOptions): express$Router;
+  use(middleware: express$Middleware): this;
+  use(...middleware: Array<express$Middleware>): this;
+  use(
+    path: express$Path | express$Path[],
+    ...middleware: Array<express$Middleware>
+  ): this;
+  use(path: string, router: express$Router): this;
+  handle(
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    next: express$NextFunction
+  ): void;
+  param(
+    param: string,
+    callback: (
+      req: $Subtype<express$Request>,
+      res: express$Response,
+      next: express$NextFunction,
+      id: string
+    ) => mixed
+  ): void;
+  (
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+}
+
+/*
+With flow-bin ^0.59, express app.listen() is deemed to return any and fails flow type coverage.
+Which is ironic because https://github.com/facebook/flow/blob/master/Changelog.md#misc-2 (release notes for 0.59)
+says "Improves typings for Node.js HTTP server listen() function."  See that?  IMPROVES!
+To work around this issue, we changed Server to ?Server here, so that our invocations of express.listen() will
+not be deemed to lack type coverage.
+*/
+
+declare class express$Application extends express$Router mixins events$EventEmitter {
+  constructor(): void;
+  locals: { [name: string]: mixed };
+  mountpath: string;
+  listen(
+    port: number,
+    hostname?: string,
+    backlog?: number,
+    callback?: (err?: ?Error) => mixed
+  ): ?http.Server;
+  listen(
+    port: number,
+    hostname?: string,
+    callback?: (err?: ?Error) => mixed
+  ): ?http.Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): ?http.Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): ?http.Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http.Server;
+  disable(name: string): void;
+  disabled(name: string): boolean;
+  enable(name: string): express$Application;
+  enabled(name: string): boolean;
+  engine(name: string, callback: Function): void;
+  /**
+   * Mixed will not be taken as a value option. Issue around using the GET http method name and the get for settings.
+   */
+  //   get(name: string): mixed;
+  set(name: string, value: mixed): mixed;
+  render(
+    name: string,
+    optionsOrFunction: { [name: string]: mixed },
+    callback: express$RenderCallback
+  ): void;
+  handle(
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+  // callable signature is not inherited
+  (
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+}
+
+declare type JsonOptions = {
+  inflate?: boolean,
+  limit?: string | number,
+  reviver?: (key: string, value: mixed) => mixed,
+  strict?: boolean,
+  type?: string | Array<string> | ((req: express$Request) => boolean),
+  verify?: (
+    req: express$Request,
+    res: express$Response,
+    buf: Buffer,
+    encoding: string
+  ) => mixed
+};
+
+declare type express$UrlEncodedOptions = {
+  extended?: boolean,
+  inflate?: boolean,
+  limit?: string | number,
+  parameterLimit?: number,
+  type?: string | Array<string> | ((req: express$Request) => boolean),
+  verify?: (
+    req: express$Request,
+    res: express$Response,
+    buf: Buffer,
+    encoding: string
+  ) => mixed,
+}
+
+declare module "express" {
+  declare export type RouterOptions = express$RouterOptions;
+  declare export type CookieOptions = express$CookieOptions;
+  declare export type Middleware = express$Middleware;
+  declare export type NextFunction = express$NextFunction;
+  declare export type RequestParams = express$RequestParams;
+  declare export type $Response = express$Response;
+  declare export type $Request = express$Request;
+  declare export type $Application = express$Application;
+
+  declare module.exports: {
+    (): express$Application, // If you try to call like a function, it will use this signature
+    json: (opts: ?JsonOptions) => express$Middleware,
+    static: (root: string, options?: Object) => express$Middleware, // `static` property on the function
+    Router: typeof express$Router, // `Router` property on the function
+    urlencoded: (opts: ?express$UrlEncodedOptions) => express$Middleware,
+  };
+}

--- a/definitions/npm/express_v4.17.x/flow_v0.93.x-v0.93.x/test_overrideUseMethodClassExtension.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.93.x-v0.93.x/test_overrideUseMethodClassExtension.js
@@ -1,0 +1,90 @@
+// @flow
+import express from "express";
+
+// Class Extensions: Global Class/Type Declarations (prefixed to prevent name clashes)
+// Use method needs to be covarient: https://github.com/facebook/flow/issues/2770#issuecomment-258955097
+declare class test_express$CustomRequest extends express$Request {
+  foo: string;
+}
+declare class test_express$CustomResponse extends express$Response {
+  bar: string;
+}
+
+declare type test_express$CustomPath = string | RegExp;
+
+declare type test_express$CustomNextFunction = express$NextFunction;
+
+declare type test_express$CustomMiddleware =
+  | ((
+      req: test_express$CustomRequest,
+      res: test_express$CustomResponse,
+      next: test_express$CustomNextFunction
+    ) => mixed)
+  | ((
+      error: Error,
+      req: test_express$CustomRequest,
+      res: test_express$CustomResponse,
+      next: test_express$CustomNextFunction
+    ) => mixed);
+
+declare class test_express$CustomApplication extends express$Application {
+  constructor(expressConstructor: () => express$Application): this;
+  use(middleware: test_express$CustomMiddleware): this;
+  use(...middleware: Array<test_express$CustomMiddleware>): this;
+  use(
+    path: test_express$CustomPath | test_express$CustomPath[],
+    ...middleware: Array<test_express$CustomMiddleware>
+  ): this;
+  use(path: string, router: express$Router): this;
+}
+
+// Class Extensions: Test Functions
+function test_express$CustomApplication(
+  expressConstructor: () => express$Application
+) {
+  const express = expressConstructor();
+  express.use((req: any, res: any, next: express$NextFunction) => {
+    // Private Constructor Mutation: Add new properties
+    req.foo = "hello";
+    res.bar = "goodbye";
+    next();
+  });
+  return express;
+}
+
+// Class Extensions: Test
+const customApp = new test_express$CustomApplication(express);
+
+// $ExpectError
+const customApp_error = new test_express$CustomApplication();
+
+customApp.use(
+  "/something",
+  (req: express$Request, res: express$Response, next: express$NextFunction) => {
+    // $ExpectError
+    req.foo;
+    // $ExpectError
+    res.bar;
+    next();
+  }
+);
+customApp.use(
+  "/something",
+  (
+    req: test_express$CustomRequest,
+    res: test_express$CustomResponse,
+    next: test_express$CustomNextFunction
+  ) => {
+    req.foo;
+    res.bar;
+    // $ExpectError
+    req.notHere;
+    // $ExpectError
+    res.notHere;
+  }
+);
+
+// $ExpectError
+customApp.use("/something", (req: string, res: string, next: Function) => {
+  next();
+});

--- a/definitions/npm/express_v4.17.x/flow_v0.93.x-v0.93.x/test_response.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.93.x-v0.93.x/test_response.js
@@ -1,0 +1,40 @@
+// @flow
+
+import express, { Router } from "express";
+import http from "http";
+
+const app = express();
+
+app.use("/response_api", (req: express$Request, res: express$Response) => {
+  const contentLength = String(2);
+  res.set("Content-Length", contentLength);
+  res.set("Content-Type", "application/json");
+  res.writeHead(200, {
+    "Content-Length": contentLength,
+    "Content-Type": "application/json"
+  });
+  res.end("{}");
+  res.req;
+});
+
+// Can manually invoke router.handle() to handle a request.
+const router = new Router();
+app.use(
+  "/router",
+  (req: express$Request, res: express$Response, next: express$NextFunction) => {
+    router.handle(req, res, next);
+  }
+);
+app.post("/post-router-callable", router);
+
+// Can use an express app directly as a server listener
+const httpServer = http.createServer(app);
+httpServer.listen(9000);
+
+const badHttpServer = null;
+// $ExpectError
+badHttpServer.listen();
+
+// Can manually invoke app.handle() to handle a request
+const httpServer2 = http.createServer((req, res) => app.handle(req, res));
+httpServer.listen(9000);

--- a/definitions/npm/express_v4.17.x/flow_v0.94.x-v0.103.x/express_v4.17.x.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.94.x-v0.103.x/express_v4.17.x.js
@@ -1,0 +1,319 @@
+declare type express$RouterOptions = {
+  caseSensitive?: boolean,
+  mergeParams?: boolean,
+  strict?: boolean
+};
+
+declare class express$RequestResponseBase {
+  app: express$Application<any, any>;
+  get(field: string): string | void;
+}
+
+declare type express$RequestParams = {
+  [param: string]: string
+};
+
+declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
+  baseUrl: string;
+  body: mixed;
+  cookies: { [cookie: string]: string };
+  connection: net$Socket;
+  fresh: boolean;
+  hostname: string;
+  ip: string;
+  ips: Array<string>;
+  method: string;
+  originalUrl: string;
+  params: express$RequestParams;
+  path: string;
+  protocol: "https" | "http";
+  query: { [name: string]: string | Array<string> };
+  route: string;
+  secure: boolean;
+  signedCookies: { [signedCookie: string]: string };
+  stale: boolean;
+  subdomains: Array<string>;
+  xhr: boolean;
+  accepts(types: string): string | false;
+  accepts(types: Array<string>): string | false;
+  acceptsCharsets(...charsets: Array<string>): string | false;
+  acceptsEncodings(...encoding: Array<string>): string | false;
+  acceptsLanguages(...lang: Array<string>): string | false;
+  header(field: string): string | void;
+  is(type: string): string | false;
+  param(name: string, defaultValue?: string): string | void;
+}
+
+declare type express$CookieOptions = {
+  domain?: string,
+  encode?: (value: string) => string,
+  expires?: Date,
+  httpOnly?: boolean,
+  maxAge?: number,
+  path?: string,
+  secure?: boolean,
+  signed?: boolean
+};
+
+declare type express$Path = string | RegExp;
+
+declare type express$RenderCallback = (
+  err: Error | null,
+  html?: string
+) => mixed;
+
+declare type express$SendFileOptions = {
+  maxAge?: number,
+  root?: string,
+  lastModified?: boolean,
+  headers?: { [name: string]: string },
+  dotfiles?: "allow" | "deny" | "ignore"
+};
+
+declare class express$Response extends http$ServerResponse mixins express$RequestResponseBase {
+  headersSent: boolean;
+  locals: { [name: string]: mixed };
+  append(field: string, value?: string): this;
+  attachment(filename?: string): this;
+  cookie(name: string, value: string, options?: express$CookieOptions): this;
+  clearCookie(name: string, options?: express$CookieOptions): this;
+  download(
+    path: string,
+    filename?: string,
+    callback?: (err?: ?Error) => void
+  ): this;
+  format(typesObject: { [type: string]: Function }): this;
+  json(body?: mixed): this;
+  jsonp(body?: mixed): this;
+  links(links: { [name: string]: string }): this;
+  location(path: string): this;
+  redirect(url: string, ...args: Array<void>): this;
+  redirect(status: number, url: string, ...args: Array<void>): this;
+  render(
+    view: string,
+    locals?: { [name: string]: mixed },
+    callback?: express$RenderCallback
+  ): this;
+  send(body?: mixed): this;
+  sendFile(
+    path: string,
+    options?: express$SendFileOptions,
+    callback?: (err?: ?Error) => mixed
+  ): this;
+  sendStatus(statusCode: number): this;
+  header(field: string, value?: string): this;
+  header(headers: { [name: string]: string }): this;
+  set(field: string, value?: string | string[]): this;
+  set(headers: { [name: string]: string }): this;
+  status(statusCode: number): this;
+  type(type: string): this;
+  vary(field: string): this;
+  req: express$Request;
+}
+
+declare type express$NextFunction = (err?: ?Error | "route") => mixed;
+declare type express$Middleware<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> =
+  ((req: Req, res: Res, next: express$NextFunction) => mixed) |
+  ((error: Error, req: Req, res: Res, next: express$NextFunction) => mixed);
+
+declare interface express$RouteMethodType<
+  T,
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> {
+  (middleware: express$Middleware<Req, Res>): T;
+  (...middleware: Array<express$Middleware<Req, Res>>): T;
+  (
+    path: express$Path | $ReadOnlyArray<express$Path>,
+    ...middleware: Array<express$Middleware<Req, Res>>
+  ): T;
+}
+
+declare class express$Route<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> {
+  all: express$RouteMethodType<this, Req, Res>;
+  get: express$RouteMethodType<this, Req, Res>;
+  post: express$RouteMethodType<this, Req, Res>;
+  put: express$RouteMethodType<this, Req, Res>;
+  head: express$RouteMethodType<this, Req, Res>;
+  delete: express$RouteMethodType<this, Req, Res>;
+  options: express$RouteMethodType<this, Req, Res>;
+  trace: express$RouteMethodType<this, Req, Res>;
+  copy: express$RouteMethodType<this, Req, Res>;
+  lock: express$RouteMethodType<this, Req, Res>;
+  mkcol: express$RouteMethodType<this, Req, Res>;
+  move: express$RouteMethodType<this, Req, Res>;
+  purge: express$RouteMethodType<this, Req, Res>;
+  propfind: express$RouteMethodType<this, Req, Res>;
+  proppatch: express$RouteMethodType<this, Req, Res>;
+  unlock: express$RouteMethodType<this, Req, Res>;
+  report: express$RouteMethodType<this, Req, Res>;
+  mkactivity: express$RouteMethodType<this, Req, Res>;
+  checkout: express$RouteMethodType<this, Req, Res>;
+  merge: express$RouteMethodType<this, Req, Res>;
+
+  // @TODO Missing 'm-search' but get flow illegal name error.
+
+  notify: express$RouteMethodType<this, Req, Res>;
+  subscribe: express$RouteMethodType<this, Req, Res>;
+  unsubscribe: express$RouteMethodType<this, Req, Res>;
+  patch: express$RouteMethodType<this, Req, Res>;
+  search: express$RouteMethodType<this, Req, Res>;
+  connect: express$RouteMethodType<this, Req, Res>;
+}
+
+declare class express$Router<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> extends express$Route<Req, Res> {
+  constructor(options?: express$RouterOptions): void;
+  route(path: string): express$Route<Req, Res>;
+  static <Req2: express$Request, Res2: express$Response>(
+    options?: express$RouterOptions,
+  ): express$Router<Req2, Res2>;
+  use(middleware: express$Middleware<Req, Res>): this;
+  use(...middleware: Array<express$Middleware<Req, Res>>): this;
+  use(
+    path: express$Path | $ReadOnlyArray<express$Path>,
+    ...middleware: Array<express$Middleware<Req, Res>>
+  ): this;
+  use(path: string, router: express$Router<Req, Res>): this;
+  handle(
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    next: express$NextFunction
+  ): void;
+  param(
+    param: string,
+    callback: (
+      req: Req,
+      res: Res,
+      next: express$NextFunction,
+      value: string,
+      paramName: string,
+    ) => mixed
+  ): void;
+  (
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+}
+
+/*
+With flow-bin ^0.59, express app.listen() is deemed to return any and fails flow type coverage.
+Which is ironic because https://github.com/facebook/flow/blob/master/Changelog.md#misc-2 (release notes for 0.59)
+says "Improves typings for Node.js HTTP server listen() function."  See that?  IMPROVES!
+To work around this issue, we changed Server to ?Server here, so that our invocations of express.listen() will
+not be deemed to lack type coverage.
+*/
+
+declare class express$Application<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> extends express$Router<Req, Res> mixins events$EventEmitter {
+  constructor(): void;
+  locals: { [name: string]: mixed };
+  mountpath: string;
+  listen(
+    port: number,
+    hostname?: string,
+    backlog?: number,
+    callback?: (err?: ?Error) => mixed
+  ): ?http$Server;
+  listen(
+    port: number,
+    hostname?: string,
+    callback?: (err?: ?Error) => mixed
+  ): ?http$Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): ?http$Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http$Server;
+  disable(name: string): void;
+  disabled(name: string): boolean;
+  enable(name: string): this;
+  enabled(name: string): boolean;
+  engine(name: string, callback: Function): void;
+  /**
+   * Mixed will not be taken as a value option. Issue around using the GET http method name and the get for settings.
+   */
+  //   get(name: string): mixed;
+  set(name: string, value: mixed): mixed;
+  render(
+    name: string,
+    optionsOrFunction: { [name: string]: mixed },
+    callback: express$RenderCallback
+  ): void;
+  handle(
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+  // callable signature is not inherited
+  (
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+}
+
+declare type JsonOptions = {
+  inflate?: boolean,
+  limit?: string | number,
+  reviver?: (key: string, value: mixed) => mixed,
+  strict?: boolean,
+  type?: string | Array<string> | ((req: express$Request) => boolean),
+  verify?: (
+    req: express$Request,
+    res: express$Response,
+    buf: Buffer,
+    encoding: string
+  ) => mixed
+};
+
+declare type express$UrlEncodedOptions = {
+  extended?: boolean,
+  inflate?: boolean,
+  limit?: string | number,
+  parameterLimit?: number,
+  type?: string | Array<string> | ((req: express$Request) => boolean),
+  verify?: (
+    req: express$Request,
+    res: express$Response,
+    buf: Buffer,
+    encoding: string
+  ) => mixed,
+}
+
+declare module "express" {
+  declare export type RouterOptions = express$RouterOptions;
+  declare export type CookieOptions = express$CookieOptions;
+  declare export type Middleware<
+    Req: express$Request = express$Request,
+    Res: express$Response = express$Response,
+  > = express$Middleware<Req, Res>;
+  declare export type NextFunction = express$NextFunction;
+  declare export type RequestParams = express$RequestParams;
+  declare export type $Response = express$Response;
+  declare export type $Request = express$Request;
+  declare export type $Application<
+    Req: express$Request = express$Request,
+    Res: express$Response = express$Response,
+  > = express$Application<Req, Res>;
+
+  declare module.exports: {
+    // If you try to call like a function, it will use this signature
+    <Req: express$Request, Res: express$Response>(): express$Application<Req, Res>,
+    json: (opts: ?JsonOptions) => express$Middleware<>,
+    // `static` property on the function
+    static: <Req: express$Request, Res: express$Response>(root: string, options?: Object) => express$Middleware<Req, Res>,
+    // `Router` property on the function
+    Router: typeof express$Router,
+    urlencoded: (opts: ?express$UrlEncodedOptions) => express$Middleware<>,
+  };
+}

--- a/definitions/npm/express_v4.17.x/flow_v0.94.x-v0.103.x/express_v4.17.x.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.94.x-v0.103.x/express_v4.17.x.js
@@ -13,6 +13,33 @@ declare type express$RequestParams = {
   [param: string]: string
 };
 
+/*
+  NOTE: Use caution when extending `express$Request` or `express$Response`. When
+  a request first hits the server, its `req` and `res` will not have any
+  additional properties, even if you explicitly type them with your custom
+  subclass. Subsequent middleware may assign these properties, but you must be
+  cognizant of this ordering. One way to handle this is marking all properties
+  as optional to force refinement every time a property is accessed. Therefore,
+  we advise that you always mark properties as _optional_ in `express$Request`
+  and `express$Response` subclasses.
+
+  You may decide not to do this, in which case the typings will be unsound and
+  the behavior will be similar to how arrays work in Flow. See here for more
+  information: https://flow.org/en/docs/types/arrays/#toc-array-access-is-unsafe
+
+  See #3578 and #3337 for additional discussion. If you have ideas on how to
+  improve these typings, please share them in #3578 or open a new issue.
+
+  **BAD**
+  declare class test_express$CustomRequest extends express$Request {
+    foo: string;
+  }
+
+  **GOOD**
+  declare class test_express$CustomRequest extends express$Request {
+    foo: string | void;
+  }
+*/
 declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
   baseUrl: string;
   body: mixed;

--- a/definitions/npm/express_v4.17.x/flow_v0.94.x-v0.103.x/test_overrideUseMethodClassExtension.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.94.x-v0.103.x/test_overrideUseMethodClassExtension.js
@@ -1,0 +1,76 @@
+// @flow
+import express from "express";
+
+// Class Extensions: Global Class/Type Declarations (prefixed to prevent name clashes)
+// Use method needs to be covarient: https://github.com/facebook/flow/issues/2770#issuecomment-258955097
+declare class test_express$CustomRequest extends express$Request {
+  foo: string;
+}
+declare class test_express$CustomResponse extends express$Response {
+  bar: string;
+}
+
+declare type expressConstructor =
+  <Req: express$Request, Res: express$Response>() => express$Application<Req, Res>;
+
+declare class test_express$CustomApplication extends express$Application<
+  test_express$CustomRequest,
+  test_express$CustomResponse,
+> {
+  constructor(expressConstructor: expressConstructor): this;
+}
+
+// Class Extensions: Test Functions
+function test_express$CustomApplication(
+  expressConstructor: expressConstructor,
+) {
+  const express = expressConstructor();
+  express.use((
+    req: test_express$CustomRequest,
+    res: test_express$CustomResponse,
+    next: express$NextFunction,
+  ) => {
+    // Private Constructor Mutation: Add new properties
+    req.foo = "hello";
+    res.bar = "goodbye";
+    next();
+  });
+  return express;
+}
+
+// Class Extensions: Test
+const customApp = new test_express$CustomApplication(express);
+
+// $ExpectError
+const customApp_error = new test_express$CustomApplication();
+
+customApp.use(
+  "/something",
+  (req: express$Request, res: express$Response, next: express$NextFunction) => {
+    // $ExpectError
+    req.foo;
+    // $ExpectError
+    res.bar;
+    next();
+  }
+);
+customApp.use(
+  "/something",
+  (
+    req: test_express$CustomRequest,
+    res: test_express$CustomResponse,
+    next: express$NextFunction
+  ) => {
+    req.foo;
+    res.bar;
+    // $ExpectError
+    req.notHere;
+    // $ExpectError
+    res.notHere;
+  }
+);
+
+// $ExpectError
+customApp.use("/something", (req: string, res: string, next: Function) => {
+  next();
+});

--- a/definitions/npm/express_v4.17.x/flow_v0.94.x-v0.103.x/test_response.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.94.x-v0.103.x/test_response.js
@@ -1,0 +1,52 @@
+// @flow
+
+import express, { Router } from "express";
+import http from "http";
+
+const app = express();
+
+app.use("/response_api", (req: express$Request, res: express$Response) => {
+  const contentLength = String(2);
+  res.set("Content-Length", contentLength);
+  res.set("Content-Type", "application/json");
+  res.writeHead(200, {
+    "Content-Length": contentLength,
+    "Content-Type": "application/json"
+  });
+  res.end("{}");
+  res.req;
+});
+
+// Can manually invoke router.handle() to handle a request.
+const router = new Router();
+app.use(
+  "/router",
+  (req: express$Request, res: express$Response, next: express$NextFunction) => {
+    router.handle(req, res, next);
+  }
+);
+app.post("/post-router-callable", router);
+
+// Can set a custom param on request
+app.param('test', (
+  req: express$Request & { testValue: string },
+  res: express$Response,
+  next: express$NextFunction,
+  id: string,
+  paramName: string,
+) => {
+  req.testValue = id;
+  next();
+});
+
+// Can use an express app directly as a server listener
+const httpServer = http.createServer(app);
+httpServer.listen(9000);
+
+const badHttpServer = null;
+// $ExpectError
+badHttpServer.listen();
+
+// Can manually invoke app.handle() to handle a request
+const httpServer2 = http.createServer((req, res) => app.handle(req, res));
+httpServer.listen(9000);

--- a/definitions/npm/express_v4.17.x/test_express_v4.17.x.js
+++ b/definitions/npm/express_v4.17.x/test_express_v4.17.x.js
@@ -1,0 +1,245 @@
+/* @flow */
+import express, { Router } from "express";
+
+const app = express();
+
+// $ExpectError property `foo` Property not found in Application:
+app.foo();
+
+app.locals.title = "My Express App";
+
+// $ExpectError Symbol: This type is incompatible with string
+app.locals[Symbol("bad")] = "Should not work";
+
+// $ExpectError
+const num: number = app.mountpath;
+
+const myRouter = new express.Router();
+
+myRouter.use(
+  "/dang",
+  (req, res: express$Response, next: express$NextFunction) => {
+    res.set("My Header", "Value");
+    res.header("Another-Header", "different value");
+    res.set({ "third-header": "123", "forth-header": "abc" });
+    res.header({ "fifth-header": "456", "sixth-header": "def" });
+    res.status(200);
+    res.render("someTemplate", {}, (err, html: ?string) => null);
+    res.render("someTemplate", (err, html: ?string) => null);
+    // $ExpectError String: This type is incompatible with Function | {[name: string]: mixed}
+    res.render("someTemplate", "Error");
+    // $ExpectError
+    res.sendFile("/myfile.txt", { dotfiles: "none" });
+    // $ExpectError
+    next("Error");
+  }
+);
+
+function handleRequest<MiddleWare>(
+  req: express$Request,
+  res: express$Response,
+  next: express$NextFunction
+): void {
+  (Math.random() >= 0.5
+    ? Promise.resolve({ books: ["Catcher and the Rye"] })
+    : Promise.reject(new Error("Something went wrong"))
+  )
+    .then(data => {
+      res.json(data);
+    })
+    .catch(err => {
+      next(err);
+    });
+}
+
+myRouter.use(
+  handleRequest,
+  (
+    err: Error,
+    req: express$Request,
+    res: express$Response,
+    next: express$NextFunction
+  ): void => {
+    console.error(err);
+    next(err);
+  }
+);
+
+app.on('mount', (parent: express$Application<>) => {
+  console.log("Parent Loaded", parent);
+  // $ExpectError
+  parent.fail();
+});
+
+app.use("/foo", (req: express$Request, res: express$Response, next) => {
+  // $ExpectError
+  res.status("400");
+  res.send("should work").status(300);
+});
+
+const bar: express$Router<> = new Router();
+
+bar.get("/", (req: express$Request, res: express$Response): void => {
+  // $ExpectError should be of type object
+  const locals: Array<any> = res.locals;
+  res.locals.title = "Home Page";
+  // $ExpectError should not allow to set keys to non string value.
+  res.locals[0] = "Fail";
+  res.send("bar").status(200);
+});
+
+app.use("/bar", bar);
+
+app.listen(9000);
+
+app.listen(9001, "127.0.0.1");
+
+app.listen(9002, "127.0.0.1", 256);
+
+app.listen(9003, "127.0.0.1", 256, () => {
+  console.log("Example app listening on port 9003!");
+});
+
+app.listen(9004, () => {
+  console.log("Example app listening on port 9004!");
+});
+
+// $ExpectError backlog should be number
+app.listen(9005, "127.0.0.1", "256", () => {
+  console.log("Example app listening on port 9005!");
+});
+
+app.set("foo");
+
+app.get("foo");
+// $ExpectError
+app.enable(100);
+// $ExpectError
+const f: number = app.enabled("100");
+
+const g: express$Application<> = app.enable('foo');
+
+app.render(
+  "view",
+  { title: "News Feed" },
+  (err: ?Error, html: ?string): void => {
+    if (err) return console.log(err);
+    console.log(html);
+  }
+);
+
+app.use("/somewhere", (req: express$Request, res: express$Response) => {
+  res.redirect("/somewhere-else");
+});
+
+app.use("/again", (req: express$Request, res: express$Response) => {
+  res.redirect(200, "/different");
+});
+
+app.use("/something", (req: express$Request, res: express$Response) => {
+  // $ExpectError
+  res.redirect("/different", 200);
+});
+
+// False positive since 0.39
+// app.use('/failure', (req: express$Request, res: express$Response) => {
+//   res.redirect();
+// });
+
+app.use(
+  (
+    err: Error,
+    req: express$Request,
+    res: express$Response,
+    next: express$NextFunction
+  ) => {
+    // test req
+    req.accepts("accepted/type");
+    req.accepts(["json", "text"]);
+    req.is("json");
+    if (typeof req.query.foo === "string") console.log((req.query.foo: string));
+    else console.log((req.query.foo: Array<string>));
+    // test response
+    res.redirect("/somewhere");
+    // test next
+    next();
+    next(err);
+  }
+);
+
+// $ExpectError path could not be an Object
+const invalidPath: express$Path = {};
+
+let validPath: express$Path = "string_path";
+validPath = "pattern?path";
+validPath = new RegExp("some.*regexp");
+
+const validPaths = ["string", "pattern?", /a[b-f]+g/];
+
+app.get(validPaths, (req: express$Request, res: express$Response) => {
+  res.end();
+});
+
+// http://expressjs.com/en/4x/api.html#express.json
+// express.json() is incorporated from body-parser.
+
+// Simple case - it can be called with no args.
+express.json();
+
+// The result of express.json() is a middleware the app can use.
+app.use(express.json());
+
+// Reviver comes from JSON.parse's reviver function.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter
+express.json({
+  reviver: (key, value) => {
+    typeof value === "number"
+      ? value * 2 // return value * 2 for numbers
+      : value; // return everything else unchanged
+  }
+});
+
+// type says it must be truthy, but intent is more clearly expressed as a bool.
+express.json({
+  // $ExpectError
+  type: req => 0
+});
+
+// https://expressjs.com/en/4x/api.html#express.urlencoded
+// body-parser based middleware for parsing urlencoded payloads
+
+// can be called with no args
+express.urlencoded();
+
+// urlencoded is a middleware
+app.use(express.urlencoded());
+
+// limit can be a string or number
+express.urlencoded({
+  limit: 100,
+});
+express.urlencoded({
+  limit: '100b',
+});
+express.urlencoded({
+  // $ExpectError
+  limit: false,
+});
+
+// type says it must be truthy, but intent is more clearly expressed as a bool.
+express.urlencoded({
+  // $ExpectError
+  type: req => 0
+});
+
+// type can be a string or array of strings
+express.urlencoded({
+  type: 'foo'
+});
+express.urlencoded({
+  type: ['foo', 'bar']
+});
+express.urlencoded({
+  // $ExpectError
+  type: [1 , 2]
+});

--- a/definitions/npm/express_v4.x.x/flow_v0.104.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.104.x-/express_v4.x.x.js
@@ -6,7 +6,7 @@ declare type express$RouterOptions = {
 };
 
 declare class express$RequestResponseBase {
-  app: express$Application;
+  app: express$Application<any, any>;
   get(field: string): string | void;
 }
 
@@ -98,68 +98,89 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 }
 
 declare type express$NextFunction = (err?: ?Error | 'route') => mixed;
-declare type express$Middleware =
-  ((req: express$Request, res: express$Response, next: express$NextFunction) => mixed) |
-  ((error: Error, req: express$Request, res: express$Response, next: express$NextFunction) => mixed);
-declare interface express$RouteMethodType<T> {
-  (middleware: express$Middleware): T;
-  (...middleware: Array<express$Middleware>): T;
-  (path: express$Path|express$Path[], ...middleware: Array<express$Middleware>): T;
+declare type express$Middleware<Req: express$Request, Res: express$Response> =
+  ((req: Req, res: Res, next: express$NextFunction) => mixed) |
+  ((error: Error, req: Req, res: Res, next: express$NextFunction) => mixed);
+
+declare interface express$RouteMethodType<
+  T,
+  Req: express$Request,
+  Res: express$Response,
+> {
+  (middleware: express$Middleware<Req, Res>): T;
+  (...middleware: Array<express$Middleware<Req, Res>>): T;
+  (
+    path: express$Path | $ReadOnlyArray<express$Path>,
+    ...middleware: Array<express$Middleware<Req, Res>>
+  ): T;
 }
-declare class express$Route {
-  all: express$RouteMethodType<this>;
-  get: express$RouteMethodType<this>;
-  post: express$RouteMethodType<this>;
-  put: express$RouteMethodType<this>;
-  head: express$RouteMethodType<this>;
-  delete: express$RouteMethodType<this>;
-  options: express$RouteMethodType<this>;
-  trace: express$RouteMethodType<this>;
-  copy: express$RouteMethodType<this>;
-  lock: express$RouteMethodType<this>;
-  mkcol: express$RouteMethodType<this>;
-  move: express$RouteMethodType<this>;
-  purge: express$RouteMethodType<this>;
-  propfind: express$RouteMethodType<this>;
-  proppatch: express$RouteMethodType<this>;
-  unlock: express$RouteMethodType<this>;
-  report: express$RouteMethodType<this>;
-  mkactivity: express$RouteMethodType<this>;
-  checkout: express$RouteMethodType<this>;
-  merge: express$RouteMethodType<this>;
+
+declare class express$Route<Req: express$Request, Res: express$Response> {
+  all: express$RouteMethodType<this, Req, Res>;
+  get: express$RouteMethodType<this, Req, Res>;
+  post: express$RouteMethodType<this, Req, Res>;
+  put: express$RouteMethodType<this, Req, Res>;
+  head: express$RouteMethodType<this, Req, Res>;
+  delete: express$RouteMethodType<this, Req, Res>;
+  options: express$RouteMethodType<this, Req, Res>;
+  trace: express$RouteMethodType<this, Req, Res>;
+  copy: express$RouteMethodType<this, Req, Res>;
+  lock: express$RouteMethodType<this, Req, Res>;
+  mkcol: express$RouteMethodType<this, Req, Res>;
+  move: express$RouteMethodType<this, Req, Res>;
+  purge: express$RouteMethodType<this, Req, Res>;
+  propfind: express$RouteMethodType<this, Req, Res>;
+  proppatch: express$RouteMethodType<this, Req, Res>;
+  unlock: express$RouteMethodType<this, Req, Res>;
+  report: express$RouteMethodType<this, Req, Res>;
+  mkactivity: express$RouteMethodType<this, Req, Res>;
+  checkout: express$RouteMethodType<this, Req, Res>;
+  merge: express$RouteMethodType<this, Req, Res>;
 
   // @TODO Missing 'm-search' but get flow illegal name error.
 
-  notify: express$RouteMethodType<this>;
-  subscribe: express$RouteMethodType<this>;
-  unsubscribe: express$RouteMethodType<this>;
-  patch: express$RouteMethodType<this>;
-  search: express$RouteMethodType<this>;
-  connect: express$RouteMethodType<this>;
+  notify: express$RouteMethodType<this, Req, Res>;
+  subscribe: express$RouteMethodType<this, Req, Res>;
+  unsubscribe: express$RouteMethodType<this, Req, Res>;
+  patch: express$RouteMethodType<this, Req, Res>;
+  search: express$RouteMethodType<this, Req, Res>;
+  connect: express$RouteMethodType<this, Req, Res>;
 }
 
-declare class express$Router extends express$Route {
+declare class express$Router<
+  Req: express$Request,
+  Res: express$Response,
+> extends express$Route<Req, Res> {
   constructor(options?: express$RouterOptions): void;
-  route(path: string): express$Route;
-  static (options?: express$RouterOptions): express$Router;
-  use(middleware: express$Middleware): this;
-  use(...middleware: Array<express$Middleware>): this;
-  use(path: express$Path|express$Path[], ...middleware: Array<express$Middleware>): this;
-  use(path: string, router: express$Router): this;
+  route(path: string): express$Route<Req, Res>;
+  static <Req2: express$Request, Res2: express$Response>(
+    options?: express$RouterOptions,
+  ): express$Router<Req2, Res2>;
+  use(middleware: express$Middleware<Req, Res>): this;
+  use(...middleware: Array<express$Middleware<Req, Res>>): this;
+  use(
+    path: express$Path | $ReadOnlyArray<express$Path>,
+    ...middleware: Array<express$Middleware<Req, Res>>
+  ): this;
+  use(path: string, router: express$Router<Req, Res>): this;
   handle(req: http$IncomingMessage<>, res: http$ServerResponse, next: express$NextFunction): void;
   param(
     param: string,
     callback: (
-      req: express$Request,
-      res: express$Response,
+      req: Req,
+      res: Res,
       next: express$NextFunction,
-      id: string
+      value: string,
+      paramName: string,
     ) => mixed
   ): void;
   (req: http$IncomingMessage<>, res: http$ServerResponse, next?: ?express$NextFunction): void;
 }
 
-declare class express$Application extends express$Router mixins events$EventEmitter {
+declare class express$Application<
+  Req: express$Request,
+  Res: express$Response,
+> extends express$Router<Req, Res> mixins events$EventEmitter {
   constructor(): void;
   locals: { [name: string]: mixed, ... };
   mountpath: string;
@@ -170,7 +191,7 @@ declare class express$Application extends express$Router mixins events$EventEmit
   listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http$Server;
   disable(name: string): void;
   disabled(name: string): boolean;
-  enable(name: string): express$Application;
+  enable(name: string): this;
   enabled(name: string): boolean;
   engine(name: string, callback: Function): void;
   /**
@@ -187,18 +208,24 @@ declare class express$Application extends express$Router mixins events$EventEmit
 declare module 'express' {
   declare export type RouterOptions = express$RouterOptions;
   declare export type CookieOptions = express$CookieOptions;
-  declare export type Middleware = express$Middleware;
+  declare export type Middleware<
+    Req: express$Request,
+    Res: express$Response,
+  > = express$Middleware<Req, Res>;
   declare export type NextFunction = express$NextFunction;
   declare export type RequestParams = express$RequestParams;
   declare export type $Response = express$Response;
   declare export type $Request = express$Request;
-  declare export type $Application = express$Application;
+  declare export type $Application<
+    Req: express$Request,
+    Res: express$Response,
+  > = express$Application<Req, Res>;
 
   declare module.exports: {
     // If you try to call like a function, it will use this signature
-    (): express$Application,
+    <Req: express$Request, Res: express$Response>(): express$Application<Req, Res>,
     // `static` property on the function
-    static: (root: string, options?: Object) => express$Middleware,
+    static: <Req: express$Request, Res: express$Response>(root: string, options?: Object) => express$Middleware<Req, Res>,
     // `Router` property on the function
     Router: typeof express$Router,
     ...

--- a/definitions/npm/express_v4.x.x/flow_v0.104.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.104.x-/express_v4.x.x.js
@@ -12,6 +12,33 @@ declare class express$RequestResponseBase {
 
 declare type express$RequestParams = { [param: string]: string, ... }
 
+/*
+  NOTE: Use caution when extending `express$Request` or `express$Response`. When
+  a request first hits the server, its `req` and `res` will not have any
+  additional properties, even if you explicitly type them with your custom
+  subclass. Subsequent middleware may assign these properties, but you must be
+  cognizant of this ordering. One way to handle this is marking all properties
+  as optional to force refinement every time a property is accessed. Therefore,
+  we advise that you always mark properties as _optional_ in `express$Request`
+  and `express$Response` subclasses.
+
+  You may decide not to do this, in which case the typings will be unsound and
+  the behavior will be similar to how arrays work in Flow. See here for more
+  information: https://flow.org/en/docs/types/arrays/#toc-array-access-is-unsafe
+
+  See #3578 and #3337 for additional discussion. If you have ideas on how to
+  improve these typings, please share them in #3578 or open a new issue.
+
+  **BAD**
+  declare class test_express$CustomRequest extends express$Request {
+    foo: string;
+  }
+
+  **GOOD**
+  declare class test_express$CustomRequest extends express$Request {
+    foo: string | void;
+  }
+*/
 declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
   baseUrl: string;
   body: mixed;

--- a/definitions/npm/express_v4.x.x/flow_v0.104.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.104.x-/express_v4.x.x.js
@@ -99,8 +99,8 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 
 declare type express$NextFunction = (err?: ?Error | 'route') => mixed;
 declare type express$Middleware =
-  ((req: $Subtype<express$Request>, res: express$Response, next: express$NextFunction) => mixed) |
-  ((error: Error, req: $Subtype<express$Request>, res: express$Response, next: express$NextFunction) => mixed);
+  ((req: express$Request, res: express$Response, next: express$NextFunction) => mixed) |
+  ((error: Error, req: express$Request, res: express$Response, next: express$NextFunction) => mixed);
 declare interface express$RouteMethodType<T> {
   (middleware: express$Middleware): T;
   (...middleware: Array<express$Middleware>): T;
@@ -150,7 +150,7 @@ declare class express$Router extends express$Route {
   param(
     param: string,
     callback: (
-      req: $Subtype<express$Request>,
+      req: express$Request,
       res: express$Response,
       next: express$NextFunction,
       id: string

--- a/definitions/npm/express_v4.x.x/flow_v0.104.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.104.x-/express_v4.x.x.js
@@ -98,14 +98,17 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 }
 
 declare type express$NextFunction = (err?: ?Error | 'route') => mixed;
-declare type express$Middleware<Req: express$Request, Res: express$Response> =
+declare type express$Middleware<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> =
   ((req: Req, res: Res, next: express$NextFunction) => mixed) |
   ((error: Error, req: Req, res: Res, next: express$NextFunction) => mixed);
 
 declare interface express$RouteMethodType<
   T,
-  Req: express$Request,
-  Res: express$Response,
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
 > {
   (middleware: express$Middleware<Req, Res>): T;
   (...middleware: Array<express$Middleware<Req, Res>>): T;
@@ -115,7 +118,10 @@ declare interface express$RouteMethodType<
   ): T;
 }
 
-declare class express$Route<Req: express$Request, Res: express$Response> {
+declare class express$Route<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> {
   all: express$RouteMethodType<this, Req, Res>;
   get: express$RouteMethodType<this, Req, Res>;
   post: express$RouteMethodType<this, Req, Res>;
@@ -148,8 +154,8 @@ declare class express$Route<Req: express$Request, Res: express$Response> {
 }
 
 declare class express$Router<
-  Req: express$Request,
-  Res: express$Response,
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
 > extends express$Route<Req, Res> {
   constructor(options?: express$RouterOptions): void;
   route(path: string): express$Route<Req, Res>;
@@ -178,8 +184,8 @@ declare class express$Router<
 }
 
 declare class express$Application<
-  Req: express$Request,
-  Res: express$Response,
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
 > extends express$Router<Req, Res> mixins events$EventEmitter {
   constructor(): void;
   locals: { [name: string]: mixed, ... };
@@ -209,16 +215,16 @@ declare module 'express' {
   declare export type RouterOptions = express$RouterOptions;
   declare export type CookieOptions = express$CookieOptions;
   declare export type Middleware<
-    Req: express$Request,
-    Res: express$Response,
+    Req: express$Request = express$Request,
+    Res: express$Response = express$Response,
   > = express$Middleware<Req, Res>;
   declare export type NextFunction = express$NextFunction;
   declare export type RequestParams = express$RequestParams;
   declare export type $Response = express$Response;
   declare export type $Request = express$Request;
   declare export type $Application<
-    Req: express$Request,
-    Res: express$Response,
+    Req: express$Request = express$Request,
+    Res: express$Response = express$Response,
   > = express$Application<Req, Res>;
 
   declare module.exports: {

--- a/definitions/npm/express_v4.x.x/flow_v0.104.x-/test_overrideUseMethodClassExtension.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.104.x-/test_overrideUseMethodClassExtension.js
@@ -10,28 +10,26 @@ declare class test_express$CustomResponse extends express$Response {
   bar: string;
 }
 
-declare type test_express$CustomPath = string | RegExp;
+declare type expressConstructor =
+  <Req: express$Request, Res: express$Response>() => express$Application<Req, Res>;
 
-declare type test_express$CustomNextFunction = express$NextFunction;
-
-declare type test_express$CustomMiddleware =
-  ((req: test_express$CustomRequest, res: test_express$CustomResponse, next: test_express$CustomNextFunction) => mixed) |
-  ((error: Error, req: test_express$CustomRequest, res: test_express$CustomResponse, next: test_express$CustomNextFunction) => mixed);
-
-declare class test_express$CustomApplication extends express$Application {
-  constructor(expressConstructor: () => express$Application): this;
-  use(middleware: test_express$CustomMiddleware): this;
-  use(...middleware: Array<test_express$CustomMiddleware>): this;
-  use(path: test_express$CustomPath|test_express$CustomPath[], ...middleware: Array<test_express$CustomMiddleware>): this;
-  use(path: string, router: express$Router): this;
+declare class test_express$CustomApplication extends express$Application<
+  test_express$CustomRequest,
+  test_express$CustomResponse,
+> {
+  constructor(expressConstructor: expressConstructor): this;
 }
 
 // Class Extensions: Test Functions
 function test_express$CustomApplication(
-  expressConstructor: () => express$Application
+  expressConstructor: expressConstructor,
 ) {
   const express = expressConstructor();
-  express.use((req: any, res: any, next: express$NextFunction) => {
+  express.use((
+    req: test_express$CustomRequest,
+    res: test_express$CustomResponse,
+    next: express$NextFunction,
+  ) => {
     // Private Constructor Mutation: Add new properties
     req.foo = 'hello';
     res.bar = 'goodbye';
@@ -46,21 +44,33 @@ const customApp = new test_express$CustomApplication(express);
 // $ExpectError
 const customApp_error = new test_express$CustomApplication();
 
-customApp.use('/something', (req: express$Request, res: express$Response, next: express$NextFunction) => {
-  // $ExpectError
-  req.foo;
-  // $ExpectError
-  res.bar;
-  next();
-});
-customApp.use('/something', (req: test_express$CustomRequest, res: test_express$CustomResponse, next: test_express$CustomNextFunction) => {
-  req.foo;
-  res.bar;
-  // $ExpectError
-  req.notHere;
-  // $ExpectError
-  res.notHere;
-});
+customApp.use(
+  "/something",
+  (req: express$Request, res: express$Response, next: express$NextFunction) => {
+    // $ExpectError
+    req.foo;
+    // $ExpectError
+    res.bar;
+    next();
+  }
+);
+customApp.use(
+  "/something",
+  (
+    req: test_express$CustomRequest,
+    res: test_express$CustomResponse,
+    next: express$NextFunction
+  ) => {
+    req.foo;
+    res.bar;
+    // $ExpectError
+    req.notHere;
+    // $ExpectError
+    res.notHere;
+  }
+);
 
 // $ExpectError
-customApp.use('/something', (req: string, res: string, next: Function) => { next() });
+customApp.use("/something", (req: string, res: string, next: Function) => {
+  next();
+});

--- a/definitions/npm/express_v4.x.x/flow_v0.104.x-/test_response.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.104.x-/test_response.js
@@ -27,6 +27,18 @@ app.use(
 );
 app.post("/post-router-callable", router);
 
+// Can set a custom param on request
+app.param('test', (
+  req: express$Request & { testValue: string, ... },
+  res: express$Response,
+  next: express$NextFunction,
+  id: string,
+  paramName: string,
+) => {
+  req.testValue = id;
+  next();
+});
+
 // Can use an express app directly as a server listener
 const httpServer = http.createServer(app);
 httpServer.listen(9000);

--- a/definitions/npm/express_v4.x.x/flow_v0.94.x-v0.103.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.94.x-v0.103.x/express_v4.x.x.js
@@ -98,8 +98,8 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 
 declare type express$NextFunction = (err?: ?Error | 'route') => mixed;
 declare type express$Middleware =
-  ((req: $Subtype<express$Request>, res: express$Response, next: express$NextFunction) => mixed) |
-  ((error: Error, req: $Subtype<express$Request>, res: express$Response, next: express$NextFunction) => mixed);
+  ((req: express$Request, res: express$Response, next: express$NextFunction) => mixed) |
+  ((error: Error, req: express$Request, res: express$Response, next: express$NextFunction) => mixed);
 declare interface express$RouteMethodType<T> {
   (middleware: express$Middleware): T;
   (...middleware: Array<express$Middleware>): T;
@@ -149,7 +149,7 @@ declare class express$Router extends express$Route {
   param(
     param: string,
     callback: (
-      req: $Subtype<express$Request>,
+      req: express$Request,
       res: express$Response,
       next: express$NextFunction,
       id: string

--- a/definitions/npm/express_v4.x.x/flow_v0.94.x-v0.103.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.94.x-v0.103.x/express_v4.x.x.js
@@ -13,6 +13,33 @@ declare type express$RequestParams = {
   [param: string]: string
 }
 
+/*
+  NOTE: Use caution when extending `express$Request` or `express$Response`. When
+  a request first hits the server, its `req` and `res` will not have any
+  additional properties, even if you explicitly type them with your custom
+  subclass. Subsequent middleware may assign these properties, but you must be
+  cognizant of this ordering. One way to handle this is marking all properties
+  as optional to force refinement every time a property is accessed. Therefore,
+  we advise that you always mark properties as _optional_ in `express$Request`
+  and `express$Response` subclasses.
+
+  You may decide not to do this, in which case the typings will be unsound and
+  the behavior will be similar to how arrays work in Flow. See here for more
+  information: https://flow.org/en/docs/types/arrays/#toc-array-access-is-unsafe
+
+  See #3578 and #3337 for additional discussion. If you have ideas on how to
+  improve these typings, please share them in #3578 or open a new issue.
+
+  **BAD**
+  declare class test_express$CustomRequest extends express$Request {
+    foo: string;
+  }
+
+  **GOOD**
+  declare class test_express$CustomRequest extends express$Request {
+    foo: string | void;
+  }
+*/
 declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
   baseUrl: string;
   body: mixed;

--- a/definitions/npm/express_v4.x.x/flow_v0.94.x-v0.103.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.94.x-v0.103.x/express_v4.x.x.js
@@ -5,7 +5,7 @@ declare type express$RouterOptions = {
 };
 
 declare class express$RequestResponseBase {
-  app: express$Application;
+  app: express$Application<any, any>;
   get(field: string): string | void;
 }
 
@@ -97,68 +97,89 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 }
 
 declare type express$NextFunction = (err?: ?Error | 'route') => mixed;
-declare type express$Middleware =
-  ((req: express$Request, res: express$Response, next: express$NextFunction) => mixed) |
-  ((error: Error, req: express$Request, res: express$Response, next: express$NextFunction) => mixed);
-declare interface express$RouteMethodType<T> {
-  (middleware: express$Middleware): T;
-  (...middleware: Array<express$Middleware>): T;
-  (path: express$Path|express$Path[], ...middleware: Array<express$Middleware>): T;
+declare type express$Middleware<Req: express$Request, Res: express$Response> =
+  ((req: Req, res: Res, next: express$NextFunction) => mixed) |
+  ((error: Error, req: Req, res: Res, next: express$NextFunction) => mixed);
+
+declare interface express$RouteMethodType<
+  T,
+  Req: express$Request,
+  Res: express$Response,
+> {
+  (middleware: express$Middleware<Req, Res>): T;
+  (...middleware: Array<express$Middleware<Req, Res>>): T;
+  (
+    path: express$Path | $ReadOnlyArray<express$Path>,
+    ...middleware: Array<express$Middleware<Req, Res>>
+  ): T;
 }
-declare class express$Route {
-  all: express$RouteMethodType<this>;
-  get: express$RouteMethodType<this>;
-  post: express$RouteMethodType<this>;
-  put: express$RouteMethodType<this>;
-  head: express$RouteMethodType<this>;
-  delete: express$RouteMethodType<this>;
-  options: express$RouteMethodType<this>;
-  trace: express$RouteMethodType<this>;
-  copy: express$RouteMethodType<this>;
-  lock: express$RouteMethodType<this>;
-  mkcol: express$RouteMethodType<this>;
-  move: express$RouteMethodType<this>;
-  purge: express$RouteMethodType<this>;
-  propfind: express$RouteMethodType<this>;
-  proppatch: express$RouteMethodType<this>;
-  unlock: express$RouteMethodType<this>;
-  report: express$RouteMethodType<this>;
-  mkactivity: express$RouteMethodType<this>;
-  checkout: express$RouteMethodType<this>;
-  merge: express$RouteMethodType<this>;
+
+declare class express$Route<Req: express$Request, Res: express$Response> {
+  all: express$RouteMethodType<this, Req, Res>;
+  get: express$RouteMethodType<this, Req, Res>;
+  post: express$RouteMethodType<this, Req, Res>;
+  put: express$RouteMethodType<this, Req, Res>;
+  head: express$RouteMethodType<this, Req, Res>;
+  delete: express$RouteMethodType<this, Req, Res>;
+  options: express$RouteMethodType<this, Req, Res>;
+  trace: express$RouteMethodType<this, Req, Res>;
+  copy: express$RouteMethodType<this, Req, Res>;
+  lock: express$RouteMethodType<this, Req, Res>;
+  mkcol: express$RouteMethodType<this, Req, Res>;
+  move: express$RouteMethodType<this, Req, Res>;
+  purge: express$RouteMethodType<this, Req, Res>;
+  propfind: express$RouteMethodType<this, Req, Res>;
+  proppatch: express$RouteMethodType<this, Req, Res>;
+  unlock: express$RouteMethodType<this, Req, Res>;
+  report: express$RouteMethodType<this, Req, Res>;
+  mkactivity: express$RouteMethodType<this, Req, Res>;
+  checkout: express$RouteMethodType<this, Req, Res>;
+  merge: express$RouteMethodType<this, Req, Res>;
 
   // @TODO Missing 'm-search' but get flow illegal name error.
 
-  notify: express$RouteMethodType<this>;
-  subscribe: express$RouteMethodType<this>;
-  unsubscribe: express$RouteMethodType<this>;
-  patch: express$RouteMethodType<this>;
-  search: express$RouteMethodType<this>;
-  connect: express$RouteMethodType<this>;
+  notify: express$RouteMethodType<this, Req, Res>;
+  subscribe: express$RouteMethodType<this, Req, Res>;
+  unsubscribe: express$RouteMethodType<this, Req, Res>;
+  patch: express$RouteMethodType<this, Req, Res>;
+  search: express$RouteMethodType<this, Req, Res>;
+  connect: express$RouteMethodType<this, Req, Res>;
 }
 
-declare class express$Router extends express$Route {
+declare class express$Router<
+  Req: express$Request,
+  Res: express$Response,
+> extends express$Route<Req, Res> {
   constructor(options?: express$RouterOptions): void;
-  route(path: string): express$Route;
-  static (options?: express$RouterOptions): express$Router;
-  use(middleware: express$Middleware): this;
-  use(...middleware: Array<express$Middleware>): this;
-  use(path: express$Path|express$Path[], ...middleware: Array<express$Middleware>): this;
-  use(path: string, router: express$Router): this;
+  route(path: string): express$Route<Req, Res>;
+  static <Req2: express$Request, Res2: express$Response>(
+    options?: express$RouterOptions,
+  ): express$Router<Req2, Res2>;
+  use(middleware: express$Middleware<Req, Res>): this;
+  use(...middleware: Array<express$Middleware<Req, Res>>): this;
+  use(
+    path: express$Path | $ReadOnlyArray<express$Path>,
+    ...middleware: Array<express$Middleware<Req, Res>>
+  ): this;
+  use(path: string, router: express$Router<Req, Res>): this;
   handle(req: http$IncomingMessage<>, res: http$ServerResponse, next: express$NextFunction): void;
   param(
     param: string,
     callback: (
-      req: express$Request,
-      res: express$Response,
+      req: Req,
+      res: Res,
       next: express$NextFunction,
-      id: string
+      value: string,
+      paramName: string,
     ) => mixed
   ): void;
   (req: http$IncomingMessage<>, res: http$ServerResponse, next?: ?express$NextFunction): void;
 }
 
-declare class express$Application extends express$Router mixins events$EventEmitter {
+declare class express$Application<
+  Req: express$Request,
+  Res: express$Response,
+> extends express$Router<Req, Res> mixins events$EventEmitter {
   constructor(): void;
   locals: {[name: string]: mixed};
   mountpath: string;
@@ -169,7 +190,7 @@ declare class express$Application extends express$Router mixins events$EventEmit
   listen(handle: Object, callback?: (err?: ?Error) => mixed): ?http$Server;
   disable(name: string): void;
   disabled(name: string): boolean;
-  enable(name: string): express$Application;
+  enable(name: string): this;
   enabled(name: string): boolean;
   engine(name: string, callback: Function): void;
   /**
@@ -186,16 +207,25 @@ declare class express$Application extends express$Router mixins events$EventEmit
 declare module 'express' {
   declare export type RouterOptions = express$RouterOptions;
   declare export type CookieOptions = express$CookieOptions;
-  declare export type Middleware = express$Middleware;
+  declare export type Middleware<
+    Req: express$Request,
+    Res: express$Response,
+  > = express$Middleware<Req, Res>;
   declare export type NextFunction = express$NextFunction;
   declare export type RequestParams = express$RequestParams;
   declare export type $Response = express$Response;
   declare export type $Request = express$Request;
-  declare export type $Application = express$Application;
+  declare export type $Application<
+    Req: express$Request,
+    Res: express$Response,
+  > = express$Application<Req, Res>;
 
   declare module.exports: {
-    (): express$Application, // If you try to call like a function, it will use this signature
-    static: (root: string, options?: Object) => express$Middleware, // `static` property on the function
-    Router: typeof express$Router, // `Router` property on the function
+    // If you try to call like a function, it will use this signature
+    <Req: express$Request, Res: express$Response>(): express$Application<Req, Res>,
+    // `static` property on the function
+    static: <Req: express$Request, Res: express$Response>(root: string, options?: Object) => express$Middleware<Req, Res>,
+    // `Router` property on the function
+    Router: typeof express$Router,
   };
 }

--- a/definitions/npm/express_v4.x.x/flow_v0.94.x-v0.103.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.94.x-v0.103.x/express_v4.x.x.js
@@ -97,14 +97,17 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
 }
 
 declare type express$NextFunction = (err?: ?Error | 'route') => mixed;
-declare type express$Middleware<Req: express$Request, Res: express$Response> =
+declare type express$Middleware<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> =
   ((req: Req, res: Res, next: express$NextFunction) => mixed) |
   ((error: Error, req: Req, res: Res, next: express$NextFunction) => mixed);
 
 declare interface express$RouteMethodType<
   T,
-  Req: express$Request,
-  Res: express$Response,
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
 > {
   (middleware: express$Middleware<Req, Res>): T;
   (...middleware: Array<express$Middleware<Req, Res>>): T;
@@ -114,7 +117,10 @@ declare interface express$RouteMethodType<
   ): T;
 }
 
-declare class express$Route<Req: express$Request, Res: express$Response> {
+declare class express$Route<
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
+> {
   all: express$RouteMethodType<this, Req, Res>;
   get: express$RouteMethodType<this, Req, Res>;
   post: express$RouteMethodType<this, Req, Res>;
@@ -147,8 +153,8 @@ declare class express$Route<Req: express$Request, Res: express$Response> {
 }
 
 declare class express$Router<
-  Req: express$Request,
-  Res: express$Response,
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
 > extends express$Route<Req, Res> {
   constructor(options?: express$RouterOptions): void;
   route(path: string): express$Route<Req, Res>;
@@ -177,8 +183,8 @@ declare class express$Router<
 }
 
 declare class express$Application<
-  Req: express$Request,
-  Res: express$Response,
+  Req: express$Request = express$Request,
+  Res: express$Response = express$Response,
 > extends express$Router<Req, Res> mixins events$EventEmitter {
   constructor(): void;
   locals: {[name: string]: mixed};
@@ -208,16 +214,16 @@ declare module 'express' {
   declare export type RouterOptions = express$RouterOptions;
   declare export type CookieOptions = express$CookieOptions;
   declare export type Middleware<
-    Req: express$Request,
-    Res: express$Response,
+    Req: express$Request = express$Request,
+    Res: express$Response = express$Response,
   > = express$Middleware<Req, Res>;
   declare export type NextFunction = express$NextFunction;
   declare export type RequestParams = express$RequestParams;
   declare export type $Response = express$Response;
   declare export type $Request = express$Request;
   declare export type $Application<
-    Req: express$Request,
-    Res: express$Response,
+    Req: express$Request = express$Request,
+    Res: express$Response = express$Response,
   > = express$Application<Req, Res>;
 
   declare module.exports: {

--- a/definitions/npm/express_v4.x.x/flow_v0.94.x-v0.103.x/test_overrideUseMethodClassExtension.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.94.x-v0.103.x/test_overrideUseMethodClassExtension.js
@@ -10,28 +10,26 @@ declare class test_express$CustomResponse extends express$Response {
   bar: string;
 }
 
-declare type test_express$CustomPath = string | RegExp;
+declare type expressConstructor =
+  <Req: express$Request, Res: express$Response>() => express$Application<Req, Res>;
 
-declare type test_express$CustomNextFunction = express$NextFunction;
-
-declare type test_express$CustomMiddleware =
-  ((req: test_express$CustomRequest, res: test_express$CustomResponse, next: test_express$CustomNextFunction) => mixed) |
-  ((error: Error, req: test_express$CustomRequest, res: test_express$CustomResponse, next: test_express$CustomNextFunction) => mixed);
-
-declare class test_express$CustomApplication extends express$Application {
-  constructor(expressConstructor: () => express$Application): this;
-  use(middleware: test_express$CustomMiddleware): this;
-  use(...middleware: Array<test_express$CustomMiddleware>): this;
-  use(path: test_express$CustomPath|test_express$CustomPath[], ...middleware: Array<test_express$CustomMiddleware>): this;
-  use(path: string, router: express$Router): this;
+declare class test_express$CustomApplication extends express$Application<
+  test_express$CustomRequest,
+  test_express$CustomResponse,
+> {
+  constructor(expressConstructor: expressConstructor): this;
 }
 
 // Class Extensions: Test Functions
 function test_express$CustomApplication(
-  expressConstructor: () => express$Application
+  expressConstructor: expressConstructor,
 ) {
   const express = expressConstructor();
-  express.use((req: any, res: any, next: express$NextFunction) => {
+  express.use((
+    req: test_express$CustomRequest,
+    res: test_express$CustomResponse,
+    next: express$NextFunction,
+  ) => {
     // Private Constructor Mutation: Add new properties
     req.foo = 'hello';
     res.bar = 'goodbye';
@@ -53,7 +51,7 @@ customApp.use('/something', (req: express$Request, res: express$Response, next: 
   res.bar;
   next();
 });
-customApp.use('/something', (req: test_express$CustomRequest, res: test_express$CustomResponse, next: test_express$CustomNextFunction) => {
+customApp.use('/something', (req: test_express$CustomRequest, res: test_express$CustomResponse, next: express$NextFunction) => {
   req.foo;
   res.bar;
   // $ExpectError

--- a/definitions/npm/express_v4.x.x/flow_v0.94.x-v0.103.x/test_response.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.94.x-v0.103.x/test_response.js
@@ -27,6 +27,18 @@ app.use(
 );
 app.post("/post-router-callable", router);
 
+// Can set a custom param on request
+app.param('test', (
+  req: express$Request & { testValue: string },
+  res: express$Response,
+  next: express$NextFunction,
+  id: string,
+  paramName: string,
+) => {
+  req.testValue = id;
+  next();
+});
+
 // Can use an express app directly as a server listener
 const httpServer = http.createServer(app);
 httpServer.listen(9000);

--- a/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
@@ -49,7 +49,7 @@ myRouter.use(handleRequest, (err: Error, req: express$Request, res: express$Resp
     next(err);
 });
 
-app.on('mount', (parent: express$Application) => {
+app.on('mount', (parent: express$Application<express$Request, express$Response>) => {
     console.log('Parent Loaded', parent);
     // $ExpectError
     parent.fail();
@@ -62,7 +62,7 @@ app.use('/foo', (req: express$Request, res: express$Response, next) => {
         .status(300);
 });
 
-const bar: express$Router = new Router();
+const bar: express$Router<express$Request, express$Response> = new Router();
 
 bar.get('/', (req: express$Request, res: express$Response): void => {
   // $ExpectError should be of type object
@@ -103,7 +103,7 @@ app.enable(100);
 // $ExpectError
 const f: number = app.enabled('100');
 
-const g: express$Application = app.enable('foo');
+const g: express$Application<express$Request, express$Response> = app.enable('foo');
 
 app.render('view', { title: 'News Feed' }, (err: ?Error, html: ?string): void => {
     if (err) return console.log(err);

--- a/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
@@ -49,7 +49,7 @@ myRouter.use(handleRequest, (err: Error, req: express$Request, res: express$Resp
     next(err);
 });
 
-app.on('mount', (parent: express$Application<express$Request, express$Response>) => {
+app.on('mount', (parent: express$Application<>) => {
     console.log('Parent Loaded', parent);
     // $ExpectError
     parent.fail();
@@ -62,7 +62,7 @@ app.use('/foo', (req: express$Request, res: express$Response, next) => {
         .status(300);
 });
 
-const bar: express$Router<express$Request, express$Response> = new Router();
+const bar: express$Router<> = new Router();
 
 bar.get('/', (req: express$Request, res: express$Response): void => {
   // $ExpectError should be of type object
@@ -103,7 +103,7 @@ app.enable(100);
 // $ExpectError
 const f: number = app.enabled('100');
 
-const g: express$Application<express$Request, express$Response> = app.enable('foo');
+const g: express$Application<> = app.enable('foo');
 
 app.render('view', { title: 'News Feed' }, (err: ?Error, html: ?string): void => {
     if (err) return console.log(err);


### PR DESCRIPTION
Flow 0.89 and above have a lint that complains about this, and it has been considered "unclear" outside libdefs since 0.72.