### PR TITLE
Make history interface compatible with react-router

### DIFF
--- a/definitions/npm/history_v4.x.x/flow_v0.104.x-/history_v4.x.x.js
+++ b/definitions/npm/history_v4.x.x/flow_v0.104.x-/history_v4.x.x.js
@@ -13,9 +13,9 @@ declare module "history/createBrowserHistory" {
     ...
   };
 
-  declare interface IBrowserHistory {
+  declare export interface BrowserHistory {
     length: number,
-    location: BrowserLocation,
+    location: $Shape<BrowserLocation>,
     action: Action,
     push(path: string, state?: {...}): void,
     push(location: $Shape<BrowserLocation>): void,
@@ -29,9 +29,7 @@ declare module "history/createBrowserHistory" {
     block((location: BrowserLocation, action: Action) => string): typeof Unblock,
   }
 
-  declare export type BrowserHistory = IBrowserHistory;
-
-  declare type HistoryOpts = {
+  declare type BrowserHistoryOpts = {
     basename?: string,
     forceRefresh?: boolean,
     getUserConfirmation?: (
@@ -41,7 +39,7 @@ declare module "history/createBrowserHistory" {
     ...
   };
 
-  declare export default (opts?: HistoryOpts) => BrowserHistory;
+  declare export default (opts?: BrowserHistoryOpts) => BrowserHistory;
 }
 
 declare module "history/createMemoryHistory" {
@@ -59,12 +57,12 @@ declare module "history/createMemoryHistory" {
     ...
   };
 
-  declare interface IMemoryHistory {
+  declare export interface MemoryHistory {
     length: number,
-    location: MemoryLocation,
+    location: $Shape<MemoryLocation>,
     action: Action,
     index: number,
-    entries: Array<string>,
+    entries: Array<MemoryLocation | string>,
     push(path: string, state?: {...}): void,
     push(location: $Shape<MemoryLocation>): void,
     replace(path: string, state?: {...}): void,
@@ -73,16 +71,14 @@ declare module "history/createMemoryHistory" {
     goBack(): void,
     goForward(): void,
     // Memory only
-    canGo(n: number): boolean,
+    canGo?: (n: number) => boolean,
     listen: Function,
     block(message: string): typeof Unblock,
-    block((location: MemoryLocation, action: Action) => string): typeof Unblock,
+    block((location: MemoryLocation, action: Action) => ?string): typeof Unblock,
   }
 
-  declare export type MemoryHistory = IMemoryHistory;
-
-  declare type HistoryOpts = {
-    initialEntries?: Array<string>,
+  declare type MemoryHistoryOpts = {
+    initialEntries?: Array<MemoryLocation | string>,
     initialIndex?: number,
     keyLength?: number,
     getUserConfirmation?: (
@@ -92,7 +88,7 @@ declare module "history/createMemoryHistory" {
     ...
   };
 
-  declare export default (opts?: HistoryOpts) => MemoryHistory;
+  declare export default (opts?: MemoryHistoryOpts) => MemoryHistory;
 }
 
 declare module "history/createHashHistory" {
@@ -107,9 +103,9 @@ declare module "history/createHashHistory" {
     ...
   };
 
-  declare interface IHashHistory {
+  declare export interface HashHistory {
     length: number,
-    location: HashLocation,
+    location: $Shape<HashLocation>,
     action: Action,
     push(path: string, state?: {...}): void,
     push(location: $Shape<HashLocation>): void,
@@ -124,9 +120,7 @@ declare module "history/createHashHistory" {
     push(path: string): void,
   }
 
-  declare export type HashHistory = IHashHistory;
-
-  declare type HistoryOpts = {
+  declare type HashHistoryOpts = {
     basename?: string,
     hashType: "slash" | "noslash" | "hashbang",
     getUserConfirmation?: (
@@ -136,5 +130,43 @@ declare module "history/createHashHistory" {
     ...
   };
 
-  declare export default (opts?: HistoryOpts) => HashHistory;
+  declare export default (opts?: HashHistoryOpts) => HashHistory;
+}
+
+declare module 'history' {
+  import typeof CreateMemoryHistory from 'history/createMemoryHistory';
+  import typeof CreateHashHistory from 'history/createHashHistory';
+  import typeof CreateBrowserHistory from 'history/createBrowserHistory';
+
+  import type {
+    MemoryHistory,
+    MemoryLocation,
+    MemoryHistoryOpts
+  } from 'history/createMemoryHistory';
+  import type {
+    HashHistory,
+    HashLocation,
+    HashHistoryOpts
+  } from 'history/createHashHistory';
+  import type {
+    BrowserHistory,
+    BrowserLocation,
+    BrowserHistoryOpts
+  } from 'history/createBrowserHistory';
+
+  declare module.exports: {|
+    createMemoryHistory: CreateMemoryHistory,
+    createHashHistory: CreateHashHistory,
+    createBrowserHistory: CreateBrowserHistory,
+    HashHistory: HashHistory,
+    HashLocation: HashHistory,
+    HashHistoryOpts: HashHistory,
+    MemoryHistory: MemoryHistory,
+    MemoryLocation: MemoryHistory,
+    MemoryHistoryOpts: MemoryHistory,
+    BrowserHistory: BrowserHistory,
+    BrowserLocation: BrowserHistory,
+    BrowserHistoryOpts: BrowserHistory,
+    Action: 'PUSH' | 'REPLACE' | 'POP'
+  |}
 }

--- a/definitions/npm/history_v4.x.x/flow_v0.104.x-/test_history_v4.x.x.js
+++ b/definitions/npm/history_v4.x.x/flow_v0.104.x-/test_history_v4.x.x.js
@@ -2,9 +2,11 @@
 
 import { describe, it } from 'flow-typed-test';
 
-import createBrowserHistory from 'history/createBrowserHistory';
-import createMemoryHistory from 'history/createMemoryHistory';
-import createHashHistory from 'history/createHashHistory';
+import {
+  createBrowserHistory,
+  createMemoryHistory ,
+  createHashHistory
+} from 'history';
 
 // browser history
 

--- a/definitions/npm/react-router-dom_v5.x.x/flow_v0.104.x-/react-router-dom_v5.x.x.js
+++ b/definitions/npm/react-router-dom_v5.x.x/flow_v0.104.x-/react-router-dom_v5.x.x.js
@@ -41,8 +41,6 @@ declare module "react-router-dom" {
     pathname: string,
     search: string,
     hash: string,
-    state?: any,
-    key?: string,
     ...
   };
 
@@ -50,7 +48,6 @@ declare module "react-router-dom" {
     pathname?: string,
     search?: string,
     hash?: string,
-    state?: any,
     ...
   };
 
@@ -72,9 +69,6 @@ declare module "react-router-dom" {
     block(
       callback: string | (location: Location, action: HistoryAction) => ?string
     ): () => void,
-    // createMemoryHistory
-    index?: number,
-    entries?: Array<Location>,
     ...
   };
 

--- a/definitions/npm/react-router-native_v4.x.x/flow_v0.104.x-/react-router-native_v4.x.x.js
+++ b/definitions/npm/react-router-native_v4.x.x/flow_v0.104.x-/react-router-native_v4.x.x.js
@@ -25,8 +25,6 @@ declare module "react-router-native" {
     pathname: string,
     search: string,
     hash: string,
-    state?: any,
-    key?: string,
     ...
   };
 
@@ -34,7 +32,6 @@ declare module "react-router-native" {
     pathname?: string,
     search?: string,
     hash?: string,
-    state?: any,
     ...
   };
 
@@ -56,9 +53,6 @@ declare module "react-router-native" {
     block(
       callback: (location: Location, action: HistoryAction) => boolean
     ): void,
-    // createMemoryHistory
-    index?: number,
-    entries?: Array<Location>,
     ...
   };
 

--- a/definitions/npm/react-router_v5.x.x/flow_v0.104.x-/react-router_v5.x.x.js
+++ b/definitions/npm/react-router_v5.x.x/flow_v0.104.x-/react-router_v5.x.x.js
@@ -6,8 +6,6 @@ declare module "react-router" {
     pathname: string,
     search: string,
     hash: string,
-    state?: any,
-    key?: string,
     ...
   };
 
@@ -15,7 +13,6 @@ declare module "react-router" {
     pathname?: string,
     search?: string,
     hash?: string,
-    state?: any,
     ...
   };
 
@@ -37,9 +34,6 @@ declare module "react-router" {
     block(
       callback: string | (location: Location, action: HistoryAction) => ?string
     ): () => void,
-    // createMemoryHistory
-    index?: number,
-    entries?: Array<Location>,
     ...
   };
 


### PR DESCRIPTION
- Links to documentation:
https://github.com/ReactTraining/history/tree/master/docs
https://github.com/ReactTraining/react-router/tree/master/packages/react-router/docs/api

- Type of contribution: fix

Other notes:

Should fix #1910.
Making `MemoryHistory.canGo` optional is actually wrong, but I don't see another way to work around flow bugs.
All `history/*` modules can be probably moved to `history`, it would reduce duplication. But I added `history` anyway becase normally everything is exported from `history`.
Properties I removed from `react-router-*` don't belong to the generic Location interface.