### PR TITLE
Add a lib def for @koa/router

### DIFF
--- a/definitions/npm/@koa/router_v8.0.x/flow_v0.84.x-/router_v8.0.x.js
+++ b/definitions/npm/@koa/router_v8.0.x/flow_v0.84.x-/router_v8.0.x.js
@@ -1,0 +1,119 @@
+declare module "koa-router" {
+  declare type Middleware = (
+    ctx: any,
+    next: () => Promise<void>
+  ) => Promise<void> | void;
+
+  declare type ParamMiddleware = (
+    param: string,
+    ctx: any,
+    next: () => Promise<void>
+  ) => Promise<void> | void;
+
+  declare class Router {
+    constructor(opts?: $Shape<{|
+      +prefix: string,
+      +sensitive: boolean,
+      +strict: boolean,
+      +methods: Array<string>,
+    |}>): Router;
+
+    get(
+      name: string,
+      route: string | string[],
+      handler: Middleware
+    ): this;
+    get(
+      route: string | string[],
+      ...middleware: Array<Middleware>
+    ): this;
+
+    patch(
+      name: string,
+      route: string | string[],
+      handler: Middleware
+    ): this;
+    patch(
+      route: string | string[],
+      ...middleware: Array<Middleware>
+    ): this;
+
+    post(
+      name: string,
+      route: string | string[],
+      handler: Middleware
+    ): this;
+    post(
+      route: string | string[],
+      ...middleware: Array<Middleware>
+    ): this;
+
+    put(
+      name: string,
+      route: string | string[],
+      handler: Middleware
+    ): this;
+    put(
+      route: string | string[],
+      ...middleware: Array<Middleware>
+    ): this;
+
+    delete(
+      name: string,
+      route: string | string[],
+      handler: Middleware
+    ): this;
+    delete(
+      route: string | string[],
+      ...middleware: Array<Middleware>
+    ): this;
+
+    del(
+      name: string,
+      route: string | string[],
+      handler: Middleware
+    ): this;
+    del(
+      route: string | string[],
+      ...middleware: Array<Middleware>
+    ): this;
+
+    all(
+      name: string,
+      route: string | string[],
+      handler: Middleware
+    ): this;
+    all(
+      route: string | string[],
+      ...middleware: Array<Middleware>
+    ): this;
+
+    use(...middleware: Array<Middleware>): this;
+    use(
+      path: string | Array<string>,
+      ...middleware: Array<Middleware>
+    ): this;
+
+    prefix(prefix: string): this;
+
+    routes(): Middleware;
+
+    allowedMethods(options?: $Shape<{|
+      +throw: boolean,
+      +notImplemented: () => any,
+      +methodNotAllowed: () => any,
+    |}>): Middleware;
+
+    param(param: string, middleware: ParamMiddleware): this;
+
+    redirect(source: string, destination: string, code?: number): this;
+
+    route(name: string): any | false;
+
+    url(name: string, params: { ... }, options?: {| query: { ... } | string |}): string | Error;
+
+    static url(path: string, params: { ... }): string;
+  }
+
+  declare module.exports: typeof Router;
+}

