### PR TITLE
fix: replace intlshape intersection type with spread

### DIFF
--- a/definitions/npm/react-intl_v2.x.x/flow_v0.104.x-/react-intl_v2.x.x.js
+++ b/definitions/npm/react-intl_v2.x.x/flow_v0.104.x-/react-intl_v2.x.x.js
@@ -55,8 +55,11 @@ declare module "react-intl" {
     ...
   };
 
-  declare type $npm$ReactIntl$IntlShape = $npm$ReactIntl$IntlConfig &
-    $npm$ReactIntl$IntlFormat & { now: () => number, ... };
+  declare type $npm$ReactIntl$IntlShape = {|
+    ...$Exact<$npm$ReactIntl$IntlConfig>,
+    ...$Exact<$npm$ReactIntl$IntlFormat>,
+    ...{| now: () => number |},
+  |};
 
   declare type $npm$ReactIntl$DateTimeFormatOptions = {
     localeMatcher?: "best fit" | "lookup",

--- a/definitions/npm/react-intl_v2.x.x/flow_v0.104.x-/test_react-intl_v2.x.x.js
+++ b/definitions/npm/react-intl_v2.x.x/flow_v0.104.x-/test_react-intl_v2.x.x.js
@@ -34,6 +34,7 @@ addLocaleData(localeData);
 // $ExpectError number. This type is incompatible with void
 const resultLocaleData: number = addLocaleData(localeData);
 
+
 const messages = {
   messagekey1: {
     id: "messageid1",
@@ -437,6 +438,49 @@ describe("react-intl", () => {
 
         <PluralComponent />;
       });
+    });
+  });
+
+  describe('IntlShape', () => {
+    it('is exact type', () => {
+      // $ExpectError notValidProperty should not be allowed
+     const mockIntlInvalid: IntlShape = {
+        locale: 'en_US',
+        formats: {},
+        messages: {},
+        notValidProperty: '',
+        defaultLocale: undefined,
+        defaultFormats: undefined,
+        formatDate: (value: number) => String(value),
+        formatTime: (value: number | Date) => String(value),
+        formatRelative: (value: number) => String(value),
+        formatNumber: (value: number) => String(value),
+        formatPlural: (value: number) => String(value),
+        formatMessage: (messageDescriptor: MessageDescriptor) => messageDescriptor.defaultMessage || '',
+        formatHTMLMessage: (messageDescriptor: MessageDescriptor) =>
+            messageDescriptor.defaultMessage || '',
+        now: () => Date.now(),
+      };
+    });
+
+    it('spreading does not throw an error', () => {
+      const mockIntl: IntlShape = {
+        locale: 'en_US',
+        formats: {},
+        messages: {},
+        defaultLocale: undefined,
+        defaultFormats: undefined,
+        formatDate: (value: number) => String(value),
+        formatTime: (value: number | Date) => String(value),
+        formatRelative: (value: number) => String(value),
+        formatNumber: (value: number) => String(value),
+        formatPlural: (value: number) => String(value),
+        formatMessage: (messageDescriptor: MessageDescriptor) => messageDescriptor.defaultMessage || '',
+        formatHTMLMessage: (messageDescriptor: MessageDescriptor) =>
+            messageDescriptor.defaultMessage || '',
+        now: () => Date.now(),
+      };
+      const mockIntlSpreaded: IntlShape = {...mockIntl };
     });
   });
 });


### PR DESCRIPTION
Hello Flow Typed Team,

this change removes a bug which we experienced with `IntlShape`. In our case, everything except the first of type in the intersection `$npm$ReactIntl$IntlConfig` was missing when we did a spread of the property. This makes me believe that `$npm$ReactIntl$IntlConfig` is treated `exact` in our code base, even though it is not declared as exact.

We do not experience the bug in https://flow.org/try/ unless we make the first type of the intersection `$npm$ReactIntl$IntlShape` exact as you can see below:


[example](https://flow.org/try/#0C4TwDgpgBAJAdmAtjAShAhgY2ASTsAGxj0IGEB7OAMwEsBzKAXigG8AfAKCm6gPM3QEIALigBnYACcacOgBouPKuUmJ0wMaIDyAIwBWEbAp5REEMWPR1zollADaNACaiJ02QF1XUmQwC+CorcThBU6ACuBMAAMvyCEAD83u7yQVAhYZHAAGIqahpJULoG2IpsfgDcHBygkLAIyGhYuPhEALLmltYAIuaY0mDAKkysac7JvsY8IWL9NIM0lIVuk2kZEVEdFlaJE7KKldW10PBIqBjYJERXuarqIyxpynfA3eoiUAAUAG6C4R-oOAgORQcgLShiQrFQzAACUTAAfOIfLIptxnvkACo0MyiH5-AFAkFg4CLOCQ7T6GHwxhIlaop55dRoAjqGjfD74gj-USA4Gg8HkqFU7A0uko1ImDHqABy4UQOggkjxv25hP5JLJFKKIrhiORKTRUGlwAACtzJIIVQTeUSBaSIcKSnraQbVlKmcAtl1OWluGZtj0+gMhsr6mcmpdWjBvTterMQyojdxVf9tdDSiYxW6GR6XgAJTFtaKx6x4v2mTpx4PzUOiU6NC4tQgxqtBhO1pMV1PmJ0wtLZ+l0A5VI7gE4Nc7NK7EVoAZQAFug6swG1Ooy2rhRqPQoAAyNJryPN66tW75fesKBwcgAdzx2bg8sVkighxq46gV0Xy+gq8nx4zt+S6QGOdSlhA8ZzIMwz-hGTYzhBUGJpI1SYBCwCmPwADWVyiMBv4PGkfACEIogAOQQHAAD6ACqc7kUaJqaKwARpAGPosSwbEmOsWSxKRHzhHAGQyBAThGnxUTnuoLHCaJcDiUxnpvMAnI9qIT4Kkq2ZzhKXL-LCykvNiuJfBp17PkqUBsFAqkQLp+k9kZjIvCybIctaaqaVZkiOSkBkOcZ+RytpYaBT5YX+b4gUuXm+TmuEloEF5PKWVF+p6QFznBeoEF4hx1YdjBYZITWJXZoV7bQaGAB0Ulem20BsLZ5GMa5+SFsW+VfFVkHlXWUBlcVoZihW-pNchnaSPVoQbI1gbNa17UmDe95fNm9m1Wtnwue+6HkphMiEG0OH4fOIF-lhmC4a0o4APT3VAmILjQYhQBAAAe6CIGAQjiAud7vTeH2SJIKjvTIxp8LetUqHQ91SCAUA6OER2YU45DmFAUPkElUCSBAYDkGINChsjwifBwj1FHAUDAAu0AEGJKMQDDIJUDD4joCA70M-cABE5C6rwZNKoI6RY8D5CYUuHJQGA4OQJIoDGip7wC9TT0ANQ45h6G-ayx3vegOh45hggEPTjMK0rSqktjX2YETmEMyT0BUODiD05+AtHgh0ZbpQtB0JrB0SDjrSnTdACM52ED+K5XrVKeIDhVxvlUQA)


The solution for us is using spreading instead.

- Type of contribution: fix

Other notes:

@jbrown215 is the change to make most of the types inexact intentional?

Thank you very much!
Cheers Max
