### PR TITLE
Update query-string 6.x definitions

### DIFF
--- a/definitions/npm/query-string_v6.x.x/flow_v0.104.x-/query-string_v6.x.x.js
+++ b/definitions/npm/query-string_v6.x.x/flow_v0.104.x-/query-string_v6.x.x.js
@@ -20,7 +20,7 @@ declare module 'query-string' {
 
   declare type ObjectParameters = $ReadOnly<{ [string]: ObjectParameter | $ReadOnlyArray<ObjectParameter>, ... }>
 
-  declare type QueryParameters = { [string]: string | Array<string> | null, ... }
+  declare type QueryParameters = { [string]: string | Array<string | number> | null, ... }
 
   declare type StringifyObjectParameter = {| url: string, query?: QueryParameters |}
 

--- a/definitions/npm/query-string_v6.x.x/flow_v0.104.x-/query-string_v6.x.x.js
+++ b/definitions/npm/query-string_v6.x.x/flow_v0.104.x-/query-string_v6.x.x.js
@@ -22,7 +22,7 @@ declare module 'query-string' {
 
   declare type QueryParameters = { [string]: string | Array<string> | null, ... }
 
-  declare type StringifyObjectParameter = { url: string, query: QueryParameters }
+  declare type StringifyObjectParameter = {| url: string, query?: QueryParameters |}
 
   declare module.exports: {
     extract(str: string): string,

--- a/definitions/npm/query-string_v6.x.x/flow_v0.104.x-/query-string_v6.x.x.js
+++ b/definitions/npm/query-string_v6.x.x/flow_v0.104.x-/query-string_v6.x.x.js
@@ -2,6 +2,10 @@ declare module 'query-string' {
   declare type ArrayFormat = 'none' | 'bracket' | 'index' | 'comma'
   declare type ParseOptions = {|
     arrayFormat?: ArrayFormat,
+    decode?: boolean,
+    sort?: false | <A, B>(A, B) => number,
+    parseNumbers?: boolean,
+    parseBooleans?: boolean,
   |}
 
   declare type StringifyOptions = {|
@@ -9,6 +13,7 @@ declare module 'query-string' {
     encode?: boolean,
     strict?: boolean,
     sort?: false | <A, B>(A, B) => number,
+    skipNull?: boolean,
   |}
 
   declare type ObjectParameter = string | number | boolean | null | void;
@@ -16,6 +21,8 @@ declare module 'query-string' {
   declare type ObjectParameters = $ReadOnly<{ [string]: ObjectParameter | $ReadOnlyArray<ObjectParameter>, ... }>
 
   declare type QueryParameters = { [string]: string | Array<string> | null, ... }
+
+  declare type StringifyObjectParameter = { url: string, query: QueryParameters }
 
   declare module.exports: {
     extract(str: string): string,
@@ -26,6 +33,7 @@ declare module 'query-string' {
       ...
     },
     stringify(obj: ObjectParameters, opts?: StringifyOptions): string,
+    stringifyUrl(obj: StringifyObjectParameter, opts?: StringifyOptions): string,
     ...
   }
 }

--- a/definitions/npm/query-string_v6.x.x/test_query-string_v6.x.x.js
+++ b/definitions/npm/query-string_v6.x.x/test_query-string_v6.x.x.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { extract, parse, stringify, parseUrl } from 'query-string';
+import { extract, parse, parseUrl, stringify, stringifyUrl } from 'query-string';
 
 extract('?test');
 
@@ -10,6 +10,8 @@ extract({});
 parse('test');
 
 parse('test', { arrayFormat: 'bracket' });
+
+parse('test', { decode: true, sort: false, parseNumbers: true, parseBooleans: true });
 
 // $ExpectError: strict is not a parse option
 parse('test', { strict: true });
@@ -32,6 +34,12 @@ stringify('test');
 // $ExpectError: true is not a stringify option
 stringify({ test: null }, { test: true });
 
+stringify({ test: [1, 2, 3] }, { arrayFormat: 'bracket' });
+stringify(
+    { test: 1, empty: null },
+    { encode: true, strict: true, sort: false, skipNull: true }
+);
+
 stringify({ test: 1 });
 
 stringify({ test: [1, 2, 3] });
@@ -41,6 +49,8 @@ stringify({ test: false });
 stringify({ test: null });
 
 stringify({ test: undefined });
+
+stringify({ test: 'test', empty: null }, { skipNull: true });
 
 // Check we can strongly type the query object.
 type Query = {|
@@ -78,3 +88,8 @@ parseUrl('test', { strict: true });
 
 // $ExpectError: should be a string
 parseUrl({ test: null });
+
+stringifyUrl(
+    { url: 'https://example.com', query: { test: [1, 2, 3] } },
+    { encode: true, strict: true, sort: false, skipNull: true }
+);

--- a/definitions/npm/query-string_v6.x.x/test_query-string_v6.x.x.js
+++ b/definitions/npm/query-string_v6.x.x/test_query-string_v6.x.x.js
@@ -89,7 +89,12 @@ parseUrl('test', { strict: true });
 // $ExpectError: should be a string
 parseUrl({ test: null });
 
+stringifyUrl({ url: 'https://example.com' });
+
 stringifyUrl(
     { url: 'https://example.com', query: { test: [1, 2, 3] } },
     { encode: true, strict: true, sort: false, skipNull: true }
 );
+
+// $ExpectError: missing url in first param. object
+stringifyUrl({ query: { value: 'test' } });

--- a/definitions/npm/query-string_v6.x.x/test_query-string_v6.x.x.js
+++ b/definitions/npm/query-string_v6.x.x/test_query-string_v6.x.x.js
@@ -19,7 +19,7 @@ parse('test', { strict: true });
 // $ExpectError: should be a string
 parse({ test: null });
 
-(parse('foo').foo: null | string | Array<string>);
+(parse('foo').foo: null | string | Array<string | number>);
 
 // $ExpectError: result props cannot be undefined
 (parse('foo').foo: void);


### PR DESCRIPTION
Update `query-string_v6.x.x.js` definitions with latest options and methods that were missing.

- Type of contribution: update definition
- Links to documentation: https://github.com/sindresorhus/query-string#stringifyobject-options

I updated the tests as well as I could, hope that's sufficient.

closes #3693 
