### PR TITLE
Fix typo in styled comonent SCMProps children type

### DIFF
--- a/definitions/npm/styled-components_v4.x.x/flow_v0.104.x-/styled-components_v4.x.x.js
+++ b/definitions/npm/styled-components_v4.x.x/flow_v0.104.x-/styled-components_v4.x.x.js
@@ -83,7 +83,7 @@ declare module 'styled-components' {
   declare export function isStyledComponent(target: any): boolean;
 
   declare type SCMProps = {
-    children?: Reactt$Element<any>,
+    children?: React$Element<any>,
     sheet?: StyleSheet,
     target?: HTMLElement,
     ...


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation:
- Link to GitHub or NPM: 
- Type of contribution: fix

Other notes:

This is a tiny fix to a typo that was causing FlowJS to complain about a type not being found