### PR TITLE
fix: Make DataProxyReadQueryOptions generic in @apollo/react-hooks

### DIFF
--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
@@ -982,9 +982,9 @@ declare module '@apollo/react-hooks' {
   > = DataProxyWriteFragmentOptions<TData, TVariables>;
   declare type CacheWriteDataOptions<TData> = DataProxyWriteDataOptions<TData>;
 
-  declare interface DataProxyReadQueryOptions {
+  declare interface DataProxyReadQueryOptions<TVariables> {
     query: DocumentNode;
-    variables?: any;
+    variables?: TVariables;
   }
 
   declare interface DataProxyReadFragmentOptions<TVariables> {


### PR DESCRIPTION
DataProxyReadQueryOptions is used with a generic type in other places (i.e. readQuery in line 1023), so flow threw an error.

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://www.apollographql.com/docs/react/caching/cache-interaction/
- Link to GitHub or NPM: https://www.npmjs.com/package/@apollo/react-hooks
- Type of contribution: fix 

I think people who worked previously on this were: @ganemone and @pascalduez 
