### PR TITLE
[@testing-library/react_v9.x.x] refactor: Clean up the types

### DIFF
--- a/definitions/npm/@testing-library/react_v8.x.x/flow_v0.104.x-/test_react_v8.x.x.js
+++ b/definitions/npm/@testing-library/react_v8.x.x/flow_v0.104.x-/test_react_v8.x.x.js
@@ -12,7 +12,6 @@ import {
   within,
 } from '@testing-library/react';
 import { describe, it } from 'flow-typed-test';
-import { domainToASCII } from 'url';
 
 describe('act', () => {
   it('should fail on invalid inputs', () => {

--- a/definitions/npm/@testing-library/react_v8.x.x/flow_v0.67.1-v0.103.x/test_react_v8.x.x.js
+++ b/definitions/npm/@testing-library/react_v8.x.x/flow_v0.67.1-v0.103.x/test_react_v8.x.x.js
@@ -12,7 +12,6 @@ import {
   within,
 } from '@testing-library/react';
 import { describe, it } from 'flow-typed-test';
-import { domainToASCII } from 'url';
 
 describe('act', () => {
   it('should fail on invalid inputs', () => {

--- a/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/react_v9.x.x.js
+++ b/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/react_v9.x.x.js
@@ -115,16 +115,8 @@ declare module '@testing-library/react' {
     eventProperties?: TInit
   ) => boolean;
 
-  declare type RenderResult<Queries = GetsAndQueries> = {|
-    container: HTMLDivElement,
-    unmount: () => void,
-    baseElement: HTMLElement,
-    asFragment: () => DocumentFragment,
-    debug: (baseElement?: HTMLElement) => void,
-    rerender: (ui: React$Element<*>) => void,
-  |} & Queries;
-  declare type RenderResultWithCustomQueries<CustomQueries> = {
-    ...CustomQueries,
+  declare type RenderResult<Queries = GetsAndQueries> = {
+    ...Queries,
     container: HTMLDivElement,
     unmount: () => void,
     baseElement: HTMLElement,
@@ -160,7 +152,7 @@ declare module '@testing-library/react' {
   >(
     ui: React.ReactElement<any>,
     options: RenderOptionsWithCustomQueries<CustomQueries>
-  ): RenderResultWithCustomQueries<CustomQueries>;
+  ): RenderResult<CustomQueries>;
 
   declare export var act: ReactDOMTestUtilsAct;
   declare export function cleanup(): void;

--- a/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/test_react_v9.x.x.js
+++ b/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/test_react_v9.x.x.js
@@ -12,7 +12,6 @@ import {
   within,
 } from '@testing-library/react';
 import { describe, it } from 'flow-typed-test';
-import { domainToASCII } from 'url';
 
 describe('act', () => {
   it('should fail on invalid inputs', () => {

--- a/definitions/npm/react-testing-library_v3.x.x/flow_v0.104.x-/test_react-testing-library_v3.x.x.js
+++ b/definitions/npm/react-testing-library_v3.x.x/flow_v0.104.x-/test_react-testing-library_v3.x.x.js
@@ -3,7 +3,6 @@
 import React from 'react';
 import { render, Simulate, wait, fireEvent, renderIntoDocument, cleanup, waitForElement } from 'react-testing-library';
 import { describe, it } from 'flow-typed-test';
-import { domainToASCII } from 'url';
 
 describe('wait', () => {
   it('should fail on invalid inputs', () => {

--- a/definitions/npm/react-testing-library_v3.x.x/flow_v0.60.0-v0.103.x/test_react-testing-library_v3.x.x.js
+++ b/definitions/npm/react-testing-library_v3.x.x/flow_v0.60.0-v0.103.x/test_react-testing-library_v3.x.x.js
@@ -3,7 +3,6 @@
 import React from 'react';
 import { render, Simulate, wait, fireEvent, renderIntoDocument, cleanup, waitForElement } from 'react-testing-library';
 import { describe, it } from 'flow-typed-test';
-import { domainToASCII } from 'url';
 
 describe('wait', () => {
   it('should fail on invalid inputs', () => {

--- a/definitions/npm/react-testing-library_v5.x.x/flow_v0.104.x-/test_react-testing-library_v5.x.x.js
+++ b/definitions/npm/react-testing-library_v5.x.x/flow_v0.104.x-/test_react-testing-library_v5.x.x.js
@@ -11,7 +11,6 @@ import {
   within,
 } from 'react-testing-library';
 import { describe, it } from 'flow-typed-test';
-import { domainToASCII } from 'url';
 
 describe('wait', () => {
   it('should fail on invalid inputs', () => {

--- a/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-v0.103.x/test_react-testing-library_v5.x.x.js
+++ b/definitions/npm/react-testing-library_v5.x.x/flow_v0.67.1-v0.103.x/test_react-testing-library_v5.x.x.js
@@ -11,7 +11,6 @@ import {
   within,
 } from 'react-testing-library';
 import { describe, it } from 'flow-typed-test';
-import { domainToASCII } from 'url';
 
 describe('wait', () => {
   it('should fail on invalid inputs', () => {


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://testing-library.com/docs/react-testing-library/intro
- Link to GitHub or NPM: https://github.com/flow-typed/flow-typed/pull/3705
- Type of contribution: refactor

Other notes:

Following up from https://github.com/flow-typed/flow-typed/pull/3705, this PR cleans up the existing `@testing-library/react_v9.x.x` types so that there are less confusing parts.

At any point of this PR, this is ready to be merged. When reviewers have time, I will be happy to get this PR merged and then can continue future work on these types in another PR :relaxed: