### PR TITLE
[AntD] Add missing flow-typed entry for AntD Tree type. Need help!!

### DIFF
--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-v0.103.x/antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-v0.103.x/antd_v3.x.x.js
@@ -323,7 +323,7 @@ declare module "antd" {
   declare type InputPasswordProps = {
     visibilityToggle?: boolean
   };
-  
+
   // Added in 3.12.0
   declare class InputPassword extends React$Component<InputPasswordProps> {}
 
@@ -478,7 +478,7 @@ declare module "antd" {
   declare class RadioButton extends React$Component<{}> {}
 
   declare export class Row extends React$Component<{}> {}
-  
+
   declare export type SelectValue = string | string[] | number | number[];
 
   declare export type SelectProps<T = SelectValue> = {
@@ -600,6 +600,19 @@ declare module "antd" {
   } & TooltipSharedProps
 
   declare export class Tooltip extends React$Component<TooltipProps> {}
+
+  declare export class Tree extends React$Component<TreeProps, any> {
+    static TreeNode: typeof React$ComponentClass<AntTreeNodeProps>;
+    static defaultProps: {
+      checkable: boolean;
+      showIcon: boolean;
+      openAnimation: {
+        appear: null;
+        enter(node: HTMLElement, done: () => void): any;
+        leave(node: HTMLElement, done: () => void): any;
+      };
+    };
+  }
 
   declare export class TreeSelect extends React$Component<{}> {
     static TreeNode: typeof TreeSelectTreeNode;


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://ant.design/components/tree/
- Link to GitHub or NPM: https://github.com/ant-design/ant-design/tree/master/components/tree
- Type of contribution: addition

Other notes:

Hey everyone,

I'm incredibly new to react and flow so I know I haven't done this PR justice but I've been reading and googling non-stop and I finally managed to fix a flow error. I saw the message in the console about contributing back so I figured I'd add a WIP to get things kicked off rather than just commit the local changes where no one would see them.

When I used google on the missing type definition I surprisingly came up with no 1:1 results which makes me think my problem is unique and unique problems usually mean something is configured incorrectly or not set up correctly. But hopefully that's not the case this time!

The error message was something similar to `antd has no module named Tree` and realized it was probably because the type wasn't present in `flow-typed`!

Below is the definition for the `Tree` component in the source code itself. I translated as much of it as I felt comfortable but I know there's a couple more entries to add to the `flow-typed` definition. I'll have to leave the rest of the translation and the tests to an expert in this area.

```
export default class Tree extends React.Component<TreeProps, any> {
    static TreeNode: React.ComponentClass<AntTreeNodeProps>;
    static DirectoryTree: typeof DirectoryTree;
    static defaultProps: {
        checkable: boolean;
        showIcon: boolean;
        openAnimation: {
            appear: null;
            enter(node: HTMLElement, done: () => void): any;
            leave(node: HTMLElement, done: () => void): any;
        };
    };
    tree: any;
    renderSwitcherIcon: (prefixCls: string, switcherIcon: React.ReactElement<any, string | ((props: any) => React.ReactElement<any, string | any | (new (props: any) => React.Component<any, any, any>)> | null) | (new (props: any) => React.Component<any, any, any>)> | undefined, { isLeaf, expanded, loading }: AntTreeNodeProps) => JSX.Element | null;
    setTreeRef: (node: any) => void;
    renderTree: ({ getPrefixCls }: ConfigConsumerProps) => JSX.Element;
    render(): JSX.Element;
}
```