### PR TITLE
Add enzyme invoke definition

### DIFF
--- a/definitions/npm/enzyme_v3.x.x/flow_v0.104.x-/enzyme_v3.x.x.js
+++ b/definitions/npm/enzyme_v3.x.x/flow_v0.104.x-/enzyme_v3.x.x.js
@@ -44,6 +44,7 @@ declare module "enzyme" {
     unmount(): this,
     text(): string,
     html(): string,
+    invoke(propName: string): (...args: $ReadOnlyArray<any>) => mixed,
     get(index: number): React$Node,
     getDOMNode(): HTMLElement | HTMLInputElement,
     at(index: number): this,

--- a/definitions/npm/enzyme_v3.x.x/flow_v0.104.x-/test_enzyme-v3.x.js
+++ b/definitions/npm/enzyme_v3.x.x/flow_v0.104.x-/test_enzyme-v3.x.js
@@ -8,6 +8,7 @@ import {
   type ShallowWrapper,
   type ReactWrapper
 } from "enzyme";
+import { describe, it } from 'flow-typed-test';
 
 configure({
   disableLifecycleMethods: true
@@ -157,3 +158,34 @@ mount(<div><DeepInstance onChange={() => {}}/></div>).children(DeepInstance).ins
 (mount(<div />).containsAllMatchingElements([<div />, <div />]): boolean);
 (mount(<div />).containsAnyMatchingElements(<div />): boolean);
 (mount(<div />).containsAnyMatchingElements([<div />, <div />]): boolean);
+
+describe('invoke', () => {
+    describe('invoke event handler prop on shallowWrapper', () => {
+        it('test', () => {
+            // This is common use case for triggering event handler for user action
+            const shallowWrapper = shallow(<div onClick={() => {}} />);
+            shallowWrapper.invoke('onClick')();
+        });
+    });
+
+    describe('invoke regular function prop on shallowWrapper', () => {
+        // Less common use case, allowable by enzyime for prop to simply be a function
+
+        it('user uses type refinement', () => {
+            const shallowWrapper = shallow(<div getName={() => {return 'test';}} />);
+            const name = shallowWrapper.invoke('getName')();
+
+            if (typeof name === 'string') {
+                name.substring(0);
+            };
+        });
+
+        it('user does not refine type', () => {
+            const shallowWrapper = shallow(<div getNumber={() => {return 'not a number';}} />);
+            const string = shallowWrapper.invoke('getNumber')();
+
+            // $ExpectError
+            name.toFixed();
+        });
+    });
+});

--- a/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-v0.103.x/enzyme_v3.x.x.js
+++ b/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-v0.103.x/enzyme_v3.x.x.js
@@ -44,6 +44,7 @@ declare module "enzyme" {
     unmount(): this,
     text(): string,
     html(): string,
+    invoke(propName: string): (...args: $ReadOnlyArray<any>) => mixed,
     get(index: number): React$Node,
     getDOMNode(): HTMLElement | HTMLInputElement,
     at(index: number): this,

--- a/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-v0.103.x/test_enzyme-v3.x.js
+++ b/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-v0.103.x/test_enzyme-v3.x.js
@@ -152,3 +152,34 @@ mount(<div><DeepInstance onChange={() => {}}/></div>).children(DeepInstance).ins
 (mount(<div />).containsAllMatchingElements([<div />, <div />]): boolean);
 (mount(<div />).containsAnyMatchingElements(<div />): boolean);
 (mount(<div />).containsAnyMatchingElements([<div />, <div />]): boolean);
+
+describe('invoke', () => {
+    describe('invoke event handler prop on shallowWrapper', () => {
+        it('test', () => {
+            // This is common use case for triggering event handler for user action
+            const shallowWrapper = shallow(<div onClick={() => {}} />);
+            shallowWrapper.invoke('onClick')();
+        });
+    });
+
+    describe('invoke regular function prop on shallowWrapper', () => {
+        // Less common use case, allowable by enzyime for prop to simply be a function
+
+        it('user uses type refinement', () => {
+            const shallowWrapper = shallow(<div getName={() => {return 'test';}} />);
+            const name = shallowWrapper.invoke('getName')();
+
+            if (typeof name === 'string') {
+                name.substring(0);
+            };
+        });
+
+        it('user does not refine type', () => {
+            const shallowWrapper = shallow(<div getNumber={() => {return 'not a number';}} />);
+            const string = shallowWrapper.invoke('getNumber')();
+
+            // $ExpectError
+            name.toFixed();
+        });
+    });
+});


### PR DESCRIPTION
Fixes #3720
Enzyme 3.10.0 introduced `invoke` function to wrappers. This function
accepts a prop name and returns a function, decorated with enzyme internal magic.

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: [Changelog][1] and [invoke function documentation][3]
- Link to GitHub or NPM:  [function implementation][2]
- Type of contribution: **addition**

[1]: https://github.com/airbnb/enzyme/blob/enzyme%403.10.0/CHANGELOG.md#new-stuff
[2]: https://github.com/airbnb/enzyme/blob/c62cc4114f97f73283b2c1153c6110e574cdbe81/packages/enzyme/src/ReactWrapper.js#L837-L851 "invoke function implementation"
[3]: https://github.com/airbnb/enzyme/blob/e3d6d5effc44be40718729c425205ffffb242ac2/docs/api/ReactWrapper/invoke.md

Other notes: