### PR TITLE
fix(jest): add missing toIncludeSameMembers

### DIFF
--- a/definitions/npm/jest_v24.x.x/flow_v0.39.x-v0.103.x/jest_v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.39.x-v0.103.x/jest_v24.x.x.js
@@ -329,6 +329,12 @@ type JestExtendedMatchersType = {
   toIncludeAnyMembers(members: any[]): void,
 
   /**
+   * Use `.toIncludeSameMembers` when checking if two arrays contain equal values, in any order.
+   * @param {Array.<*>} members
+   */
+  toIncludeSameMembers(members: any[]): void,
+
+  /**
    * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
    * @param {Function} predicate
    */


### PR DESCRIPTION
Part of jest-extended, but missing from `JestExtendedMatchersType` for some reason.

See https://github.com/jest-community/jest-extended#toincludesamemembersmembers.

- Links to documentation: https://github.com/jest-community/jest-extended#toincludesamemembersmembers.
- Link to GitHub or NPM: https://github.com/jest-community/jest
- Type of contribution: addition

Other notes:
- All the other methods were using `any[]`, so I did that too. Should I use `mixed`?