### PR TITLE
fix(@apollo/*): export ApolloError type

### DIFF
--- a/definitions/npm/@apollo/react-common_v3.x.x/flow_v0.104.x-/react-common_v3.x.x.js
+++ b/definitions/npm/@apollo/react-common_v3.x.x/flow_v0.104.x-/react-common_v3.x.x.js
@@ -669,13 +669,14 @@ declare module '@apollo/react-common' {
     ...,
   };
 
-  declare class ApolloError extends Error {
+  declare class $ApolloError extends Error {
     message: string;
     graphQLErrors: Array<GraphQLError>;
     networkError: Error | null;
     extraInfo: any;
     constructor(info: ErrorConstructor): this;
   }
+  declare export type ApolloError = $ApolloError;
 
   declare interface ErrorConstructor {
     graphQLErrors?: Array<GraphQLError>;

--- a/definitions/npm/@apollo/react-components_v3.x.x/flow_v0.104.x-/react-components_v3.x.x.js
+++ b/definitions/npm/@apollo/react-components_v3.x.x/flow_v0.104.x-/react-components_v3.x.x.js
@@ -405,13 +405,14 @@ declare module '@apollo/react-components' {
     ...,
   };
 
-  declare class ApolloError extends Error {
+  declare class $ApolloError extends Error {
     message: string;
     graphQLErrors: Array<GraphQLError>;
     networkError: Error | null;
     extraInfo: any;
     constructor(info: ErrorConstructor): this;
   }
+  declare export type ApolloError = $ApolloError;
 
   declare interface ErrorConstructor {
     graphQLErrors?: Array<GraphQLError>;

--- a/definitions/npm/@apollo/react-components_v3.x.x/flow_v0.58.x-v0.103.x/react-components_v3.x.x.js
+++ b/definitions/npm/@apollo/react-components_v3.x.x/flow_v0.58.x-v0.103.x/react-components_v3.x.x.js
@@ -387,13 +387,14 @@ declare module '@apollo/react-components' {
     [queryName: string]: MutationQueryReducer<T>,
   };
 
-  declare class ApolloError extends Error {
+  declare class $ApolloError extends Error {
     message: string;
     graphQLErrors: Array<GraphQLError>;
     networkError: Error | null;
     extraInfo: any;
     constructor(info: ErrorConstructor): this;
   }
+  declare export type ApolloError = $ApolloError;
 
   declare interface ErrorConstructor {
     graphQLErrors?: Array<GraphQLError>;

--- a/definitions/npm/@apollo/react-hoc_v3.x.x/flow_v0.104.x-/react-hoc_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hoc_v3.x.x/flow_v0.104.x-/react-hoc_v3.x.x.js
@@ -1,8 +1,8 @@
 declare module '@apollo/react-hoc' {
   import type { ComponentType, Element, Node } from 'react';
-  
+
   declare type Dict = { [key: string]: any, ...};
-  
+
 
   declare type MakeOptional = <V>(V) => ?V;
   declare type MakeDataOptional<TData> = $ObjMap<TData, MakeOptional> | void;
@@ -400,13 +400,14 @@ declare module '@apollo/react-hoc' {
     T = { [key: string]: any, ... }
   > = { [queryName: string]: MutationQueryReducer<T>, ... };
 
-  declare class ApolloError extends Error {
+  declare class $ApolloError extends Error {
     message: string;
     graphQLErrors: Array<GraphQLError>;
     networkError: Error | null;
     extraInfo: any;
     constructor(info: ErrorConstructor): this;
   }
+  declare export type ApolloError = $ApolloError;
 
   declare interface ErrorConstructor {
     graphQLErrors?: Array<GraphQLError>;

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
@@ -806,13 +806,14 @@ declare module '@apollo/react-hooks' {
     ...,
   };
 
-  declare class ApolloError extends Error {
+  declare class $ApolloError extends Error {
     message: string;
     graphQLErrors: Array<GraphQLError>;
     networkError: Error | null;
     extraInfo: any;
     constructor(info: ErrorConstructor): this;
   }
+  declare export type ApolloError = $ApolloError;
 
   declare interface ErrorConstructor {
     graphQLErrors?: Array<GraphQLError>;

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
@@ -699,13 +699,14 @@ declare module '@apollo/react-hooks' {
     [queryName: string]: MutationQueryReducer<T>,
   };
 
-  declare class ApolloError extends Error {
+  declare class $ApolloError extends Error {
     message: string;
     graphQLErrors: Array<GraphQLError>;
     networkError: Error | null;
     extraInfo: any;
     constructor(info: ErrorConstructor): this;
   }
+  declare export type ApolloError = $ApolloError;
 
   declare interface ErrorConstructor {
     graphQLErrors?: Array<GraphQLError>;


### PR DESCRIPTION
I'm migrating a lot of code that has `import { type ApolloError } from 'react-apollo'` to `@apollo/react-hooks` and `@apollo/react-components`