### PR TITLE
[react-router] Specify default export

### DIFF
--- a/definitions/npm/react-router_v5.x.x/flow_v0.104.x-/react-router_v5.x.x.js
+++ b/definitions/npm/react-router_v5.x.x/flow_v0.104.x-/react-router_v5.x.x.js
@@ -137,4 +137,17 @@ declare module "react-router" {
   ): null | Match;
   
   declare export function generatePath(pattern?: string, params?: {...}): string;
+
+  declare export default {
+    StaticRouter: typeof StaticRouter,
+    MemoryRouter: typeof MemoryRouter,
+    Router: typeof Router,
+    Prompt: typeof Prompt,
+    Redirect: typeof Redirect,
+    Route: typeof Route,
+    Switch: typeof Switch,
+    withRouter: typeof withRouter,
+    matchPath: typeof matchPath,
+    generatePath: typeof generatePath,
+  };
 }

--- a/definitions/npm/react-router_v5.x.x/flow_v0.104.x-/react-router_v5.x.x.js
+++ b/definitions/npm/react-router_v5.x.x/flow_v0.104.x-/react-router_v5.x.x.js
@@ -149,5 +149,6 @@ declare module "react-router" {
     withRouter: typeof withRouter,
     matchPath: typeof matchPath,
     generatePath: typeof generatePath,
+    ...
   };
 }

--- a/definitions/npm/react-router_v5.x.x/flow_v0.63.x-v0.103.x/react-router_v5.x.x.js
+++ b/definitions/npm/react-router_v5.x.x/flow_v0.63.x-v0.103.x/react-router_v5.x.x.js
@@ -130,4 +130,17 @@ declare module "react-router" {
   ): null | Match;
   
   declare export function generatePath(pattern?: string, params?: {}): string;
+
+  declare export default {
+    StaticRouter: typeof StaticRouter,
+    MemoryRouter: typeof MemoryRouter,
+    Router: typeof Router,
+    Prompt: typeof Prompt,
+    Redirect: typeof Redirect,
+    Route: typeof Route,
+    Switch: typeof Switch,
+    withRouter: typeof withRouter,
+    matchPath: typeof matchPath,
+    generatePath: typeof generatePath,
+  };
 }


### PR DESCRIPTION
The ESM version of `react-router` doesn't actually have a default export.

Node's experimental ESM support does not support destructuring imports from CommonJS modules. Since React Router 5 introduces a destructuring import on `is-react`, which is CJS-only, Node is unable to treat RR5 as ESM.

Instead, it's necessary to treat RR5 as CJS, but this means that a destructuring import on RR5 is impossible, and a "default" import is necessary. Without a default export in the libdef, Flow complains when it sees this.

For context, I've had to do this for `react-redux` in the past as well. Example: #3062