### PR TITLE
fix: remove invalid react-navigation-stack back button props

### DIFF
--- a/definitions/npm/react-navigation-stack_v1.x.x/flow_v0.104.x-/react-navigation-stack_v1.x.x.js
+++ b/definitions/npm/react-navigation-stack_v1.x.x/flow_v0.104.x-/react-navigation-stack_v1.x.x.js
@@ -621,9 +621,7 @@ declare module 'react-navigation-stack' {
     backTitleVisible?: boolean,
     allowFontScaling?: boolean,
     titleStyle?: ?TextStyleProp,
-    headerLayoutPreset: 'left' | 'center',
     width?: ?number,
-    scene: NavigationStackScene,
   |};
 
   declare export type NavigationStackScreenOptions = NavigationScreenOptions & {

--- a/definitions/npm/react-navigation-stack_v1.x.x/flow_v0.92.x-v0.103.x/react-navigation-stack_v1.x.x.js
+++ b/definitions/npm/react-navigation-stack_v1.x.x/flow_v0.92.x-v0.103.x/react-navigation-stack_v1.x.x.js
@@ -616,9 +616,7 @@ declare module 'react-navigation-stack' {
     backTitleVisible?: boolean,
     allowFontScaling?: boolean,
     titleStyle?: ?TextStyleProp,
-    headerLayoutPreset: 'left' | 'center',
     width?: ?number,
-    scene: NavigationStackScene,
   };
 
   declare export type NavigationStackScreenOptions = NavigationScreenOptions & {


### PR DESCRIPTION
the `Props` for .a back button do not need to contain the entries I removed - see https://github.com/react-navigation/stack/blob/deb5605be8b1c7ccd27d339ba354923dbe762d3a/src/views/Header/HeaderBackButton.tsx#L19