### PR TITLE
Apollo hooks read query fix

### DIFF
--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
@@ -1063,13 +1063,13 @@ declare module '@apollo/react-hooks' {
     success: boolean;
   }
 
-  declare interface CacheReadOptions extends DataProxyReadQueryOptions {
+  declare interface CacheReadOptions extends DataProxyReadQueryOptions<any> {
     rootId?: string;
     previousResult?: any;
     optimistic: boolean;
   }
 
-  declare interface CacheWriteOptions extends DataProxyReadQueryOptions {
+  declare interface CacheWriteOptions extends DataProxyReadQueryOptions<any> {
     dataId: string;
     result: any;
   }
@@ -1082,7 +1082,7 @@ declare module '@apollo/react-hooks' {
     callback: CacheWatchCallback;
   }
 
-  declare interface CacheEvictOptions extends DataProxyReadQueryOptions {
+  declare interface CacheEvictOptions extends DataProxyReadQueryOptions<any> {
     rootId?: string;
   }
 
@@ -1097,9 +1097,9 @@ declare module '@apollo/react-hooks' {
   > = DataProxyWriteFragmentOptions<TData, TVariables>;
   declare type CacheWriteDataOptions<TData> = DataProxyWriteDataOptions<TData>;
 
-  declare interface DataProxyReadQueryOptions {
+  declare interface DataProxyReadQueryOptions<D> {
     query: DocumentNode;
-    variables?: any;
+    variables?: D;
   }
 
   declare interface DataProxyReadFragmentOptions<TVariables> {

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/test_react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/test_react-hooks_v3.x.x.js
@@ -127,4 +127,17 @@ describe('useMutation hook', () => {
     // $ExpectError
     (loading: string);
   });
+  it('can manually update the cache after a mutation using update on the mutation function', async () => {
+    const mutationResult = await mutation({
+      variables: {
+        c: 'test'
+      },
+      update: cache => {
+        cache.readQuery({ query: 'test' })
+        cache.readQuery<string, number>({ query: 'test' })
+        // $ExpectError
+        cache.readQuery<string>({ query: 'test' })
+      }
+    });
+  })
 });

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
@@ -948,13 +948,13 @@ declare module '@apollo/react-hooks' {
     success: boolean;
   }
 
-  declare interface CacheReadOptions extends DataProxyReadQueryOptions {
+  declare interface CacheReadOptions extends DataProxyReadQueryOptions<any> {
     rootId?: string;
     previousResult?: any;
     optimistic: boolean;
   }
 
-  declare interface CacheWriteOptions extends DataProxyReadQueryOptions {
+  declare interface CacheWriteOptions extends DataProxyReadQueryOptions<any> {
     dataId: string;
     result: any;
   }
@@ -967,7 +967,7 @@ declare module '@apollo/react-hooks' {
     callback: CacheWatchCallback;
   }
 
-  declare interface CacheEvictOptions extends DataProxyReadQueryOptions {
+  declare interface CacheEvictOptions extends DataProxyReadQueryOptions<any> {
     rootId?: string;
   }
 
@@ -982,9 +982,9 @@ declare module '@apollo/react-hooks' {
   > = DataProxyWriteFragmentOptions<TData, TVariables>;
   declare type CacheWriteDataOptions<TData> = DataProxyWriteDataOptions<TData>;
 
-  declare interface DataProxyReadQueryOptions {
+  declare interface DataProxyReadQueryOptions<D> {
     query: DocumentNode;
-    variables?: any;
+    variables?: D;
   }
 
   declare interface DataProxyReadFragmentOptions<TVariables> {

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/test_react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/test_react-hooks_v3.x.x.js
@@ -127,4 +127,17 @@ describe('useMutation hook', () => {
     // $ExpectError
     (loading: string);
   });
+  it('can manually update the cache after a mutation using update on the mutation function', async () => {
+    const mutationResult = await mutation({
+      variables: {
+        c: 'test'
+      },
+      update: cache => {
+        cache.readQuery({ query: 'test' })
+        cache.readQuery<string, number>({ query: 'test' })
+        // $ExpectError
+        cache.readQuery<string>({ query: 'test' })
+      }
+    });
+  })
 });


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Type of contribution: fix

Other notes:
Fix for issue described here

https://github.com/flow-typed/flow-typed/issues/3718

I have made the `DataProxyReadQueryOptions` type accept the generic type that it is being passed, and added a couple of tests for this