--- a/definitions/npm/@koa/router_v8.0.x/test_koa-router.js
+++ b/definitions/npm/@koa/router_v8.0.x/test_koa-router.js
@@ -1,0 +1,155 @@
+import { describe, it } from 'flow-typed-test';
+import Router from "koa-router";
+
+describe('expectations', () => {
+  it('defines a Middleware type', () => {
+    // $ExpectError
+    const badMiddleware: KoaRouter$Middleware = 10;
+    const goodMiddleware: KoaRouter$Middleware = async (ctx, next) => {};
+  });
+
+  it('types the constructor properly', () => {
+    // $ExpectError
+    const badRouter = new Router({ prefix: 10 });
+    const goodRouter = new Router({ prefix: "/api" });
+  });
+
+  it('static url()', () => {
+    // $ExpectError
+    Router.url('/users/:id', 1);
+    (Router.url('/users/:id', { id: 1 }): string);
+  });
+
+  it('Router is typechecked', () => {
+    // $ExpectError
+    Router.foobar();
+  })
+
+  describe('router methods', () => {
+    const router = new Router();
+
+    it('is typechecked', () => {
+      // $ExpectError
+      router.foobar();
+    });
+
+    it('get()', () => {
+      // $ExpectError
+      router.get(10);
+      router.get("/", async ctx => {
+        ctx.body = "Hello World";
+      });
+      router.get(["/", "/foo"], ctx => {});
+      router.get(["/", "/foo"], ctx => {}, ctx => {});
+      router.get('user', "/", ctx => {});
+    });
+
+    it('post()', () => {
+      // $ExpectError
+      router.post(10);
+      router.post("/", async ctx => {
+        ctx.body = "Hello World";
+      });
+      router.post(["/", "/foo"], ctx => {});
+      router.post(["/", "/foo"], ctx => {}, ctx => {});
+      router.post('user', "/", ctx => {});
+    });
+
+    it('patch()', () => {
+      // $ExpectError
+      router.patch(10);
+      router.patch("/", async ctx => {
+        ctx.body = "Hello World";
+      });
+      router.patch(["/", "/foo"], ctx => {});
+      router.patch(["/", "/foo"], ctx => {}, ctx => {});
+      router.patch('user', "/", ctx => {});
+    });
+
+    it('put()', () => {
+      // $ExpectError
+      router.put(10);
+      router.put("/", async ctx => {
+        ctx.body = "Hello World";
+      });
+      router.put(["/", "/foo"], ctx => {});
+      router.put(["/", "/foo"], ctx => {}, ctx => {});
+      router.put('user', "/", ctx => {});
+    });
+
+    it('delete()', () => {
+      // $ExpectError
+      router.delete(10);
+      router.delete("/", async ctx => {
+        ctx.body = "Hello World";
+      });
+      router.delete(["/", "/foo"], ctx => {});
+      router.delete(["/", "/foo"], ctx => {}, ctx => {});
+      router.delete('user', "/", ctx => {});
+    });
+
+    it('del()', () => {
+      // $ExpectError
+      router.del(10);
+      router.del("/", async ctx => {
+        ctx.body = "Hello World";
+      });
+      router.del(["/", "/foo"], ctx => {});
+      router.del(["/", "/foo"], ctx => {}, ctx => {});
+      router.del('user', "/", ctx => {});
+    });
+
+    it('all()', () => {
+      // $ExpectError
+      router.all(10);
+      router.all("/", async ctx => {
+        ctx.body = "Hello World";
+      });
+      router.all(["/", "/foo"], ctx => {});
+      router.all(["/", "/foo"], ctx => {}, ctx => {});
+      router.all('user', "/", ctx => {});
+    });
+
+    it('use()', () => {
+      // $ExpectError
+      router.use(10);
+      router.use(async ctx => {});
+      router.use("/foo", async ctx => {});
+      router.use(["/foo", "/bar"], async ctx => {});
+    });
+
+    it('param()', () => {
+      router.param("foo", async ctx => {
+        // $ExpectError
+        console.log(ctx.params.foo);
+      });
+      router.param("foo", async (foo, ctx) => {});
+      router.param("foo", (foo, ctx, next) => {});
+    });
+
+    it('url()', () => {
+      // $ExpectError
+      router.url(10);
+      // $ExpectError
+      router.url('user');
+      (router.url('user', { id: 3 }): string | Error);
+      (router.url('user', { id: 3 }, { query: "limit=1" }): string | Error);
+      (router.url('user', { id: 3 }, { query: { limit: 1 } }): string | Error);
+    });
+
+    it('redirect()', () => {
+      router.redirect('/source', 'destination');
+      router.redirect('/source', 'destination', 302);
+      // $ExpectError
+      router.redirect('/source', 302);
+    });
+
+    it('routes() and allowedMethods()', () => {
+      const nestedRouter = new Router();
+      router.use(nestedRouter.routes());
+      router.use(nestedRouter.allowedMethods());
+      router.use(nestedRouter.routes(), nestedRouter.allowedMethods());
+    });
+  });
+});
+


### PR DESCRIPTION
- Links to documentation: https://github.com/koajs/router/blob/master/API.md
- Link to GitHub or NPM: https://github.com/koajs/router
- Type of contribution: new definition

Other notes:
I copied most of it from `koa-router`; indeed this npm module has been forked and renamed because the original was unmaintained.
I only kept the version for "v0.104-" but adapted it to make it work with some earlier flow versions, which is simpler if we don't want to support versions of flow earlier than v0.84.
Also I added the newest additions (there's a new parameter in the `url` method).
Lastly I kept most tests but reorganized them with describe and it, as well as added new ones.

Tell me what you think!