### PR TITLE
[antd_v3.x.x] Updates enum for "type" in Button (to support new "link" type)

### DIFF
--- a/definitions/npm/antd_v3.x.x/flow_v0.104.x-/antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.104.x-/antd_v3.x.x.js
@@ -71,7 +71,7 @@ declare module "antd" {
     shape?: 'circle' | 'round',
     size?: 'small' | 'large',
     target?: string,
-    type?: 'primary' | 'ghost' | 'dashed' | 'danger' | 'default',
+    type?: 'primary' | 'ghost' | 'dashed' | 'danger' | 'link' | 'default',
     onClick?: (event: SyntheticEvent<HTMLButtonElement>) => void,
     block?: boolean,
     ...
@@ -342,7 +342,7 @@ declare module "antd" {
   declare class InputTextArea extends React$Component<{...}> {}
 
   declare type InputPasswordProps = { visibilityToggle?: boolean, ... };
-  
+
   // Added in 3.12.0
   declare class InputPassword extends React$Component<InputPasswordProps> {}
 
@@ -502,7 +502,7 @@ declare module "antd" {
   declare class RadioButton extends React$Component<{...}> {}
 
   declare export class Row extends React$Component<{...}> {}
-  
+
   declare export type SelectValue = string | string[] | number | number[];
 
   declare export type SelectProps<T = SelectValue> = {

--- a/definitions/npm/antd_v3.x.x/flow_v0.104.x-/test_antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.104.x-/test_antd_v3.x.x.js
@@ -176,10 +176,14 @@ describe("Button", () => {
     const button = <Button />;
   });
   it("should accept nullary or unary onClick handler", () => {
-    const good0 = <Button onClick={() => undefined} />
-    const good1 = <Button onClick={(event: SyntheticEvent<HTMLButtonElement>) => undefined} />
+    const good0 = <Button onClick={() => undefined} />;
+    const good1 = (
+      <Button
+        onClick={(event: SyntheticEvent<HTMLButtonElement>) => undefined}
+      />
+    );
     // $ExpectError
-    const bad = <Button onClick='bad' />
+    const bad = <Button onClick="bad" />;
   });
 });
 

--- a/definitions/npm/antd_v3.x.x/flow_v0.104.x-/test_antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.104.x-/test_antd_v3.x.x.js
@@ -185,6 +185,15 @@ describe("Button", () => {
     // $ExpectError
     const bad = <Button onClick="bad" />;
   });
+  it("should accept only certain strings for type prop", () => {
+    const good0 = <Button type="primary" />;
+    const good1 = <Button type="ghost" />;
+    const good2 = <Button type="dashed" />;
+    const good3 = <Button type="danger" />;
+    const good4 = <Button type="default" />;
+    // $ExpectError
+    const bad = <Button type="bad" />;
+  });
 });
 
 describe("Button.Group", () => {

--- a/definitions/npm/antd_v3.x.x/flow_v0.104.x-/test_antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.104.x-/test_antd_v3.x.x.js
@@ -190,6 +190,7 @@ describe("Button", () => {
     const good1 = <Button type="ghost" />;
     const good2 = <Button type="dashed" />;
     const good3 = <Button type="danger" />;
+    const good5 = <Button type="link" />;
     const good4 = <Button type="default" />;
     // $ExpectError
     const bad = <Button type="bad" />;


### PR DESCRIPTION
**Ant-design** has added support for a new `type` value in the `<Button />` component in version 3.17 ([see changelog](https://ant.design/changelog#3.17.0)).
This PR adds support for this new `link` type, as well as a test to cover this.

- Links to documentation: https://ant.design/components/button/
- Link to GitHub or NPM: https://github.com/ant-design/ant-design + the [PR implementing this](https://github.com/ant-design/ant-design/pull/16289)
- Type of contribution: addition/fix

Other notes:
I'm unsure if the test is needed, since Flow should cover this - but I see similar tests have been added to the test-suite [in the past](https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/antd_v3.x.x/flow_v0.104.x-/test_antd_v3.x.x.js#L512). Also, this is my first contribution, so sorry if I missed something :)