### PR TITLE
Fixed wrong type in phoenix socket transport option

### DIFF
--- a/definitions/npm/phoenix_v1.4.x/flow_v0.104.x-/phoenix_v1.4.x.js
+++ b/definitions/npm/phoenix_v1.4.x/flow_v0.104.x-/phoenix_v1.4.x.js
@@ -24,7 +24,7 @@ declare module 'phoenix' {
   declare export interface SocketConnectOption {
     binaryType: BinaryType,
     params: { [key: string]: any, ... } | (() => { [key: string]: any, ... }),
-    transport: string,
+    transport: typeof LongPoll | typeof WebSocket,
     timeout: number,
     heartbeatIntervalMs: number,
     longpollerTimeout: number,

--- a/definitions/npm/phoenix_v1.4.x/flow_v0.25.x-v0.103.x/phoenix_v1.4.x.js
+++ b/definitions/npm/phoenix_v1.4.x/flow_v0.25.x-v0.103.x/phoenix_v1.4.x.js
@@ -24,7 +24,7 @@ declare module 'phoenix' {
   declare export interface SocketConnectOption {
     binaryType: BinaryType,
     params: { [key: string]: any } | (() => { [key: string]: any }),
-    transport: string,
+    transport: typeof LongPoll | typeof WebSocket,
     timeout: number,
     heartbeatIntervalMs: number,
     longpollerTimeout: number,

--- a/definitions/npm/phoenix_v1.4.x/test_phoenix_v1.4.x.js
+++ b/definitions/npm/phoenix_v1.4.x/test_phoenix_v1.4.x.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-import { Channel, Socket, Presence } from 'phoenix';
+import { Channel, Socket, Presence, LongPoll } from 'phoenix';
 import { describe, it } from 'flow-typed-test';
 
 
@@ -54,5 +54,27 @@ describe('#phoenix', () => {
     // $ExpectError `Channel` instances must take a `Socket` as the final param
     const channel = new Channel('foo', {});
   })
+
+  it('sets up transport option correctly', () => {
+    const socket1 = new Socket('/socket', {
+      params: { userToken: '123' },
+      transport: LongPoll
+    });
+    socket1.connect();
+    const socket2 = new Socket('/socket', {
+      params: { userToken: '123' },
+      transport: WebSocket
+    });
+    socket2.connect();
+  })
+
+  it('errors on malformed transport option', () => {
+    // $ExpectError
+    const socket = new Socket('/socket', {
+      params: { userToken: '123' },
+      transport: {}
+    });
+  })
+
 });
 


### PR DESCRIPTION
On Phoenix `Socket` initialization, option `transport` is expected by type definitions to be string. This is also found in Phoenix.js official documentation, but it's an error. What the constructor actually expects is either `window.WebSocket` or `Phoenix.LongPoll`. Giving any string as transport option to the constructor will throw an error when `socket.connect()` is called.

The source code for phoenix sockets can be found here: https://github.com/phoenixframework/phoenix/blob/master/assets/js/phoenix.js
The initialization of Socket transport happens at row 737 and an error will be thrown at row 836 if the user erroneously gave a string to the constructor.

- Links to documentation: https://hexdocs.pm/phoenix/js/
- Link to GitHub or NPM: https://github.com/phoenixframework/phoenix
- Type of contribution: fix

Other notes:

