### PR TITLE
Add types for the Timestamp to the google-protobuf_v3.6.x.js

### DIFF
--- a/definitions/npm/google-protobuf_v3.6.x/flow_v0.83.x-/google-protobuf_v3.6.x.js
+++ b/definitions/npm/google-protobuf_v3.6.x/flow_v0.83.x-/google-protobuf_v3.6.x.js
@@ -679,3 +679,18 @@ declare module 'google-protobuf' {
 
   // jspb.utils package excluded as it likely shouldn't be called by user code
 }
+
+declare module 'google-protobuf/google/protobuf/timestamp_pb' {
+  declare class Timestamp {
+    constructor(): Timestamp;
+
+    getSeconds(): number;
+    setSeconds(value: number): void;
+
+    getNanos(): number;
+    setNanos(value: number): void;
+
+    static toDate(): Date;
+    static fromDate(date: Date): void;
+  }
+}


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Link to documentation: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/google-protobuf/google/protobuf/timestamp_pb.d.ts.
- Type of contribution: addition.

