### PR TITLE
Update react-redux_v7.x.x.js - shallowEqual

### DIFF
--- a/definitions/npm/react-redux_v7.x.x/flow_v0.104.x-/react-redux_v7.x.x.js
+++ b/definitions/npm/react-redux_v7.x.x/flow_v0.104.x-/react-redux_v7.x.x.js
@@ -281,6 +281,8 @@ declare module "react-redux" {
     connectAdvancedOptions: ?(ConnectAdvancedOptions & EFO),
   ): (component: Com) => React$ComponentType<OP> & $Shape<ST>;
 
+  declare export function shallowEqual<T>(a: T, b: T): boolean;
+
   declare export default {
     Provider: typeof Provider,
     createProvider: typeof createProvider,
@@ -289,6 +291,7 @@ declare module "react-redux" {
     useDispatch: typeof useDispatch,
     useSelector: typeof useSelector,
     useStore: typeof useStore,
+    shallowEqual: typeof shallowEqual,
     ...
   };
 }

--- a/definitions/npm/react-redux_v7.x.x/flow_v0.104.x-/test_shallowEqual.js
+++ b/definitions/npm/react-redux_v7.x.x/flow_v0.104.x-/test_shallowEqual.js
@@ -1,0 +1,12 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import { shallowEqual } from 'react-redux';
+
+describe('shallowEqual', () => {
+  it('fails with different types', () => {
+    // $ExpectError types differ
+    shallowEqual('a', 1);
+  })
+});
+


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

### Links to documentation:
There is no explicit documentation for this function, just assorted references to it:

- https://react-redux.js.org/api/hooks#equality-comparisons-and-updates
- https://react-redux.js.org/api/hooks#recipe-useshallowequalselector
And a long discussion:
- https://github.com/reduxjs/react-redux/pull/1288

### Link to GitHub or NPM: 
https://github.com/reduxjs/react-redux/blob/master/src/utils/shallowEqual.js

### Type of contribution: addition

### Other notes:
A fairly simple helper function that's commonly used to ease migration from `connect()` in react-redux to hooks.

