### PR TITLE
move react-dom to flow-typed

### DIFF
--- a/definitions/npm/react-dom_v16.x.x/flow_v0.117.x-/react-dom_v16.x.x.js
+++ b/definitions/npm/react-dom_v16.x.x/flow_v0.117.x-/react-dom_v16.x.x.js
@@ -1,0 +1,107 @@
+declare module 'react-dom' {
+  declare function findDOMNode(
+    componentOrElement: Element | ?React$Component<any, any>,
+  ): null | Element | Text;
+
+  declare function render<ElementType: React$ElementType>(
+    element: React$Element<ElementType>,
+    container: Element,
+    callback?: () => void,
+  ): React$ElementRef<ElementType>;
+
+  declare function hydrate<ElementType: React$ElementType>(
+    element: React$Element<ElementType>,
+    container: Element,
+    callback?: () => void,
+  ): React$ElementRef<ElementType>;
+
+  declare function createPortal(
+    node: React$Node,
+    container: Element,
+  ): React$Portal;
+
+  declare function unmountComponentAtNode(container: any): boolean;
+  declare var version: string;
+
+  declare function unstable_batchedUpdates<A, B, C, D, E>(
+    callback: (a: A, b: B, c: C, d: D, e: E) => mixed,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+  ): void;
+  declare function unstable_renderSubtreeIntoContainer<
+    ElementType: React$ElementType,
+  >(
+    parentComponent: React$Component<any, any>,
+    nextElement: React$Element<ElementType>,
+    container: any,
+    callback?: () => void,
+  ): React$ElementRef<ElementType>;
+}
+
+declare module 'react-dom/server' {
+  declare function renderToString(element: React$Node): string;
+  declare function renderToStaticMarkup(element: React$Node): string;
+  declare function renderToNodeStream(element: React$Node): stream$Readable;
+  declare function renderToStaticNodeStream(
+    element: React$Node,
+  ): stream$Readable;
+  declare var version: string;
+}
+
+type Thenable = { then(resolve: () => mixed, reject?: () => mixed): mixed, ... };
+
+declare module 'react-dom/test-utils' {
+  declare var Simulate: { [eventName: string]: (element: Element, eventData?: Object) => void, ... };
+  declare function renderIntoDocument(
+    instance: React$Element<any>,
+  ): React$Component<any, any>;
+  declare function mockComponent(
+    componentClass: React$ElementType,
+    mockTagName?: string,
+  ): Object;
+  declare function isElement(element: React$Element<any>): boolean;
+  declare function isElementOfType(
+    element: React$Element<any>,
+    componentClass: React$ElementType,
+  ): boolean;
+  declare function isDOMComponent(instance: any): boolean;
+  declare function isCompositeComponent(
+    instance: React$Component<any, any>,
+  ): boolean;
+  declare function isCompositeComponentWithType(
+    instance: React$Component<any, any>,
+    componentClass: React$ElementType,
+  ): boolean;
+  declare function findAllInRenderedTree(
+    tree: React$Component<any, any>,
+    test: (child: React$Component<any, any>) => boolean,
+  ): Array<React$Component<any, any>>;
+  declare function scryRenderedDOMComponentsWithClass(
+    tree: React$Component<any, any>,
+    className: string,
+  ): Array<Element>;
+  declare function findRenderedDOMComponentWithClass(
+    tree: React$Component<any, any>,
+    className: string,
+  ): ?Element;
+  declare function scryRenderedDOMComponentsWithTag(
+    tree: React$Component<any, any>,
+    tagName: string,
+  ): Array<Element>;
+  declare function findRenderedDOMComponentWithTag(
+    tree: React$Component<any, any>,
+    tagName: string,
+  ): ?Element;
+  declare function scryRenderedComponentsWithType(
+    tree: React$Component<any, any>,
+    componentClass: React$ElementType,
+  ): Array<React$Component<any, any>>;
+  declare function findRenderedComponentWithType(
+    tree: React$Component<any, any>,
+    componentClass: React$ElementType,
+  ): ?React$Component<any, any>;
+  declare function act(callback: () => void | Thenable): Thenable;
+}

