### PR TITLE
Fix react-router useRouteMatch definitions

### DIFF
--- a/definitions/npm/react-router-dom_v5.x.x/flow_v0.104.x-/react-router-dom_v5.x.x.js
+++ b/definitions/npm/react-router-dom_v5.x.x/flow_v0.104.x-/react-router-dom_v5.x.x.js
@@ -178,7 +178,7 @@ declare module "react-router-dom" {
   declare export function useHistory(): $PropertyType<ContextRouter, 'history'>;
   declare export function useLocation(): $PropertyType<ContextRouter, 'location'>;
   declare export function useParams(): $PropertyType<$PropertyType<ContextRouter, 'match'>, 'params'>;
-  declare export function useRouteMatch(path?: string): $PropertyType<ContextRouter, 'match'>;
+  declare export function useRouteMatch(path?: MatchPathOptions | string | string[]): $PropertyType<ContextRouter, 'match'>;
 
   declare export function generatePath(pattern?: string, params?: { +[string]: mixed, ... }): string;
 }

--- a/definitions/npm/react-router-dom_v5.x.x/flow_v0.104.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v5.x.x/flow_v0.104.x-/test_react-router-dom.js
@@ -416,6 +416,19 @@ describe("react-router-dom", () => {
     it('useRouteMatch', () => {
       const match: Match = useRouteMatch();
       const matchPath: Match = useRouteMatch('/path');
+      const matchArray: Match = useRouteMatch(['/path', '/the/otherRoute']);
+
+      const matchObject: Match = useRouteMatch({
+        path: '/path',
+        strict: true,
+        sensitive: true,
+        exact: true,
+      });
+
+      // $ExpectError
+      const matchObject2: Match = useRouteMatch({
+        sensitive: 'foo',
+      });
     });
   });
 });

--- a/definitions/npm/react-router_v5.x.x/flow_v0.104.x-/react-router_v5.x.x.js
+++ b/definitions/npm/react-router_v5.x.x/flow_v0.104.x-/react-router_v5.x.x.js
@@ -139,7 +139,7 @@ declare module "react-router" {
   declare export function useHistory(): $PropertyType<ContextRouter, 'history'>;
   declare export function useLocation(): $PropertyType<ContextRouter, 'location'>;
   declare export function useParams(): $PropertyType<$PropertyType<ContextRouter, 'match'>, 'params'>;
-  declare export function useRouteMatch(path?: string): $PropertyType<ContextRouter, 'match'>;
+  declare export function useRouteMatch(path?: MatchPathOptions | string | string[]): $PropertyType<ContextRouter, 'match'>;
 
   declare export function generatePath(pattern?: string, params?: {...}): string;
 

--- a/definitions/npm/react-router_v5.x.x/flow_v0.104.x-/test_react-router.js
+++ b/definitions/npm/react-router_v5.x.x/flow_v0.104.x-/test_react-router.js
@@ -232,5 +232,18 @@ describe('react hook', () => {
   it('useRouteMatch', () => {
     const match: Match = useRouteMatch();
     const matchPath: Match = useRouteMatch('/path');
+    const matchArray: Match = useRouteMatch(['/path', '/the/otherRoute']);
+
+    const matchObject: Match = useRouteMatch({
+      path: '/path',
+      strict: true,
+      sensitive: true,
+      exact: true,
+    });
+
+    // $ExpectError
+    const matchObject2: Match = useRouteMatch({
+      sensitive: 'foo',
+    });
   });
 });


### PR DESCRIPTION
- Links to documentation: https://reacttraining.com/react-router/web/api/Hooks/useroutematch / https://reacttraining.com/blog/react-router-v5-1/#useroutematch
- Link to GitHub or NPM: https://github.com/ReactTraining/react-router/blob/ef60b08d514e1db3354316c303783158f108bd3b/packages/react-router/modules/hooks.js#L54
- Type of contribution: fix

Other notes:
If you just read the documentation, it would appear that `useRouteMatch` only takes a `string`. However if you read the [accompanying blog post](https://reacttraining.com/blog/react-router-v5-1/#useroutematch), they use an object. I dove into the [source code](https://github.com/ReactTraining/react-router/blob/ef60b08d514e1db3354316c303783158f108bd3b/packages/react-router/modules/hooks.js#L54) and `useRouteMatch` takes the same arguments as the second argument of `matchPath`.
