### PR TITLE
lodash - use $ReadOnlyArray for `min` and `max`

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -950,11 +950,11 @@ declare module "lodash" {
     ceil(number: number, precision?: number): number;
     divide(dividend: number, divisor: number): number;
     floor(number: number, precision?: number): number;
-    max<T>(array: ?Array<T>): T;
+    max<T>(array: ?$ReadOnlyArray<T>): T;
     maxBy<T>(array: ?$ReadOnlyArray<T>, iteratee?: Iteratee<T>): T;
     mean(array: Array<*>): number;
     meanBy<T>(array: Array<T>, iteratee?: Iteratee<T>): number;
-    min<T>(array: ?Array<T>): T;
+    min<T>(array: ?$ReadOnlyArray<T>): T;
     minBy<T>(array: ?$ReadOnlyArray<T>, iteratee?: Iteratee<T>): T;
     multiply(multiplier: number, multiplicand: number): number;
     round(number: number, precision?: number): number;


### PR DESCRIPTION
- Links to documentation: https://lodash.com/docs/4.17.15#min and https://lodash.com/docs/4.17.15#max
- Type of contribution: fix

min and max do not mutate the array so they should accept `$ReadOnlyArray`

