### PR TITLE
[next_v9.x.x] add support for next 9.x

### DIFF
--- a/definitions/npm/next_v9.x.x/flow_v0.104.x-/next_v9.x.x.js
+++ b/definitions/npm/next_v9.x.x/flow_v0.104.x-/next_v9.x.x.js
@@ -1,0 +1,232 @@
+declare module "next" {
+  declare type RequestHandler = (
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    parsedUrl: any
+  ) => Promise<void>;
+
+  declare type NextApp = {
+    prepare(): Promise<void>,
+    getRequestHandler(): RequestHandler,
+    setAssetPrefix(url: string): void,
+    render(
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse,
+      pathname: string,
+      query?: Object
+    ): Promise<void>,
+    renderToHTML(
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse,
+      pathname: string,
+      query?: Object
+    ): string,
+    renderError(
+      err: Error,
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse,
+      pathname: string,
+      query?: Object
+    ): Promise<void>,
+    renderErrorToHTML(
+      err: Error,
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse,
+      pathname: string,
+      query?: Object
+    ): string,
+    ...
+  };
+
+  declare export type Options = {
+    dev?: boolean,
+    dir?: string,
+    quiet?: boolean,
+    staticMarkup?: boolean,
+    ...
+  };
+
+  declare export type Context = {
+    +pathname: string,
+    +query: any,
+    +req?: any,
+    +res?: any,
+    +xhr?: any,
+    +err?: any,
+    ...
+  };
+
+  declare export type Page<T, S> = {
+    ...React$Component<T, S>,
+    getInitialProps: (ctx: Context) => Promise<*>,
+    ...
+  };
+
+  declare export default (opts: Options) => NextApp;
+}
+
+declare module "next/head" {
+  declare module.exports: Class<React$Component<any, any>>;
+}
+
+declare module "next/config" {
+  declare module.exports: () => {
+    publicRuntimeConfig: { [string]: string, ... },
+    serverRuntimeConfig: { [string]: string, ... },
+    ...
+  };
+}
+
+declare type URLObject = {
+  +href?: string,
+  +protocol?: string,
+  +slashes?: boolean,
+  +auth?: string,
+  +hostname?: string,
+  +port?: string | number,
+  +host?: string,
+  +pathname?: string,
+  +search?: string,
+  +query?: Object,
+  +hash?: string,
+  ...
+};
+
+declare module "next/link" {
+  declare export type Props = {
+    prefetch?: boolean,
+    shallow?: boolean,
+    scroll?: boolean,
+    replace?: boolean,
+    onError?: (error: any) => void,
+    href: string | URLObject,
+    as?: string | URLObject,
+    passHref?: boolean,
+    ...
+  };
+
+  declare export default Class<React$Component<Props>>;
+}
+
+declare module "next/router" {
+  declare export type RouteError = Error & { cancelled: boolean, ... };
+  declare export type RouteCallback = (url: string) => void;
+  declare export type RouteErrorCallback = (
+    err: RouteError,
+    url: string
+  ) => void;
+
+  declare export interface RouterEvents {
+    on(event: "routeChangeStart", cb: RouteCallback): RouterEvents,
+    on(event: "routeChangeComplete", cb: RouteCallback): RouterEvents,
+    on(event: "routeChangeError", cb: RouteErrorCallback): RouterEvents,
+    on(event: "beforeHistoryChange", cb: RouteCallback): RouterEvents,
+    on(event: "hashChangeStart", cb: RouteCallback): RouterEvents,
+    on(event: "hashChangeComplete", cb: RouteCallback): RouterEvents,
+
+    off(event: "routeChangeStart", cb: RouteCallback): RouterEvents,
+    off(event: "routeChangeComplete", cb: RouteCallback): RouterEvents,
+    off(event: "routeChangeError", cb: RouteErrorCallback): RouterEvents,
+    off(event: "beforeHistoryChange", cb: RouteCallback): RouterEvents,
+    off(event: "hashChangeStart", cb: RouteCallback): RouterEvents,
+    off(event: "hashChangeComplete", cb: RouteCallback): RouterEvents
+  }
+
+  declare export type EventChangeOptions = {
+    [key: string]: any,
+    shallow?: boolean,
+    ...
+  };
+
+  declare export type BeforePopStateCallback = (options: {
+    url: string,
+    as: ?string,
+    options: EventChangeOptions,
+    ...
+  }) => boolean;
+
+  declare export type Router = {
+    +route: string,
+    +pathname: string,
+    +asPath: string,
+    +query: Object,
+    events: RouterEvents,
+    push(
+      url: string | URLObject,
+      as: ?(string | URLObject),
+      options?: EventChangeOptions
+    ): Promise<boolean>,
+    replace(
+      url: string | URLObject,
+      as: ?(string | URLObject),
+      options?: EventChangeOptions
+    ): Promise<boolean>,
+    prefetch(url: string): Promise<*>,
+    beforePopState(cb: BeforePopStateCallback): void,
+    ...
+  };
+
+  declare export function withRouter<T>(
+    Component: React$ComponentType<T & { router: Router, ... }>
+  ): Class<React$Component<T>>;
+
+  declare export default Router;
+}
+
+declare module "next/document" {
+  import type { Context } from "next";
+
+  declare export var Head: Class<React$Component<any, any>>;
+  declare export var Main: Class<React$Component<any, any>>;
+  declare export var NextScript: Class<React$Component<any, any>>;
+  declare export default Class<React$Component<any, any>> & {
+    getInitialProps: (ctx: Context) => Promise<*>,
+    renderPage(cb: Function): void,
+    ...
+  };
+}
+
+declare module "next/app" {
+  import type { Context, Page } from "next";
+  import type { Router } from "next/router";
+
+  declare export var Container: Class<React$Component<any, any>>;
+
+  declare export type AppInitialProps = {
+    Component: Page<any, any>,
+    router: Router,
+    ctx: Context,
+    ...
+  };
+
+  declare export default Class<React$Component<any, any>> & { getInitialProps: (appInitialProps: AppInitialProps) => Promise<*>, ... };
+}
+
+declare module "next/dynamic" {
+  declare type ImportedComponent = Promise<null | React$ElementType>;
+  declare type ComponentMapping = { [componentName: string]: ImportedComponent, ... };
+
+  declare type NextDynamicOptions = {
+    loader?: ComponentMapping | (() => ImportedComponent),
+    loading?: React$ElementType,
+    timeout?: number,
+    delay?: number,
+    ssr?: boolean,
+    render?: (
+      props: any,
+      loaded: { [componentName: string]: React$ElementType, ... }
+    ) => React$ElementType,
+    modules?: () => ComponentMapping,
+    loadableGenerated?: {
+      webpack?: any,
+      modules?: any,
+      ...
+    },
+    ...
+  };
+
+  declare export default function dynamic(
+    dynamicOptions: any,
+    options: ?NextDynamicOptions
+  ): Object;
+}

