### PR TITLE
Add libdefs for dotenv v8

### DIFF
--- a/definitions/npm/dotenv_v8.x.x/flow_v0.53.x-/dotenv_v8.x.x.js
+++ b/definitions/npm/dotenv_v8.x.x/flow_v0.53.x-/dotenv_v8.x.x.js
@@ -1,0 +1,23 @@
+// @flow
+
+declare module 'dotenv' {
+  declare type ParseResult = {| [key: string]: string |};
+  declare type ConfigResult = {| parsed: ParseResult |} | {| error: Error |};
+  declare function config(
+    options?: $Shape<{| path: string, encoding: string, debug: boolean |}>
+  ): ConfigResult;
+
+  declare function parse(
+    buffer: Buffer | string,
+    options?: $Shape<{| debug: boolean |}>
+  ): ParseResult;
+
+  declare module.exports: {|
+    config: typeof config,
+    parse: typeof parse,
+  |};
+}
+
+// eslint-disable-next-line no-empty
+declare module 'dotenv/config' {
+}

--- a/definitions/npm/dotenv_v8.x.x/test_dotenv_v8.x.x.js
+++ b/definitions/npm/dotenv_v8.x.x/test_dotenv_v8.x.x.js
@@ -1,0 +1,58 @@
+// @flow
+
+import dotenv from 'dotenv';
+import 'dotenv/config';
+
+const configResult = dotenv.config();
+if (configResult.error) {
+  (configResult.error: Error);
+
+  // $ExpectError
+  (parsed['KEY']: string);
+} else {
+  const parsed = configResult.parsed;
+  (parsed['KEY']: string);
+
+  // $ExpectError
+  (parsed['KEY']: number);
+
+  // $ExpectError
+  (parsed[1]: string);
+}
+
+dotenv.config({
+  encoding: 'utf8'
+});
+
+dotenv.config({
+  path: '.env'
+});
+
+dotenv.config({
+  encoding: 'utf8',
+  path: '.env',
+  debug: true,
+});
+
+// $ExpectError
+dotenv.config({ foo: 'bar' });
+
+const parsed = dotenv.parse('KEY=VALUE');
+(parsed['KEY']: string);
+
+// $ExpectError
+(parsed['KEY']: number);
+
+// $ExpectError
+(parsed[1]: string);
+
+dotenv.parse('KEY=VALUE', { debug: true });
+
+// $ExpectError
+dotenv.parse('KEY=VALUE', { debug: 'foo' });
+
+// $ExpectError
+dotenv.parse('KEY=VALUE', { foo: 'bar' });
+
+// $ExpectError
+dotenv.foo();


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/motdotla/dotenv
- Link to GitHub or NPM: https://github.com/motdotla/dotenv
- Type of contribution: new definition

The libdefs for the v4 were already present but aren't accurate for v8 so I rewrote them from scratch, while borrowing and updating the tests.
I also quickly looked at the source code where they use Flow as well. Main differences with my libdefs is my use of `$Shape` over objects with only optional properties.