### PR TITLE
Fix GH_CLIENT usage in runTests test

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -116,7 +116,7 @@ async function getOrderedFlowBinVersions(
     const OS_ARCH_FILTER_RE = new RegExp(`flow-${BIN_PLATFORM}`);
 
     let page = 0;
-    const apiPayload = await GH_CLIENT.repos.getReleases({
+    const apiPayload = await GH_CLIENT.repos.listReleases({
       owner: 'facebook',
       repo: 'flow',
       page: page++,


### PR DESCRIPTION
- Links to documentation: https://octokit.github.io/rest.js/#octokit-routes-repos-list-releases
- Type of contribution:  fix

Other notes:

The `getReleases` method was renamed to `listReleases` in version 16 of
the @octokit/rest package (https://github.com/octokit/rest.js/releases/tag/v16.0.1 first item
     of breaking changes). flow-typed upgraded from 15.12.1 to 16.33.1
in [recently](fed266bbb15f7bf75780b573317720fbee497dd8) and that's when the bug was probably introduced.

The bug is not triggered in Travis CI because:

1.  the flow binaries are probably all cached and you don't need to
    download them
2.  the code that downloads them is in a try/catch block. If the
    download fails, the tests default to using the cached binaries. This
    works for people who have run the tests before, but not for
    newcomers like me.