### PR TITLE
[webpack_v4.x.x] Fix type error

### DIFF
--- a/definitions/npm/webpack_v4.x.x/flow_v0.104.x-/webpack_v4.x.x.js
+++ b/definitions/npm/webpack_v4.x.x/flow_v0.104.x-/webpack_v4.x.x.js
@@ -14,7 +14,7 @@ declare module 'webpack' {
     hasErrors(): boolean;
     hasWarnings(): boolean;
     toJson(options?: StatsOptions): any;
-    toString(options?: StatsOptions & { colors?: boolean, ... }): string;
+    toString(options?: { ...StatsOptions, colors?: boolean, ... }): string;
   }
 
   declare type Callback = (error: WebpackError, stats: Stats) => void;

--- a/definitions/npm/webpack_v4.x.x/flow_v0.71.x-v0.103.x/webpack_v4.x.x.js
+++ b/definitions/npm/webpack_v4.x.x/flow_v0.71.x-v0.103.x/webpack_v4.x.x.js
@@ -14,7 +14,7 @@ declare module 'webpack' {
     hasErrors(): boolean;
     hasWarnings(): boolean;
     toJson(options?: StatsOptions): any;
-    toString(options?: StatsOptions & { colors?: boolean }): string;
+    toString(options?: { ...StatsOptions, colors?: boolean }): string;
   }
 
   declare type Callback = (error: WebpackError, stats: Stats) => void;


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://webpack.js.org/
- Link to GitHub or NPM: https://www.npmjs.com/package/webpack
- Type of contribution: Fix

Other notes:

```sh
Error --------------------------------------------------------------------------------------- src/utils/buildJs.js:42:26
 

Cannot call `stats.toString` with object literal bound to `options` because object type [1] is incompatible with
 boolean [2] in property `colors`.

    src/utils/buildJs.js:42:26
    42|       log(stats.toString({ logStats, colors: true }));
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 References:
    ../../flow-typed/npm/webpack_v4.x.x.js:399:9
                 v
   399|       | {
   400|       bold?: string,
   401|       cyan?: string,
   402|       green?: string,
   403|       magenta?: string,
   404|       red?: string,
   405|       yellow?: string,
   406|       ...
   407|     },
            ^ [1]
   ../../flow-typed/npm/webpack_v4.x.x.js:20:50
    20|     toString(options?: StatsOptions & { colors?: boolean, ... }): string;
                                                         ^^^^^^^ [2]
```