### PR TITLE
Add libdefs & tests for throttle-debounce@2.x.x

### DIFF
--- a/definitions/npm/throttle-debounce_v2.x.x/flow_v0.104.x-/throttle-debounce_v2.x.x.js
+++ b/definitions/npm/throttle-debounce_v2.x.x/flow_v0.104.x-/throttle-debounce_v2.x.x.js
@@ -1,0 +1,35 @@
+declare module "throttle-debounce" {
+  /**
+   * Throttle execution of a function. Especially useful for rate limiting execution of handlers
+   * on events like resize and scroll.
+   */
+  declare function throttle<T>(
+    delay: number,
+    noTrailing: boolean,
+    callback: (...args: Array<any>) => T,
+    debounceMode: boolean
+  ): (...args: Array<any>) => T;
+  declare function throttle<T>(
+    delay: number,
+    noTrailing: boolean,
+    callback: (...args: Array<any>) => T
+  ): (...args: Array<any>) => T;
+  declare function throttle<T>(
+    delay: number,
+    callback: (...args: Array<any>) => T,
+    debounceMode: boolean
+  ): (...args: Array<any>) => T;
+  declare function throttle<T>(delay: number, callback: (...args: Array<any>) => T): (...args: Array<any>) => T;
+
+  /**
+   * Debounce execution of a function. Debouncing, unlike throttling, guarantees that a function is only executed a single time,
+   * either at the very beginning of a series of calls, or at the very end.
+   */
+  declare function debounce<T>(
+    delay: number,
+    atBegin: boolean,
+    callback: (...args: Array<any>) => T
+  ): (...args: Array<any>) => T;
+
+  declare function debounce<T>(delay: number, callback: (...args: Array<any>) => T): (...args: Array<any>) => T;
+}

--- a/definitions/npm/throttle-debounce_v2.x.x/flow_v0.25.x-v0.103.x/throttle-debounce_v2.x.x.js
+++ b/definitions/npm/throttle-debounce_v2.x.x/flow_v0.25.x-v0.103.x/throttle-debounce_v2.x.x.js
@@ -1,0 +1,35 @@
+declare module "throttle-debounce" {
+  /**
+   * Throttle execution of a function. Especially useful for rate limiting execution of handlers
+   * on events like resize and scroll.
+   */
+  declare function throttle<T>(
+    delay: number,
+    noTrailing: boolean,
+    callback: (...args: Array<any>) => T,
+    debounceMode: boolean
+  ): (...args: Array<any>) => T;
+  declare function throttle<T>(
+    delay: number,
+    noTrailing: boolean,
+    callback: (...args: Array<any>) => T
+  ): (...args: Array<any>) => T;
+  declare function throttle<T>(
+    delay: number,
+    callback: (...args: Array<any>) => T,
+    debounceMode: boolean
+  ): (...args: Array<any>) => T;
+  declare function throttle<T>(delay: number, callback: (...args: Array<any>) => T): (...args: Array<any>) => T;
+
+  /**
+   * Debounce execution of a function. Debouncing, unlike throttling, guarantees that a function is only executed a single time,
+   * either at the very beginning of a series of calls, or at the very end.
+   */
+  declare function debounce<T>(
+    delay: number,
+    atBegin: boolean,
+    callback: (...args: Array<any>) => T
+  ): (...args: Array<any>) => T;
+
+  declare function debounce<T>(delay: number, callback: (...args: Array<any>) => T): (...args: Array<any>) => T;
+}

--- a/definitions/npm/throttle-debounce_v2.x.x/test_throttle-debounce_v2.x.x.js
+++ b/definitions/npm/throttle-debounce_v2.x.x/test_throttle-debounce_v2.x.x.js
@@ -40,7 +40,7 @@ describe('debounce', () => {
 
   it('can be called', () => {
     it('with 3 args: delay, atBegin, callback', () => {
-      debounce(1, true, () => 1)
+      debounce(1, true, () => 1);
     });
 
     it('with 2 args: delay, callback', () => {
@@ -50,9 +50,9 @@ describe('debounce', () => {
 
   it('can not be called with incorrect options', () => {
     // $ExpectError
-    debounce(() => 1)
+    debounce(() => 1);
 
     // $ExpectError
-    debounce('1', () => 1)
+    debounce('1', () => 1);
   });
 });

--- a/definitions/npm/throttle-debounce_v2.x.x/test_throttle-debounce_v2.x.x.js
+++ b/definitions/npm/throttle-debounce_v2.x.x/test_throttle-debounce_v2.x.x.js
@@ -1,0 +1,58 @@
+import { describe, it } from "flow-typed-test";
+import { throttle, debounce } from 'throttle-debounce';
+
+describe('throttle', () => {
+  it('should create throttled function', () => {
+    const func: () => string = throttle(1, () => '');
+  });
+
+  it('can be called', () => {
+    it('with 4 args: delay, noTrailing, callback, debounceMode', () => {
+      throttle(1, true, () => '', true);
+    });
+
+    it('with 3 args: delay, noTrailing, callback', () => {
+      throttle(1, true, () => '');
+    });
+
+    it('with 3 args: delay, callback, debounceMode', () => {
+      throttle(1, () => '', true);
+    });
+
+    it('with 2 args: delay, callback', () => {
+      throttle(1, () => '');
+    });
+  });
+
+  it('can not be called with incorrect options', () => {
+    // $ExpectError
+    throttle(() => '');
+
+    // $ExpectError
+    throttle('1', () => '');
+  });
+});
+
+describe('debounce', () => {
+  it('should create debounce function', () => {
+    const func: () => number = debounce(1, () => 1);
+  });
+
+  it('can be called', () => {
+    it('with 3 args: delay, atBegin, callback', () => {
+      debounce(1, true, () => 1)
+    });
+
+    it('with 2 args: delay, callback', () => {
+      debounce(1, () => 1);
+    });
+  });
+
+  it('can not be called with incorrect options', () => {
+    // $ExpectError
+    debounce(() => 1)
+
+    // $ExpectError
+    debounce('1', () => 1)
+  });
+});


### PR DESCRIPTION
- Links to documentation: https://github.com/niksy/throttle-debounce
- Link to GitHub or NPM: https://www.npmjs.com/package/throttle-debounce
- Type of contribution: new definition

Other notes:
No difference between the API v1 and v2, so I just copied the libdefs from v1 and update the test cases.
