### PR TITLE
[react-color] Remove $Supertype usage

### DIFF
--- a/definitions/npm/react-color_v2.x.x/flow_v0.104.x-/react-color_v2.x.x.js
+++ b/definitions/npm/react-color_v2.x.x/flow_v0.104.x-/react-color_v2.x.x.js
@@ -164,9 +164,12 @@ declare module "react-color" {
   declare export var SwatchesPicker: Class<Component<SwatchesPickerProps>>;
   declare export var TwitterPicker: Class<Component<TwitterPickerProps>>;
 
-  declare export function CustomPicker<Props: {...}>(
-    Component: ComponentType<InjectedColorProps & $Supertype<Props>>
-  ): ComponentType<Props>;
+  declare export function CustomPicker<
+    Props: InjectedColorProps,
+    Comp: ComponentType<Props>,
+  >(
+    Component: Comp
+  ): ComponentType<$Diff<React$ElementConfig<Comp>, InjectedColorProps>>;
 }
 
 declare module "react-color/lib/components/common" {

--- a/definitions/npm/react-color_v2.x.x/flow_v0.56.x-v0.103.x/react-color_v2.x.x.js
+++ b/definitions/npm/react-color_v2.x.x/flow_v0.56.x-v0.103.x/react-color_v2.x.x.js
@@ -163,9 +163,12 @@ declare module "react-color" {
   declare export var SwatchesPicker: Class<Component<SwatchesPickerProps>>;
   declare export var TwitterPicker: Class<Component<TwitterPickerProps>>;
 
-  declare export function CustomPicker<Props: {}>(
-    Component: ComponentType<InjectedColorProps & $Supertype<Props>>
-  ): ComponentType<Props>;
+  declare export function CustomPicker<
+    Props: InjectedColorProps,
+    Comp: ComponentType<Props>,
+  >(
+    Component: Comp
+  ): ComponentType<$Diff<React$ElementConfig<Comp>, InjectedColorProps>>;
 }
 
 declare module "react-color/lib/components/common" {


### PR DESCRIPTION
Flow 0.89 and above have a lint that complains about this, and it has been considered "unclear" outside libdefs since 0.72.