### PR TITLE
Updated octokit/rest to avoid vulnerability

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
-    "@octokit/rest": "^15.12.1",
+    "@octokit/rest": "^16.33.1",
     "colors": "^1.3.2",
     "flowgen": "^1.9.0",
     "fs-extra": "^7.0.0",


### PR DESCRIPTION
npm audit identified a vulnerability in https-proxy-agent which is included through octokit/rest. Updating octokit/rest will use a version that does not use the vulnerable https-proxy-agen

https://www.npmjs.com/advisories/1184
