### PR TITLE
[@testing-library/react_v8.x.x] and [@testing-library/react_v9.x.x]: Fix typing regression

### DIFF
--- a/definitions/npm/@testing-library/react_v8.x.x/flow_v0.104.x-/react_v8.x.x.js
+++ b/definitions/npm/@testing-library/react_v8.x.x/flow_v0.104.x-/react_v8.x.x.js
@@ -115,35 +115,28 @@ declare module '@testing-library/react' {
     eventProperties?: TInit
   ) => boolean;
 
-  declare type Queries = { ... };
-
-  declare type RenderResult<Q: Queries = GetsAndQueries> = {|
+  declare type RenderResult = {|
     container: HTMLDivElement,
     unmount: () => void,
     baseElement: HTMLElement,
     asFragment: () => DocumentFragment,
     debug: (baseElement?: HTMLElement) => void,
     rerender: (ui: React$Element<*>) => void,
-  |} & Q;
+  |} & GetsAndQueries;
 
-  declare export type RenderOptions<Q: Queries = { ... }> = {|
+  declare export type RenderOptions = {|
     container?: HTMLElement,
     baseElement?: HTMLElement,
     hydrate?: boolean,
-    queries?: Q,
+    queries?: any,
     wrapper?: React.ComponentType,
   |};
 
   declare module.exports: {
     render(
       ui: React.ReactElement<any>,
-      options?: $Diff<RenderOptions<>, {| queries: any |}>
-    ): RenderResult<>,
-
-    render<Q: Queries>(
-      ui: React.ReactElement<any>,
-      options?: RenderOptions<Q>
-    ): RenderResult<Q>,
+      options?: RenderOptions
+    ): RenderResult,
 
     act: ReactDOMTestUtilsAct,
     cleanup: () => void,

--- a/definitions/npm/@testing-library/react_v8.x.x/flow_v0.104.x-/test_react_v8.x.x.js
+++ b/definitions/npm/@testing-library/react_v8.x.x/flow_v0.104.x-/test_react_v8.x.x.js
@@ -1,5 +1,7 @@
 // @flow
 
+// REMOVE ME: Comment added to force testing of types
+
 import React from 'react';
 import {
   act,

--- a/definitions/npm/@testing-library/react_v8.x.x/flow_v0.104.x-/test_react_v8.x.x.js
+++ b/definitions/npm/@testing-library/react_v8.x.x/flow_v0.104.x-/test_react_v8.x.x.js
@@ -1,7 +1,5 @@
 // @flow
 
-// REMOVE ME: Comment added to force testing of types
-
 import React from 'react';
 import {
   act,

--- a/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/react_v9.x.x.js
+++ b/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/react_v9.x.x.js
@@ -115,35 +115,28 @@ declare module '@testing-library/react' {
     eventProperties?: TInit
   ) => boolean;
 
-  declare type Queries = { ... };
-
-  declare type RenderResult<Q: Queries = GetsAndQueries> = {|
+  declare type RenderResult = {|
     container: HTMLDivElement,
     unmount: () => void,
     baseElement: HTMLElement,
     asFragment: () => DocumentFragment,
     debug: (baseElement?: HTMLElement) => void,
     rerender: (ui: React$Element<*>) => void,
-  |} & Q;
+  |} & GetsAndQueries;
 
-  declare export type RenderOptions<Q: Queries = { ... }> = {|
+  declare export type RenderOptions = {|
     container?: HTMLElement,
     baseElement?: HTMLElement,
     hydrate?: boolean,
-    queries?: Q,
+    queries?: any,
     wrapper?: React.ComponentType,
   |};
 
   declare module.exports: {
     render(
       ui: React.ReactElement<any>,
-      options?: $Diff<RenderOptions<>, {| queries: any |}>
-    ): RenderResult<>,
-
-    render<Q: Queries>(
-      ui: React.ReactElement<any>,
-      options?: RenderOptions<Q>
-    ): RenderResult<Q>,
+      options?: RenderOptions
+    ): RenderResult,
 
     act: ReactDOMTestUtilsAct,
     cleanup: () => void,

--- a/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/test_react_v9.x.x.js
+++ b/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/test_react_v9.x.x.js
@@ -1120,3 +1120,18 @@ describe('text matching API', () => {
     const result: Array<HTMLElement> = queryAllByValue('1');
   });
 });
+
+describe('render() parameters', () => {
+  class Component extends React.Component<{ ... }> {}
+
+  it('allows supplying parameters to render()', () => {
+    class CustomWrapper extends React.Component<{ ... }> {}
+    const element = document.createElement('div');
+    render(<Component />, {
+      baseElement: element,
+      container: element,
+      hydrate: true,
+      wrapper: CustomWrapper,
+    });
+  });
+});

--- a/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/test_react_v9.x.x.js
+++ b/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/test_react_v9.x.x.js
@@ -1,5 +1,7 @@
 // @flow
 
+// REMOVE ME: Comment added to force testing of types
+
 import React from 'react';
 import {
   act,

--- a/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/test_react_v9.x.x.js
+++ b/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/test_react_v9.x.x.js
@@ -1,7 +1,5 @@
 // @flow
 
-// REMOVE ME: Comment added to force testing of types
-
 import React from 'react';
 import {
   act,


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation:
- Link to GitHub or NPM: Fixes https://github.com/flow-typed/flow-typed/issues/3520
- Type of contribution: fix

Other notes:

Fixes https://github.com/flow-typed/flow-typed/issues/3520, that is, `@testing-library/react` types being broken ever since https://github.com/flow-typed/flow-typed/pull/3510 was merged in.

The first commit in this PR shows how the existing types are broken.