--- a/definitions/npm/react-dom_v16.x.x/flow_v0.117.x-/test_react-dom_v16.x.x.js
+++ b/definitions/npm/react-dom_v16.x.x/flow_v0.117.x-/test_react-dom_v16.x.x.js
@@ -1,0 +1,152 @@
+// @flow
+
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+// All of these tests were originally in the flow repository.
+
+declare function test$getElementById(string): HTMLElement | null;
+
+declare class MyPortalComponent extends React.Component<{...}> {}
+
+class MyComponent extends React.Component<{...}> {
+  render() {
+    return ReactDOM.createPortal(
+      <MyPortalComponent />,
+      // $ExpectError
+      test$getElementById('portal'),
+    );
+  }
+}
+
+class JDiv extends React.Component<{id: string, ...}> {}
+
+// $ExpectError
+<JDiv id={42} />;
+
+class Example extends React.Component<{ bar: string, ... }> {
+  render() {
+    return <div>{this.props.bar}</div>
+  }
+}
+
+ReactDOM.render(
+  // $ExpectError
+  <Example foo="foo" />,
+  // $ExpectError
+  document.body
+);
+
+function Clock(props) {
+  return (
+    <div>
+      <h1>Hello, world!</h1>
+      <h2>It is {props.date.toLocaleTimeString()}.</h2>
+    </div>
+  );
+}
+
+function tick() {
+  const element = document.getElementById('root');
+  if (element) {
+    ReactDOM.render(
+      <Clock date={new Date()} />,
+      element
+    );
+  }
+}
+
+// test-utils tests
+import TestUtils from 'react-dom/test-utils';
+
+class MyTestingComponent extends React.Component<{...}> {
+  render() {
+    return <button className="my-button" />;
+  }
+}
+
+const tree = TestUtils.renderIntoDocument(<MyTestingComponent />);
+TestUtils.mockComponent(MyTestingComponent);
+TestUtils.mockComponent(MyTestingComponent, 'span');
+(TestUtils.isElement(<MyTestingComponent />): boolean);
+(TestUtils.isElementOfType(
+  <MyTestingComponent />,
+  MyTestingComponent,
+): boolean);
+(TestUtils.findRenderedDOMComponentWithClass(tree, 'my-button'): ?Element);
+(TestUtils.isDOMComponent(MyTestingComponent): boolean);
+(TestUtils.isCompositeComponent(tree): boolean);
+(TestUtils.isCompositeComponentWithType(tree, MyTestingComponent): boolean);
+(TestUtils.findAllInRenderedTree(
+  tree,
+  // $ExpectError
+  child => child.tagName === 'BUTTON',
+): Array<React.Component<any, any>>);
+(TestUtils.scryRenderedDOMComponentsWithClass(
+  tree,
+  'my-button',
+): Array<Element>);
+
+const buttonEl = TestUtils.findRenderedDOMComponentWithClass(tree, 'my-button');
+if (buttonEl != null) {
+  TestUtils.Simulate.click(buttonEl);
+}
+
+(TestUtils.scryRenderedDOMComponentsWithTag(tree, 'button'): Array<Element>);
+(TestUtils.findRenderedDOMComponentWithTag(tree, 'button'): ?Element);
+(TestUtils.scryRenderedComponentsWithType(tree, MyTestingComponent): Array<
+  React.Component<any, any>,
+>);
+(TestUtils.findRenderedComponentWithType(
+  tree,
+  MyTestingComponent,
+): ?React.Component<any, any>);
+TestUtils.act(() => {
+  Math.random();
+});
+// $ExpectError
+TestUtils.act(() => ({count: 123}));
+async function runTest() {
+  await TestUtils.act(async () => {
+    // .. some test code
+    await Promise.resolve();
+  });
+  /* // wishlist -
+  act(async () => {
+    // some test code
+  }); // ideally this should error
+  await act(() => {
+    // ...
+  }); // ideally this should error
+  */
+}
+
+// render callback tests
+declare function test$querySelector(selector: string): HTMLElement | null
+
+const Example2 = React.createClass({
+  propTypes: {
+  },
+  render() {
+  	return <div>Hello</div>;
+  }
+});
+
+// $ExpectError
+ReactDOM.render(<Example2/>, test$querySelector('#site'), () => {
+	console.log('Rendered - arrow callback');
+});
+
+// $ExpectError
+ReactDOM.render(<Example2/>, test$querySelector('#site'), function() {
+	console.log('Rendered - function callback');
+});
+
+// $ExpectError
+ReactDOM.render(<Example2/>, test$querySelector('#site'), 1);
+// $ExpectError
+ReactDOM.render(<Example2/>, test$querySelector('#site'), {});
+// $ExpectError
+ReactDOM.render(<Example2/>, test$querySelector('#site'), '');
+// $ExpectError
+ReactDOM.render(<Example2/>, test$querySelector('#site'), null);


### PR DESCRIPTION
- Type of contribution: new definition
Other notes:

[This is verbatim the Flow definitions](https://github.com/facebook/flow/blob/90fcd8f83df4c791266f985689ad959a775f8667/lib/react-dom.js#L1-L117). I also moved the relevant tests to flow-typed.

We're keeping the Synthetic*Event types in Flow for now. We will need to keep the $JSXIntrinsics in Flow forever, since we use that type internally in our type checking.

These types will be moved out of Flow as early as 0.118, but might not make the cut until 0.119.

On the Flow side, I added a test where we have a `flow-typed/npm/react-dom_v16.x.x.js` with this exact definition and I ensure that we have access both to types in `react-dom.js` in Flow and `react-dom_v16.x.x.js` from flow-typed.
