### PR TITLE
[ramda] Improve propSatisfies type definition

### DIFF
--- a/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/ramda_v0.26.x.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/ramda_v0.26.x.js
@@ -2058,19 +2058,19 @@ declare module ramda {
     boolean
   >;
 
-  declare function propSatisfies<T>(
-    cond: (x: $Values<T>) => boolean,
-    prop: $Keys<T>,
+  declare function propSatisfies<T, K>(
+    cond: (x: $ElementType<T, K>) => boolean,
+    prop: K,
     o: T
   ): boolean;
-  declare function propSatisfies<T>(
-    cond: (x: $Values<T>) => boolean,
-    prop: $Keys<T>,
+  declare function propSatisfies<T, K>(
+    cond: (x: $ElementType<T, K>) => boolean,
+    prop: K,
   ): (o: T) => boolean;
-  declare function propSatisfies<T>(
-    cond: (x: $Values<T>) => boolean,
-  ): ((prop:  $Keys<T>) => (o: T) => boolean) &
-    ((prop:  $Keys<T>, o: T) => boolean);
+  declare function propSatisfies<T, K>(
+    cond: (x: $ElementType<T, K>) => boolean,
+  ): ((prop:  K) => (o: T) => boolean) &
+    ((prop:  K, o: T) => boolean);
 
   declare function unless<T, V, S>(
     pred: UnaryPredicateFn<T>,

--- a/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/test_ramda_v0.26.x_logic.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/test_ramda_v0.26.x_logic.js
@@ -162,9 +162,20 @@ describe('propSatisfies', () => {
     it('should works with object', () => {
       const propSat: boolean = _.propSatisfies(x => x > 0, 'x', { x: 1, y: 2 });
     });
+    it('should works with object with properties of different types', () => {
+      const propSat: boolean = _.propSatisfies(x => x > 0, 'x', { x: 1, y: 2, str: 'different type' });
+      // same again but this time using a curried function
+      const propSatCurry: boolean = _.propSatisfies((x: number) => x > 0, 'x')({ x: 1, y: 2, str: 'different type' });
+    });
     it('should error when property does not exist', () => {
       //$ExpectError
       const propSat3: boolean = _.propSatisfies((x: number) => x > 0, 'z', { x: 1, y: 2 });
+    });
+    it('should error when condition param does not match property type', () => {
+      //$ExpectError
+      const propSat: boolean = _.propSatisfies(x => x > 0, 'str', { x: 1, y: 2, str: 'different type' });
+      //$ExpectError
+      const propSatCurry: boolean = _.propSatisfies((x: number) => x > 0, 'str')({ x: 1, y: 2, str: 'different type' });
     });
   });
   describe('with object as maps', () => {

--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/ramda_v0.26.x.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/ramda_v0.26.x.js
@@ -2061,19 +2061,19 @@ declare module ramda {
     boolean
   >;
 
-  declare function propSatisfies<T>(
-    cond: (x: $Values<T>) => boolean,
-    prop: $Keys<T>,
+  declare function propSatisfies<T, K>(
+    cond: (x: $ElementType<T, K>) => boolean,
+    prop: K,
     o: T
   ): boolean;
-  declare function propSatisfies<T>(
-    cond: (x: $Values<T>) => boolean,
-    prop: $Keys<T>,
+  declare function propSatisfies<T, K>(
+    cond: (x: $ElementType<T, K>) => boolean,
+    prop: K,
   ): (o: T) => boolean;
-  declare function propSatisfies<T>(
-    cond: (x: $Values<T>) => boolean,
-  ): ((prop:  $Keys<T>) => (o: T) => boolean) &
-    ((prop:  $Keys<T>, o: T) => boolean);
+  declare function propSatisfies<T, K>(
+    cond: (x: $ElementType<T, K>) => boolean,
+  ): ((prop:  K) => (o: T) => boolean) &
+    ((prop:  K, o: T) => boolean);
 
   declare function unless<T, V, S>(
     pred: UnaryPredicateFn<T>,

--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/test_ramda_v0.26.x_logic.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/test_ramda_v0.26.x_logic.js
@@ -162,9 +162,20 @@ describe('propSatisfies', () => {
     it('should works with object', () => {
       const propSat: boolean = _.propSatisfies(x => x > 0, 'x', { x: 1, y: 2 });
     });
+    it('should works with object with properties of different types', () => {
+      const propSat: boolean = _.propSatisfies(x => x > 0, 'x', { x: 1, y: 2, str: 'different type' });
+      // same again but this time using a curried function
+      const propSatCurry: boolean = _.propSatisfies((x: number) => x > 0, 'x')({ x: 1, y: 2, str: 'different type' });
+    });
     it('should error when property does not exist', () => {
       //$ExpectError
       const propSat3: boolean = _.propSatisfies((x: number) => x > 0, 'z', { x: 1, y: 2 });
+    });
+    it('should error when condition param does not match property type', () => {
+      //$ExpectError
+      const propSat: boolean = _.propSatisfies(x => x > 0, 'str', { x: 1, y: 2, str: 'different type' });
+      //$ExpectError
+      const propSatCurry: boolean = _.propSatisfies((x: number) => x > 0, 'str')({ x: 1, y: 2, str: 'different type' });
     });
   });
   describe('with object as maps', () => {


### PR DESCRIPTION
### Reason:
The current type definition of the `propSatisfies` Ramda function only works properly when using an object with properties of the same type. Otherwise it will complain as seen [here](https://flow.org/try/#0ATAmFMGMBsEMCdzAGYFcB2kAuBLA9usAA7x5EDKsuAzsjuNQDwAqAfABQBQIIkBoALmDsAHkIAkANVjRUDFqwCUwALytgAIzx5o4WOgA03HiTISA0uACeTNkZ7A8Q5scVCtOvegDcxiDAQkNExcAmJSCiocWnpbDmNefiFRCWlZeTZlNU1tXX17EwiLaziCt2EnYGYs9Q88nz8oOEQUDGx8QlNImjoM+Ic+dEFhMWApGTk4mpzPfNdk9i6hMcsbBWn2SurVWtyvZQAyBOFFopBxVdLHZ2m6-d9OTgB6J+AAOTxgcHhSeGAAC2+SFg1GAAHIRGDgPpQOCrFDAjksP9gOhUABbDTfUGcQbULDhMwzeqqQndaK9aiiHbAETAdQABgM4MhzIA3rShABGZlWIQAJmAAF9FA8XsAAKrUHDoADm0MIeA0ACsoASAO44ZFk764BiOZBgHDIZBA9AErBWIjgZnIaB4dXATXQaDAPjoohwGXUXEEfFk-nuPb6UldSg9WLU7J0xnMiFg9mc4A84B88H8hPAABeQiw8DkwtFjyAA).

### Solution:
One solution could be checking the type of the argument in the condition function (e.g. `typeof x === 'number'`) but it is quite verbose. Instead it would be better flow to infer what will be pass as an argument by using `$ElementType` as shown [here](https://flow.org/try/#0ATAmFMGMBsEMCdzAGYFcB2kAuBLA9usAA7x5EDKsuAzsjuNQDwAqANMANIB8AFAFAgQkAqABcwHgA9xAEgCi0cAFtw6LMwCeRcC3bcAlMAC8XYACM8eRbHSsBgkmXEc7g4HnHN7+8RavgbAG57CBgEJDRMXAJiUgoqHFp6JjZOXnshEXEpWQVlVXUtHVSDY1M-a1sM2KdOV2AfCQ9gZkMTc0tK4JBQuEQUDGx8Qkd4mjoGXTT+N2F0MQlpYHlFFTVNbSnS9oqAqpBGnh5R8U420x5m1rKO-xtDADJqo5OQF3dPc9vK-WC+Pjm1CwNSIvk6e2MIMo42SUhukmApgADOwAOSSVHsADewCWAEZ2BpxAAmYAAX1+-wA9FTgAA5PAAdxQ0CZwAA1ugmdRgAADSS84CJYCwYDoVBKMzgeAi+bAah4YCMgio4HCJREOA4Qja4BYAAWSDmoAGUWGAIIQJBxLBd0IRihCSSDDh7QRyLRGOxuPEBOAROAxPYQPg4lRoBwyGQ0oKeqKqPJlL4QA)

@LoganBarnett This is my first contribution so please let me know if I'm doing something wrong