### PR TITLE
Add missing param in react-native-navigation's registerComponent

### DIFF
--- a/definitions/npm/react-native-navigation_v3.x.x/flow_v0.104.x-/react-native-navigation_v3.x.x.js
+++ b/definitions/npm/react-native-navigation_v3.x.x/flow_v0.104.x-/react-native-navigation_v3.x.x.js
@@ -485,7 +485,7 @@ declare module 'react-native-navigation' {
 
   /* --- Events end  --- */
 
-  declare export type GetComponentClassFunc = () => React$ComponentType<{ componentId: string, ... }>;
+  declare export type ComponentProvider = () => React$ComponentType<{ componentId: string, ... }>;
 
   declare export type NavigationConstants = {|
     backButtonId: string,
@@ -497,13 +497,13 @@ declare module 'react-native-navigation' {
   declare export var Navigation: {|
     registerComponent(
       screenID: string | number,
-      getComponentClassFunc: GetComponentClassFunc,
-      concreteGetComponentClassFunc?: GetComponentClassFunc,
+      componentProvider: ComponentProvider,
+      concreteComponentProvider?: ComponentProvider,
     ): void,
     // Deprecated
     registerComponentWithRedux(
       screenID: string | number,
-      getComponentClassFunc: GetComponentClassFunc,
+      getComponentClassFunc: ComponentProvider,
       Provider: any,
       store: any
     ): void,

--- a/definitions/npm/react-native-navigation_v3.x.x/flow_v0.104.x-/react-native-navigation_v3.x.x.js
+++ b/definitions/npm/react-native-navigation_v3.x.x/flow_v0.104.x-/react-native-navigation_v3.x.x.js
@@ -497,7 +497,8 @@ declare module 'react-native-navigation' {
   declare export var Navigation: {|
     registerComponent(
       screenID: string | number,
-      getComponentClassFunc: GetComponentClassFunc
+      getComponentClassFunc: GetComponentClassFunc,
+      concreteGetComponentClassFunc?: GetComponentClassFunc,
     ): void,
     // Deprecated
     registerComponentWithRedux(

--- a/definitions/npm/react-native-navigation_v3.x.x/flow_v0.104.x-/test_react-native-navigation.js
+++ b/definitions/npm/react-native-navigation_v3.x.x/flow_v0.104.x-/test_react-native-navigation.js
@@ -145,17 +145,20 @@ describe('Navigation.registerComponent', () => {
   class CompWithProps extends React$Component<{ componentId: string, ... }> {}
   class CompWithWrongProps extends React$Component<{ componentId: boolean, ... }> {}
 
-  it('should passed when call with id as string', () => {
+  it('should pass when call with id as string', () => {
     Navigation.registerComponent('home', () => Comp);
   });
-  it('should passed when call with id as number', () => {
+  it('should pass when call with id as number', () => {
     Navigation.registerComponent(1, () => Comp);
   });
-  it('should passed when prop componentId is string', () => {
+  it('should pass when prop componentId is string', () => {
     Navigation.registerComponent(1, () => CompWithProps);
   });
+  it('should pass when componentProvider is given', () => {
+    Navigation.registerComponent(1, () => CompWithProps, () => Comp);
+  });
 
-  it("should raises an error when prop `componentId` ins't string", () => {
+  it("should raise an error when prop `componentId` isn't string", () => {
     // $ExpectError - `componentId: boolean` but need `string`
     Navigation.registerComponent('1', () => CompWithWrongProps);
   });
@@ -163,6 +166,12 @@ describe('Navigation.registerComponent', () => {
     const screenId = null;
     // $ExpectError - `screenId: void` but need string or number
     Navigation.registerComponent(screenId, () => Comp);
+  });
+  it('should raise an error when invalid componentProvider is given', () => {
+    // $ExpectError - `componentProvider: () => string` but need () => React$Component
+    Navigation.registerComponent(1, () => CompWithProps, () => 'string');
+    // $ExpectError - `componentProvider: string` but need () => React$Component
+    Navigation.registerComponent(1, () => CompWithProps, 'string');
   });
 });
 

--- a/definitions/npm/react-native-navigation_v3.x.x/flow_v0.91.1-v0.103.x/react-native-navigation_v3.x.x.js
+++ b/definitions/npm/react-native-navigation_v3.x.x/flow_v0.91.1-v0.103.x/react-native-navigation_v3.x.x.js
@@ -496,7 +496,8 @@ declare module 'react-native-navigation' {
   declare export var Navigation: {
     registerComponent(
       screenID: string | number,
-      getComponentClassFunc: GetComponentClassFunc
+      getComponentClassFunc: GetComponentClassFunc,
+      concreteGetComponentClassFunc?: GetComponentClassFunc,
     ): void,
 
     // Deprecated

--- a/definitions/npm/react-native-navigation_v3.x.x/flow_v0.91.1-v0.103.x/react-native-navigation_v3.x.x.js
+++ b/definitions/npm/react-native-navigation_v3.x.x/flow_v0.91.1-v0.103.x/react-native-navigation_v3.x.x.js
@@ -482,7 +482,7 @@ declare module 'react-native-navigation' {
 
   /* --- Events end  --- */
 
-  declare export type GetComponentClassFunc = () => React$ComponentType<{
+  declare export type ComponentProvider = () => React$ComponentType<{
     componentId: string,
   }>;
 
@@ -496,14 +496,14 @@ declare module 'react-native-navigation' {
   declare export var Navigation: {
     registerComponent(
       screenID: string | number,
-      getComponentClassFunc: GetComponentClassFunc,
-      concreteGetComponentClassFunc?: GetComponentClassFunc,
+      componentProvider: ComponentProvider,
+      concreteComponentProvider?: ComponentProvider,
     ): void,
 
     // Deprecated
     registerComponentWithRedux(
       screenID: string | number,
-      getComponentClassFunc: GetComponentClassFunc,
+      getComponentClassFunc: ComponentProvider,
       Provider: any,
       store: any
     ): void,

--- a/definitions/npm/react-native-navigation_v3.x.x/flow_v0.91.1-v0.103.x/test_react-native-navigation.js
+++ b/definitions/npm/react-native-navigation_v3.x.x/flow_v0.91.1-v0.103.x/test_react-native-navigation.js
@@ -143,24 +143,33 @@ describe('Navigation.registerComponent', () => {
   class CompWithProps extends React$Component<{ componentId: string }> {}
   class CompWithWrongProps extends React$Component<{ componentId: boolean }> {}
 
-  it('should passed when call with id as string', () => {
+  it('should pass when call with id as string', () => {
     Navigation.registerComponent('home', () => Comp);
   });
-  it('should passed when call with id as number', () => {
+  it('should pass when call with id as number', () => {
     Navigation.registerComponent(1, () => Comp);
   });
-  it('should passed when prop componentId is string', () => {
+  it('should pass when prop componentId is string', () => {
     Navigation.registerComponent(1, () => CompWithProps);
   });
+  it('should pass when componentProvider is given', () => {
+    Navigation.registerComponent(1, () => CompWithProps, () => Comp);
+  });
 
-  it("should raises an error when prop `componentId` ins't string", () => {
+  it("should raise an error when prop `componentId` isn't string", () => {
     // $ExpectError - `componentId: boolean` but need `string`
     Navigation.registerComponent('1', () => CompWithWrongProps);
   });
-  it('should raises an error when invalid screenID type', () => {
+  it('should raise an error when invalid screenID type', () => {
     const screenId = null;
     // $ExpectError - `screenId: void` but need string or number
     Navigation.registerComponent(screenId, () => Comp);
+  });
+  it('should raise an error when invalid componentProvider is given', () => {
+    // $ExpectError - `componentProvider: () => string` but need () => React$Component
+    Navigation.registerComponent(1, () => CompWithProps, () => 'string');
+    // $ExpectError - `componentProvider: string` but need () => React$Component
+    Navigation.registerComponent(1, () => CompWithProps, 'string');
   });
 });
 


### PR DESCRIPTION
I have added the optional third parameter `concreteComponentProvider` which was missing from `registerComponent`. I have also renamed `getClassComponentFunc` to `componentProvider` to match the TypeScript definition: https://github.com/wix/react-native-navigation/blob/master/lib/src/Navigation.ts#L77