### PR TITLE
Use readonly for lodash4 pickBy and omitBy

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -1251,14 +1251,14 @@ declare module "lodash" {
     omit(object?: ?Object, ...props: $ReadOnlyArray<string>): Object;
     omit(object?: ?Object, props: $ReadOnlyArray<string>): Object;
     omitBy<A, T: { [id: any]: A, ... } | { [id: number]: A, ... }>(
-      object: T,
+      object: $ReadOnly<T>,
       predicate?: ?OPredicate<A, T>
     ): Object;
     omitBy<A, T>(object: void | null, predicate?: ?OPredicate<A, T>): {...};
     pick(object?: ?Object, ...props: $ReadOnlyArray<string>): Object;
     pick(object?: ?Object, props: $ReadOnlyArray<string>): Object;
     pickBy<A, T: { [id: any]: A, ... } | { [id: number]: A, ... }>(
-      object: T,
+      object: $ReadOnly<T>,
       predicate?: ?OPredicate<A, T>
     ): Object;
     pickBy<A, T>(object: void | null, predicate?: ?OPredicate<A, T>): {...};


### PR DESCRIPTION
I was trying to use omitBy and pickBy on some properly defined $ReadOnly props, but was unable to due to the definitions of pickBy and omitBy.

Updated the definitions and it works. Figured I'd pass along my findings to the community :)

- Type of contribution: fix

Other notes: Please enlighten me if you find my PR lacking.

