### PR TITLE
Export NetInfo enumerations

### DIFF
--- a/definitions/npm/@react-native-community/netinfo_v4.x.x/flow_v0.69.x-/netinfo_v4.x.x.js
+++ b/definitions/npm/@react-native-community/netinfo_v4.x.x/flow_v0.69.x-/netinfo_v4.x.x.js
@@ -50,6 +50,24 @@ declare module '@react-native-community/netinfo' {
     listener: (NetInfoState) => mixed
   ): NetInfoSubscription;
 
+  declare export var NetInfoStateType: $ReadOnly<{|
+    unknown: "unknown",
+    none: "none",
+    cellular: "cellular",
+    wifi: "wifi",
+    bluetooth: "bluetooth",
+    ethernet: "ethernet",
+    wimax: "wimax",
+    vpn: "vpn",
+    other: "other"
+  |}>
+
+  declare export var NetInfoCellularGeneration: $ReadOnly<{|
+    '2g': "2g",
+    '3g': "3g",
+    '4g': "4g"
+  |}>
+
   declare export default $ReadOnly<{|
     fetch: typeof fetch,
     addEventListener: typeof addEventListener,


### PR DESCRIPTION
NetInfo packages exports enums to our reuse but are not visible to Flow because are missing in definition.

- Links to documentation:
  - https://github.com/react-native-community/react-native-netinfo#netinfostatetype
  - https://github.com/react-native-community/react-native-netinfo#netinfocellulargeneration
- Link to GitHub or NPM:
  - https://github.com/react-native-community/react-native-netinfo/blob/master/src/internal/types.ts#L10
  - https://github.com/react-native-community/react-native-netinfo/blob/master/src/internal/types.ts#L22
- Type of contribution: addition

Other notes:
The enums are exported here: https://github.com/react-native-community/react-native-netinfo/blob/master/src/index.ts#L215

