### PR TITLE
[antd_v3.x.x] Remove duplicate declaration of DatePicker

### DIFF
--- a/definitions/npm/antd_v3.x.x/flow_v0.104.x-/antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.104.x-/antd_v3.x.x.js
@@ -184,8 +184,6 @@ declare module "antd" {
     static Panel: typeof CollapsePanel;
   }
 
-  declare export class DatePicker extends React$Component<{...}> {}
-
   declare export class Dropdown extends React$Component<{...}> {}
 
   declare export class Drawer extends React$Component<{...}> {}

--- a/definitions/npm/antd_v3.x.x/flow_v0.104.x-/test_antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.104.x-/test_antd_v3.x.x.js
@@ -38,6 +38,8 @@ import {
   TreeSelect
 } from "antd";
 
+const { RangePicker } = DatePicker;
+
 import type { WrappedFormUtils } from "antd";
 
 describe("Alert", () => {
@@ -310,6 +312,12 @@ describe("Collapse.Panel", () => {
 describe("DatePicker", () => {
   it("is a react component", () => {
     const datePicker = <DatePicker />;
+  });
+});
+
+describe("RangePicker", () => {
+  it("is a react component", () => {
+    const rangePicker = <RangePicker />;
   });
 });
 

--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-v0.103.x/antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-v0.103.x/antd_v3.x.x.js
@@ -170,8 +170,6 @@ declare module "antd" {
     static Panel: typeof CollapsePanel;
   }
 
-  declare export class DatePicker extends React$Component<{}> {}
-
   declare export class Dropdown extends React$Component<{}> {}
 
   declare export class Drawer extends React$Component<{}> {}

--- a/definitions/npm/antd_v3.x.x/flow_v0.25.x-v0.103.x/test_antd_v3.x.x.js
+++ b/definitions/npm/antd_v3.x.x/flow_v0.25.x-v0.103.x/test_antd_v3.x.x.js
@@ -38,6 +38,8 @@ import {
   TreeSelect
 } from "antd";
 
+const { RangePicker } = DatePicker;
+
 import type { WrappedFormUtils } from "antd";
 
 describe("Alert", () => {
@@ -296,6 +298,12 @@ describe("Collapse.Panel", () => {
 describe("DatePicker", () => {
   it("is a react component", () => {
     const datePicker = <DatePicker />;
+  });
+});
+
+describe("RangePicker", () => {
+  it("is a react component", () => {
+    const rangePicker = <RangePicker />;
   });
 });
 


### PR DESCRIPTION
`DatePicker` was declared before, which could cause overwriting and losing the declaration of `RangePicker`.

See: [Another Declaration](https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/antd_v3.x.x/flow_v0.104.x-/antd_v3.x.x.js#L100)
