### PR TITLE
Add the 'called' property to supertest

### DIFF
--- a/definitions/npm/supertest_v4.x.x/flow_v0.94.x-/supertest_v4.x.x.js
+++ b/definitions/npm/supertest_v4.x.x/flow_v0.94.x-/supertest_v4.x.x.js
@@ -87,6 +87,8 @@ declare module 'supertest' {
   // Stream, but I don't know how to do it with Flow... I decided to use the
   // Promise because it's likely more useful.
   declare class superagent$Request extends Promise<superagent$Response> {
+    called: boolean;
+
     abort(): void;
     accept(type: string): this;
     attach(

--- a/definitions/npm/supertest_v4.x.x/test_basic-functionality.js
+++ b/definitions/npm/supertest_v4.x.x/test_basic-functionality.js
@@ -174,4 +174,16 @@ describe('expectations', () => {
     // $ExpectError
     (response.tpye: string);
   })
+
+  it('there is a called boolean in the request', () => {
+    let req = request(serverFunction).get('/user');
+    (req.called: boolean);
+    // $ExpectError
+    req.foo;
+
+    req = req.expect(200);
+    (req.called: boolean);
+    // $ExpectError
+    req.foo;
+  })
 });


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: I don't think this is documented really, but this is set in https://github.com/visionmedia/superagent/blob/477f3c5141cb0f80e593baf477e4b5a172ac1839/src/node/index.js#L854
- Link to GitHub or NPM: https://github.com/visionmedia/supertest
- Type of contribution: addition

Other notes:

