### PR TITLE
Add cookie_v0.4.x support

### DIFF
--- a/definitions/npm/cookie_v0.4.x/flow_v0.104.x-/cookie_v0.4.x.js
+++ b/definitions/npm/cookie_v0.4.x/flow_v0.104.x-/cookie_v0.4.x.js
@@ -1,0 +1,23 @@
+type SerializeOptions = {
+  domain?: string,
+  encode?: (stringToDecode: string) => string,
+  expires?: Date,
+  httpOnly?: boolean,
+  maxAge?: number,
+  path?: string,
+  sameSite?: boolean | 'lax' | 'strict' | 'none',
+  secure?: boolean,
+  ...
+};
+
+type ParseOptions = { // Library itself does not specify output for decode function.
+// Because of simplicity is output set to string which is default settings and best for working with cookies.
+decode?: (stringToDecode: string) => string, ... };
+
+declare module 'cookie' {
+  declare module.exports: {
+    serialize(name: string, val: string, options: ?SerializeOptions): string,
+    parse(data: string, options: ?ParseOptions): { [string]: string, ... },
+    ...
+  };
+};

--- a/definitions/npm/cookie_v0.4.x/flow_v0.104.x-/test_cookie_v0.4.x.js
+++ b/definitions/npm/cookie_v0.4.x/flow_v0.104.x-/test_cookie_v0.4.x.js
@@ -1,0 +1,49 @@
+import { describe, it } from 'flow-typed-test';
+import cookie from 'cookie';
+
+describe('cookie library', () => {
+  describe('parse method', () => {
+    it('parse string', () => {
+      const parsedData: {[string]: string, ...} = cookie.parse('some-string');
+    });
+
+    it('parse string with custom decode method', () => {
+      cookie.parse('some-string', {
+        decode: () => { return 'some-string' },
+      });
+    });
+
+    it('cannot parse object', () => {
+      // $ExpectError
+      cookie.parse({});
+    });
+  });
+
+  describe('serialize method', () => {
+    it('serialize strings', () => {
+      const serializedData: string = cookie.serialize('name', 'value');
+    });
+
+    it('serialize strings with custom options', () => {
+      const serializedData: string = cookie.serialize('name', 'value', {
+        expires: new Date('2018-05-05'),
+        sameSite: 'lax',
+      });
+    });
+
+    it('accept two strings only', () => {
+      // $ExpectError
+      cookie.serialize('name');
+
+      // $ExpectError
+      cookie.serialize('name', {});
+    });
+
+    it('accept expire as options only as Date', () => {
+      // $ExpectError
+      cookie.parse('name', 'value', {
+        expires: 'date',
+      });
+    });
+  });
+});

--- a/definitions/npm/cookie_v0.4.x/flow_v0.58.x-v0.103.x/cookie_v0.4.x.js
+++ b/definitions/npm/cookie_v0.4.x/flow_v0.58.x-v0.103.x/cookie_v0.4.x.js
@@ -1,0 +1,23 @@
+type SerializeOptions = {
+  domain?: string,
+  encode?: (stringToDecode: string) => string,
+  expires?: Date,
+  httpOnly?: boolean,
+  maxAge?: number,
+  path?: string,
+  sameSite?: boolean | 'lax' | 'strict' | 'none',
+  secure?: boolean,
+};
+
+type ParseOptions = {
+  // Library itself does not specify output for decode function.
+  // Because of simplicity is output set to string which is default settings and best for working with cookies.
+  decode?: (stringToDecode: string) => string,
+};
+
+declare module 'cookie' {
+  declare module.exports: {
+    serialize(name: string, val: string, options: ?SerializeOptions): string,
+    parse(data: string, options: ?ParseOptions): {[string]: string},
+  };
+};


### PR DESCRIPTION
Cookie v0.4.0 added SameSite=None support, I added this to the interface.

- Link to GitHub or NPM: https://github.com/jshttp/cookie/releases
- Type of contribution: addition
