### PR TITLE
[haversine_v1.1.x] ArrayCoordinates as 2-tuple

### DIFF
--- a/definitions/npm/haversine_v1.1.x/flow_v0.104.x-/haversine_v1.1.x.js
+++ b/definitions/npm/haversine_v1.1.x/flow_v0.104.x-/haversine_v1.1.x.js
@@ -2,7 +2,7 @@
 
 type $npm$haversine$Unit = 'km' | 'mile' | 'meter' | 'nmi'
 
-type $npm$haversine$ArrayCoordinates = Array<number>
+type $npm$haversine$ArrayCoordinates = [number, number]
 type $npm$haversine$LatitudeLongitudeCoordinates = {
   latitude: number,
   longitude: number,

--- a/definitions/npm/haversine_v1.1.x/flow_v0.25.x-v0.103.x/haversine_v1.1.x.js
+++ b/definitions/npm/haversine_v1.1.x/flow_v0.25.x-v0.103.x/haversine_v1.1.x.js
@@ -2,7 +2,7 @@
 
 type $npm$haversine$Unit = 'km' | 'mile' | 'meter' | 'nmi'
 
-type $npm$haversine$ArrayCoordinates = Array<number>
+type $npm$haversine$ArrayCoordinates = [number, number]
 type $npm$haversine$LatitudeLongitudeCoordinates = { latitude: number, longitude: number }
 type $npm$haversine$LatLonCoordinates = { lat: number, lon: number }
 type $npm$haversine$GeojsonCoordinates = { coordinates: Array<number> }

--- a/definitions/npm/haversine_v1.1.x/test_haversine_v1.1.x.js
+++ b/definitions/npm/haversine_v1.1.x/test_haversine_v1.1.x.js
@@ -20,3 +20,7 @@ haversine({ latitude: 2, longitude: 3 }, { latitude: 3, longitude: 2 }, { format
 const c: number = haversine({ type: 'Feature', coordinates: [2, 3] }, { type: 'Feature', coordinates: [2, 3] }, { format: 'geojson', threshold: 1 })
 // $ExpectError
 const d: boolean = haversine({ type: 'Feature', coordinates: [2, 3] }, { type: 'Feature', coordinates: [2, 3] }, { format: 'geojson'})
+// $ExpectError
+haversine([2])
+// $ExpectError
+haversine([2, 3, 4])


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/njj/haversine
- Link to GitHub or NPM: https://github.com/njj/haversine
- Type of contribution: fix

Other notes:
The previous definition of `ArrayCoordinates` was `Array<number>`, but its only uses expect an array of length 2 exactly. This change refines the type definition so that it is defined as a 2-tuple instead of an array.
