### PR TITLE
Fix typo in react-navigation_v4.x.x.js

### DIFF
--- a/definitions/npm/react-navigation_v4.x.x/flow_v0.104.x-/react-navigation_v4.x.x.js
+++ b/definitions/npm/react-navigation_v4.x.x/flow_v0.104.x-/react-navigation_v4.x.x.js
@@ -216,7 +216,7 @@ declare module 'react-navigation' {
 
   declare export type NavigationScreenOptionsGetter<Options: {...}> = (
     navigation: NavigationScreenProp<NavigationRoute>,
-    ncreenProps: ?NavigationScreenProps,
+    screenProps: ?NavigationScreenProps,
     theme: SupportedThemes,
   ) => Options;
 


### PR DESCRIPTION
- Type of contribution: fix

Other notes: This change fixes typo in `screenProps` property naming
 
