### PR TITLE
Add options method to instance

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -10,7 +10,7 @@
   "bugs": {
     "url": "https://github.com/flow-typed/flow-typed/issues"
   },
-  "version": "2.6.1",
+  "version": "2.6.2",
   "main": "dist/cli.js",
   "bin": "dist/cli.js",
   "scripts": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "flow-typed",
+  "name": "@flockcover/flow-typed",
   "description": "A repository of high quality flow type definitions",
   "license": "MIT",
   "homepage": "https://github.com/flow-typed/flow-typed#readme",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@flockcover/flow-typed",
+  "name": "flow-typed",
   "description": "A repository of high quality flow type definitions",
   "license": "MIT",
   "homepage": "https://github.com/flow-typed/flow-typed#readme",

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -100,7 +100,7 @@ export function setup(yargs: Yargs) {
       alias: 'o',
       describe: 'Overwrite an existing libdef',
       type: 'string',
-      demand: false
+      demand: false,
     },
     ignoreDeps: {
       alias: 'i',

--- a/definitions/npm/axios_v0.18.x/flow_v0.104.x-/axios_v0.18.x.js
+++ b/definitions/npm/axios_v0.18.x/flow_v0.104.x-/axios_v0.18.x.js
@@ -112,6 +112,10 @@ declare module 'axios' {
       url: string,
       config?: AxiosXHRConfigBase<T, R>
     ): AxiosPromise<T, R>;
+    options<T, R>(
+      url: string,
+      config?: AxiosXHRConfigBase<T, R>
+    ): AxiosPromise<T, R>;
     head<T, R>(
       url: string,
       config?: AxiosXHRConfigBase<T, R>

--- a/definitions/npm/axios_v0.18.x/flow_v0.104.x-/test_axios_v0.18.x.js
+++ b/definitions/npm/axios_v0.18.x/flow_v0.104.x-/test_axios_v0.18.x.js
@@ -22,6 +22,7 @@ import type {
 const client = axios.create();
 
 client.post('/something', {});
+client.options('/something', {});
 
 (client.defaults.headers.common.Authorization = 'test')
 

--- a/definitions/npm/axios_v0.18.x/flow_v0.25.x-v0.74.x/axios_v0.18.x.js
+++ b/definitions/npm/axios_v0.18.x/flow_v0.25.x-v0.74.x/axios_v0.18.x.js
@@ -104,6 +104,7 @@ declare module "axios" {
     request<T,R>(config: AxiosXHRConfig<T,R>): AxiosPromise<T,R>;
     delete<T,R>(url: string, config?: AxiosXHRConfigBase<T,R>): AxiosPromise<T,R>;
     get<T,R>(url: string, config?: AxiosXHRConfigBase<T,R>): AxiosPromise<T,R>;
+    options<T,R>(url: string, config?: AxiosXHRConfigBase<T,R>): AxiosPromise<T,R>;
     head<T,R>(url: string, config?: AxiosXHRConfigBase<T,R>): AxiosPromise<T,R>;
     post<T,R>(
       url: string,

--- a/definitions/npm/axios_v0.18.x/flow_v0.75.x-v0.79.x/axios_v0.18.x.js
+++ b/definitions/npm/axios_v0.18.x/flow_v0.75.x-v0.79.x/axios_v0.18.x.js
@@ -101,6 +101,7 @@ declare module "axios" {
     request<T,R>(config: AxiosXHRConfig<T,R>): AxiosPromise<T,R>;
     delete<T,R>(url: string, config?: AxiosXHRConfigBase<T,R>): AxiosPromise<T,R>;
     get<T,R>(url: string, config?: AxiosXHRConfigBase<T,R>): AxiosPromise<T,R>;
+    options<T,R>(url: string, config?: AxiosXHRConfigBase<T,R>): AxiosPromise<T,R>;
     head<T,R>(url: string, config?: AxiosXHRConfigBase<T,R>): AxiosPromise<T,R>;
     post<T,R>(
       url: string,

--- a/definitions/npm/axios_v0.18.x/flow_v0.80.x-v0.92.x/axios_v0.18.x.js
+++ b/definitions/npm/axios_v0.18.x/flow_v0.80.x-v0.92.x/axios_v0.18.x.js
@@ -110,6 +110,10 @@ declare module 'axios' {
       url: string,
       config?: AxiosXHRConfigBase<T, R>
     ): AxiosPromise<T, R>;
+    options<T, R>(
+      url: string,
+      config?: AxiosXHRConfigBase<T, R>
+    ): AxiosPromise<T, R>;
     head<T, R>(
       url: string,
       config?: AxiosXHRConfigBase<T, R>

--- a/definitions/npm/axios_v0.18.x/flow_v0.93.x-v0.103.x/axios_v0.18.x.js
+++ b/definitions/npm/axios_v0.18.x/flow_v0.93.x-v0.103.x/axios_v0.18.x.js
@@ -110,6 +110,10 @@ declare module 'axios' {
       url: string,
       config?: AxiosXHRConfigBase<T, R>
     ): AxiosPromise<T, R>;
+    options<T, R>(
+      url: string,
+      config?: AxiosXHRConfigBase<T, R>
+    ): AxiosPromise<T, R>;
     head<T, R>(
       url: string,
       config?: AxiosXHRConfigBase<T, R>


### PR DESCRIPTION
Based on the api documentation of the 0.18.1 version, the options method is available
[`axios.options(url[, config])`](https://github.com/axios/axios/tree/release/0.18.X#axiosoptionsurl-config)

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation:
- Link to GitHub or NPM: 
- Type of contribution: new definition | addition | fix | refactor

Other notes:

