### PR TITLE
Amended type-defination of url-parser

### DIFF
--- a/definitions/npm/url-parse_v1.3.x/flow_v0.104.x-/url-parse_v1.3.x.js
+++ b/definitions/npm/url-parse_v1.3.x/flow_v0.104.x-/url-parse_v1.3.x.js
@@ -9,7 +9,7 @@ declare module 'url-parse' {
     hostname: string,
     port: string,
     pathname: string,
-    query: Object,
+    query: { [key: string]: string },
     hash: string,
     href: string,
     origin: string,

--- a/definitions/npm/url-parse_v1.3.x/flow_v0.59.x-v0.103.x/url-parse_v1.3.x.js
+++ b/definitions/npm/url-parse_v1.3.x/flow_v0.59.x-v0.103.x/url-parse_v1.3.x.js
@@ -9,7 +9,7 @@ declare module 'url-parse' {
     hostname: string,
     port: string,
     pathname: string,
-    query: Object,
+    query: { [key: string]: string },
     hash: string,
     href: string,
     origin: string,

--- a/definitions/npm/url-parse_v1.3.x/test_url-parse.js
+++ b/definitions/npm/url-parse_v1.3.x/test_url-parse.js
@@ -68,8 +68,10 @@ const pathname: string = url.pathname;
 const pathname2: number = url.pathname;
 
 const query: Object = url.query;
+const query2: { [key: string]: string } = url.query;
+
 // $ExpectError number. This type is incompatible with Object
-const query2: number = url.query;
+const query3: number = url.query;
 
 const hash: string = url.hash;
 // $ExpectError number. This type is incompatible with boolean


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/unshiftio/url-parse
- Link to GitHub or NPM: https://www.npmjs.com/package/url-parse
- Type of contribution: refactor

Other notes:
Always parses query `"?a=b&c=2"` as  `{ "a" : "b", "c" : "2" }`
https://github.com/unshiftio/url-parse/blob/master/test/test.js