--- a/definitions/npm/next_v9.x.x/flow_v0.104.x-/next_v9.x.x.js
+++ b/definitions/npm/next_v9.x.x/flow_v0.104.x-/next_v9.x.x.js
@@ -176,11 +176,24 @@ declare module "next/router" {
 declare module "next/document" {
   import type { Context } from "next";
 
+  declare type ComponentsEnhancer = any;
+
+  declare type RenderPageResult = {
+    html: string,
+    head?: Array<React$Node | null>,
+    ...
+  };
+
+  declare export type DocumentContext = Context & {
+    renderPage: (options?: ComponentsEnhancer) => RenderPageResult | Promise<RenderPageResult>,
+    ...
+  }
+
   declare export var Head: Class<React$Component<any, any>>;
   declare export var Main: Class<React$Component<any, any>>;
   declare export var NextScript: Class<React$Component<any, any>>;
   declare export default Class<React$Component<any, any>> & {
-    getInitialProps: (ctx: Context) => Promise<*>,
+    getInitialProps: (ctx: DocumentContext) => Promise<*>,
     renderPage(cb: Function): void,
     ...
   };

--- a/definitions/npm/next_v9.x.x/flow_v0.104.x-/test_next_v9.x.x.js
+++ b/definitions/npm/next_v9.x.x/flow_v0.104.x-/test_next_v9.x.x.js
@@ -3,7 +3,7 @@ import next, {type Context} from "next";
 import Link from "next/link";
 import Head from "next/head";
 import Router, {type RouteError} from "next/router";
-import Document, {Head as DocumentHead, Main, NextScript} from "next/document";
+import Document, {Head as DocumentHead, Main, NextScript, type DocumentContext} from "next/document";
 import App, {type AppInitialProps, Container} from "next/app";
 import dynamic from "next/dynamic";
 import getConfig from "next/config";
@@ -108,7 +108,7 @@ const p: string = Router.pathname;
 const q: { ... } = Router.query;
 
 export default class TestDocument extends Document {
-  static async getInitialProps(ctx: Context) {
+  static async getInitialProps(ctx: DocumentContext) {
     const props = await Document.getInitialProps(ctx);
     return { ...props, customValue: "hi there!" };
   }

--- a/definitions/npm/next_v9.x.x/flow_v0.104.x-/test_next_v9.x.x.js
+++ b/definitions/npm/next_v9.x.x/flow_v0.104.x-/test_next_v9.x.x.js
@@ -1,0 +1,168 @@
+import React from "react";
+import next, {type Context} from "next";
+import Link from "next/link";
+import Head from "next/head";
+import Router, {type RouteError} from "next/router";
+import Document, {Head as DocumentHead, Main, NextScript} from "next/document";
+import App, {type AppInitialProps, Container} from "next/app";
+import dynamic from "next/dynamic";
+import getConfig from "next/config";
+
+const { createServer } = require("http");
+const { parse } = require("url");
+
+// server
+// $ExpectError
+next({ dev: 1 });
+// $ExpectError
+next({ dir: false });
+// $ExpectError
+next({ quiet: "derp" });
+// $ExpectError
+next({ staticMarkup: 42 });
+
+const app = next({ dev: true, dir: ".", quiet: false });
+const handle = app.getRequestHandler();
+app.prepare().then(() => {
+  createServer((req, res) => {
+    const parsedUrl = parse(req.url, true);
+    const { pathname, query } = parsedUrl;
+
+    let q: Object | void;
+
+    if (typeof query === "object") {
+      q = query;
+    }
+
+    if (pathname === "/") {
+      app.render(req, res, "/index", q);
+    } else if (pathname === "/foo") {
+      app.render(req, res, "/index", q);
+    } else if (pathname === "/about") {
+      app.render(req, res, "/about", q);
+    } else {
+      handle(req, res, parsedUrl);
+    }
+  }).listen("3500", err => {
+    if (err) throw err;
+    console.log("> Ready on http://localhost:3500");
+  });
+});
+
+app.setAssetPrefix('');
+
+class ConfigAwareComponent extends React.Component<*> {
+  render() {
+    const { publicRuntimeConfig, serverRuntimeConfig } = getConfig();
+    return (
+      <div>
+        {publicRuntimeConfig.publicConfigVar}
+        {serverRuntimeConfig.privateConfigVar}
+      </div>
+    );
+  }
+}
+
+<Head>
+  <meta charSet="utf-8" />
+</Head>;
+
+<Link href="/">Index</Link>;
+
+// $ExpectError
+<Link href={1}>InvalidNumLink</Link>;
+
+// $ExpectError
+Router.onRouteChangeStart = {};
+
+// $ExpectError
+Router.events.on('unknown', (url: string) => {});
+// $ExpectError
+Router.events.off('unknown', (url: string) => {});
+
+Router.events.on('routeChangeStart', (url: string) => {});
+Router.events.off('routeChangeStart', (url: string) => {});
+
+Router.events.on('routeChangeComplete', (url: string) => {});
+Router.events.off('routeChangeComplete', (url: string) => {});
+
+Router.events.on('routeChangeError', (err: RouteError, url: string) => {
+  if (err.cancelled) {
+    console.log(`Route to ${url} was cancelled!`);
+  }
+});
+
+Router.push({});
+
+Router.push("/about");
+Router.push("/about", "/");
+Router.push("/about", "/", { shallow: true });
+Router.replace("/about");
+Router.replace("/about", "/");
+Router.prefetch("/dynamic");
+
+Router.beforePopState(({ url, as, options }) => true);
+
+const r: string = Router.route;
+const p: string = Router.pathname;
+const q: { ... } = Router.query;
+
+export default class TestDocument extends Document {
+  static async getInitialProps(ctx: Context) {
+    const props = await Document.getInitialProps(ctx);
+    return { ...props, customValue: "hi there!" };
+  }
+
+  render() {
+    return (
+      <html>
+        <DocumentHead />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    );
+  }
+}
+
+export class TestApp extends App {
+  static async getInitialProps({ Component, router, ctx }: AppInitialProps) {
+    const props = await Component.getInitialProps(ctx);
+    return { ...props }
+  }
+
+  render () {
+    const { Component, pageProps } = this.props;
+
+    return (
+      <Container>
+        <Component {...pageProps} />
+      </Container>
+    )
+  }
+}
+
+const DynamicComponent = dynamic(() => import('./test_next_v9.x.x'));
+
+const DynamicComponentWithCustomLoading = dynamic(() => import('./test_next_v9.x.x'), {
+  loading: () => <p>...</p>
+});
+
+const DynamicComponentWithNoSSR = dynamic(() => import('./test_next_v9.x.x'), {
+  ssr: false
+});
+
+const HelloBundle = dynamic({
+  modules: () => {
+    return {
+      Hello1: () => import('./test_next_v9.x.x'),
+      Hello2: () => import('./test_next_v9.x.x')
+    }
+  },
+  render: (props, { Hello1, Hello2 }) =>
+    <div>
+      <Hello1 />
+      <Hello2 />
+    </div>
+});


### PR DESCRIPTION
Hi 👋 

I would like to add definitions for next 9.x - https://nextjs.org/ 

We use definitions for version 7 in our app built on next 9.x without issues, so I would like to kick it off with simple reuse of these definitions.

- `DocumentContext` - see https://github.com/zeit/next.js/blob/8f662c44c944b46693e666013a83f88e4fcffc5a/examples/with-typescript-styled-components/pages/_document.tsx#L5 and https://github.com/zeit/next.js/blob/58b2d9e208c56cee0dab2eff287d2a19cb0e6de1/packages/next/next-server/lib/utils.ts#L137
