### PR TITLE
Type fixed for options of winston timestamp format

### DIFF
--- a/definitions/npm/winston_v3.x.x/flow_v0.104.x-/winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/flow_v0.104.x-/winston_v3.x.x.js
@@ -81,7 +81,7 @@ declare type $winstonFormatSubModule = {
   splat: () => $winstonFormat,
   timestamp: (?{
     alias?: string,
-    format?: string,
+    format?: string | () => string,
     ...
   }) => $winstonFormat,
   colorize: () => $winstonFormat,

--- a/definitions/npm/winston_v3.x.x/flow_v0.34.x-v0.103.x/winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/flow_v0.34.x-v0.103.x/winston_v3.x.x.js
@@ -79,7 +79,7 @@ declare type $winstonFormatSubModule = {
   prettyPrint: () => $winstonFormat,
   simple: () => $winstonFormat,
   splat: () => $winstonFormat,
-  timestamp: (?{ alias?: string, format?: string }) => $winstonFormat,
+  timestamp: (?{ alias?: string, format?: string | () => string }) => $winstonFormat,
   colorize: () => $winstonFormat,
   logstash: () => $winstonFormat,
   printf: ((args: $winstonInfo<Object>) => string) => $winstonFormat

--- a/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
@@ -22,6 +22,7 @@ const customPrintf: Format = winston.format.printf(info => {
 
 let logger: Logger<Levels> = winston.createLogger({
   format: winston.format.combine(
+    winston.format.timestamp(),
     customFormat(),
     winston.format.json(),
     winston.format.label({label: 'label'}),
@@ -35,7 +36,7 @@ let logger: Logger<Levels> = winston.createLogger({
     new winston.transports.File({ filename: "error.log", level: "error" }),
     new winston.transports.Console({
       format: winston.format.combine(
-        winston.format.timestamp(),
+        winston.format.timestamp({ format: 'This is timestamp string' }),
         winston.format.simple()
       )
     })
@@ -50,7 +51,12 @@ logger.log({
 
 logger.clear();
 
-const consoleTransport: ConsoleTransport<Levels> = new winston.transports.Console();
+const consoleTransport: ConsoleTransport<Levels> = new winston.transports.Console({
+  format: winston.format.combine(
+    winston.format.timestamp({ format: () => 'This is timestamp function' }),
+    winston.format.simple()
+  )
+});
 
 consoleTransport.level = 'debug';
 consoleTransport.silent = true;


### PR DESCRIPTION
- Links to documentation:
https://github.com/winstonjs/winston
- Type of contribution: fix

Winston timestamp format takes options object. The `format` field of this object can be either of type `string` or of type `() => string`.

