### PR TITLE
Luxon v1.x.x: fix DateTime.until definition

### DIFF
--- a/definitions/npm/luxon_v1.x.x/flow_v0.104.x-/luxon_v1.x.x.js
+++ b/definitions/npm/luxon_v1.x.x/flow_v0.104.x-/luxon_v1.x.x.js
@@ -543,7 +543,7 @@ declare module "luxon" {
     |}): string;
     toString(): string;
     toUTC(offset?: number, options?: SetZoneOptions): DateTime;
-    until(other: DateTime): Duration;
+    until(other: DateTime): Interval;
     valueOf(): number;
   }
 }

--- a/definitions/npm/luxon_v1.x.x/flow_v0.104.x-/test_luxon.js
+++ b/definitions/npm/luxon_v1.x.x/flow_v0.104.x-/test_luxon.js
@@ -617,7 +617,7 @@ date.toObject({ includeConfig: false }).numberingSystem;
 (date.toUTC(32, { keepCalendarTime: true }): DateTime); // Support deprecated name for keepLocalTime
 (date.toUTC(32, { keepLocalTime: true }): DateTime);
 
-(date.until(DateTime.utc()): Duration);
+(date.until(DateTime.utc()): Interval);
 
 (date.valueOf(): number);
 

--- a/definitions/npm/luxon_v1.x.x/flow_v0.32.0-v0.103.x/luxon_v1.x.x.js
+++ b/definitions/npm/luxon_v1.x.x/flow_v0.32.0-v0.103.x/luxon_v1.x.x.js
@@ -527,7 +527,7 @@ declare module "luxon" {
     |}): string;
     toString(): string;
     toUTC(offset?: number, options?: SetZoneOptions): DateTime;
-    until(other: DateTime): Duration;
+    until(other: DateTime): Interval;
     valueOf(): number;
   }
 }


### PR DESCRIPTION
Fix of incorrect return type of `DateTime.until` method in [Luxon](https://www.npmjs.com/package/luxon), for reference please [see latest docs](https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#instance-method-until).