### PR TITLE
add ramda 0.27.x definitions

### DIFF
--- a/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/ramda_v0.26.x.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/ramda_v0.26.x.js
@@ -756,8 +756,13 @@ declare module ramda {
   declare function findLast<V>(fn: UnaryPredicateFn<V>): (xs: $ReadOnlyArray<V>) => ?V | O;
   declare function findLast<V>(fn: UnaryPredicateFn<V>, xs: $ReadOnlyArray<V>): ?V;
 
-  declare function findIndex<K, V>(fn: UnaryPredicateFn<V>): (xs: $ReadOnlyArray<V>) => number;
-  declare function findIndex<K, V>(fn: UnaryPredicateFn<V>, xs: $ReadOnlyArray<V>): number;
+  declare function findIndex<K, V, T: Array<V> | { [key: K]: V, ...}>(
+    fn: UnaryPredicateFn<V>,
+  ): (xs: T) => number;
+  declare function findIndex<K, V, T: Array<V> | { [key: K]: V, ... }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): number;
 
   declare function findLastIndex<K, V>(fn: UnaryPredicateFn<V>): (xs: $ReadOnlyArray<V>) => number;
   declare function findLastIndex<K, V>(fn: UnaryPredicateFn<V>, xs: $ReadOnlyArray<V>): number;

--- a/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/test_ramda_v0.26.x_object.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/test_ramda_v0.26.x_object.js
@@ -445,10 +445,20 @@ const ob3 = _.merge(ob1, ob2);
 const propX = ob3.x;
 const propA = ob3.a;
 
-const mLeft: { name: string, age: number } = _.mergeLeft({ 'age': 40 }, { 'name': 'fred', 'age': 10 });
+type User = {
+  name: string,
+  age: number,
+  ...
+}
+const mLeft: User = _.mergeLeft({ 'age': 40 }, { 'name': 'fred', 'age': 10 });
 const mLeftName: string = mLeft.name;
 const mLeftAge: number = mLeft.age;
-const mLeft2: { x: number, y: number } = _.mergeLeft({x: 0})({x: 5, y: 2});
+type Point = {
+  x: number,
+  y: number,
+  ...
+}
+const mLeft2: Point = _.mergeLeft({x: 0})({x: 5, y: 2});
 const mLeftX: number = mLeft2.x;
 const mLeftY: number = mLeft2.y;
 

--- a/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/test_ramda_v0.26.x_object.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.104.x-/test_ramda_v0.26.x_object.js
@@ -462,11 +462,11 @@ const mLeft2: Point = _.mergeLeft({x: 0})({x: 5, y: 2});
 const mLeftX: number = mLeft2.x;
 const mLeftY: number = mLeft2.y;
 
-const mRight: { name: string, age: number } = _.mergeRight({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
+const mRight: User = _.mergeRight({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
 const mRightName: string = mRight.name;
 // $ExpectError
 const mRightAge: number = mRight.name;
-const mRight2: { x: number, y: number } = _.mergeRight({x: 0, y: 0})({y: 2});
+const mRight2: Point = _.mergeRight({x: 0, y: 0})({y: 2});
 const mRightX: number = mRight2.x;
 const mRightY: number = mRight2.y;
 

--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/test_ramda_v0.26.x_object.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/test_ramda_v0.26.x_object.js
@@ -439,17 +439,18 @@ const ob3 = _.merge(ob1, ob2);
 const propX = ob3.x;
 const propA = ob3.a;
 
-const mLeft: Object = _.mergeLeft({ 'age': 40 }, { 'name': 'fred', 'age': 10 });
+const mLeft: { name: string, age: number } = _.mergeLeft({ 'age': 40 }, { 'name': 'fred', 'age': 10 });
 const mLeftName: string = mLeft.name;
 const mLeftAge: number = mLeft.age;
-const mLeft2: Object = _.mergeLeft({x: 0})({x: 5, y: 2});
+const mLeft2: { x: number, y: number } = _.mergeLeft({x: 0})({x: 5, y: 2});
 const mLeftX: number = mLeft2.x;
 const mLeftY: number = mLeft2.y;
 
-const mRight: Object = _.mergeRight({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
+const mRight: { name: string, age: number } = _.mergeRight({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
 const mRightName: string = mRight.name;
+// $ExpectError
 const mRightAge: number = mRight.name;
-const mRight2: Object = _.mergeRight({x: 0, y: 0})({y: 2});
+const mRight2: { x: number, y: number } = _.mergeRight({x: 0, y: 0})({y: 2});
 const mRightX: number = mRight2.x;
 const mRightY: number = mRight2.y;
 

--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/test_ramda_v0.26.x_object.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/test_ramda_v0.26.x_object.js
@@ -456,11 +456,11 @@ const mLeft2: Point = _.mergeLeft({x: 0})({x: 5, y: 2});
 const mLeftX: number = mLeft2.x;
 const mLeftY: number = mLeft2.y;
 
-const mRight: { name: string, age: number } = _.mergeRight({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
+const mRight: User = _.mergeRight({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
 const mRightName: string = mRight.name;
 // $ExpectError
 const mRightAge: number = mRight.name;
-const mRight2: { x: number, y: number } = _.mergeRight({x: 0, y: 0})({y: 2});
+const mRight2: Point = _.mergeRight({x: 0, y: 0})({y: 2});
 const mRightX: number = mRight2.x;
 const mRightY: number = mRight2.y;
 

--- a/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/test_ramda_v0.26.x_object.js
+++ b/definitions/npm/ramda_v0.26.x/flow_v0.76.x-v0.103.x/test_ramda_v0.26.x_object.js
@@ -439,10 +439,20 @@ const ob3 = _.merge(ob1, ob2);
 const propX = ob3.x;
 const propA = ob3.a;
 
-const mLeft: { name: string, age: number } = _.mergeLeft({ 'age': 40 }, { 'name': 'fred', 'age': 10 });
+type User = {
+  name: string,
+  age: number,
+  ...
+}
+const mLeft: User = _.mergeLeft({ 'age': 40 }, { 'name': 'fred', 'age': 10 });
 const mLeftName: string = mLeft.name;
 const mLeftAge: number = mLeft.age;
-const mLeft2: { x: number, y: number } = _.mergeLeft({x: 0})({x: 5, y: 2});
+type Point = {
+  x: number,
+  y: number,
+  ...
+}
+const mLeft2: Point = _.mergeLeft({x: 0})({x: 5, y: 2});
 const mLeftX: number = mLeft2.x;
 const mLeftY: number = mLeft2.y;
 

--- a/definitions/npm/ramda_v0.27.x/CONTRIBUTING.md
+++ b/definitions/npm/ramda_v0.27.x/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to the Ramda definition
+
+Hello, and thank you for wanting to improve the Ramda flow type definition!
+If you're looking to write or improve tests, please read the recommendations about [writing tests](https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md#writing-tests).
+
+## How can you help?
+
+- Addressing curently unclosed [issues](https://github.com/flow-typed/flow-typed/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+ramda)
+- Implementing features of the new [ramda realizes](https://github.com/ramda/ramda/issues?q=label%3A%22upgrade+guide%22)
+
+And finally, if you need feedback on your PR, feel free to ask **@LoganBarnett**.

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/ramda_v0.27.x.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/ramda_v0.27.x.js
@@ -27,7 +27,7 @@ declare module ramda {
   declare type BinaryPredicateFn2<T, S> = (x: T, y: S) => boolean;
 
   declare interface ObjPredicate {
-    (value: any, key: string): boolean;
+    (value: mixed, key: string): boolean;
   }
 
   declare type __CurriedFunction1<A, R, AA: A> = (...r: [AA]) => R;
@@ -386,79 +386,39 @@ declare module ramda {
 
   declare type Pipe = typeof pipe;
 
-  declare type Compose = (<A, B, C, D, E, F, G, H, I, J, K>(
-    jk: UnaryFn<J, K>,
-    ij: UnaryFn<I, J>,
-    hi: UnaryFn<H, I>,
-    gh: UnaryFn<G, H>,
-    fg: UnaryFn<F, G>,
-    ef: UnaryFn<E, F>,
-    de: UnaryFn<D, E>,
-    cd: UnaryFn<C, D>,
-    bc: UnaryFn<B, C>,
-    ab: UnaryFn<A, B>
-  ) => UnaryFn<A, K>) &
-    (<A, B, C, D, E, F, G, H, I, J>(
-      ij: UnaryFn<I, J>,
-      hi: UnaryFn<H, I>,
-      gh: UnaryFn<G, H>,
-      fg: UnaryFn<F, G>,
-      ef: UnaryFn<E, F>,
-      de: UnaryFn<D, E>,
-      cd: UnaryFn<C, D>,
-      bc: UnaryFn<B, C>,
-      ab: UnaryFn<A, B>
-    ) => UnaryFn<A, J>) &
-    (<A, B, C, D, E, F, G, H, I>(
-      hi: UnaryFn<H, I>,
-      gh: UnaryFn<G, H>,
-      fg: UnaryFn<F, G>,
-      ef: UnaryFn<E, F>,
-      de: UnaryFn<D, E>,
-      cd: UnaryFn<C, D>,
-      bc: UnaryFn<B, C>,
-      ab: UnaryFn<A, B>
-    ) => UnaryFn<A, I>) &
-    (<A, B, C, D, E, F, G, H>(
-      gh: UnaryFn<G, H>,
-      fg: UnaryFn<F, G>,
-      ef: UnaryFn<E, F>,
-      de: UnaryFn<D, E>,
-      cd: UnaryFn<C, D>,
-      bc: UnaryFn<B, C>,
-      ab: UnaryFn<A, B>
-    ) => UnaryFn<A, H>) &
-    (<A, B, C, D, E, F, G>(
-      fg: UnaryFn<F, G>,
-      ef: UnaryFn<E, F>,
-      de: UnaryFn<D, E>,
-      cd: UnaryFn<C, D>,
-      bc: UnaryFn<B, C>,
-      ab: UnaryFn<A, B>
-    ) => UnaryFn<A, G>) &
+  declare type PipeP = (<A, B, C, D, E, F, G>(
+    ab: UnaryPromiseFn<A, B>,
+    bc: UnaryPromiseFn<B, C>,
+    cd: UnaryPromiseFn<C, D>,
+    de: UnaryPromiseFn<D, E>,
+    ef: UnaryPromiseFn<E, F>,
+    fg: UnaryPromiseFn<F, G>,
+  ) => UnaryPromiseFn<A, G>) &
     (<A, B, C, D, E, F>(
-      ef: UnaryFn<E, F>,
-      de: UnaryFn<D, E>,
-      cd: UnaryFn<C, D>,
-      bc: UnaryFn<B, C>,
-      ab: UnaryFn<A, B>,
-    ) => UnaryFn<A, F>) &
+      ab: UnaryPromiseFn<A, B>,
+      bc: UnaryPromiseFn<B, C>,
+      cd: UnaryPromiseFn<C, D>,
+      de: UnaryPromiseFn<D, E>,
+      ef: UnaryPromiseFn<E, F>,
+    ) => UnaryPromiseFn<A, F>) &
     (<A, B, C, D, E>(
-      de: UnaryFn<D, E>,
-      cd: UnaryFn<C, D>,
-      bc: UnaryFn<B, C>,
-      ab: UnaryFn<A, B>,
-    ) => UnaryFn<A, E>) &
+      ab: UnaryPromiseFn<A, B>,
+      bc: UnaryPromiseFn<B, C>,
+      cd: UnaryPromiseFn<C, D>,
+      de: UnaryPromiseFn<D, E>,
+    ) => UnaryPromiseFn<A, E>) &
     (<A, B, C, D>(
-      cd: UnaryFn<C, D>,
-      bc: UnaryFn<B, C>,
-      ab: UnaryFn<A, B>,
-    ) => UnaryFn<A, D>) &
+      ab: UnaryPromiseFn<A, B>,
+      bc: UnaryPromiseFn<B, C>,
+      cd: UnaryPromiseFn<C, D>,
+    ) => UnaryPromiseFn<A, D>) &
     (<A, B, C>(
-      bc: UnaryFn<B, C>,
-      ab: UnaryFn<A, B>,
-    ) => UnaryFn<A, C>) &
-    (<A, B>(ab: UnaryFn<A, B>) => UnaryFn<A, B>);
+      ab: UnaryPromiseFn<A, B>,
+      bc: UnaryPromiseFn<B, C>,
+    ) => UnaryPromiseFn<A, C>) &
+    (<A, B>(
+      ab: UnaryPromiseFn<A, B>,
+    ) => UnaryPromiseFn<A, B>);
 
   // This kind of filter allows us to do type refinement on the result, but we
   // still need Filter so that non-refining predicates still pass a type check.
@@ -480,16 +440,16 @@ declare module ramda {
   declare class Semigroup<T> {}
 
   declare class Chain {
-    chain<T, V: Monad<T> | Array<T>>(fn: (a: T) => V, x: V): V;
-    chain<T, V: Monad<T> | Array<T>>(fn: (a: T) => V): (x: V) => V;
+    chain<T, V: Monad<T> | $ReadOnlyArray<T>>(fn: (a: T) => V, x: V): V;
+    chain<T, V: Monad<T> | $ReadOnlyArray<T>>(fn: (a: T) => V): (x: V) => V;
   }
 
   declare class GenericContructor<T> {
-    constructor(x: T): GenericContructor<any>;
+    constructor(x: T): GenericContructor<T>;
   }
 
-  declare class GenericContructorMulti {
-    constructor(...args: Array<any>): GenericContructor<any>;
+  declare class GenericContructorMulti<T> {
+    constructor(...args: Array<T>): GenericContructor<T>;
   }
 
   /**
@@ -505,14 +465,12 @@ declare module ramda {
    */
 
   declare var compose: Compose;
-  // TODO: composeWith
-  // TODO: pipeWith
   declare function then<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>): CurriedFunction1<Promise<A>, Promise<R>>
   declare function then<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>, p: Promise<A>): Promise<R>;
   declare var curry: Curry;
-  declare function curryN(
+  declare function curryN<A, R>(
     length: number,
-    fn: (...args: Array<any>) => any
+    fn: (...args: Array<A>) => R
   ): Function;
 
   // *Math
@@ -554,72 +512,55 @@ declare module ramda {
   declare function replace<A: RegExp | string, B: string | ReplacementFn>(A, B, string): string;
   declare var split: CurriedFunction2<RegExp | string, string, Array<string>>;
   declare var test: CurriedFunction2<RegExp, string, boolean>;
-  // startsWith and endsWith use the same signature:
-  declare type EdgeWith<A> =
-    & (
-        & ((Array<A>) => (Array<A>) => boolean)
-        & (Array<A>, Array<A>) => boolean
-    )
-    & (
-        & ((string) => (string) => boolean)
-        & (string, string) => boolean
-    )
-  ;
-  declare var startsWith: EdgeWith<*>;
-  declare var endsWith: EdgeWith<*>;
+
+  declare function startsWith<A>(prefix: $ReadOnlyArray<A>): $ReadOnlyArray<A> => boolean;
+  declare function startsWith(prefix: string): string => boolean;
+  declare function startsWith<A>(prefix: $ReadOnlyArray<A>, list: $ReadOnlyArray<A>): boolean;
+  declare function startsWith(prefix: string, list: string): boolean;
+
+  declare function endsWith<A>(prefix: $ReadOnlyArray<A>): $ReadOnlyArray<A> => boolean;
+  declare function endsWith(prefix: string): string => boolean;
+  declare function endsWith<A>(prefix: $ReadOnlyArray<A>, list: $ReadOnlyArray<A>): boolean;
+  declare function endsWith(prefix: string, list: string): boolean;
+
   declare function toLower(a: string): string;
-  declare function toString(x: any): string;
+  declare function toString(x: mixed): string;
   declare function toUpper(a: string): string;
   declare function trim(a: string): string;
 
   // *Type
-  declare function is<T>(t: T): (v: any) => boolean;
-  declare function is<T>(t: T, v: any): boolean;
-  declare var propIs: CurriedFunction3<any, string, Object, boolean>;
-  declare function type(x: ?any): string;
 
-  declare function isNil(x: mixed): boolean %checks(x === undefined ||
-    x === null);
+  declare function is<T>(t: T): mixed => boolean;
+  declare function is<T>(t: T, v: mixed): boolean;
+  declare function propIs<O>(mixed, $Keys<O>): CurriedFunction1<O, boolean>;
+  declare function propIs<O>(mixed): CurriedFunction2<$Keys<O>, O, boolean>;
+  declare function propIs<O>(mixed, $Keys<O>, O): boolean;
+  declare function type(x: mixed): string;
+
+  declare function isNil(x: mixed): boolean %checks(x === undefined || x === null);
 
   // *List
-  declare function adjust<A>(
-    index: number,
-  ): (fn: (a: A) => A) => (src: $ReadOnlyArray<A>) => Array<A>;
-  declare function adjust<A>(
-    index: number,
-    fn: (a: A) => A,
-  ): (src: $ReadOnlyArray<A>) => Array<A>;
-  declare function adjust<A>(
-    index: number,
-    fn: (a: A) => A,
-    src: $ReadOnlyArray<A>
-  ): Array<A>;
+  declare function adjust<T>(index: number): CurriedFunction2<(a: T) => T, $ReadOnlyArray<T>, Array<T>>;
+  declare function adjust<T>(index: number, fn: (a: T) => T): CurriedFunction1<$ReadOnlyArray<T>, Array<T>>;
+  declare function adjust<T>(index: number, fn: (a: T) => T, src: $ReadOnlyArray<T>): Array<T>;
 
-  declare function all<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
-  declare function all<T>(
-    fn: UnaryPredicateFn<T>,
-  ): (xs: Array<T>) => boolean;
+  declare function all<T>(fn: UnaryPredicateFn<T>): CurriedFunction1<$ReadOnlyArray<T>, boolean>;
+  declare function all<T>(fn: UnaryPredicateFn<T>, xs: $ReadOnlyArray<T>): boolean;
 
-  declare function any<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
-  declare function any<T>(
-    fn: UnaryPredicateFn<T>,
-  ): (xs: Array<T>) => boolean;
+  declare function any<T>(fn: UnaryPredicateFn<T>): CurriedFunction1<$ReadOnlyArray<T>, boolean>;
+  declare function any<T>(fn: UnaryPredicateFn<T>, xs: $ReadOnlyArray<T>): boolean;
 
-  declare function aperture<T>(n: number, xs: Array<T>): Array<Array<T>>;
-  declare function aperture<T>(
-    n: number,
-  ): (xs: Array<T>) => Array<Array<T>>;
+  declare function aperture<T>(n: number): CurriedFunction1<$ReadOnlyArray<T>, Array<Array<T>>>;
+  declare function aperture<T>(n: number, xs: $ReadOnlyArray<T>): Array<Array<T>>;
 
   declare function append<A, E>(A, $ReadOnlyArray<E>): Array<E|A>;
   declare function append<A, E>(A): CurriedFunction1<$ReadOnlyArray<E>, Array<E|A>>;
 
-  declare function prepend<E>(x: E, xs: Array<E>): Array<E>;
-  declare function prepend<E>(
-    x: E,
-  ): (xs: Array<E>) => Array<E>;
+  declare function prepend<E>(x: E, xs: $ReadOnlyArray<E>): Array<E>;
+  declare function prepend<E>(x: E): (xs: $ReadOnlyArray<E>) => Array<E>;
 
-  declare function chain<A, B>(f: (x: A) => Array<B>, xs: $ReadOnlyArray<A>): Array<B>;
-  declare function chain<A, B>(f: (x: A) => Array<B>): (xs: $ReadOnlyArray<A>) => Array<B>;
+  declare function chain<A, B>(f: (x: A) => B[], xs: $ReadOnlyArray<A>): B[]
+  declare function chain<A, B>(f: (x: A) => B[]): (xs: $ReadOnlyArray<A>) => B[]
 
   // Additional chain functionality documented at https://ramdajs.com/docs/#chain:
   //
@@ -644,282 +585,233 @@ declare module ramda {
 
   declare var includes: Includes;
 
-  declare function drop<V, T: Array<V> | string>(
-    n: number,
-  ): (xs: T) => T;
-  declare function drop<V, T: Array<V> | string>(n: number, xs: T): T;
+  declare function drop(n: number): (xs: string) => string;
+  declare function drop(n: number, xs: string): string;
+  declare function drop<V, T: $ReadOnlyArray<V>>(n: number): (xs: T) => V[];
+  declare function drop<V, T: $ReadOnlyArray<V>>(n: number, xs: T): V[];
 
-  declare function dropLast<V, T: Array<V> | string>(
-    n: number,
-  ): (xs: T) => T;
-  declare function dropLast<V, T: Array<V> | string>(n: number, xs: T): T;
+  declare function dropLast(n: number): (xs: string) => string;
+  declare function dropLast(n: number, xs: string): string;
+  declare function dropLast<V, T: $ReadOnlyArray<V>>(n: number): (xs: T) => V[];
+  declare function dropLast<V, T: $ReadOnlyArray<V>>(n: number, xs: T): V[];
 
-  declare function dropLastWhile<V, T: Array<V>>(
-    fn: UnaryPredicateFn<V>,
-  ): (xs: T) => T;
-  declare function dropLastWhile<V, T: Array<V>>(
-    fn: UnaryPredicateFn<V>,
-    xs: T
-  ): T;
+  declare function dropLastWhile(fn: UnaryPredicateFn<string>): (xs: string) => string;
+  declare function dropLastWhile(fn: UnaryPredicateFn<string>, xs: string): string;
+  declare function dropLastWhile<V, T: $ReadOnlyArray<V>>(fn: UnaryPredicateFn<V>): (xs: T) => V[];
+  declare function dropLastWhile<V, T: $ReadOnlyArray<V>>(fn: UnaryPredicateFn<V>, xs: T): V[];
 
-  declare function dropWhile<V, T: Array<V>>(
-    fn: UnaryPredicateFn<V>,
-  ): (xs: T) => T;
-  declare function dropWhile<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: T): T;
+  declare function dropWhile(fn: UnaryPredicateFn<string>): (xs: string) => string;
+  declare function dropWhile(fn: UnaryPredicateFn<string>, xs: string): string;
+  declare function dropWhile<V, T: $ReadOnlyArray<V>>(fn: UnaryPredicateFn<V>): (xs: T) => V[];
+  declare function dropWhile<V, T: $ReadOnlyArray<V>>(fn: UnaryPredicateFn<V>, xs: T): V[];
 
-  declare function dropRepeats<V, T: Array<V>>(xs: T): T;
+  declare function dropRepeats<V>(xs: $ReadOnlyArray<V>): V[];
 
-  declare function dropRepeatsWith<V, T: Array<V>>(
-    fn: BinaryPredicateFn<V>,
-  ): (xs: T) => T;
-  declare function dropRepeatsWith<V, T: Array<V>>(
-    fn: BinaryPredicateFn<V>,
-    xs: T
-  ): T;
+  declare function dropRepeatsWith<V>(fn: BinaryPredicateFn<V>): (xs: $ReadOnlyArray<V>) => V[];
+  declare function dropRepeatsWith<V>(fn: BinaryPredicateFn<V>, xs: $ReadOnlyArray<V>): V[];
 
   declare function groupBy<T>(fn: (x: T) => string, xs: $ReadOnlyArray<T>): { [key: string]: Array<T>, ... };
   declare function groupBy<T>(fn: (x: T) => string): CurriedFunction1<$ReadOnlyArray<T>, { [string]: Array<T>, ... }>;
 
-  declare function groupWith<T, V: Array<T> | string>(
-    fn: BinaryPredicateFn<T>,
-    xs: V
-  ): Array<V>;
-  declare function groupWith<T, V: Array<T> | string>(
-    fn: BinaryPredicateFn<T>,
-  ): (xs: V) => Array<V>;
+  declare function groupWith<V>(fn: BinaryPredicateFn<V>): (xs: $ReadOnlyArray<V>) => V[][];
+  declare function groupWith<V>(fn: BinaryPredicateFn<V>, xs: $ReadOnlyArray<V>): V[][];
+  declare function groupWith(fn: BinaryPredicateFn<string>): (xs: $ReadOnlyArray<string>) => string[];
+  declare function groupWith(fn: BinaryPredicateFn<string>, xs: $ReadOnlyArray<string>): string[];
 
-  declare function head<T, V: Array<T>>(xs: V): $ElementType<V, 0>;
-  declare function head<T, V: string>(xs: V): V;
+  declare function head<T, V: $ReadOnlyArray<T>>(xs: V): $ElementType<V, 0>;
+  declare function head(xs: string): string;
 
-  declare function into<I, T, A: Array<T>, R: Array<*> | string | Object>(
+  declare function into<I, T, A: $ReadOnlyArray<T>, R>(
     accum: R,
     xf: (a: A) => I,
     input: A
   ): R;
-  declare function into<I, T, A: Array<T>, R>(
+  declare function into<I, T, A: $ReadOnlyArray<T>, R>(
     accum: Transformer<I, R>,
     xf: (a: A) => R,
     input: A
   ): R;
 
-  declare function indexOf<E>(x: ?E, xs: Array<E>): number;
-  declare function indexOf<E>(
-    x: ?E,
-  ): (xs: Array<E>) => number;
+  declare function indexOf<E>(x: ?E, xs: $ReadOnlyArray<E>): number;
+  declare function indexOf<E>(x: ?E): (xs: $ReadOnlyArray<E>) => number;
 
-  declare function indexBy<V, T: { [key: string]: *, ... }>(
-    fn: (x: T) => string,
-  ): (xs: Array<T>) => { [key: string]: T, ... };
-  declare function indexBy<V, T: { [key: string]: *, ... }>(
-    fn: (x: T) => string,
-    xs: Array<T>
-  ): { [key: string]: T, ... };
+  declare function indexBy<V>(fn: (x: V) => string): (xs: $ReadOnlyArray<V>) => { [key: string]: V, ... };
+  declare function indexBy<V>(fn: (x: V) => string, xs: $ReadOnlyArray<V>): { [key: string]: V, ... };
 
-  declare function insert<T>(
-    index: number,
-  ): (elem: T) => (src: Array<T>) => Array<T>;
-  declare function insert<T>(
-    index: number,
-    elem: T,
-  ): (src: Array<T>) => Array<T>;
-  declare function insert<T>(index: number, elem: T, src: Array<T>): Array<T>;
+  declare function insert<T>(index: number): (
+    & ((elem: T) => (src: $ReadOnlyArray<T>) => Array<T>)
+    & ((elem: T, src: $ReadOnlyArray<T>) => Array<T>)
+  );
+  declare function insert<T>(index: number, elem: T): (src: $ReadOnlyArray<T>) => Array<T>;
+  declare function insert<T>(index: number, elem: T, src: $ReadOnlyArray<T>): Array<T>;
 
-  declare function insertAll<T, S>(
-    index: number,
-  ): (elem: Array<S>) => (src: Array<T>) => Array<S | T>;
-  declare function insertAll<T, S>(
-    index: number,
-    elems: Array<S>,
-  ): (src: Array<T>) => Array<S | T>;
-  declare function insertAll<T, S>(
-    index: number,
-    elems: Array<S>,
-    src: Array<T>
-  ): Array<S | T>;
+  declare function insertAll<T, S>(index: number): (
+    & ((elem: $ReadOnlyArray<S>) => (src: $ReadOnlyArray<T>) => Array<S | T>)
+    & ((elem: $ReadOnlyArray<S>, src: $ReadOnlyArray<T>) => Array<S | T>)
+  );
+  declare function insertAll<T, S>(index: number, elems: $ReadOnlyArray<S>): (src: $ReadOnlyArray<T>) => Array<S | T>;
+  declare function insertAll<T, S>(index: number, elems: $ReadOnlyArray<S>, src: $ReadOnlyArray<T>): Array<S | T>;
 
-  declare function join(x: string, xs: Array<any>): string;
-  declare function join(
-    x: string,
-  ): (xs: Array<any>) => string;
+  declare function join(x: string, xs: $ReadOnlyArray<string | number>): string;
+  declare function join(x: string): (xs: $ReadOnlyArray<string | number>) => string;
 
-  declare function last<T, V: Array<T>>(xs: V): ?T;
-  declare function last<T, V: string>(xs: V): V;
+  declare function last<T>(xs: $ReadOnlyArray<T>): ?T;
+  declare function last(xs: string): string;
 
-  declare function none<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
-  declare function none<T>(
-    fn: UnaryPredicateFn<T>,
-  ): (xs: Array<T>) => boolean;
+  declare function none<T>(fn: UnaryPredicateFn<T>, xs: $ReadOnlyArray<T>): boolean;
+  declare function none<T>(fn: UnaryPredicateFn<T>): (xs: $ReadOnlyArray<T>) => boolean;
 
-  declare var nth: {|
-    <A, As: $ReadOnlyArray<A>>(n: number, xs: As): ?A,
-    <A, As: $ReadOnlyArray<A> | string>(
-      n: number,
-    ): ((xs: string) => string) & ((xs: As) => ?A),
-    (n: number, xs: string): string,
-  |}
+  declare function nth<V>(i: number, xs: $ReadOnlyArray<V>): ?V;
+  declare function nth(i: number, xs: string): string;
+  declare function nth<V>(i: number): (
+    & ((xs: string) => string)
+    & ((xs: $ReadOnlyArray<V>) => ?V)
+  );
 
-
-  declare type Find = (<V, T: Array<V>>(
-    fn: UnaryPredicateFn<V>
-  ) => (xs: T) => ?V) &
-    (<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: T) => ?V);
+  declare type Find = (
+    & (<V>(fn: UnaryPredicateFn<V>) => (xs: $ReadOnlyArray<V>) => ?V)
+    & (<V>(fn: UnaryPredicateFn<V>, xs: $ReadOnlyArray<V>) => ?V)
+  );
 
   declare var find: Find;
 
-  declare function findLast<V, O: { [key: string]: *, ... }, T: Array<V> | O>(
-    fn: UnaryPredicateFn<V>,
-  ): (xs: T | O) => ?V | O;
-  declare function findLast<V, O: { [key: string]: *, ... }, T: Array<V> | O>(
-    fn: UnaryPredicateFn<V>,
-    xs: T | O
-  ): ?V | O;
+  declare function findLast<V>(fn: UnaryPredicateFn<V>): (xs: $ReadOnlyArray<V>) => ?V | O;
+  declare function findLast<V>(fn: UnaryPredicateFn<V>, xs: $ReadOnlyArray<V>): ?V;
 
-  declare function findIndex<K, V, T: Array<V> | { [key: K]: V, ... }>(
-    fn: UnaryPredicateFn<V>,
-  ): (xs: T) => number;
-  declare function findIndex<K, V, T: Array<V> | { [key: K]: V, ... }>(
-    fn: UnaryPredicateFn<V>,
-    xs: T
-  ): number;
-  declare function findLastIndex<K, V, T: Array<V> | { [key: K]: V, ... }>(
-    fn: UnaryPredicateFn<V>,
-  ): (xs: T) => number;
-  declare function findLastIndex<K, V, T: Array<V> | { [key: K]: V, ... }>(
-    fn: UnaryPredicateFn<V>,
-    xs: T
-  ): number;
+  declare function findIndex<K, V>(fn: UnaryPredicateFn<V>): (xs: $ReadOnlyArray<V>) => number;
+  declare function findIndex<K, V>(fn: UnaryPredicateFn<V>, xs: $ReadOnlyArray<V>): number;
 
-  declare function forEach<T, V>(fn: (x: T) => ?V, xs: Array<T>): Array<T>;
-  declare function forEach<T, V>(
-    fn: (x: T) => ?V,
-  ): (xs: Array<T>) => Array<T>;
+  declare function findLastIndex<K, V>(fn: UnaryPredicateFn<V>): (xs: $ReadOnlyArray<V>) => number;
+  declare function findLastIndex<K, V>(fn: UnaryPredicateFn<V>, xs: $ReadOnlyArray<V>): number;
 
-  declare function forEachObjIndexed<O: Object, A, B>(
-    fn: (val: A, key: string, o: O) => B,
-    o: { [key: string]: A, ... }
+  declare function forEach<T, V>(fn: (x: T) => mixed, xs: $ReadOnlyArray<T>): Array<T>;
+  declare function forEach<T, V>(fn: (x: T) => mixed): (xs: $ReadOnlyArray<T>) => Array<T>;
+
+  declare function forEachObjIndexed<O, K: $Keys<O>, V: $Values<O>>(
+    fn: (val: V, key: K, o: O) => mixed,
+    o: O
   ): O;
+  declare function forEachObjIndexed<O, K: $Keys<O>, V: $Values<O>>(
+    fn: (val: V, key: K, o: O) => mixed,
+  ): O => O;
 
-  declare function forEachObjIndexed<O: Object, A, B>(
-    fn: (val: A, key: string, o: O) => B,
-    ...args: Array<void>
-  ): (o: { [key: string]: A, ... }) => O;
-
-  declare function lastIndexOf<E>(x: E, xs: Array<E>): number;
-  declare function lastIndexOf<E>(
-    x: E,
-  ): (xs: Array<E>) => number;
+  declare function lastIndexOf<E>(x: E, xs: $ReadOnlyArray<E>): number;
+  declare function lastIndexOf<E>(x: E): (xs: $ReadOnlyArray<E>) => number;
 
   declare var map: {
-    <T, R, R, FN: (x: T) => R, SR, S: { +map: FN => SR, ... }>(fn: FN, xs: S): SR,
-    <T, R, FN: (x: T) => R>(fn: FN):
+    <T, R, FN: (x: T) => R, SR, S: { +map: FN => SR, ... }>(fn: FN, xs: S): SR,
+
+    <T, R, FN: (x: T) => R>(fn: FN): (
       (<SR, S: { +map: FN => SR, ... }>(xs: S) => SR) &
-      ((xs: { [key: string]: T, ... }) => { [key: string]: R, ... }) &
-      ((xs: { +[key: string]: T, ... }) => { +[key: string]: R, ... }) &
-      ((xs: Array<T>) => Array<R>) &
-      ((xs: $ReadOnlyArray<T>) => $ReadOnlyArray<R>),
-    <T, R>(fn: (x: T) => R, xs: Array<T>): Array<R>,
-    <T, R>(fn: (x: T) => R, xs: $ReadOnlyArray<T>): $ReadOnlyArray<R>,
-    <T, R>(fn: (x: T) => R, xs: { [key: string]: T, ... }): { [key: string]: R, ... },
-    <T, R>(fn: (x: T) => R, xs: { +[key: string]: T, ... }): { +[key: string]: R, ... },
+      ((xs: { +[key: string]: T, ... }) => { [key: string]: R, ... }) &
+      ((xs: $ReadOnlyArray<T> | Array<T>) => Array<R>)
+    ),
+    <T, R>(fn: (x: T) => R, xs: $ReadOnlyArray<T>): Array<R>,
+    <T, R>(fn: (x: T) => R, xs: { +[key: string]: T, ... }): { [key: string]: R, ... },
     ...
   };
-
 
   declare type AccumIterator<A, B, R> = (acc: R, x: A) => [R, B];
   declare function mapAccum<A, B, R>(
     fn: AccumIterator<A, B, R>,
     acc: R,
-    xs: Array<A>
+    xs: $ReadOnlyArray<A>
   ): [R, Array<B>];
   declare function mapAccum<A, B, R>(
     fn: AccumIterator<A, B, R>,
-  ): (acc: R, xs: Array<A>) => [R, Array<B>];
+  ): (acc: R, xs: $ReadOnlyArray<A>) => [R, Array<B>];
 
   declare function mapAccumRight<A, B, R>(
     fn: AccumIterator<A, B, R>,
     acc: R,
-    xs: Array<A>
+    xs: $ReadOnlyArray<A>
   ): [R, Array<B>];
   declare function mapAccumRight<A, B, R>(
     fn: AccumIterator<A, B, R>,
-  ): (acc: R, xs: Array<A>) => [R, Array<B>];
+  ): (acc: R, xs: $ReadOnlyArray<A>) => [R, Array<B>];
 
-  declare function intersperse<E>(x: E, xs: Array<E>): Array<E>;
+  declare function intersperse<E>(x: E, xs: $ReadOnlyArray<E>): Array<E>;
   declare function intersperse<E>(
     x: E,
-  ): (xs: Array<E>) => Array<E>;
+  ): (xs: $ReadOnlyArray<E>) => Array<E>;
 
   declare function pair<A, B>(a: A, b: B): [A, B];
   declare function pair<A, B>(a: A): (b: B) => [A, B];
 
-  declare function partition<K, V, T: Array<V> | { [key: K]: V, ... }>(
-    fn: UnaryPredicateFn<V>,
-    xs: T
-  ): [T, T];
-  declare function partition<K, V, T: Array<V> | { [key: K]: V, ... }>(
-    fn: UnaryPredicateFn<V>,
-  ): (xs: T) => [T, T];
+  declare function partition<V>(fn: UnaryPredicateFn<V>, xs: $ReadOnlyArray<V>): [V[], V[]];
+  declare function partition<O, V: $Values<O>>(fn: UnaryPredicateFn<V>, xs: O): [$Shape<O>, $Shape<O>];
+  declare function partition<V>(fn: UnaryPredicateFn<V>): ((xs: $ReadOnlyArray<V>) => [V[], V[]]);
+  declare function partition<O, V>(fn: UnaryPredicateFn<V>): ((xs: O) => [$Shape<O>, $Shape<O>]);
 
   declare function pluck<
     V,
     K: $Keys<V>,
-  >(key: K, list: V[]): Array<$ElementType<V, K>>;
+  >(key: K, list: $ReadOnlyArray<V>): Array<$ElementType<V, K>>;
   declare function pluck<
     V,
     K: $Keys<V>,
-  >(key: K): (list: V[]) => Array<$ElementType<V, K>>;
+  >(key: K): (list: $ReadOnlyArray<V>) => Array<$ElementType<V, K>>;
   declare function pluck<
     T,
-    V: T[],
-  >(key: number, list: V[]): Array<$ElementType<V, number>>;
+    V: $ReadOnlyArray<T>,
+  >(key: number, list: $ReadOnlyArray<V>): Array<$ElementType<V, number>>;
   declare function pluck<
     T,
-    V: T[],
-  >(key: number): (list: V[]) => Array<$ElementType<V, number>>;
+    V: $ReadOnlyArray<V>,
+  >(key: number): (list: $ReadOnlyArray<V>) => Array<$ElementType<V, number>>;
 
   declare var range: CurriedFunction2<number, number, Array<number>>;
 
-  declare function reduced<T>(x: T | $npm$ramda$Reduced<T>): $npm$ramda$Reduced<T>;
+  declare function reduced<T>(x: T): $npm$ramda$Reduced<T>;
 
   declare function remove<T>(
     from: number,
-  ): ((to: number) => (src: Array<T>) => Array<T>) &
-    ((to: number, src: Array<T>) => Array<T>);
+  ): ((to: number) => (src: $ReadOnlyArray<T>) => Array<T>) &
+    ((to: number, src: $ReadOnlyArray<T>) => Array<T>);
   declare function remove<T>(
     from: number,
     to: number,
-  ): (src: Array<T>) => Array<T>;
-  declare function remove<T>(from: number, to: number, src: Array<T>): Array<T>;
+  ): (src: $ReadOnlyArray<T>) => Array<T>;
+  declare function remove<T>(from: number, to: number, src: $ReadOnlyArray<T>): Array<T>;
 
   declare function repeat<T>(x: T, times: number): Array<T>;
   declare function repeat<T>(x: T): (times: number) => Array<T>;
 
-  declare function slice<V, T: Array<V> | string>(
-    from: number,
-  ): ((to: number) => (src: T) => T) &
-    ((to: number, src: T) => T);
-  declare function slice<V, T: Array<V> | string>(
+  declare function slice(from: number): (
+    & ((to: number) => (
+        & (<V>(src: $ReadOnlyArray<V>) => V[])
+        & ((src: string) => string)
+    ))
+    & (<V>(to: number, src: $ReadOnlyArray<V>) => V[])
+    & ((to: number, src: string) => string)
+  );
+  declare function slice(from: number, to: number): (
+    & (<V>(src: $ReadOnlyArray<V>) => V[])
+    & ((src: string) => string)
+  );
+  declare function slice<V>(
     from: number,
     to: number,
-  ): (src: T) => T;
-  declare function slice<V, T: Array<V> | string>(
+    src: $ReadOnlyArray<V>,
+  ): V[];
+  declare function slice(
     from: number,
     to: number,
-    src: T
-  ): T;
+    src: string,
+  ): string;
 
-  declare function sort<V, T: Array<V>>(fn: (a: V, b: V) => number, xs: T): T;
+  declare function sort<V, T: Array<V>>(fn: (a: V, b: V) => number, xs: $ReadOnlyArray<V>): T;
   declare function sort<V, T: Array<V>>(
     fn: (a: V, b: V) => number,
-  ): (xs: T) => T;
+  ): (xs: $ReadOnlyArray<V>) => T;
 
   declare function sortWith<V, T: Array<V>>(
-    fns: Array<(a: V, b: V) => number>,
-    xs: T
+    fns: $ReadOnlyArray<(a: V, b: V) => number>,
+    xs: $ReadOnlyArray<V>
   ): T;
   declare function sortWith<V, T: Array<V>>(
-    fns: Array<(a: V, b: V) => number>,
-  ): (xs: T) => T;
+    fns: $ReadOnlyArray<(a: V, b: V) => number>,
+  ): (xs: $ReadOnlyArray<V>) => T;
 
   /**
    * In the examples for ascend and descend, its result is plugged into sort.
@@ -945,16 +837,16 @@ declare module ramda {
 
   declare function takeLastWhile<V, T: Array<V>>(
     fn: UnaryPredicateFn<V>,
-    xs: T
+    xs: $ReadOnlyArray<V>
   ): T;
   declare function takeLastWhile<V, T: Array<V>>(
     fn: UnaryPredicateFn<V>
-  ): (xs: T) => T;
+  ): (xs: $ReadOnlyArray<V>) => T;
 
-  declare function takeWhile<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: T): T;
+  declare function takeWhile<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: $ReadOnlyArray<V>): T;
   declare function takeWhile<V, T: Array<V>>(
     fn: UnaryPredicateFn<V>
-  ): (xs: T) => T;
+  ): (xs: $ReadOnlyArray<V>) => T;
 
   declare function unfold<T, R>(
     fn: (seed: T) => [R, T] | boolean,
@@ -966,73 +858,75 @@ declare module ramda {
 
   declare function uniqBy<T, V>(
     fn: (x: T) => V,
-  ): (xs: Array<T>) => Array<T>;
-  declare function uniqBy<T, V>(fn: (x: T) => V, xs: Array<T>): Array<T>;
+  ): (xs: $ReadOnlyArray<T>) => Array<T>;
+  declare function uniqBy<T, V>(fn: (x: T) => V, xs: $ReadOnlyArray<T>): Array<T>;
 
   declare function uniqWith<T>(
     fn: BinaryPredicateFn<T>,
-  ): (xs: Array<T>) => Array<T>;
+  ): (xs: $ReadOnlyArray<T>) => Array<T>;
   declare function uniqWith<T>(
     fn: BinaryPredicateFn<T>,
-    xs: Array<T>
+    xs: $ReadOnlyArray<T>
   ): Array<T>;
 
   declare function update<T>(
     index: number,
-  ): ((elem: T) => (src: Array<T>) => Array<T>) &
-    ((elem: T, src: Array<T>) => Array<T>);
+  ): ((elem: T) => (src: $ReadOnlyArray<T>) => Array<T>) &
+    ((elem: T, src: $ReadOnlyArray<T>) => Array<T>);
   declare function update<T>(
     index: number,
     elem: T,
-  ): (src: Array<T>) => Array<T>;
-  declare function update<T>(index: number, elem: T, src: Array<T>): Array<T>;
+  ): (src: $ReadOnlyArray<T>) => Array<T>;
+  declare function update<T>(index: number, elem: T, src: $ReadOnlyArray<T>): Array<T>;
 
   // TODO `without` as a transducer
   declare function without<T, E>($ReadOnlyArray<E>, $ReadOnlyArray<E|T>): Array<E|T>;
   declare function without<T, E>($ReadOnlyArray<E>): CurriedFunction1<$ReadOnlyArray<E|T>, Array<E|T>>;
 
-  declare function xprod<T, S>(xs: Array<T>, ys: Array<S>): Array<[T, S]>;
+  declare function xprod<T, S>(xs: $ReadOnlyArray<T>, ys: $ReadOnlyArray<S>): Array<[T, S]>;
   declare function xprod<T, S>(
-    xs: Array<T>,
-  ): (ys: Array<S>) => Array<[T, S]>;
+    xs: $ReadOnlyArray<T>,
+  ): (ys: $ReadOnlyArray<S>) => Array<[T, S]>;
 
-  declare function zip<T, S>(xs: Array<T>, ys: Array<S>): Array<[T, S]>;
+  declare function zip<T, S>(xs: $ReadOnlyArray<T>, ys: $ReadOnlyArray<S>): Array<[T, S]>;
   declare function zip<T, S>(
-    xs: Array<T>,
-  ): (ys: Array<S>) => Array<[T, S]>;
+    xs: $ReadOnlyArray<T>,
+  ): (ys: $ReadOnlyArray<S>) => Array<[T, S]>;
 
   declare function zipObj<T: string, S>(
-    xs: Array<T>,
-    ys: Array<S>
+    xs: $ReadOnlyArray<T>,
+    ys: $ReadOnlyArray<S>
   ): { [key: T]: S, ... };
   declare function zipObj<T: string, S>(
-    xs: Array<T>,
-  ): (ys: Array<S>) => { [key: T]: S, ... };
+    xs: $ReadOnlyArray<T>,
+  ): (ys: $ReadOnlyArray<S>) => { [key: T]: S, ... };
 
-  declare type NestedArray<T> = Array<T | NestedArray<T>>;
+  declare type NestedArray<T> = $ReadOnlyArray<T | NestedArray<T>>;
   declare function flatten<T>(xs: NestedArray<T>): Array<T>;
 
-  declare function fromPairs<T, V>(pair: Array<[T, V]>): { [key: string]: V, ... };
+  declare function fromPairs<T, V>(pairs: $ReadOnlyArray<[T, V]>): { [key: string]: V, ... };
 
-  declare function init<T, V: Array<T> | string>(xs: V): V;
+  declare function init<T>(xs: $ReadOnlyArray<T>): T[];
+  declare function init(xs: string): string;
 
-  declare function length<T>(xs: Array<T> | string | { length: number, ... }): number;
+  declare function length<T>(xs: $ReadOnlyArray<T> | string | { length: number, ... }): number;
 
-  declare function reverse<T, V: Array<T> | string>(xs: V): V;
+  declare function reverse<T, V: Array<T> | string>(xs: $ReadOnlyArray<T>): V;
 
-  declare type Reduce = (<A, B>(
-    fn: (acc: A, elm: B) => $npm$ramda$Reduced<A> | A
-  ) => ((init: A) => (xs: Array<B> | $ReadOnlyArray<B>) => A) &
-    ((init: A, xs: Array<B> | $ReadOnlyArray<B>) => A)) &
-    (<A, B>(
-      fn: (acc: A, elm: B) => $npm$ramda$Reduced<A> | A,
-      init: A
-    ) => (xs: Array<B> | $ReadOnlyArray<B>) => A) &
-    (<A, B>(
-      fn: (acc: A, elm: B) => $npm$ramda$Reduced<A> | A,
-      init: A,
-      xs: Array<B> | $ReadOnlyArray<B>
-    ) => A);
+  declare type Reduce = (
+    & (
+      <A, B, I = A>(fn: (acc: A | I, elm: B) => $npm$ramda$Reduced<A> | A) => (
+        & ((init: I) => (xs: $ReadOnlyArray<B>) => (A | I))
+        & ((init: I, xs: $ReadOnlyArray<B>) => (A | I))
+      )
+    )
+    & (
+      <A, B, I = A>(fn: (acc: A | I, elm: B) => $npm$ramda$Reduced<A> | A, init: I) => (xs: $ReadOnlyArray<B>) => (A | I)
+    )
+    & (
+      <A, B, I = A>(fn: (acc: A | I, elm: B) => $npm$ramda$Reduced<A> | A, init: I, xs: $ReadOnlyArray<B>) => (A | I)
+    )
+  );
 
   declare var reduce: Reduce;
 
@@ -1125,45 +1019,48 @@ declare module ramda {
     xs: Array<B>
   ): Array<A>;
 
-  declare function splitAt<V, T: Array<V> | string>(i: number, xs: T): [T, T];
-  declare function splitAt<V, T: Array<V> | string>(
-    i: number
-  ): (xs: T) => [T, T];
-  declare function splitEvery<V, T: Array<V> | string>(
-    i: number,
-    xs: T
-  ): Array<T>;
-  declare function splitEvery<V, T: Array<V> | string>(
-    i: number
-  ): (xs: T) => Array<T>;
-  declare function splitWhen<V, T: Array<V>>(
-    fn: UnaryPredicateFn<V>,
-    xs: T
-  ): [T, T];
-  declare function splitWhen<V, T: Array<V>>(
-    fn: UnaryPredicateFn<V>
-  ): (xs: T) => [T, T];
+  declare function splitAt<V>(i: number, xs: $ReadOnlyArray<V>): [V[], V[]];
+  declare function splitAt(i: number, xs: string): [string, string];
+  declare function splitAt(i: number): (
+    & (string => [string, string])
+    & <V>($ReadOnlyArray<V>) => [V[], V[]]
+  );
 
-  declare function tail<T, V: Array<T> | string>(xs: V): V;
+  declare function splitEvery<V>(i: number, xs: $ReadOnlyArray<V>): V[][];
+  declare function splitEvery(i: number, xs: string): string[];
+  declare function splitEvery(i: number): (
+    & (string => string[])
+    & <V>($ReadOnlyArray<V>) => V[][]
+  );
 
-  declare function transpose<T>(xs: Array<Array<T>>): Array<Array<T>>;
+  declare function splitWhen<V>(fn: UnaryPredicateFn<V>, xs: $ReadOnlyArray<V>): [V[], V[]];
+  declare function splitWhen(fn: UnaryPredicateFn<string>, xs: string): [string, string];
+  declare function splitWhen<V>(fn: V => boolean): (
+  	& ($ReadOnlyArray<V> => [V[], V[]])
+  	& ((V & string) => [string, string])
+  );
+
+  declare function tail<V>(xs: $ReadOnlyArray<V>): V[];
+  declare function tail<V>(xs: string): string;
+
+  declare function transpose<T>(xs: $ReadOnlyArray<$ReadOnlyArray<T>>): Array<Array<T>>;
 
   declare function uniq<T>(xs: $ReadOnlyArray<T>): Array<T>;
 
-  declare function unnest<T>(xs: NestedArray<T>): NestedArray<T>;
+  declare function unnest<T>(xs: $ReadOnlyArray<T | $ReadOnlyArray<T>>): $ReadOnlyArray<T>;
 
   declare function zipWith<T, S, R>(
     fn: (a: T, b: S) => R,
-  ): ((xs: Array<T>, ys: Array<S>) => Array<R>) &
-    ((xs: Array<T>) => (ys: Array<S>) => Array<R>);
+  ): ((xs: $ReadOnlyArray<T>, ys: $ReadOnlyArray<S>) => Array<R>) &
+    ((xs: $ReadOnlyArray<T>) => (ys: $ReadOnlyArray<S>) => Array<R>);
   declare function zipWith<T, S, R>(
     fn: (a: T, b: S) => R,
-    xs: Array<T>,
-  ): (ys: Array<S>) => Array<R>;
+    xs: $ReadOnlyArray<T>,
+  ): (ys: $ReadOnlyArray<S>) => Array<R>;
   declare function zipWith<T, S, R>(
     fn: (a: T, b: S) => R,
-    xs: Array<T>,
-    ys: Array<S>
+    xs: $ReadOnlyArray<T>,
+    ys: $ReadOnlyArray<S>
   ): Array<R>;
 
   // *Relation
@@ -1182,30 +1079,47 @@ declare module ramda {
 
   // Flow cares about the order in which these appear. Generally function
   // siguatures should go from smallest arity to largest arity.
-  declare type PropEq = (<T>(
-    prop: $Keys<T>
-  ) => ((val: mixed) => (obj: T) => boolean) &
-    ((val: mixed, obj: T) => boolean)) &
-    (<T>(prop: $Keys<T>, val: mixed) => (obj: T) => boolean) &
-    (<T>(prop: $Keys<T>, val: mixed, obj: T) => boolean) &
+  declare type PropEq = (
+    & (
+        <T>(prop: $Keys<T>) => (
+          & ((val: mixed) => (obj: T) => boolean)
+          & ((val: mixed, obj: T) => boolean)
+        )
+    )
+    & (
+      <T>(prop: $Keys<T>, val: mixed) => (obj: T) => boolean
+    )
+    & (
+      <T>(prop: $Keys<T>, val: mixed, obj: T) => boolean
+    )
     // Array variants.
-    (<T>(
-      prop: number
-    ) => ((val: mixed) => (obj: Array<*>) => boolean) &
-      ((val: mixed, obj: Array<*>) => boolean)) &
-    (<T>(prop: number, val: mixed) => (obj: Array<*>) => boolean) &
-    (<T>(prop: number, val: mixed, obj: Array<*>) => boolean);
+    & (
+      <T>(prop: number) => (
+        & ((val: mixed) => (obj: $ReadOnlyArray<T>) => boolean)
+        & ((val: mixed, obj: $ReadOnlyArray<T>) => boolean)
+      )
+    )
+    & (
+      <T>(prop: number, val: mixed) => (obj: $ReadOnlyArray<T>) => boolean
+    )
+    & (
+      <T>(prop: number, val: mixed, obj: $ReadOnlyArray<T>) => boolean
+    )
+  );
   declare var propEq: PropEq;
 
-  declare function pathEq<T: string | number>(
-    path: Array<T>,
-  ): ((val: mixed) => (o: Object) => boolean) &
-    ((val: mixed, o: Object) => boolean);
-  declare function pathEq<T: string | number>(
-    path: Array<T>,
-    val: mixed,
-  ): (o: Object) => boolean;
-  declare function pathEq<T: string | number>(path: Array<T>, val: mixed, o: Object): boolean;
+  declare function pathEq<
+    T: string | number, E, O: { ... } | $ReadOnlyArray<E>
+  >(path: $ReadOnlyArray<T>): (
+    & ((val: mixed) => (o: O) => boolean)
+    & ((val: mixed, o: O) => boolean)
+  );
+  declare function pathEq<
+    T: string | number, E, O: { ... } | $ReadOnlyArray<E>
+  >(path: $ReadOnlyArray<T>, val: mixed): (o: O) => boolean;
+  declare function pathEq<
+    T: string | number, E, O: { ... } | $ReadOnlyArray<E>
+  >(path: $ReadOnlyArray<T>, val: mixed, O): boolean;
 
   declare function clamp<T: number | string | Date>(
     min: T,
@@ -1218,29 +1132,29 @@ declare module ramda {
 
   declare function countBy<T>(
     fn: (x: T) => string,
-  ): (list: Array<T>) => { [key: string]: number, ... };
+  ): (list: $ReadOnlyArray<T>) => { [key: string]: number, ... };
   declare function countBy<T>(
     fn: (x: T) => string,
-    list: Array<T>
+    list: $ReadOnlyArray<T>
   ): { [key: string]: number, ... };
 
   declare function difference<T>(
-    xs1: Array<T>,
-  ): (xs2: Array<T>) => Array<T>;
-  declare function difference<T>(xs1: Array<T>, xs2: Array<T>): Array<T>;
+    xs1: $ReadOnlyArray<T>,
+  ): (xs2: $ReadOnlyArray<T>) => Array<T>;
+  declare function difference<T>(xs1: $ReadOnlyArray<T>, xs2: $ReadOnlyArray<T>): Array<T>;
 
   declare function differenceWith<T>(
     fn: BinaryPredicateFn<T>,
-  ): ((xs1: Array<T>) => (xs2: Array<T>) => Array<T>) &
-    ((xs1: Array<T>, xs2: Array<T>) => Array<T>);
+  ): ((xs1: $ReadOnlyArray<T>) => (xs2: $ReadOnlyArray<T>) => Array<T>) &
+    ((xs1: $ReadOnlyArray<T>, xs2: $ReadOnlyArray<T>) => Array<T>);
   declare function differenceWith<T>(
     fn: BinaryPredicateFn<T>,
-    xs1: Array<T>,
-  ): (xs2: Array<T>) => Array<T>;
+    xs1: $ReadOnlyArray<T>,
+  ): (xs2: $ReadOnlyArray<T>) => Array<T>;
   declare function differenceWith<T>(
     fn: BinaryPredicateFn<T>,
-    xs1: Array<T>,
-    xs2: Array<T>
+    xs1: $ReadOnlyArray<T>,
+    xs2: $ReadOnlyArray<T>
   ): Array<T>;
 
   declare function eqBy<T>(fn: (x: T) => T, x: T, y: T): boolean;
@@ -1265,20 +1179,20 @@ declare module ramda {
   declare function innerJoin<A, B>(
     pred: (a: A, b: B) => boolean,
   ): (
-    a: Array<A>,
-  ) => (b: Array<B>) => Array<A> & ((a: Array<A>, b: Array<B>) => Array<A>);
+    a: $ReadOnlyArray<A>,
+  ) => (b: $ReadOnlyArray<B>) => Array<A> & ((a: $ReadOnlyArray<A>, b: $ReadOnlyArray<B>) => Array<A>);
   declare function innerJoin<A, B>(
     pred: (a: A, b: B) => boolean,
-    a: Array<A>,
-  ): (b: Array<B>) => Array<A>;
+    a: $ReadOnlyArray<A>,
+  ): (b: $ReadOnlyArray<B>) => Array<A>;
   declare function innerJoin<A, B>(
     pred: (a: A, b: B) => boolean,
-    a: Array<A>,
-    b: Array<B>
+    a: $ReadOnlyArray<A>,
+    b: $ReadOnlyArray<B>
   ): Array<A>;
 
-  declare function intersection<T>(xs: $ReadOnlyArray<T>, ys: $ReadOnlyArray<T>): Array<T>;
-  declare function intersection<T>(xs: $ReadOnlyArray<T>): (ys: $ReadOnlyArray<T>) => Array<T>;
+  declare function intersection<T>(x: $ReadOnlyArray<T>, y: $ReadOnlyArray<T>): Array<T>;
+  declare function intersection<T>(x: $ReadOnlyArray<T>): (y: $ReadOnlyArray<T>) => Array<T>;
 
   declare function max<T>(x: T): (y: T) => T;
   declare function max<T>(x: T, y: T): T;
@@ -1303,45 +1217,45 @@ declare module ramda {
 
   declare function sortBy<T, V>(
     fn: (x: T) => V,
-  ): (x: Array<T>) => Array<T>;
-  declare function sortBy<T, V>(fn: (x: T) => V, x: Array<T>): Array<T>;
+  ): (x: $ReadOnlyArray<T>) => Array<T>;
+  declare function sortBy<T, V>(fn: (x: T) => V, x: $ReadOnlyArray<T>): Array<T>;
 
   declare function symmetricDifference<T>(
-    x: Array<T>,
-  ): (y: Array<T>) => Array<T>;
-  declare function symmetricDifference<T>(x: Array<T>, y: Array<T>): Array<T>;
+    x: $ReadOnlyArray<T>,
+  ): (y: $ReadOnlyArray<T>) => Array<T>;
+  declare function symmetricDifference<T>(x: $ReadOnlyArray<T>, y: $ReadOnlyArray<T>): Array<T>;
 
   declare function symmetricDifferenceWith<T>(
     fn: BinaryPredicateFn<T>,
-  ): ((x: Array<T>) => (y: Array<T>) => Array<T>) &
-    ((x: Array<T>, y: Array<T>) => Array<T>);
+  ): ((x: $ReadOnlyArray<T>) => (y: Array<T>) => Array<T>) &
+    ((x: $ReadOnlyArray<T>, y: $ReadOnlyArray<T>) => Array<T>);
   declare function symmetricDifferenceWith<T>(
     fn: BinaryPredicateFn<T>,
-    x: Array<T>,
-  ): (y: Array<T>) => Array<T>;
+    x: $ReadOnlyArray<T>,
+  ): (y: $ReadOnlyArray<T>) => Array<T>;
   declare function symmetricDifferenceWith<T>(
     fn: BinaryPredicateFn<T>,
-    x: Array<T>,
-    y: Array<T>
+    x: $ReadOnlyArray<T>,
+    y: $ReadOnlyArray<T>
   ): Array<T>;
 
   declare function union<T>(
-    x: Array<T>,
-  ): (y: Array<T>) => Array<T>;
-  declare function union<T>(x: Array<T>, y: Array<T>): Array<T>;
+    x: $ReadOnlyArray<T>,
+  ): (y: $ReadOnlyArray<T>) => Array<T>;
+  declare function union<T>(x: $ReadOnlyArray<T>, y: $ReadOnlyArray<T>): Array<T>;
 
   declare function unionWith<T>(
     fn: BinaryPredicateFn<T>,
-  ): ((x: Array<T>) => (y: Array<T>) => Array<T>) &
-    ((x: Array<T>, y: Array<T>) => Array<T>);
+  ): ((x: $ReadOnlyArray<T>) => (y: Array<T>) => Array<T>) &
+    ((x: $ReadOnlyArray<T>, y: $ReadOnlyArray<T>) => Array<T>);
   declare function unionWith<T>(
     fn: BinaryPredicateFn<T>,
-    x: Array<T>,
-  ): (y: Array<T>) => Array<T>;
+    x: $ReadOnlyArray<T>,
+  ): (y: $ReadOnlyArray<T>) => Array<T>;
   declare function unionWith<T>(
     fn: BinaryPredicateFn<T>,
-    x: Array<T>,
-    y: Array<T>
+    x: $ReadOnlyArray<T>,
+    y: $ReadOnlyArray<T>
   ): Array<T>;
 
   // *Object
@@ -1357,8 +1271,8 @@ declare module ramda {
       val: T,
       ...args: Array<void>
     ): (src: S) => ({ [k: string]: T, ... } & S),
-    <T, S: Object, K: $Keys<S>> (key: K, val: T, src: S):      ({ [k: string]: T, ... } & S),
-    <T, S: Object>              (key: string, val: T, src: S): ({
+    <T, S: { ... }, K: $Keys<S>> (key: K, val: T, src: S):      ({ [k: string]: T, ... } & S),
+    <T, S: { ... }>              (key: string, val: T, src: S): ({
       [k: string]: T,
       ...$Exact<S>,
       ...
@@ -1367,17 +1281,17 @@ declare module ramda {
   };
 
   declare function assocPath<T: string | number, S, V>(
-    key: Array<T>,
+    key: $ReadOnlyArray<T>,
     ...args: Array<void>
   ): ((val: V) => (src: S) => { [k: string]: V, ... }) &
     ((val: V) => (src: S) => { [k: string]: V, ... } & S);
   declare function assocPath<T: string | number, S, V>(
-    key: Array<T>,
+    key: $ReadOnlyArray<T>,
     val: V,
     ...args: Array<void>
   ): (src: S) => { [k: string]: V, ... } & S;
   declare function assocPath<T: string | number, S, V>(
-    key: Array<T>,
+    key: $ReadOnlyArray<T>,
     val: V,
     src: S
   ): { [k: string]: V, ... } & S;
@@ -1394,42 +1308,42 @@ declare module ramda {
   ): { [k: string]: T, ... };
 
   declare function dissocPath<T: string | number, U>(
-    key: Array<T>,
+    key: $ReadOnlyArray<T>,
     ...args: Array<void>
   ): (src: { [k: string]: U, ... }) => { [k: string]: U, ... };
   declare function dissocPath<T: string | number, U>(
-    key: Array<T>,
+    key: $ReadOnlyArray<T>,
     src: { [k: string]: U, ... }
   ): { [k: string]: U, ... };
 
-  declare function evolve<A: Object>(NestedObject<Function>): A => A;
-  declare function evolve<A: Object>(NestedObject<Function>, A): A;
+  declare function evolve(NestedObject<Function>): { ... } => { ... };
+  declare function evolve(NestedObject<Function>, { ... }): { ... };
 
   declare function eqProps(
     key: string,
     ...args: Array<void>
-  ): ((o1: Object) => (o2: Object) => boolean) &
-    ((o1: Object, o2: Object) => boolean);
+  ): ((o1: { ... }) => (o2: { ... }) => boolean) &
+    ((o1: { ... }, o2: { ... }) => boolean);
   declare function eqProps(
     key: string,
-    o1: Object,
+    o1: { ... },
     ...args: Array<void>
-  ): (o2: Object) => boolean;
-  declare function eqProps(key: string, o1: Object, o2: Object): boolean;
+  ): (o2: { ... }) => boolean;
+  declare function eqProps(key: string, o1: { ... }, o2: { ... }): boolean;
 
-  declare function has(key: string): (o: Object) => boolean;
-  declare function has(key: string, o: Object): boolean;
+  declare function has(key: string): (o: ?{ ... }) => boolean;
+  declare function has(key: string, o: ?{ ... }): boolean;
 
-  declare function hasPath<T: string | number>(path: Array<T>): (o: Object) => boolean;
-  declare function hasPath<T: string | number>(path: Array<T>, o: Object): boolean;
+  declare function hasPath<T: string | number>(path: $ReadOnlyArray<T>): (o: { ... }) => boolean;
+  declare function hasPath<T: string | number>(path: $ReadOnlyArray<T>, o: { ... }): boolean;
 
-  declare function hasIn(key: string, o: Object): boolean;
-  declare function hasIn(key: string): (o: Object) => boolean;
+  declare function hasIn(key: string, o: { ... }): boolean;
+  declare function hasIn(key: string): (o: { ... }) => boolean;
 
-  declare function invert(o: Object): { [k: string]: Array<string>, ... };
-  declare function invertObj(o: Object): { [k: string]: string, ... };
+  declare function invert(o: { ... }): { [k: string]: Array<string>, ... };
+  declare function invertObj(o: { ... }): { [k: string]: string, ... };
 
-  declare function keys(o: ?Object): Array<string>;
+  declare function keys(o: ?{ ... }): Array<string>;
 
   declare type Lens<A, B, Fa: Functor<A>, Fb: Functor<B>> = (A => Fb) => Fb;
   /**
@@ -1496,11 +1410,11 @@ declare module ramda {
   declare function lensProp<O, F, K: $Keys<F>>(K): LensObj<F, $ElementType<F, K>, O>;
 
   declare function mapObjIndexed<A, B>(
-    fn: (val: A, key: string, o: Object) => B,
+    fn: (val: A, key: string, o: { ... }) => B,
     o: { [key: string]: A, ... }
   ): { [key: string]: B, ... };
   declare function mapObjIndexed<A, B>(
-    fn: (val: A, key: string, o: Object) => B,
+    fn: (val: A, key: string, o: { ... }) => B,
     ...args: Array<void>
   ): (o: { [key: string]: A, ... }) => { [key: string]: B, ... };
 
@@ -1513,7 +1427,7 @@ declare module ramda {
   declare var mergeRight: Merge;
 
   declare function mergeAll<T>(
-    os: Array<{ [k: string]: T, ... }>
+    os: $ReadOnlyArray<{ [k: string]: T, ... }>
   ): { [k: string]: T, ... };
 
   declare var mergeDeepRight: (<A, B>(a: A, b: B) => B & A) &
@@ -1569,10 +1483,10 @@ declare module ramda {
   ): (val: T) => { [key: string]: T, ... };
   declare function objOf<T>(key: string, val: T): { [key: string]: T, ... };
 
-  declare function omit<T: Object>(
-    keys: Array<string>,
-  ): (val: T) => Object;
-  declare function omit<T: Object>(keys: Array<string>, val: T): Object;
+  declare function omit<T: { ... }>(
+    keys: $ReadOnlyArray<string>,
+  ): (val: T) => $Shape<T>;
+  declare function omit<T: { ... }>(keys: $ReadOnlyArray<string>, val: T): $Shape<T>;
 
   declare type Functor<A> =
     | { @@iterator(): Iterator<A>, ... }
@@ -1590,42 +1504,42 @@ declare module ramda {
     & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(lens: Lens<A, B, Fa, Fb>, A => B, Fa) => Fb)
 
   declare function path<T: string | number, V>(
-    p: Array<T>,
+    p: $ReadOnlyArray<T>,
   ): (o: NestedObject<V>) => V;
   declare function path<T: string | number, V>(
-    p: Array<T>,
+    p: $ReadOnlyArray<T>,
   ): (o: null | void) => void;
   declare function path<T: string | number, V>(
-    p: Array<T>,
+    p: $ReadOnlyArray<T>,
   ): (o: mixed) => ?V;
-  declare function path<T: string | number, V, A: NestedObject<V>>(p: Array<T>, o: A): V;
-  declare function path<T: string | number, V, A: null | void>(p: Array<T>, o: A): void;
-  declare function path<T: string | number, V, A>(p: Array<T>, o: A): ?V;
+  declare function path<T: string | number, V, A: NestedObject<V>>(p: $ReadOnlyArray<T>, o: A): V;
+  declare function path<T: string | number, V, A: null | void>(p: $ReadOnlyArray<T>, o: A): void;
+  declare function path<T: string | number, V, A>(p: $ReadOnlyArray<T>, o: A): ?V;
 
   declare function path<V>(
-    p: Array<string>,
+    p: $ReadOnlyArray<string>,
   ): (o: NestedObject<V>) => V;
   declare function path<V>(
-    p: Array<string>,
+    p: $ReadOnlyArray<string>,
   ): (o: null | void) => void;
   declare function path<V>(
-    p: Array<string>,
+    p: $ReadOnlyArray<string>,
   ): (o: mixed) => ?V;
-  declare function path<V, A: NestedObject<V>>(p: Array<string>, o: A): V;
-  declare function path<V, A: null | void>(p: Array<string>, o: A): void;
-  declare function path<V, A: mixed>(p: Array<string>, o: A): ?V;
+  declare function path<V, A: NestedObject<V>>(p: $ReadOnlyArray<string>, o: A): V;
+  declare function path<V, A: null | void>(p: $ReadOnlyArray<string>, o: A): void;
+  declare function path<V, A: mixed>(p: $ReadOnlyArray<string>, o: A): ?V;
 
   declare function pathOr<T, U: string | number, V, A: NestedObject<V>>(
     or: T,
-  ): ((p: Array<U>) => (o: ?A) => V | T) &
-    ((p: Array<U>, o: ?A) => V | T);
+  ): ((p: $ReadOnlyArray<U>) => (o: ?A) => V | T) &
+    ((p: $ReadOnlyArray<U>, o: ?A) => V | T);
   declare function pathOr<T, U: string | number, V, A: NestedObject<V>>(
     or: T,
-    p: Array<U>,
+    p: $ReadOnlyArray<U>,
   ): (o: ?A) => V | T;
   declare function pathOr<T, U: string | number, V, A: NestedObject<V>>(
     or: T,
-    p: Array<U>,
+    p: $ReadOnlyArray<U>,
     o: ?A
   ): V | T;
 
@@ -1638,10 +1552,10 @@ declare module ramda {
   ): O;
 
   declare function pickAll<A>(
-    keys: Array<string>,
+    keys: $ReadOnlyArray<string>,
   ): (val: { [key: string]: A, ... }) => { [key: string]: ?A, ... };
   declare function pickAll<A>(
-    keys: Array<string>,
+    keys: $ReadOnlyArray<string>,
     val: { [key: string]: A, ... }
   ): { [key: string]: ?A, ... };
 
@@ -1654,11 +1568,11 @@ declare module ramda {
   ): { [key: string]: A, ... };
 
   declare function project<T>(
-    keys: Array<string>,
-  ): (val: Array<{ [key: string]: T, ... }>) => Array<{ [key: string]: T, ... }>;
+    keys: $ReadOnlyArray<string>,
+  ): (val: $ReadOnlyArray<{ [key: string]: T, ... }>) => Array<{ [key: string]: T, ... }>;
   declare function project<T>(
-    keys: Array<string>,
-    val: Array<{ [key: string]: T, ... }>
+    keys: $ReadOnlyArray<string>,
+    val: $ReadOnlyArray<{ [key: string]: T, ... }>
   ): Array<{ [key: string]: T, ... }>;
 
   declare function prop<T: string, O>(
@@ -1684,13 +1598,13 @@ declare module ramda {
     o: A
   ): V | T;
 
-  declare function keysIn(o: Object): Array<string>;
+  declare function keysIn(o: { ... }): Array<string>;
 
   declare function props<T: string, O>(
-    keys: Array<T>,
+    keys: $ReadOnlyArray<T>,
   ): (o: O) => Array<$ElementType<O, T>>;
   declare function props<T: string, O>(
-    keys: Array<T>,
+    keys: $ReadOnlyArray<T>,
     o: O
   ): Array<$ElementType<O, T>>;
 
@@ -1722,7 +1636,7 @@ declare module ramda {
 
   declare function values<T>(o: T): Array<$Values<T>>;
 
-  declare function valuesIn<T, O: { [k: string]: T, ... }>(o: O): Array<T | any>;
+  declare function valuesIn<T, O>(o: O): Array<$Values<T> | mixed>;
 
   declare function where<O>(
     predObj: $ObjMap<O, MapUnaryPredicateFn>,
@@ -1749,29 +1663,29 @@ declare module ramda {
   // *Function
   declare var __: $npm$ramda$Placeholder;
 
-  declare var T: (_: any) => true;
-  declare var F: (_: any) => false;
+  declare var T: (_: mixed) => true;
+  declare var F: (_: mixed) => false;
 
   declare function addIndex<A, B>(
-    iterFn: (fn: (x: A) => B, xs: Array<A>) => Array<B>
-  ): (fn: (x: A, idx: number, xs: Array<A>) => B, xs: Array<A>) => Array<B>;
+    iterFn: (fn: (x: A) => B, xs: $ReadOnlyArray<A>) => Array<B>
+  ): (fn: (x: A, idx: number, xs: $ReadOnlyArray<A>) => B, xs: $ReadOnlyArray<A>) => Array<B>;
 
-  declare function always<T>(x: T): (x: any) => T;
+  declare function always<T>(x: T): (x: mixed) => T;
 
   declare function ap<T, V>(
-    fns: Array<(x: T) => V>,
-  ): (xs: Array<T>) => Array<V>;
-  declare function ap<T, V>(fns: Array<(x: T) => V>, xs: Array<T>): Array<V>;
+    fns: $ReadOnlyArray<(x: T) => V>,
+  ): (xs: $ReadOnlyArray<T>) => Array<V>;
+  declare function ap<T, V>(fns: $ReadOnlyArray<(x: T) => V>, xs: $ReadOnlyArray<T>): Array<V>;
 
   declare function apply<T, V>(
     fn: (...args: Array<T>) => V,
-  ): (xs: Array<T>) => V;
-  declare function apply<T, V>(fn: (...args: Array<T>) => V, xs: Array<T>): V;
+  ): (xs: $ReadOnlyArray<T>) => V;
+  declare function apply<T, V>(fn: (...args: Array<T>) => V, xs: $ReadOnlyArray<T>): V;
 
   declare function applySpec<
     V,
     S,
-    A: Array<V>,
+    A: $ReadOnlyArray<V>,
     T: NestedObject<(...args: A) => S>
   >(
     spec: T
@@ -1780,14 +1694,14 @@ declare module ramda {
   declare function applyTo<A, B>(a: A): (fn: (x: A) => B) => B;
   declare function applyTo<A, B>(a: A, fn: (x: A) => B): B;
 
-  declare function binary<T>(
-    fn: (...args: Array<any>) => T
-  ): (x: any, y: any) => T;
+  declare function binary<T, A, B>(
+    fn: (a: A, b: B, ...args: Array<mixed>) => T
+  ): (x: A, y: B) => T;
 
-  declare function bind<T>(
-    fn: (...args: Array<any>) => any,
+  declare function bind<T, A, R, F: (...args: A) => R>(
+    fn: F,
     thisObj: T
-  ): (...args: Array<any>) => any;
+  ): F;
 
   declare function call<T, V>(
     fn: (...args: Array<V>) => T,
@@ -1804,13 +1718,13 @@ declare module ramda {
   ): (x: T) => GenericContructor<T>;
 
   // TODO add tests
-  declare function constructN<T>(
+  declare function constructN<T, E>(
     n: number,
-    ctor: Class<GenericContructorMulti<any>>
-  ): (...args: any) => GenericContructorMulti<any>;
+    ctor: Class<GenericContructorMulti<T>>
+  ): (...args: Array<T>) => GenericContructorMulti<T>;
 
   // TODO make less generic
-  declare function converge(after: Function, fns: Array<Function>): Function;
+  declare function converge(after: Function, fns: $ReadOnlyArray<Function>): Function;
 
   declare function empty<T>(x: T): T;
 
@@ -1846,7 +1760,7 @@ declare module ramda {
     CurriedFunction4<A, B, C, O, D>;
 
   declare function juxt<T, S>(
-    fns: Array<(...args: Array<S>) => T>
+    fns: $ReadOnlyArray<(...args: Array<S>) => T>
   ): (...args: Array<S>) => Array<T>;
 
   // TODO lift
@@ -1854,17 +1768,17 @@ declare module ramda {
   // TODO liftN
 
   declare function memoizeWith<A, B, C>(
-    keyFn: (...args: Array<A>) => C
+    keyFn: (...args: $ReadOnlyArray<A>) => C
   ): (...args: Array<A>) => (...args: Array<A>) => B;
   declare function memoizeWith<A, B, C>(
-    keyFn: (...args: Array<A>) => C,
+    keyFn: (...args: $ReadOnlyArray<A>) => C,
     fn: (...args: Array<A>) => B
   ): (...args: Array<A>) => B;
 
-  declare function nAry<T>(
+  declare function nAry<T, V>(
     arity: number,
-    fn: (...args: Array<any>) => T
-  ): (...args: Array<any>) => T;
+    fn: (...args: Array<V>) => T
+  ): (...args: Array<V>) => T;
 
   declare function nthArg<T>(n: number): (...args: Array<T>) => T;
 
@@ -1889,8 +1803,8 @@ declare module ramda {
 
   declare type UnaryMonadFn<A, R> = UnaryFn<A, Monad<R>>;
 
-  declare function tap<T>(fn: (x: T) => any): (x: T) => T;
-  declare function tap<T>(fn: (x: T) => any, x: T): T;
+  declare function tap<T>(fn: (x: T) => mixed): (x: T) => T;
+  declare function tap<T>(fn: (x: T) => mixed, x: T): T;
 
   declare function tryCatch<A, B, E>(
     tryer: (a: A) => B
@@ -1907,10 +1821,10 @@ declare module ramda {
   ): B;
 
   declare function unapply<T, V>(
-    fn: (xs: Array<T>) => V
+    fn: (xs: $ReadOnlyArray<T>) => V
   ): (...args: Array<T>) => V;
 
-  declare function unary<T>(fn: (...args: Array<any>) => T): (x: any) => T;
+  declare function unary<T, A, V>(fn: (A, ...args: Array<V>) => T): (x: A) => T;
 
   declare var uncurryN: (<A, B, C>(2, (A) => B => C) => (A, B) => C) &
     (<A, B, C, D>(3, (A) => B => C => D) => (A, B, C) => D) &
@@ -1937,23 +1851,18 @@ declare module ramda {
   // *Logic
 
   declare function allPass<T>(
-    fns: Array<(...args: Array<T>) => boolean>
+    fns: $ReadOnlyArray<(...args: Array<T>) => boolean>
   ): (...args: Array<T>) => boolean;
 
   declare function and<X, Y>(x: X): (y: Y) => X | Y;
   declare function and<X, Y>(x: X, y: Y): X | Y;
 
   declare function anyPass<T>(
-    fns: Array<(...args: Array<T>) => boolean>
+    fns: $ReadOnlyArray<(...args: Array<T>) => boolean>
   ): (...args: Array<T>) => boolean;
 
-  declare function both<T>(
-    x: (...args: Array<T>) => boolean,
-  ): (y: (...args: Array<T>) => boolean) => (...args: Array<T>) => boolean;
-  declare function both<T>(
-    x: (...args: Array<T>) => boolean,
-    y: (...args: Array<T>) => boolean
-  ): (...args: Array<T>) => boolean;
+  declare function both<T, F: (...args: Array<T>) => boolean>(x: F): (y: F) => F;
+  declare function both<T, F: (...args: Array<T>) => boolean>(x: F, y: F): F;
 
   // The following code is generated from
   // https://github.com/LoganBarnett/typedef-gen due to Flow not being able to
@@ -2006,20 +1915,18 @@ declare module ramda {
   ): Fn;
   // End generated complement declaration.
 
-  declare function cond<A, B>(
-    fns: Array<[(...args: Array<A>) => boolean, (...args: Array<A>) => B]>
-  ): (...args: Array<A>) => B;
+  declare function cond<A>(
+    fns: $ReadOnlyArray<[
+      (...r: Array<A>) => boolean,
+      (...r: Array<A>) => B
+    ]>
+  ): (...r: Array<A>) => B;
 
   declare function defaultTo<T, V>(d: T): (x: ?V) => V | T;
   declare function defaultTo<T, V>(d: T, x: ?V): V | T;
 
-  declare function either(
-    x: (...args: Array<any>) => *,
-  ): (y: (...args: Array<any>) => *) => (...args: Array<any>) => *;
-  declare function either(
-    x: (...args: Array<any>) => *,
-    y: (...args: Array<any>) => *
-  ): (...args: Array<any>) => *;
+  declare function either<A, F: (...args: Array<A>) => boolean>(x: F): (y: F) => F;
+  declare function either<A, F: (...args: Array<A>) => boolean>(x: F, y: F): F;
 
   declare function ifElse<Args, B, C>(
     cond: (...args: Args) => boolean
@@ -2036,7 +1943,7 @@ declare module ramda {
     f2: (...args: Args) => C
   ): (...args: Args) => B | C;
 
-  declare function isEmpty(x: ?Array<any> | Object | string): boolean;
+  declare function isEmpty<A>(x: ?$ReadOnlyArray<A> | { ... } | string): boolean;
 
   declare function not(x: boolean): boolean;
 
@@ -2044,25 +1951,25 @@ declare module ramda {
   declare function or<X, Y>(x: X, y: Y): X | Y;
 
   declare var pathSatisfies: CurriedFunction3<
-    UnaryPredicateFn<any>,
-    Array<string | number>,
-    Object,
+    UnaryPredicateFn<mixed>,
+    $ReadOnlyArray<string | number>,
+    { ... },
     boolean
   >;
 
   declare function propSatisfies<T, K>(
     cond: (x: $ElementType<T, K>) => boolean,
-    prop: K,
-    o: T
-  ): boolean;
+  ): ((prop:  K) => (o: T) => boolean) &
+    ((prop:  K, o: T) => boolean);
   declare function propSatisfies<T, K>(
     cond: (x: $ElementType<T, K>) => boolean,
     prop: K,
   ): (o: T) => boolean;
   declare function propSatisfies<T, K>(
     cond: (x: $ElementType<T, K>) => boolean,
-  ): ((prop:  K) => (o: T) => boolean) &
-    ((prop:  K, o: T) => boolean);
+    prop: K,
+    o: T
+  ): boolean;
 
   declare function unless<T, V, S>(
     pred: UnaryPredicateFn<T>,

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/ramda_v0.27.x.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/ramda_v0.27.x.js
@@ -1,0 +1,2108 @@
+/* eslint-disable no-unused-vars, no-redeclare */
+
+type Transformer<A, B> = {
+  "@@transducer/step": <I, R>(r: A, a: *) => R,
+  "@@transducer/init": () => A,
+  "@@transducer/result": (result: *) => B,
+  ...
+};
+
+declare type $npm$ramda$Placeholder = { "@@functional/placeholder": true, ... };
+
+declare opaque type $npm$ramda$Reduced<T>;
+
+declare module ramda {
+  declare type FunctorObj<A> = { map: (<B>(A => B) => FunctorObj<B>), ... }
+  declare type FunctorFantasyLand<A> = { 'fantasy-land/map': (<B>(A => B) => FunctorFantasyLand<B>), ... }
+  declare type UnaryFn<A, R> = (a: A) => R;
+  declare type UnaryPromiseFn<A, R> = UnaryFn<A, Promise<R>>;
+  declare type BinaryFn<A, B, R> = ((a: A, b: B) => R) &
+    ((a: A) => (b: B) => R);
+  declare type UnarySameTypeFn<T> = UnaryFn<T, T>;
+  declare type BinarySameTypeFn<T> = BinaryFn<T, T, T>;
+  declare type NestedObject<T> = { [k: string]: T | NestedObject<T>, ... };
+  declare type UnaryPredicateFn<T> = (x: T) => boolean;
+  declare type MapUnaryPredicateFn = <V>(V) => V => boolean;
+  declare type BinaryPredicateFn<T> = (x: T, y: T) => boolean;
+  declare type BinaryPredicateFn2<T, S> = (x: T, y: S) => boolean;
+
+  declare interface ObjPredicate {
+    (value: any, key: string): boolean;
+  }
+
+  declare type __CurriedFunction1<A, R, AA: A> = (...r: [AA]) => R;
+  declare type CurriedFunction1<A, R> = __CurriedFunction1<A, R, *>;
+
+  declare type __CurriedFunction2<A, B, R, AA: A, BB: B> = (
+    ((...r: [AA]) => CurriedFunction1<BB, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB]) => CurriedFunction1<AA, R>) &
+    ((...r: [AA, BB]) => R)
+  );
+  declare type CurriedFunction2<A, B, R> = __CurriedFunction2<A, B, R, *, *>;
+
+  declare type __CurriedFunction3<A, B, C, R, AA: A, BB: B, CC: C> = (
+    ((...r: [AA]) => CurriedFunction2<BB, CC, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB]) => CurriedFunction2<AA, CC, R>) &
+    ((...r: [AA, BB]) => CurriedFunction1<CC, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC]) => CurriedFunction1<AA, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC]) => CurriedFunction1<BB, R>) &
+    ((...r: [AA, BB, CC]) => R)
+  );
+  declare type CurriedFunction3<A, B, C, R> = __CurriedFunction3<
+    A,
+    B,
+    C,
+    R,
+    *,
+    *,
+    *
+  >;
+
+  declare type __CurriedFunction4<
+    A,
+    B,
+    C,
+    D,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D
+  > = ((...r: [AA]) => CurriedFunction3<BB, CC, DD, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB]) => CurriedFunction3<AA, CC, DD, R>) &
+    ((...r: [AA, BB]) => CurriedFunction2<CC, DD, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC]) => CurriedFunction2<AA, DD, R>) &
+    ((...r: [BB, $npm$ramda$Placeholder, CC]) => CurriedFunction2<BB, DD, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction1<DD, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC, DD]) => CurriedFunction1<AA, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC, DD]) => CurriedFunction1<BB, R>) &
+    ((...r: [AA, BB, $npm$ramda$Placeholder, DD]) => CurriedFunction1<CC, R>) &
+    ((...r: [AA, BB, CC, DD]) => R);
+  declare type CurriedFunction4<A, B, C, D, R> = __CurriedFunction4<
+    A,
+    B,
+    C,
+    D,
+    R,
+    *,
+    *,
+    *,
+    *
+  >;
+
+  declare type __CurriedFunction5<
+    A,
+    B,
+    C,
+    D,
+    E,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D,
+    EE: E
+  > = ((...r: [AA]) => CurriedFunction4<BB, CC, DD, EE, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB]) => CurriedFunction4<AA, CC, DD, EE, R>) &
+    ((...r: [AA, BB]) => CurriedFunction3<CC, DD, EE, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC]) => CurriedFunction3<AA, DD, EE, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC]) => CurriedFunction3<BB, DD, EE, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction2<DD, EE, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC, DD]) => CurriedFunction2<AA, EE, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC, DD]) => CurriedFunction2<BB, EE, R>) &
+    ((...r: [AA, BB, $npm$ramda$Placeholder, DD]) => CurriedFunction2<CC, EE, R>) &
+    ((...r: [AA, BB, CC, DD]) => CurriedFunction1<EE, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC, DD, EE]) => CurriedFunction1<AA, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC, DD, EE]) => CurriedFunction1<BB, R>) &
+    ((...r: [AA, BB, $npm$ramda$Placeholder, DD, EE]) => CurriedFunction1<CC, R>) &
+    ((...r: [AA, BB, CC, $npm$ramda$Placeholder, EE]) => CurriedFunction1<DD, R>) &
+    ((...r: [AA, BB, CC, DD, EE]) => R);
+  declare type CurriedFunction5<A, B, C, D, E, R> = __CurriedFunction5<
+    A,
+    B,
+    C,
+    D,
+    E,
+    R,
+    *,
+    *,
+    *,
+    *,
+    *
+  >;
+
+  declare type __CurriedFunction6<
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D,
+    EE: E,
+    FF: F
+  > = ((...r: [AA]) => CurriedFunction5<BB, CC, DD, EE, FF, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB]) => CurriedFunction5<AA, CC, DD, EE, FF, R>) &
+    ((...r: [AA, BB]) => CurriedFunction4<CC, DD, EE, FF, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC]) => CurriedFunction4<AA, DD, EE, FF, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC]) => CurriedFunction4<BB, DD, EE, FF, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction3<DD, EE, FF, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC, DD]) => CurriedFunction3<AA, EE, FF, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC, DD]) => CurriedFunction3<BB, EE, FF, R>) &
+    ((...r: [AA, BB, $npm$ramda$Placeholder, DD]) => CurriedFunction3<CC, EE, FF, R>) &
+    ((...r: [AA, BB, CC, DD]) => CurriedFunction2<EE, FF, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC, DD, EE]) => CurriedFunction2<AA, FF, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC, DD, EE]) => CurriedFunction2<BB, FF, R>) &
+    ((...r: [AA, BB, $npm$ramda$Placeholder, DD, EE]) => CurriedFunction2<CC, FF, R>) &
+    ((...r: [AA, BB, CC, $npm$ramda$Placeholder, EE]) => CurriedFunction2<DD, FF, R>) &
+    ((...r: [AA, BB, CC, DD, EE]) => CurriedFunction1<FF, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC, DD, EE, FF]) => CurriedFunction1<AA, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC, DD, EE, FF]) => CurriedFunction1<BB, R>) &
+    ((...r: [AA, BB, $npm$ramda$Placeholder, DD, EE, FF]) => CurriedFunction1<CC, R>) &
+    ((...r: [AA, BB, CC, $npm$ramda$Placeholder, EE, FF]) => CurriedFunction1<DD, R>) &
+    ((...r: [AA, BB, CC, DD, $npm$ramda$Placeholder, FF]) => CurriedFunction1<EE, R>) &
+    ((...r: [AA, BB, CC, DD, EE, FF]) => R);
+  declare type CurriedFunction6<A, B, C, D, E, F, R> = __CurriedFunction6<
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    R,
+    *,
+    *,
+    *,
+    *,
+    *,
+    *
+  >;
+
+  declare type Curry = (<A, R>((...r: [A]) => R) => CurriedFunction1<A, R>) &
+    (<A, B, R>((...r: [A, B]) => R) => CurriedFunction2<A, B, R>) &
+    (<A, B, C, R>((...r: [A, B, C]) => R) => CurriedFunction3<A, B, C, R>) &
+    (<A, B, C, D, R>(
+      (...r: [A, B, C, D]) => R
+    ) => CurriedFunction4<A, B, C, D, R>) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R
+    ) => CurriedFunction5<A, B, C, D, E, R>) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R
+    ) => CurriedFunction6<A, B, C, D, E, F, R>);
+
+  declare type Partial = (<A, R>((...r: [A]) => R, args: [A]) => () => R) &
+    (<A, B, R>((...r: [A, B]) => R, args: [A]) => B => R) &
+    (<A, B, R>((...r: [A, B]) => R, args: [A, B]) => () => R) &
+    (<A, B, C, R>((...r: [A, B, C]) => R, args: [A]) => (B, C) => R) &
+    (<A, B, C, R>((...r: [A, B, C]) => R, args: [A, B]) => C => R) &
+    (<A, B, C, R>((...r: [A, B, C]) => R, args: [A, B, C]) => () => R) &
+    (<A, B, C, D, R>((...r: [A, B, C, D]) => R, args: [A]) => (B, C, D) => R) &
+    (<A, B, C, D, R>((...r: [A, B, C, D]) => R, args: [A, B]) => (C, D) => R) &
+    (<A, B, C, D, R>((...r: [A, B, C, D]) => R, args: [A, B, C]) => D => R) &
+    (<A, B, C, D, R>(
+      (...r: [A, B, C, D]) => R,
+      args: [A, B, C, D]
+    ) => () => R) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A]
+    ) => (B, C, D, E) => R) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A, B]
+    ) => (C, D, E) => R) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A, B, C]
+    ) => (D, E) => R) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A, B, C, D]
+    ) => E => R) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A, B, C, D, E]
+    ) => () => R) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A]
+    ) => (B, C, D, E, F) => R) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B]
+    ) => (C, D, E, F) => R) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B, C]
+    ) => (D, E, F) => R) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B, C, D]
+    ) => (E, F) => R) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B, C, D, E]
+    ) => F => R) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B, C, D, E, F]
+    ) => () => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A]
+    ) => (B, C, D, E, F, G) => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B]
+    ) => (C, D, E, F, G) => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B, C]
+    ) => (D, E, F, G) => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B, C, D]
+    ) => (E, F, G) => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B, C, D, E]
+    ) => (F, G) => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B, C, D, E, F]
+    ) => G => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B, C, D, E, F, G]
+    ) => () => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A]
+    ) => (B, C, D, E, F, G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B]
+    ) => (C, D, E, F, G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C]
+    ) => (D, E, F, G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C, D]
+    ) => (E, F, G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C, D, E]
+    ) => (F, G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C, D, E, F]
+    ) => (G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C, D, E, F, G]
+    ) => H => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C, D, E, F, G, H]
+    ) => () => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A]
+    ) => (B, C, D, E, F, G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B]
+    ) => (C, D, E, F, G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C]
+    ) => (D, E, F, G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D]
+    ) => (E, F, G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D, E]
+    ) => (F, G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D, E, F]
+    ) => (G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D, E, F, G]
+    ) => (H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D, E, F, G, H]
+    ) => I => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D, E, F, G, H, I]
+    ) => () => R);
+
+  declare var pipe: {
+    <Args, Return, B, C, D, E, F>(
+      ab: (...a: Args) => B,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, D>,
+      de: UnaryFn<D, E>,
+      ef: UnaryFn<E, F>,
+      fg: UnaryFn<F, Return>,
+    ): (...a: Args) => Return,
+    <Args, Return, B, C, D, E,>(
+      ab: (...a: Args) => B,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, D>,
+      de: UnaryFn<D, E>,
+      ef: UnaryFn<E, Return>,
+    ): (...a: Args) => Return,
+    <Args, Return, B, C, D,>(
+      ab: (...a: Args) => B,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, D>,
+      de: UnaryFn<D, Return>,
+    ): (...a: Args) => Return,
+    <Args, Return, B, C,>(
+      ab: (...a: Args) => B,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, Return>,
+    ): (...a: Args) => Return,
+    <Args, Return, B,>(
+      ab: (...a: Args) => B,
+      bc: UnaryFn<B, Return>,
+    ): (...a: Args) => Return,
+    <A, B>(ab: UnaryFn<A, B>): UnaryFn<A, B>,
+    ...
+  };
+
+  declare type Pipe = typeof pipe;
+
+  declare type Compose = (<A, B, C, D, E, F, G, H, I, J, K>(
+    jk: UnaryFn<J, K>,
+    ij: UnaryFn<I, J>,
+    hi: UnaryFn<H, I>,
+    gh: UnaryFn<G, H>,
+    fg: UnaryFn<F, G>,
+    ef: UnaryFn<E, F>,
+    de: UnaryFn<D, E>,
+    cd: UnaryFn<C, D>,
+    bc: UnaryFn<B, C>,
+    ab: UnaryFn<A, B>
+  ) => UnaryFn<A, K>) &
+    (<A, B, C, D, E, F, G, H, I, J>(
+      ij: UnaryFn<I, J>,
+      hi: UnaryFn<H, I>,
+      gh: UnaryFn<G, H>,
+      fg: UnaryFn<F, G>,
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>
+    ) => UnaryFn<A, J>) &
+    (<A, B, C, D, E, F, G, H, I>(
+      hi: UnaryFn<H, I>,
+      gh: UnaryFn<G, H>,
+      fg: UnaryFn<F, G>,
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>
+    ) => UnaryFn<A, I>) &
+    (<A, B, C, D, E, F, G, H>(
+      gh: UnaryFn<G, H>,
+      fg: UnaryFn<F, G>,
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>
+    ) => UnaryFn<A, H>) &
+    (<A, B, C, D, E, F, G>(
+      fg: UnaryFn<F, G>,
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>
+    ) => UnaryFn<A, G>) &
+    (<A, B, C, D, E, F>(
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+    ) => UnaryFn<A, F>) &
+    (<A, B, C, D, E>(
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+    ) => UnaryFn<A, E>) &
+    (<A, B, C, D>(
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+    ) => UnaryFn<A, D>) &
+    (<A, B, C>(
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+    ) => UnaryFn<A, C>) &
+    (<A, B>(ab: UnaryFn<A, B>) => UnaryFn<A, B>);
+
+  // This kind of filter allows us to do type refinement on the result, but we
+  // still need Filter so that non-refining predicates still pass a type check.
+  declare type RefineFilter =
+    & (<K, V, P: $Pred<1>, T: Array<V> | $ReadOnlyArray<V>> (fn: P, xs: T) => Array<$Refine<V, P, 1>>)
+    & (<K, V, P: $Pred<1>, T: Array<V> | $ReadOnlyArray<V>> (fn: P) => (xs: T) => Array<$Refine<V, P, 1>>);
+
+  declare type Filter =
+    & (<K, V, T: $ReadOnlyArray<V> | { +[key: K]: V, ... }>  (fn: UnaryPredicateFn<V>, xs: T) => T)
+    & (<K, V, T: { [key: K]: V, ... } | Array<V>>   (fn: UnaryPredicateFn<V>, xs: T) => T)
+
+    & (<K, V, T: $ReadOnlyArray<V> | { +[key: K]: V, ... }>  (fn: UnaryPredicateFn<V>) =>(xs: T) => T)
+    & (<K, V, T: Array<V> | { [key: K]: V, ... }>   (fn: UnaryPredicateFn<V>) =>(xs: T) => T)
+
+  declare interface Monad<A> {
+    chain<B>(f: A => Monad<B>): Monad<B>;
+  }
+
+  declare class Semigroup<T> {}
+
+  declare class Chain {
+    chain<T, V: Monad<T> | Array<T>>(fn: (a: T) => V, x: V): V;
+    chain<T, V: Monad<T> | Array<T>>(fn: (a: T) => V): (x: V) => V;
+  }
+
+  declare class GenericContructor<T> {
+    constructor(x: T): GenericContructor<any>;
+  }
+
+  declare class GenericContructorMulti {
+    constructor(...args: Array<any>): GenericContructor<any>;
+  }
+
+  /**
+   * DONE:
+   * Function*
+   * List*
+   * Logic
+   * Math
+   * Object*
+   * Relation
+   * String
+   * Type
+   */
+
+  declare var compose: Compose;
+  // TODO: composeWith
+  // TODO: pipeWith
+  declare function then<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>): CurriedFunction1<Promise<A>, Promise<R>>
+  declare function then<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>, p: Promise<A>): Promise<R>;
+  declare var curry: Curry;
+  declare function curryN(
+    length: number,
+    fn: (...args: Array<any>) => any
+  ): Function;
+
+  // *Math
+  declare var add: CurriedFunction2<number, number, number>;
+  declare var inc: UnaryFn<number, number>;
+  declare var dec: UnaryFn<number, number>;
+  declare var mean: UnaryFn<Array<number>, number>;
+  declare var divide: CurriedFunction2<number, number, number>;
+  declare var mathMod: CurriedFunction2<number, number, number>;
+  declare var median: UnaryFn<Array<number>, number>;
+  declare var modulo: CurriedFunction2<number, number, number>;
+  declare var multiply: CurriedFunction2<number, number, number>;
+  declare var negate: UnaryFn<number, number>;
+  declare var product: UnaryFn<Array<number>, number>;
+  declare var subtract:
+    & CurriedFunction2<number, number, number>
+    & CurriedFunction2<Date, Date, number>
+    & CurriedFunction2<Date, number, number>
+    & CurriedFunction2<number, Date, number>;
+  declare var sum: UnaryFn<Array<number>, number>;
+
+  // Filter
+  // To refine with filter, be sure to import the RefineFilter type, and cast
+  // filter to a RefineFilter.
+  // ex:
+  // import { type RefineFilter, filter } from 'ramda'
+  // const notNull = (x): bool %checks => x != null
+  // const ns: Array<number> = (filter: RefineFilter)(notNull, [1, 2, null])
+  declare var filter: RefineFilter & Filter;
+  // reject doesn't get RefineFilter since it performs the opposite work of
+  // filter, and we don't have a kind of $NotPred type.
+  declare var reject: Filter;
+
+  // *String
+  declare var match: CurriedFunction2<RegExp, string, Array<string | void>>;
+  declare type ReplacementFn = (substring: string, ...args: Array<string>) => string;
+  declare function replace<A: RegExp | string, B: string | ReplacementFn>(A): CurriedFunction2<B, string, string>;
+  declare function replace<A: RegExp | string, B: string | ReplacementFn>(A, B): CurriedFunction1<string, string>;
+  declare function replace<A: RegExp | string, B: string | ReplacementFn>(A, B, string): string;
+  declare var split: CurriedFunction2<RegExp | string, string, Array<string>>;
+  declare var test: CurriedFunction2<RegExp, string, boolean>;
+  // startsWith and endsWith use the same signature:
+  declare type EdgeWith<A> =
+    & (
+        & ((Array<A>) => (Array<A>) => boolean)
+        & (Array<A>, Array<A>) => boolean
+    )
+    & (
+        & ((string) => (string) => boolean)
+        & (string, string) => boolean
+    )
+  ;
+  declare var startsWith: EdgeWith<*>;
+  declare var endsWith: EdgeWith<*>;
+  declare function toLower(a: string): string;
+  declare function toString(x: any): string;
+  declare function toUpper(a: string): string;
+  declare function trim(a: string): string;
+
+  // *Type
+  declare function is<T>(t: T): (v: any) => boolean;
+  declare function is<T>(t: T, v: any): boolean;
+  declare var propIs: CurriedFunction3<any, string, Object, boolean>;
+  declare function type(x: ?any): string;
+
+  declare function isNil(x: mixed): boolean %checks(x === undefined ||
+    x === null);
+
+  // *List
+  declare function adjust<A>(
+    index: number,
+  ): (fn: (a: A) => A) => (src: $ReadOnlyArray<A>) => Array<A>;
+  declare function adjust<A>(
+    index: number,
+    fn: (a: A) => A,
+  ): (src: $ReadOnlyArray<A>) => Array<A>;
+  declare function adjust<A>(
+    index: number,
+    fn: (a: A) => A,
+    src: $ReadOnlyArray<A>
+  ): Array<A>;
+
+  declare function all<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
+  declare function all<T>(
+    fn: UnaryPredicateFn<T>,
+  ): (xs: Array<T>) => boolean;
+
+  declare function any<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
+  declare function any<T>(
+    fn: UnaryPredicateFn<T>,
+  ): (xs: Array<T>) => boolean;
+
+  declare function aperture<T>(n: number, xs: Array<T>): Array<Array<T>>;
+  declare function aperture<T>(
+    n: number,
+  ): (xs: Array<T>) => Array<Array<T>>;
+
+  declare function append<A, E>(A, $ReadOnlyArray<E>): Array<E|A>;
+  declare function append<A, E>(A): CurriedFunction1<$ReadOnlyArray<E>, Array<E|A>>;
+
+  declare function prepend<E>(x: E, xs: Array<E>): Array<E>;
+  declare function prepend<E>(
+    x: E,
+  ): (xs: Array<E>) => Array<E>;
+
+  declare function chain<A, B>(f: (x: A) => Array<B>, xs: $ReadOnlyArray<A>): Array<B>;
+  declare function chain<A, B>(f: (x: A) => Array<B>): (xs: $ReadOnlyArray<A>) => Array<B>;
+
+  // Additional chain functionality documented at https://ramdajs.com/docs/#chain:
+  //
+  // Dispatches to the chain method of the second argument, if present, according to the FantasyLand Chain spec (https://github.com/fantasyland/fantasy-land#chain).
+  //
+  // If second argument is a function, chain(f, g)(x) is equivalent to f(g(x), x).
+  //
+  // Acts as a transducer if a transformer is given in list position.
+  declare function chain<A, B, R>(f: (x: A, y: B) => R, g: (y: B) => A):(y: B) => R;
+
+  declare function concat<A, B>(x: $ReadOnlyArray<A>, y: $ReadOnlyArray<B>): Array<A | B>;
+  declare function concat<A, B>(x: $ReadOnlyArray<A>): CurriedFunction1<$ReadOnlyArray<B>, Array<A | B>>;
+
+  declare function concat(x: string, y: string): string;
+  declare function concat(x: string): CurriedFunction1<string, string>;
+
+  declare type Includes =
+    & ((string, string) => boolean)
+    & ((string) => ((string => boolean)))
+    & (<A, T: $ReadOnlyArray<A> | Array<A>>(a: A) => (b: T) => boolean)
+    & (<A, T: $ReadOnlyArray<A> | Array<A>>(a: A, b: T) => boolean)
+
+  declare var includes: Includes;
+
+  declare function drop<V, T: Array<V> | string>(
+    n: number,
+  ): (xs: T) => T;
+  declare function drop<V, T: Array<V> | string>(n: number, xs: T): T;
+
+  declare function dropLast<V, T: Array<V> | string>(
+    n: number,
+  ): (xs: T) => T;
+  declare function dropLast<V, T: Array<V> | string>(n: number, xs: T): T;
+
+  declare function dropLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+  ): (xs: T) => T;
+  declare function dropLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): T;
+
+  declare function dropWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+  ): (xs: T) => T;
+  declare function dropWhile<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: T): T;
+
+  declare function dropRepeats<V, T: Array<V>>(xs: T): T;
+
+  declare function dropRepeatsWith<V, T: Array<V>>(
+    fn: BinaryPredicateFn<V>,
+  ): (xs: T) => T;
+  declare function dropRepeatsWith<V, T: Array<V>>(
+    fn: BinaryPredicateFn<V>,
+    xs: T
+  ): T;
+
+  declare function groupBy<T>(fn: (x: T) => string, xs: $ReadOnlyArray<T>): { [key: string]: Array<T>, ... };
+  declare function groupBy<T>(fn: (x: T) => string): CurriedFunction1<$ReadOnlyArray<T>, { [string]: Array<T>, ... }>;
+
+  declare function groupWith<T, V: Array<T> | string>(
+    fn: BinaryPredicateFn<T>,
+    xs: V
+  ): Array<V>;
+  declare function groupWith<T, V: Array<T> | string>(
+    fn: BinaryPredicateFn<T>,
+  ): (xs: V) => Array<V>;
+
+  declare function head<T, V: Array<T>>(xs: V): $ElementType<V, 0>;
+  declare function head<T, V: string>(xs: V): V;
+
+  declare function into<I, T, A: Array<T>, R: Array<*> | string | Object>(
+    accum: R,
+    xf: (a: A) => I,
+    input: A
+  ): R;
+  declare function into<I, T, A: Array<T>, R>(
+    accum: Transformer<I, R>,
+    xf: (a: A) => R,
+    input: A
+  ): R;
+
+  declare function indexOf<E>(x: ?E, xs: Array<E>): number;
+  declare function indexOf<E>(
+    x: ?E,
+  ): (xs: Array<E>) => number;
+
+  declare function indexBy<V, T: { [key: string]: *, ... }>(
+    fn: (x: T) => string,
+  ): (xs: Array<T>) => { [key: string]: T, ... };
+  declare function indexBy<V, T: { [key: string]: *, ... }>(
+    fn: (x: T) => string,
+    xs: Array<T>
+  ): { [key: string]: T, ... };
+
+  declare function insert<T>(
+    index: number,
+  ): (elem: T) => (src: Array<T>) => Array<T>;
+  declare function insert<T>(
+    index: number,
+    elem: T,
+  ): (src: Array<T>) => Array<T>;
+  declare function insert<T>(index: number, elem: T, src: Array<T>): Array<T>;
+
+  declare function insertAll<T, S>(
+    index: number,
+  ): (elem: Array<S>) => (src: Array<T>) => Array<S | T>;
+  declare function insertAll<T, S>(
+    index: number,
+    elems: Array<S>,
+  ): (src: Array<T>) => Array<S | T>;
+  declare function insertAll<T, S>(
+    index: number,
+    elems: Array<S>,
+    src: Array<T>
+  ): Array<S | T>;
+
+  declare function join(x: string, xs: Array<any>): string;
+  declare function join(
+    x: string,
+  ): (xs: Array<any>) => string;
+
+  declare function last<T, V: Array<T>>(xs: V): ?T;
+  declare function last<T, V: string>(xs: V): V;
+
+  declare function none<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
+  declare function none<T>(
+    fn: UnaryPredicateFn<T>,
+  ): (xs: Array<T>) => boolean;
+
+  declare var nth: {|
+    <A, As: $ReadOnlyArray<A>>(n: number, xs: As): ?A,
+    <A, As: $ReadOnlyArray<A> | string>(
+      n: number,
+    ): ((xs: string) => string) & ((xs: As) => ?A),
+    (n: number, xs: string): string,
+  |}
+
+
+  declare type Find = (<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ) => (xs: T) => ?V) &
+    (<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: T) => ?V);
+
+  declare var find: Find;
+
+  declare function findLast<V, O: { [key: string]: *, ... }, T: Array<V> | O>(
+    fn: UnaryPredicateFn<V>,
+  ): (xs: T | O) => ?V | O;
+  declare function findLast<V, O: { [key: string]: *, ... }, T: Array<V> | O>(
+    fn: UnaryPredicateFn<V>,
+    xs: T | O
+  ): ?V | O;
+
+  declare function findIndex<K, V, T: Array<V> | { [key: K]: V, ... }>(
+    fn: UnaryPredicateFn<V>,
+  ): (xs: T) => number;
+  declare function findIndex<K, V, T: Array<V> | { [key: K]: V, ... }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): number;
+  declare function findLastIndex<K, V, T: Array<V> | { [key: K]: V, ... }>(
+    fn: UnaryPredicateFn<V>,
+  ): (xs: T) => number;
+  declare function findLastIndex<K, V, T: Array<V> | { [key: K]: V, ... }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): number;
+
+  declare function forEach<T, V>(fn: (x: T) => ?V, xs: Array<T>): Array<T>;
+  declare function forEach<T, V>(
+    fn: (x: T) => ?V,
+  ): (xs: Array<T>) => Array<T>;
+
+  declare function forEachObjIndexed<O: Object, A, B>(
+    fn: (val: A, key: string, o: O) => B,
+    o: { [key: string]: A, ... }
+  ): O;
+
+  declare function forEachObjIndexed<O: Object, A, B>(
+    fn: (val: A, key: string, o: O) => B,
+    ...args: Array<void>
+  ): (o: { [key: string]: A, ... }) => O;
+
+  declare function lastIndexOf<E>(x: E, xs: Array<E>): number;
+  declare function lastIndexOf<E>(
+    x: E,
+  ): (xs: Array<E>) => number;
+
+  declare var map: {
+    <T, R, R, FN: (x: T) => R, SR, S: { +map: FN => SR, ... }>(fn: FN, xs: S): SR,
+    <T, R, FN: (x: T) => R>(fn: FN):
+      (<SR, S: { +map: FN => SR, ... }>(xs: S) => SR) &
+      ((xs: { [key: string]: T, ... }) => { [key: string]: R, ... }) &
+      ((xs: { +[key: string]: T, ... }) => { +[key: string]: R, ... }) &
+      ((xs: Array<T>) => Array<R>) &
+      ((xs: $ReadOnlyArray<T>) => $ReadOnlyArray<R>),
+    <T, R>(fn: (x: T) => R, xs: Array<T>): Array<R>,
+    <T, R>(fn: (x: T) => R, xs: $ReadOnlyArray<T>): $ReadOnlyArray<R>,
+    <T, R>(fn: (x: T) => R, xs: { [key: string]: T, ... }): { [key: string]: R, ... },
+    <T, R>(fn: (x: T) => R, xs: { +[key: string]: T, ... }): { +[key: string]: R, ... },
+    ...
+  };
+
+
+  declare type AccumIterator<A, B, R> = (acc: R, x: A) => [R, B];
+  declare function mapAccum<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+    acc: R,
+    xs: Array<A>
+  ): [R, Array<B>];
+  declare function mapAccum<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+  ): (acc: R, xs: Array<A>) => [R, Array<B>];
+
+  declare function mapAccumRight<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+    acc: R,
+    xs: Array<A>
+  ): [R, Array<B>];
+  declare function mapAccumRight<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+  ): (acc: R, xs: Array<A>) => [R, Array<B>];
+
+  declare function intersperse<E>(x: E, xs: Array<E>): Array<E>;
+  declare function intersperse<E>(
+    x: E,
+  ): (xs: Array<E>) => Array<E>;
+
+  declare function pair<A, B>(a: A, b: B): [A, B];
+  declare function pair<A, B>(a: A): (b: B) => [A, B];
+
+  declare function partition<K, V, T: Array<V> | { [key: K]: V, ... }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): [T, T];
+  declare function partition<K, V, T: Array<V> | { [key: K]: V, ... }>(
+    fn: UnaryPredicateFn<V>,
+  ): (xs: T) => [T, T];
+
+  declare function pluck<
+    V,
+    K: $Keys<V>,
+  >(key: K, list: V[]): Array<$ElementType<V, K>>;
+  declare function pluck<
+    V,
+    K: $Keys<V>,
+  >(key: K): (list: V[]) => Array<$ElementType<V, K>>;
+  declare function pluck<
+    T,
+    V: T[],
+  >(key: number, list: V[]): Array<$ElementType<V, number>>;
+  declare function pluck<
+    T,
+    V: T[],
+  >(key: number): (list: V[]) => Array<$ElementType<V, number>>;
+
+  declare var range: CurriedFunction2<number, number, Array<number>>;
+
+  declare function reduced<T>(x: T | $npm$ramda$Reduced<T>): $npm$ramda$Reduced<T>;
+
+  declare function remove<T>(
+    from: number,
+  ): ((to: number) => (src: Array<T>) => Array<T>) &
+    ((to: number, src: Array<T>) => Array<T>);
+  declare function remove<T>(
+    from: number,
+    to: number,
+  ): (src: Array<T>) => Array<T>;
+  declare function remove<T>(from: number, to: number, src: Array<T>): Array<T>;
+
+  declare function repeat<T>(x: T, times: number): Array<T>;
+  declare function repeat<T>(x: T): (times: number) => Array<T>;
+
+  declare function slice<V, T: Array<V> | string>(
+    from: number,
+  ): ((to: number) => (src: T) => T) &
+    ((to: number, src: T) => T);
+  declare function slice<V, T: Array<V> | string>(
+    from: number,
+    to: number,
+  ): (src: T) => T;
+  declare function slice<V, T: Array<V> | string>(
+    from: number,
+    to: number,
+    src: T
+  ): T;
+
+  declare function sort<V, T: Array<V>>(fn: (a: V, b: V) => number, xs: T): T;
+  declare function sort<V, T: Array<V>>(
+    fn: (a: V, b: V) => number,
+  ): (xs: T) => T;
+
+  declare function sortWith<V, T: Array<V>>(
+    fns: Array<(a: V, b: V) => number>,
+    xs: T
+  ): T;
+  declare function sortWith<V, T: Array<V>>(
+    fns: Array<(a: V, b: V) => number>,
+  ): (xs: T) => T;
+
+  /**
+   * In the examples for ascend and descend, its result is plugged into sort.
+   * In order for this to function properly ascend and descend need to yield a
+   * function that can take two arguments. In our case we'll declare the result
+   * function as curried, which matches the ramda behavior.
+   */
+  declare type MakeComparator = <A, B>(A => B) => CurriedFunction2<A, A, number>
+
+  declare var descend: MakeComparator
+  declare var ascend: MakeComparator
+
+  declare function times<T>(fn: (i: number) => T, n: number): Array<T>;
+  declare function times<T>(
+    fn: (i: number) => T,
+  ): (n: number) => Array<T>;
+
+  declare function take<V, T: Array<V> | string>(n: number, xs: T): T;
+  declare function take<V, T: Array<V> | string>(n: number): (xs: T) => T;
+
+  declare function takeLast<V, T: Array<V> | string>(n: number, xs: T): T;
+  declare function takeLast<V, T: Array<V> | string>(n: number): (xs: T) => T;
+
+  declare function takeLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): T;
+  declare function takeLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ): (xs: T) => T;
+
+  declare function takeWhile<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: T): T;
+  declare function takeWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ): (xs: T) => T;
+
+  declare function unfold<T, R>(
+    fn: (seed: T) => [R, T] | boolean,
+  ): (seed: T) => Array<R>;
+  declare function unfold<T, R>(
+    fn: (seed: T) => [R, T] | boolean,
+    seed: T
+  ): Array<R>;
+
+  declare function uniqBy<T, V>(
+    fn: (x: T) => V,
+  ): (xs: Array<T>) => Array<T>;
+  declare function uniqBy<T, V>(fn: (x: T) => V, xs: Array<T>): Array<T>;
+
+  declare function uniqWith<T>(
+    fn: BinaryPredicateFn<T>,
+  ): (xs: Array<T>) => Array<T>;
+  declare function uniqWith<T>(
+    fn: BinaryPredicateFn<T>,
+    xs: Array<T>
+  ): Array<T>;
+
+  declare function update<T>(
+    index: number,
+  ): ((elem: T) => (src: Array<T>) => Array<T>) &
+    ((elem: T, src: Array<T>) => Array<T>);
+  declare function update<T>(
+    index: number,
+    elem: T,
+  ): (src: Array<T>) => Array<T>;
+  declare function update<T>(index: number, elem: T, src: Array<T>): Array<T>;
+
+  // TODO `without` as a transducer
+  declare function without<T, E>($ReadOnlyArray<E>, $ReadOnlyArray<E|T>): Array<E|T>;
+  declare function without<T, E>($ReadOnlyArray<E>): CurriedFunction1<$ReadOnlyArray<E|T>, Array<E|T>>;
+
+  declare function xprod<T, S>(xs: Array<T>, ys: Array<S>): Array<[T, S]>;
+  declare function xprod<T, S>(
+    xs: Array<T>,
+  ): (ys: Array<S>) => Array<[T, S]>;
+
+  declare function zip<T, S>(xs: Array<T>, ys: Array<S>): Array<[T, S]>;
+  declare function zip<T, S>(
+    xs: Array<T>,
+  ): (ys: Array<S>) => Array<[T, S]>;
+
+  declare function zipObj<T: string, S>(
+    xs: Array<T>,
+    ys: Array<S>
+  ): { [key: T]: S, ... };
+  declare function zipObj<T: string, S>(
+    xs: Array<T>,
+  ): (ys: Array<S>) => { [key: T]: S, ... };
+
+  declare type NestedArray<T> = Array<T | NestedArray<T>>;
+  declare function flatten<T>(xs: NestedArray<T>): Array<T>;
+
+  declare function fromPairs<T, V>(pair: Array<[T, V]>): { [key: string]: V, ... };
+
+  declare function init<T, V: Array<T> | string>(xs: V): V;
+
+  declare function length<T>(xs: Array<T> | string | { length: number, ... }): number;
+
+  declare function reverse<T, V: Array<T> | string>(xs: V): V;
+
+  declare type Reduce = (<A, B>(
+    fn: (acc: A, elm: B) => $npm$ramda$Reduced<A> | A
+  ) => ((init: A) => (xs: Array<B> | $ReadOnlyArray<B>) => A) &
+    ((init: A, xs: Array<B> | $ReadOnlyArray<B>) => A)) &
+    (<A, B>(
+      fn: (acc: A, elm: B) => $npm$ramda$Reduced<A> | A,
+      init: A
+    ) => (xs: Array<B> | $ReadOnlyArray<B>) => A) &
+    (<A, B>(
+      fn: (acc: A, elm: B) => $npm$ramda$Reduced<A> | A,
+      init: A,
+      xs: Array<B> | $ReadOnlyArray<B>
+    ) => A);
+
+  declare var reduce: Reduce;
+
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+  ): ((acc: B) => ((
+    keyFn: (elem: A) => string,
+  ) => (xs: Array<A>) => { [key: string]: B, ... }) &
+    ((keyFn: (elem: A) => string, xs: Array<A>) => { [key: string]: B, ... })) &
+    ((
+      acc: B,
+      keyFn: (elem: A) => string,
+    ) => (xs: Array<A>) => { [key: string]: B, ... }) &
+    ((
+      acc: B,
+      keyFn: (elem: A) => string,
+      xs: Array<A>
+    ) => { [key: string]: B, ... });
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    acc: B,
+  ): ((
+    keyFn: (elem: A) => string,
+  ) => (xs: Array<A>) => { [key: string]: B, ... }) &
+    ((keyFn: (elem: A) => string, xs: Array<A>) => { [key: string]: B, ... });
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    acc: B,
+    keyFn: (elem: A) => string
+  ): (xs: Array<A>) => { [key: string]: B, ... };
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    acc: B,
+    keyFn: (elem: A) => string,
+    xs: Array<A>
+  ): { [key: string]: B, ... };
+
+  declare function reduceRight<A, B>(
+    fn: (elem: B, acc: A) => A,
+  ): ((init: A, xs: Array<B>) => A) &
+    ((init: A) => (xs: Array<B>) => A);
+  declare function reduceRight<A, B>(
+    fn: (elem: B, acc: A) => A,
+    init: A,
+  ): (xs: Array<B>) => A;
+  declare function reduceRight<A, B>(
+    fn: (elem: B, acc: A) => A,
+    init: A,
+    xs: Array<B>
+  ): A;
+
+  declare function reduceWhile<A, B>(pred: (acc: A, curr: B) => boolean): ((
+    fn: (a: A, b: B) => A,
+  ) => (init: A) => (
+    xs: Array<B>
+  ) => A &
+    ((
+      fn: (a: A, b: B) => A,
+    ) => (init: A, xs: Array<B>) => A)) &
+    ((
+      fn: (a: A, b: B) => A,
+      init: A,
+    ) => (xs: Array<B>) => A) &
+    ((fn: (a: A, b: B) => A, init: A, xs: Array<B>) => A);
+
+  declare function reduceWhile<A, B>(
+    pred: (acc: A, curr: B) => boolean,
+    fn: (a: A, b: B) => A,
+  ): ((init: A) => (xs: Array<B>) => A) &
+    ((init: A, xs: Array<B>) => A);
+
+  declare function reduceWhile<A, B>(
+    fn: (acc: A, curr: B) => boolean,
+    fn: (a: A, b: B) => A,
+    init: A,
+    xs: Array<B>
+  ): A;
+
+  declare function scan<A, B>(
+    fn: (acc: A, elem: B) => A,
+  ): ((init: A, xs: Array<B>) => Array<A>) &
+    ((init: A) => (xs: Array<B>) => Array<A>);
+  declare function scan<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+  ): (xs: Array<B>) => Array<A>;
+  declare function scan<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    xs: Array<B>
+  ): Array<A>;
+
+  declare function splitAt<V, T: Array<V> | string>(i: number, xs: T): [T, T];
+  declare function splitAt<V, T: Array<V> | string>(
+    i: number
+  ): (xs: T) => [T, T];
+  declare function splitEvery<V, T: Array<V> | string>(
+    i: number,
+    xs: T
+  ): Array<T>;
+  declare function splitEvery<V, T: Array<V> | string>(
+    i: number
+  ): (xs: T) => Array<T>;
+  declare function splitWhen<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): [T, T];
+  declare function splitWhen<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ): (xs: T) => [T, T];
+
+  declare function tail<T, V: Array<T> | string>(xs: V): V;
+
+  declare function transpose<T>(xs: Array<Array<T>>): Array<Array<T>>;
+
+  declare function uniq<T>(xs: $ReadOnlyArray<T>): Array<T>;
+
+  declare function unnest<T>(xs: NestedArray<T>): NestedArray<T>;
+
+  declare function zipWith<T, S, R>(
+    fn: (a: T, b: S) => R,
+  ): ((xs: Array<T>, ys: Array<S>) => Array<R>) &
+    ((xs: Array<T>) => (ys: Array<S>) => Array<R>);
+  declare function zipWith<T, S, R>(
+    fn: (a: T, b: S) => R,
+    xs: Array<T>,
+  ): (ys: Array<S>) => Array<R>;
+  declare function zipWith<T, S, R>(
+    fn: (a: T, b: S) => R,
+    xs: Array<T>,
+    ys: Array<S>
+  ): Array<R>;
+
+  // *Relation
+  declare function equals<T>(x: T): (y: T) => boolean;
+  declare function equals<T>(x: T, y: T): boolean;
+
+  declare function eqBy<A, B>(
+    fn: (x: A) => B,
+      ): ((x: A, y: A) => boolean) &
+    ((x: A) => (y: A) => boolean);
+  declare function eqBy<A, B>(
+    fn: (x: A) => B,
+    x: A,
+      ): (y: A) => boolean;
+  declare function eqBy<A, B>(fn: (x: A) => B, x: A, y: A): boolean;
+
+  // Flow cares about the order in which these appear. Generally function
+  // siguatures should go from smallest arity to largest arity.
+  declare type PropEq = (<T>(
+    prop: $Keys<T>
+  ) => ((val: mixed) => (obj: T) => boolean) &
+    ((val: mixed, obj: T) => boolean)) &
+    (<T>(prop: $Keys<T>, val: mixed) => (obj: T) => boolean) &
+    (<T>(prop: $Keys<T>, val: mixed, obj: T) => boolean) &
+    // Array variants.
+    (<T>(
+      prop: number
+    ) => ((val: mixed) => (obj: Array<*>) => boolean) &
+      ((val: mixed, obj: Array<*>) => boolean)) &
+    (<T>(prop: number, val: mixed) => (obj: Array<*>) => boolean) &
+    (<T>(prop: number, val: mixed, obj: Array<*>) => boolean);
+  declare var propEq: PropEq;
+
+  declare function pathEq<T: string | number>(
+    path: Array<T>,
+  ): ((val: mixed) => (o: Object) => boolean) &
+    ((val: mixed, o: Object) => boolean);
+  declare function pathEq<T: string | number>(
+    path: Array<T>,
+    val: mixed,
+  ): (o: Object) => boolean;
+  declare function pathEq<T: string | number>(path: Array<T>, val: mixed, o: Object): boolean;
+
+  declare function clamp<T: number | string | Date>(
+    min: T,
+  ): ((max: T) => (v: T) => T) & ((max: T, v: T) => T);
+  declare function clamp<T: number | string | Date>(
+    min: T,
+    max: T,
+  ): (v: T) => T;
+  declare function clamp<T: number | string | Date>(min: T, max: T, v: T): T;
+
+  declare function countBy<T>(
+    fn: (x: T) => string,
+  ): (list: Array<T>) => { [key: string]: number, ... };
+  declare function countBy<T>(
+    fn: (x: T) => string,
+    list: Array<T>
+  ): { [key: string]: number, ... };
+
+  declare function difference<T>(
+    xs1: Array<T>,
+  ): (xs2: Array<T>) => Array<T>;
+  declare function difference<T>(xs1: Array<T>, xs2: Array<T>): Array<T>;
+
+  declare function differenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+  ): ((xs1: Array<T>) => (xs2: Array<T>) => Array<T>) &
+    ((xs1: Array<T>, xs2: Array<T>) => Array<T>);
+  declare function differenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    xs1: Array<T>,
+  ): (xs2: Array<T>) => Array<T>;
+  declare function differenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    xs1: Array<T>,
+    xs2: Array<T>
+  ): Array<T>;
+
+  declare function eqBy<T>(fn: (x: T) => T, x: T, y: T): boolean;
+  declare function eqBy<T>(fn: (x: T) => T): (x: T, y: T) => boolean;
+  declare function eqBy<T>(fn: (x: T) => T, x: T): (y: T) => boolean;
+  declare function eqBy<T>(fn: (x: T) => T): (x: T) => (y: T) => boolean;
+
+  declare type RelationCompare =
+    & ((x: number) => (y: number) => bool)
+    & ((x: number, y: number) => bool)
+    & ((x: string) => (y: string) => bool)
+    & ((x: string, y: string) => bool)
+
+  declare var gt: RelationCompare
+  declare var gte: RelationCompare
+  declare var lt: RelationCompare
+  declare var lte: RelationCompare
+
+  declare function identical<T>(x: T): (y: T) => boolean;
+  declare function identical<T>(x: T, y: T): boolean;
+
+  declare function innerJoin<A, B>(
+    pred: (a: A, b: B) => boolean,
+  ): (
+    a: Array<A>,
+  ) => (b: Array<B>) => Array<A> & ((a: Array<A>, b: Array<B>) => Array<A>);
+  declare function innerJoin<A, B>(
+    pred: (a: A, b: B) => boolean,
+    a: Array<A>,
+  ): (b: Array<B>) => Array<A>;
+  declare function innerJoin<A, B>(
+    pred: (a: A, b: B) => boolean,
+    a: Array<A>,
+    b: Array<B>
+  ): Array<A>;
+
+  declare function intersection<T>(xs: $ReadOnlyArray<T>, ys: $ReadOnlyArray<T>): Array<T>;
+  declare function intersection<T>(xs: $ReadOnlyArray<T>): (ys: $ReadOnlyArray<T>) => Array<T>;
+
+  declare function max<T>(x: T): (y: T) => T;
+  declare function max<T>(x: T, y: T): T;
+
+  declare function maxBy<T, V>(
+    fn: (x: T) => V,
+  ): ((x: T, y: T) => T) & ((x: T) => (y: T) => T);
+  declare function maxBy<T, V>(
+    fn: (x: T) => V,
+    x: T,
+  ): (y: T) => T;
+  declare function maxBy<T, V>(fn: (x: T) => V, x: T, y: T): T;
+
+  declare function min<T>(x: T): (y: T) => T;
+  declare function min<T>(x: T, y: T): T;
+
+  declare function minBy<T, V>(
+    fn: (x: T) => V,
+  ): ((x: T, y: T) => T) & ((x: T) => (y: T) => T);
+  declare function minBy<T, V>(fn: (x: T) => V, x: T): (y: T) => T;
+  declare function minBy<T, V>(fn: (x: T) => V, x: T, y: T): T;
+
+  declare function sortBy<T, V>(
+    fn: (x: T) => V,
+  ): (x: Array<T>) => Array<T>;
+  declare function sortBy<T, V>(fn: (x: T) => V, x: Array<T>): Array<T>;
+
+  declare function symmetricDifference<T>(
+    x: Array<T>,
+  ): (y: Array<T>) => Array<T>;
+  declare function symmetricDifference<T>(x: Array<T>, y: Array<T>): Array<T>;
+
+  declare function symmetricDifferenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+  ): ((x: Array<T>) => (y: Array<T>) => Array<T>) &
+    ((x: Array<T>, y: Array<T>) => Array<T>);
+  declare function symmetricDifferenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+  ): (y: Array<T>) => Array<T>;
+  declare function symmetricDifferenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    y: Array<T>
+  ): Array<T>;
+
+  declare function union<T>(
+    x: Array<T>,
+  ): (y: Array<T>) => Array<T>;
+  declare function union<T>(x: Array<T>, y: Array<T>): Array<T>;
+
+  declare function unionWith<T>(
+    fn: BinaryPredicateFn<T>,
+  ): ((x: Array<T>) => (y: Array<T>) => Array<T>) &
+    ((x: Array<T>, y: Array<T>) => Array<T>);
+  declare function unionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+  ): (y: Array<T>) => Array<T>;
+  declare function unionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    y: Array<T>
+  ): Array<T>;
+
+  // *Object
+  declare var assoc: {
+    <T, S>(
+      key: string,
+      ...args: Array<void>
+    ):
+      & ((val: T) => (src: S) => ({ [k: string]: T, ... }))
+      & ((val: T, src: S) => ({ [k: string]: T, ... } & S)),
+    <T, S>(
+      key: string,
+      val: T,
+      ...args: Array<void>
+    ): (src: S) => ({ [k: string]: T, ... } & S),
+    <T, S: Object, K: $Keys<S>> (key: K, val: T, src: S):      ({ [k: string]: T, ... } & S),
+    <T, S: Object>              (key: string, val: T, src: S): ({
+      [k: string]: T,
+      ...$Exact<S>,
+      ...
+    }),
+    ...
+  };
+
+  declare function assocPath<T: string | number, S, V>(
+    key: Array<T>,
+    ...args: Array<void>
+  ): ((val: V) => (src: S) => { [k: string]: V, ... }) &
+    ((val: V) => (src: S) => { [k: string]: V, ... } & S);
+  declare function assocPath<T: string | number, S, V>(
+    key: Array<T>,
+    val: V,
+    ...args: Array<void>
+  ): (src: S) => { [k: string]: V, ... } & S;
+  declare function assocPath<T: string | number, S, V>(
+    key: Array<T>,
+    val: V,
+    src: S
+  ): { [k: string]: V, ... } & S;
+
+  declare function clone<T>(src: T): $Shape<T>;
+
+  declare function dissoc<T>(
+    key: string,
+    ...args: Array<void>
+  ): (src: { [k: string]: T, ... }) => { [k: string]: T, ... };
+  declare function dissoc<T>(
+    key: string,
+    src: { [k: string]: T, ... }
+  ): { [k: string]: T, ... };
+
+  declare function dissocPath<T: string | number, U>(
+    key: Array<T>,
+    ...args: Array<void>
+  ): (src: { [k: string]: U, ... }) => { [k: string]: U, ... };
+  declare function dissocPath<T: string | number, U>(
+    key: Array<T>,
+    src: { [k: string]: U, ... }
+  ): { [k: string]: U, ... };
+
+  declare function evolve<A: Object>(NestedObject<Function>): A => A;
+  declare function evolve<A: Object>(NestedObject<Function>, A): A;
+
+  declare function eqProps(
+    key: string,
+    ...args: Array<void>
+  ): ((o1: Object) => (o2: Object) => boolean) &
+    ((o1: Object, o2: Object) => boolean);
+  declare function eqProps(
+    key: string,
+    o1: Object,
+    ...args: Array<void>
+  ): (o2: Object) => boolean;
+  declare function eqProps(key: string, o1: Object, o2: Object): boolean;
+
+  declare function has(key: string): (o: Object) => boolean;
+  declare function has(key: string, o: Object): boolean;
+
+  declare function hasPath<T: string | number>(path: Array<T>): (o: Object) => boolean;
+  declare function hasPath<T: string | number>(path: Array<T>, o: Object): boolean;
+
+  declare function hasIn(key: string, o: Object): boolean;
+  declare function hasIn(key: string): (o: Object) => boolean;
+
+  declare function invert(o: Object): { [k: string]: Array<string>, ... };
+  declare function invertObj(o: Object): { [k: string]: string, ... };
+
+  declare function keys(o: ?Object): Array<string>;
+
+  declare type Lens<A, B, Fa: Functor<A>, Fb: Functor<B>> = (A => Fb) => Fb;
+  /**
+   * Because it is difficult to treat objects as if they are Functors, let's
+   * just have a lens type that works with objects, since Ramda supports objects
+   * as Functors in this context.
+   */
+  declare type LensObj<F, A, O> = (A => O) => O;
+
+  declare var lens:
+    & (<A, B, Fa, Fb>(
+      getter: (f: Fa) => A) => (
+      setter: (b: B, f: Fa) => Fb
+    ) => LensObj<Fa, A, Fb>)
+    & (<A, B, Fa, Fb>(
+      getter: (f: Fa) => A,
+      setter: (b: B, f: Fa) => Fb
+    ) => LensObj<Fa, A, Fb>)
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(
+      getter: (f: Fa) => A) => (
+      setter: (b: B, f: Fa) => Fb
+    ) => Lens<A, B, Fa, Fb>)
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(
+      getter: (f: Fa) => A,
+      setter: (b: B, f: Fa) => Fb
+    ) => Lens<A, B, Fa, Fb>)
+
+  declare function lensIndex<A, B, Fa: Functor<A>, Fb: Functor<B>, N: number, V: $ElementType<Fa, N>>(N): Lens<V, B, Fa, Fb>;
+
+  /**
+   * lensPath requires a tuple rather than an Array for its parameter. This
+   * allows us to make rested $ElementType uses in order to walk down the object
+   * hierarchy. This remains something TODO.
+   */
+  declare function lensPath<O, F, K: $Keys<F>>(p: [K]): LensObj<F, $ElementType<F, K>, O>;
+  declare function lensPath<
+    O, F,
+    K0: $Keys<F>, E0: $ElementType<F, K0>,
+    K1: $Keys<E0>
+  >(p: [K0, K1]): LensObj<F, $ElementType<E0, K1>, O>;
+  declare function lensPath<
+    O, F,
+    K0: $Keys<F>, E0: $ElementType<F, K0>,
+    K1: $Keys<E0>, E1: $ElementType<E0, K1>,
+    K2: $Keys<E1>
+  >(p: [K0, K1, K2]): LensObj<F, $ElementType<E1, K2>, O>;
+  declare function lensPath<
+    O, F,
+    K0: $Keys<F>, E0: $ElementType<F, K0>,
+    K1: $Keys<E0>, E1: $ElementType<E0, K1>,
+    K2: $Keys<E1>, E2: $ElementType<E1, K2>,
+    K3: $Keys<E2>
+  >(p: [K0, K1, K2, K3]): LensObj<F, $ElementType<E2, K3>, O>;
+  declare function lensPath<
+    O, F,
+    K0: $Keys<F>, E0: $ElementType<F, K0>,
+    K1: $Keys<E0>, E1: $ElementType<E0, K1>,
+    K2: $Keys<E1>, E2: $ElementType<E1, K2>,
+    K3: $Keys<E2>, E3: $ElementType<E2, K3>,
+    K4: $Keys<E3>
+  >(p: [K0, K1, K2, K3, K4]): LensObj<F, $ElementType<E3, K4>, O>;
+
+  // declare function lensProp(str: string): Lens;
+  declare function lensProp<O, F, K: $Keys<F>>(K): LensObj<F, $ElementType<F, K>, O>;
+
+  declare function mapObjIndexed<A, B>(
+    fn: (val: A, key: string, o: Object) => B,
+    o: { [key: string]: A, ... }
+  ): { [key: string]: B, ... };
+  declare function mapObjIndexed<A, B>(
+    fn: (val: A, key: string, o: Object) => B,
+    ...args: Array<void>
+  ): (o: { [key: string]: A, ... }) => { [key: string]: B, ... };
+
+  declare type Merge =
+    (<A, B>(a: A) => (b: B) => A & B) &
+    (<A, B>(a: A, b: B) => A & B);
+
+  declare var mergeLeft: Merge;
+  declare var mergeDeepLeft: Merge;
+  declare var mergeRight: Merge;
+
+  declare function mergeAll<T>(
+    os: Array<{ [k: string]: T, ... }>
+  ): { [k: string]: T, ... };
+
+  declare var mergeDeepRight: (<A, B>(a: A, b: B) => B & A) &
+    (<A, B>(a: A) => (b: B) => B & A);
+
+  declare type MergeWith = (<A, B, T: $Values<A> & $Values<B>>(
+    fn: (a: T, b: T) => T,
+    a: A,
+    b: B
+  ) => A & B) &
+    (<A, B, T>(
+      fn: (a: T, b: T) => T,
+    ) => (a: A) => (b: B) => A & B) &
+    (<A, B, T>(
+      fn: (a: T, b: T) => T,
+    ) => (a: A, b: B) => A & B) &
+    (<A, B, T>(
+      fn: (a: T, b: T) => T,
+      a: A,
+    ) => (b: B) => A & B);
+
+  declare type MergeWithKey = (<
+    A,
+    B,
+    S: $Keys<A> & $Keys<B>,
+    T: $ElementType<A, $Keys<A>> & $ElementType<B, $Keys<B>>,
+  >(
+    fn: (s: S, a: T, b: T) => T,
+    a: A,
+    b: B
+  ) => A & B) &
+    (<S, T, A, B>(
+      fn: (s: S, a: T, b: T) => T,
+    ) => (a: A, b: B) => A & B) &
+    (<S, T, A, B>(
+      fn: (s: S, a: T, b: T) => T,
+    ) => (a: A) => (b: B) => A & B) &
+    (<S, T, A, B>(
+      fn: (s: S, a: T, b: T) => T,
+      a: A,
+    ) => (b: B) => A & B);
+
+  declare var mergeDeepWith: MergeWith;
+
+  declare var mergeDeepWithKey: MergeWithKey;
+
+  declare var mergeWith: MergeWith;
+
+  declare var mergeWithKey: MergeWithKey;
+
+  declare function objOf<T>(
+    key: string,
+  ): (val: T) => { [key: string]: T, ... };
+  declare function objOf<T>(key: string, val: T): { [key: string]: T, ... };
+
+  declare function omit<T: Object>(
+    keys: Array<string>,
+  ): (val: T) => Object;
+  declare function omit<T: Object>(keys: Array<string>, val: T): Object;
+
+  declare type Functor<A> =
+    | { @@iterator(): Iterator<A>, ... }
+    | FunctorObj<A>
+    | FunctorFantasyLand<A>
+    | Array<A>
+    | $ReadOnlyArray<A>
+
+  declare var over:
+    & (<A, B, Oa, Ob>(lens: LensObj<Oa, A, B>) => CurriedFunction2<A => B, Oa, Ob>)
+    & (<A, B, Oa, Ob>(lens: LensObj<Oa, A, B>, A => B) => CurriedFunction1<Oa, Ob>)
+    & (<A, B, Oa, Ob>(lens: LensObj<Oa, A, B>, A => B, Oa) => Ob)
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(lens: Lens<A, B, Fa, Fb>) => CurriedFunction2<A => B, Fa, Fb>)
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(lens: Lens<A, B, Fa, Fb>, A => B) => CurriedFunction1<Fa, Fb>)
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(lens: Lens<A, B, Fa, Fb>, A => B, Fa) => Fb)
+
+  declare function path<T: string | number, V>(
+    p: Array<T>,
+  ): (o: NestedObject<V>) => V;
+  declare function path<T: string | number, V>(
+    p: Array<T>,
+  ): (o: null | void) => void;
+  declare function path<T: string | number, V>(
+    p: Array<T>,
+  ): (o: mixed) => ?V;
+  declare function path<T: string | number, V, A: NestedObject<V>>(p: Array<T>, o: A): V;
+  declare function path<T: string | number, V, A: null | void>(p: Array<T>, o: A): void;
+  declare function path<T: string | number, V, A>(p: Array<T>, o: A): ?V;
+
+  declare function path<V>(
+    p: Array<string>,
+  ): (o: NestedObject<V>) => V;
+  declare function path<V>(
+    p: Array<string>,
+  ): (o: null | void) => void;
+  declare function path<V>(
+    p: Array<string>,
+  ): (o: mixed) => ?V;
+  declare function path<V, A: NestedObject<V>>(p: Array<string>, o: A): V;
+  declare function path<V, A: null | void>(p: Array<string>, o: A): void;
+  declare function path<V, A: mixed>(p: Array<string>, o: A): ?V;
+
+  declare function pathOr<T, U: string | number, V, A: NestedObject<V>>(
+    or: T,
+  ): ((p: Array<U>) => (o: ?A) => V | T) &
+    ((p: Array<U>, o: ?A) => V | T);
+  declare function pathOr<T, U: string | number, V, A: NestedObject<V>>(
+    or: T,
+    p: Array<U>,
+  ): (o: ?A) => V | T;
+  declare function pathOr<T, U: string | number, V, A: NestedObject<V>>(
+    or: T,
+    p: Array<U>,
+    o: ?A
+  ): V | T;
+
+  declare function pick<O, K: $ReadOnlyArray<$Keys<O>>>(
+    keys: K,
+  ): (val: O) => O;
+  declare function pick<O, K: $ReadOnlyArray<$Keys<O>>>(
+    keys: K,
+    val: O
+  ): O;
+
+  declare function pickAll<A>(
+    keys: Array<string>,
+  ): (val: { [key: string]: A, ... }) => { [key: string]: ?A, ... };
+  declare function pickAll<A>(
+    keys: Array<string>,
+    val: { [key: string]: A, ... }
+  ): { [key: string]: ?A, ... };
+
+  declare function pickBy<A>(
+    fn: BinaryPredicateFn2<A, string>,
+  ): (val: { [key: string]: A, ... }) => { [key: string]: A, ... };
+  declare function pickBy<A>(
+    fn: BinaryPredicateFn2<A, string>,
+    val: { [key: string]: A, ... }
+  ): { [key: string]: A, ... };
+
+  declare function project<T>(
+    keys: Array<string>,
+  ): (val: Array<{ [key: string]: T, ... }>) => Array<{ [key: string]: T, ... }>;
+  declare function project<T>(
+    keys: Array<string>,
+    val: Array<{ [key: string]: T, ... }>
+  ): Array<{ [key: string]: T, ... }>;
+
+  declare function prop<T: string, O>(
+    key: T,
+  ): (o: O) => $ElementType<O, T>;
+  declare function prop<T: string, O>(
+    __: $npm$ramda$Placeholder,
+    o: O
+  ): (key: T) => $ElementType<O, T>;
+  declare function prop<T: string, O>(key: T, o: O): $ElementType<O, T>;
+
+  declare function propOr<T, V, A: { [k: string]: V, ... }>(
+    or: T,
+  ): ((p: string) => (o: A) => V | T) &
+    ((p: string, o: A) => V | T);
+  declare function propOr<T, V, A: { [k: string]: V, ... }>(
+    or: T,
+    p: string,
+  ): (o: A) => V | T;
+  declare function propOr<T, V, A: { [k: string]: V, ... }>(
+    or: T,
+    p: string,
+    o: A
+  ): V | T;
+
+  declare function keysIn(o: Object): Array<string>;
+
+  declare function props<T: string, O>(
+    keys: Array<T>,
+  ): (o: O) => Array<$ElementType<O, T>>;
+  declare function props<T: string, O>(
+    keys: Array<T>,
+    o: O
+  ): Array<$ElementType<O, T>>;
+
+  declare var set:
+    & (<A, B, Oa, Ob>(lens: LensObj<Oa, A, B>) => (
+      & (B => Oa => Ob)
+      & ((B, Oa) => Ob)
+    ))
+    & (<A, B, Oa, Ob>(lens: LensObj<Oa, A, B>, B, Oa) => Ob)
+    // NOTE: Other functor types might need to be directly supported here.
+    & (<A, B, Fa: Array<A>>(lens: Lens<A, B, Fa, Array<B>>) => (
+      & (B => Fa => Array<B>)
+      & ((B, Fa) => Array<B>)
+    ))
+    & (<A, B, Fa: Array<A>>(lens: Lens<A, B, Fa, Array<B>>, B, Fa) => Array<B>)
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(lens: Lens<A, B, Fa, Fb>) => (
+      & (B => Fa => Fb)
+      & ((B, Fa) => Fb)
+    ))
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(lens: Lens<A, B, Fa, Fb>, B, Fa) => Fb)
+
+  declare function toPairs<T, O: { [k: string]: T, ... }>(
+    o: O
+  ): Array<[$Keys<O>, T]>;
+
+  declare function toPairsIn<T, O: { [k: string]: T, ... }>(
+    o: O
+  ): Array<[string, T]>;
+
+  declare function values<T>(o: T): Array<$Values<T>>;
+
+  declare function valuesIn<T, O: { [k: string]: T, ... }>(o: O): Array<T | any>;
+
+  declare function where<O>(
+    predObj: $ObjMap<O, MapUnaryPredicateFn>,
+    o: O
+  ): boolean;
+  declare function where<O>(
+    predObj: $ObjMap<O, MapUnaryPredicateFn>
+  ): O => boolean;
+
+  declare function whereEq<T, S, O: { [k: string]: T, ... }, Q: { [k: string]: S, ... }>(
+    predObj: O,
+  ): (o: $Shape<O & Q>) => boolean;
+  declare function whereEq<T, S, O: { [k: string]: T, ... }, Q: { [k: string]: S, ... }>(
+    predObj: O,
+    o: $Shape<O & Q>
+  ): boolean;
+
+  declare var view:
+    & (<A, B, Oa, Ob>(LensObj<Oa, A, B>) => Oa => A)
+    & (<A, B, Oa, Ob>(LensObj<Oa, A, B>, Oa) => A)
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(Lens<A, B, Fa, Fb>) => Fa => A)
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(Lens<A, B, Fa, Fb>, Fa) => A)
+
+  // *Function
+  declare var __: $npm$ramda$Placeholder;
+
+  declare var T: (_: any) => true;
+  declare var F: (_: any) => false;
+
+  declare function addIndex<A, B>(
+    iterFn: (fn: (x: A) => B, xs: Array<A>) => Array<B>
+  ): (fn: (x: A, idx: number, xs: Array<A>) => B, xs: Array<A>) => Array<B>;
+
+  declare function always<T>(x: T): (x: any) => T;
+
+  declare function ap<T, V>(
+    fns: Array<(x: T) => V>,
+  ): (xs: Array<T>) => Array<V>;
+  declare function ap<T, V>(fns: Array<(x: T) => V>, xs: Array<T>): Array<V>;
+
+  declare function apply<T, V>(
+    fn: (...args: Array<T>) => V,
+  ): (xs: Array<T>) => V;
+  declare function apply<T, V>(fn: (...args: Array<T>) => V, xs: Array<T>): V;
+
+  declare function applySpec<
+    V,
+    S,
+    A: Array<V>,
+    T: NestedObject<(...args: A) => S>
+  >(
+    spec: T
+  ): (...args: A) => NestedObject<S>;
+
+  declare function applyTo<A, B>(a: A): (fn: (x: A) => B) => B;
+  declare function applyTo<A, B>(a: A, fn: (x: A) => B): B;
+
+  declare function binary<T>(
+    fn: (...args: Array<any>) => T
+  ): (x: any, y: any) => T;
+
+  declare function bind<T>(
+    fn: (...args: Array<any>) => any,
+    thisObj: T
+  ): (...args: Array<any>) => any;
+
+  declare function call<T, V>(
+    fn: (...args: Array<V>) => T,
+    ...args: Array<V>
+  ): T;
+
+  declare function comparator<T>(
+    fn: BinaryPredicateFn<T>
+  ): (x: T, y: T) => number;
+
+  // TODO add tests
+  declare function construct<T>(
+    ctor: Class<GenericContructor<T>>
+  ): (x: T) => GenericContructor<T>;
+
+  // TODO add tests
+  declare function constructN<T>(
+    n: number,
+    ctor: Class<GenericContructorMulti<any>>
+  ): (...args: any) => GenericContructorMulti<any>;
+
+  // TODO make less generic
+  declare function converge(after: Function, fns: Array<Function>): Function;
+
+  declare function empty<T>(x: T): T;
+
+  declare function flip<A, B, TResult>(
+    fn: (arg0: A, arg1: B) => TResult
+  ): CurriedFunction2<B, A, TResult>;
+  declare function flip<A, B, C, TResult>(
+    fn: (arg0: A, arg1: B, arg2: C) => TResult
+  ): ((arg0: B, arg1: A) => (arg2: C) => TResult) &
+    ((arg0: B, arg1: A, arg2: C) => TResult);
+  declare function flip<A, B, C, D, TResult>(
+    fn: (arg0: A, arg1: B, arg2: C, arg3: D) => TResult
+  ): ((
+    arg1: B,
+    arg0: A,
+  ) => (arg2: C, arg3: D) => TResult) &
+    ((arg1: B, arg0: A, arg2: C, arg3: D) => TResult);
+  declare function flip<A, B, C, D, E, TResult>(
+    fn: (arg0: A, arg1: B, arg2: C, arg3: D, arg4: E) => TResult
+  ): ((
+    arg1: B,
+    arg0: A,
+  ) => (arg2: C, arg3: D, arg4: E) => TResult) &
+    ((arg1: B, arg0: A, arg2: C, arg3: D, arg4: E) => TResult);
+
+  declare function identity<T>(x: T): T;
+
+  declare function invoker<A, B, C, D, O: { [k: string]: Function, ... }>(
+    arity: number,
+    name: $Keys<O>
+  ): CurriedFunction2<A, O, D> &
+    CurriedFunction3<A, B, O, D> &
+    CurriedFunction4<A, B, C, O, D>;
+
+  declare function juxt<T, S>(
+    fns: Array<(...args: Array<S>) => T>
+  ): (...args: Array<S>) => Array<T>;
+
+  // TODO lift
+
+  // TODO liftN
+
+  declare function memoizeWith<A, B, C>(
+    keyFn: (...args: Array<A>) => C
+  ): (...args: Array<A>) => (...args: Array<A>) => B;
+  declare function memoizeWith<A, B, C>(
+    keyFn: (...args: Array<A>) => C,
+    fn: (...args: Array<A>) => B
+  ): (...args: Array<A>) => B;
+
+  declare function nAry<T>(
+    arity: number,
+    fn: (...args: Array<any>) => T
+  ): (...args: Array<any>) => T;
+
+  declare function nthArg<T>(n: number): (...args: Array<T>) => T;
+
+  declare var o: (<A, B, C>(
+    fn1: (b: B) => C,
+    ...rest: void[]
+  ) => ((fn2: (a: A) => B, ...rest: void[]) => (x: A) => C) &
+    ((fn2: (a: A) => B, x: A) => C)) &
+    (<A, B, C>(
+      fn1: (b: B) => C,
+      fn2: (a: A) => B,
+      ...rest: void[]
+    ) => (x: A) => C) &
+    (<A, B, C>(fn1: (b: B) => C, fn2: (a: A) => B, x: A) => C);
+
+  declare function of<T>(x: T): Array<T>;
+
+  declare function once<A, B, T: (...args: Array<A>) => B>(fn: T): T;
+
+  declare var partial: Partial;
+  // TODO partialRight
+
+  declare type UnaryMonadFn<A, R> = UnaryFn<A, Monad<R>>;
+
+  declare function tap<T>(fn: (x: T) => any): (x: T) => T;
+  declare function tap<T>(fn: (x: T) => any, x: T): T;
+
+  declare function tryCatch<A, B, E>(
+    tryer: (a: A) => B
+  ): ((catcher: (e: E, a: A) => B) => (a: A) => B) &
+    ((catcher: (e: E, a: A) => B, a: A) => B);
+  declare function tryCatch<A, B, E>(
+    tryer: (a: A) => B,
+    catcher: (e: E, a: A) => B
+  ): (a: A) => B;
+  declare function tryCatch<A, B, E>(
+    tryer: (a: A) => B,
+    catcher: (e: E, a: A) => B,
+    a: A
+  ): B;
+
+  declare function unapply<T, V>(
+    fn: (xs: Array<T>) => V
+  ): (...args: Array<T>) => V;
+
+  declare function unary<T>(fn: (...args: Array<any>) => T): (x: any) => T;
+
+  declare var uncurryN: (<A, B, C>(2, (A) => B => C) => (A, B) => C) &
+    (<A, B, C, D>(3, (A) => B => C => D) => (A, B, C) => D) &
+    (<A, B, C, D, E>(4, (A) => B => C => D => E) => (A, B, C, D) => E) &
+    (<A, B, C, D, E, F>(
+      5,
+      (A) => B => C => D => E => F
+    ) => (A, B, C, D, E) => F) &
+    (<A, B, C, D, E, F, G>(
+      6,
+      (A) => B => C => D => E => F => G
+    ) => (A, B, C, D, E, F) => G) &
+    (<A, B, C, D, E, F, G, H>(
+      7,
+      (A) => B => C => D => E => F => G => H
+    ) => (A, B, C, D, E, F, G) => H) &
+    (<A, B, C, D, E, F, G, H, I>(
+      8,
+      (A) => B => C => D => E => F => G => H => I
+    ) => (A, B, C, D, E, F, G, H) => I);
+
+  //TODO useWith
+
+  // *Logic
+
+  declare function allPass<T>(
+    fns: Array<(...args: Array<T>) => boolean>
+  ): (...args: Array<T>) => boolean;
+
+  declare function and<X, Y>(x: X): (y: Y) => X | Y;
+  declare function and<X, Y>(x: X, y: Y): X | Y;
+
+  declare function anyPass<T>(
+    fns: Array<(...args: Array<T>) => boolean>
+  ): (...args: Array<T>) => boolean;
+
+  declare function both<T>(
+    x: (...args: Array<T>) => boolean,
+  ): (y: (...args: Array<T>) => boolean) => (...args: Array<T>) => boolean;
+  declare function both<T>(
+    x: (...args: Array<T>) => boolean,
+    y: (...args: Array<T>) => boolean
+  ): (...args: Array<T>) => boolean;
+
+  // The following code is generated from
+  // https://github.com/LoganBarnett/typedef-gen due to Flow not being able to
+  // preserve the input function's form as a return type.
+  //
+  // Begin generated complement declaration.
+
+  declare function complement< Fn: () => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, Fn: (A) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, Fn: (A, B) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, C, Fn: (A, B, C) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, C, D, Fn: (A, B, C, D) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, C, D, E, Fn: (A, B, C, D, E) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, C, D, E, F, Fn: (A, B, C, D, E, F) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, C, D, E, F, G, Fn: (A, B, C, D, E, F, G) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, C, D, E, F, G, H, Fn: (A, B, C, D, E, F, G, H) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, C, D, E, F, G, H, I, Fn: (A, B, C, D, E, F, G, H, I) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, C, D, E, F, G, H, I, J, Fn: (A, B, C, D, E, F, G, H, I, J) => boolean>(
+    f: Fn
+  ): Fn;
+  // End generated complement declaration.
+
+  declare function cond<A, B>(
+    fns: Array<[(...args: Array<A>) => boolean, (...args: Array<A>) => B]>
+  ): (...args: Array<A>) => B;
+
+  declare function defaultTo<T, V>(d: T): (x: ?V) => V | T;
+  declare function defaultTo<T, V>(d: T, x: ?V): V | T;
+
+  declare function either(
+    x: (...args: Array<any>) => *,
+  ): (y: (...args: Array<any>) => *) => (...args: Array<any>) => *;
+  declare function either(
+    x: (...args: Array<any>) => *,
+    y: (...args: Array<any>) => *
+  ): (...args: Array<any>) => *;
+
+  declare function ifElse<Args, B, C>(
+    cond: (...args: Args) => boolean
+  ): ((
+    f1: (...args: Args) => B
+  ) => (f2: (...args: Args) => C) => (...args: Args) => B | C) &
+    ((
+      f1: (...args: Args) => B,
+      f2: (...args: Args) => C
+    ) => (...args: Args) => B | C);
+  declare function ifElse<Args, B, C>(
+    cond: (...args: Args) => boolean,
+    f1: (...args: Args) => B,
+    f2: (...args: Args) => C
+  ): (...args: Args) => B | C;
+
+  declare function isEmpty(x: ?Array<any> | Object | string): boolean;
+
+  declare function not(x: boolean): boolean;
+
+  declare function or<X, Y>(x: X): (y: Y) => X | Y;
+  declare function or<X, Y>(x: X, y: Y): X | Y;
+
+  declare var pathSatisfies: CurriedFunction3<
+    UnaryPredicateFn<any>,
+    Array<string | number>,
+    Object,
+    boolean
+  >;
+
+  declare function propSatisfies<T, K>(
+    cond: (x: $ElementType<T, K>) => boolean,
+    prop: K,
+    o: T
+  ): boolean;
+  declare function propSatisfies<T, K>(
+    cond: (x: $ElementType<T, K>) => boolean,
+    prop: K,
+  ): (o: T) => boolean;
+  declare function propSatisfies<T, K>(
+    cond: (x: $ElementType<T, K>) => boolean,
+  ): ((prop:  K) => (o: T) => boolean) &
+    ((prop:  K, o: T) => boolean);
+
+  declare function unless<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+  ): ((fn: (x: S) => V) => (x: T | S) => T | V) &
+    ((fn: (x: S) => V, x: T | S) => T | V);
+  declare function unless<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+  ): (x: T | S) => V | T;
+  declare function unless<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+    x: T | S
+  ): T | V;
+
+  declare function until<T>(
+    pred: UnaryPredicateFn<T>,
+  ): ((fn: (x: T) => T) => (x: T) => T) &
+    ((fn: (x: T) => T, x: T) => T);
+  declare function until<T>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: T) => T,
+  ): (x: T) => T;
+  declare function until<T>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: T) => T,
+    x: T
+  ): T;
+
+  declare function when<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+  ): ((fn: (x: S) => V) => (x: T | S) => T | V) &
+    ((fn: (x: S) => V, x: T | S) => T | V);
+  declare function when<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+  ): (x: T | S) => V | T;
+  declare function when<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+    x: T | S
+  ): T | V;
+}

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/ramda_v0.27.x.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/ramda_v0.27.x.js
@@ -464,7 +464,81 @@ declare module ramda {
    * Type
    */
 
+  declare type Compose = (<A, B, C, D, E, F, G, H, I, J, K>(
+    jk: UnaryFn<J, K>,
+    ij: UnaryFn<I, J>,
+    hi: UnaryFn<H, I>,
+    gh: UnaryFn<G, H>,
+    fg: UnaryFn<F, G>,
+    ef: UnaryFn<E, F>,
+    de: UnaryFn<D, E>,
+    cd: UnaryFn<C, D>,
+    bc: UnaryFn<B, C>,
+    ab: UnaryFn<A, B>
+  ) => UnaryFn<A, K>) &
+    (<A, B, C, D, E, F, G, H, I, J>(
+      ij: UnaryFn<I, J>,
+      hi: UnaryFn<H, I>,
+      gh: UnaryFn<G, H>,
+      fg: UnaryFn<F, G>,
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>
+    ) => UnaryFn<A, J>) &
+    (<A, B, C, D, E, F, G, H, I>(
+      hi: UnaryFn<H, I>,
+      gh: UnaryFn<G, H>,
+      fg: UnaryFn<F, G>,
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>
+    ) => UnaryFn<A, I>) &
+    (<A, B, C, D, E, F, G, H>(
+      gh: UnaryFn<G, H>,
+      fg: UnaryFn<F, G>,
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>
+    ) => UnaryFn<A, H>) &
+    (<A, B, C, D, E, F, G>(
+      fg: UnaryFn<F, G>,
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>
+    ) => UnaryFn<A, G>) &
+    (<A, B, C, D, E, F>(
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+    ) => UnaryFn<A, F>) &
+    (<A, B, C, D, E>(
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+    ) => UnaryFn<A, E>) &
+    (<A, B, C, D>(
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+    ) => UnaryFn<A, D>) &
+    (<A, B, C>(
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+    ) => UnaryFn<A, C>) &
+    (<A, B>(ab: UnaryFn<A, B>) => UnaryFn<A, B>);
   declare var compose: Compose;
+
   declare function then<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>): CurriedFunction1<Promise<A>, Promise<R>>
   declare function then<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>, p: Promise<A>): Promise<R>;
   declare var curry: Curry;
@@ -678,8 +752,13 @@ declare module ramda {
   declare function findLast<V>(fn: UnaryPredicateFn<V>): (xs: $ReadOnlyArray<V>) => ?V | O;
   declare function findLast<V>(fn: UnaryPredicateFn<V>, xs: $ReadOnlyArray<V>): ?V;
 
-  declare function findIndex<K, V>(fn: UnaryPredicateFn<V>): (xs: $ReadOnlyArray<V>) => number;
-  declare function findIndex<K, V>(fn: UnaryPredicateFn<V>, xs: $ReadOnlyArray<V>): number;
+  declare function findIndex<K, V, T: Array<V> | { [key: K]: V, ... }>(
+    fn: UnaryPredicateFn<V>,
+  ): (xs: T) => number;
+  declare function findIndex<K, V, T: Array<V> | { [key: K]: V, ... }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): number;
 
   declare function findLastIndex<K, V>(fn: UnaryPredicateFn<V>): (xs: $ReadOnlyArray<V>) => number;
   declare function findLastIndex<K, V>(fn: UnaryPredicateFn<V>, xs: $ReadOnlyArray<V>): number;

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_cjs_modules.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_cjs_modules.js
@@ -1,0 +1,41 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+const _ = require("ramda");
+const { compose, match, toLower, trim, zipWith } = _;
+
+// $ExpectError
+inc();
+
+const str: Array<string | void> = compose(match(/2/), toLower, trim)(" 1,2,3 ");
+const str1: Array<string> = _.compose(_.split(","), _.toLower, _.trim)(
+  " 1,2,3 "
+);
+const str2: string = _.compose(_.replace("3", "4"), _.toLower, _.trim)(
+  " 1,2,3 "
+);
+
+const zipped: Array<{
+  s: number,
+  y: string,
+  ...
+}> = _.zipWith(
+  (a, b) => ({ s: a, y: b }),
+  [1, 2, 3],
+  ["1", "2", "3"]
+);
+const zipped2: Array<{
+  s: number,
+  y: string,
+  ...
+}> = zipWith(
+  (a, b) => ({ s: a, y: b }),
+  [1, 2, 3]
+)(["1", "2", "3"]);
+const zipped3: Array<{
+  s: number,
+  y: string,
+  ...
+}> = _.zipWith((a, b) => ({
+  s: a,
+  y: b
+}))([1, 2, 3])(["1", "2", "3"]);

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_compose.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_compose.js
@@ -1,0 +1,31 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import { compose } from 'ramda';
+
+const f1 = (a: number): number => 1;
+
+describe("compose()", () => {
+  describe('call "compose" with different number of arguments', () => {
+    it('rises an error when more then 10 arguments', () => {
+      // $ExpectError - compose can't take more than 10 arguments
+      compose(f1, f1, f1, f1, f1, f1, f1, f1, f1, f1, f1)(1);
+    });
+
+    it('should pass when 10 arguments are provided', () => {
+      compose(f1, f1, f1, f1, f1, f1, f1, f1, f1, f1)(1);
+    });
+
+    it('should pass when less than 10 arguments are provided', () => {
+      compose(f1, f1, f1, f1, f1, f1, f1, f1, f1)(1);
+    });
+
+    it('should pass when 1 argument is provided', () => {
+      compose(f1)(1);
+    });
+
+    it('raises and error when no argument is provided', () => {
+      // $ExpectError - compose needs at least one argument
+      compose()(1);
+    });
+  });
+});

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_es_modules.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_es_modules.js
@@ -1,0 +1,14 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+import _, { compose, match, toLower, trim } from "ramda";
+
+//$ExpectError
+inc();
+
+const str: Array<string | void> = compose(match(/2/), toLower, trim)(" 1,2,3 ");
+const str1: Array<string> = _.compose(_.split(","), _.toLower, _.trim)(
+  " 1,2,3 "
+);
+const str2: string = _.compose(_.replace("3", "4"), _.toLower, _.trim)(
+  " 1,2,3 "
+);

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_filter.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_filter.js
@@ -1,0 +1,94 @@
+// @flow
+import R, { filter, type RefineFilter } from "ramda";
+import { it, describe } from "flow-typed-test";
+
+describe("filter", () => {
+  it("perserves the element type in the predicate and result array (number)", () => {
+    const s: Array<number> = filter(x => x > 1, [1, 2]);
+  });
+
+  it("perserves the element type in the predicate and result array (number)", () => {
+    const s: Array<string> = R.filter(x => x === "2", ["2", "3"]);
+  });
+
+  it("filters objects by passing the value to the predicate", () => {
+    const s: { [key: string]: string, ... } = R.filter(x => x === "2", {
+      a: "2",
+      b: "3"
+    });
+  });
+
+  it("refines the element type using the predicate", () => {
+    const notNull = (x): boolean %checks => x != null;
+    const ns: Array<number> = (filter: RefineFilter)(notNull, [1, 2, null]);
+  });
+
+  it("fails when type refinement is incorrect", () => {
+    const isString = (x): boolean %checks => typeof x === "string";
+    // $ExpectError
+    const ns: Array<number> = (filter: RefineFilter)(isString, ["1", 2]);
+  });
+
+  it("fails when attempting to refine from a non $Pred predicate", () => {
+    const isNumber = x => typeof x === "number";
+    // $ExpectError
+    const ns: Array<number> = filter(isNumber, ["1", 2]);
+  });
+
+  it("does not accept predicates missing %checks when using RefineFilter", () => {
+    const isNumber = x => typeof x === "number";
+    // $ExpectError
+    const ns: Array<number> = (filter: RefineFilter)(isNumber, ["1", 2]);
+  });
+
+  describe("read only", () => {
+    it("should return readonly Array<number>", () => {
+      const readOnlyArrNumbers: $ReadOnlyArray<number> = Object.freeze([1, 2, 3]);
+
+      const result1 = filter(x => x > 1, readOnlyArrNumbers);
+      (result1: $ReadOnlyArray<number>);
+
+      // $ExpectError
+      (result1: { +[key: string]: number, ... });
+      // $ExpectError
+      (result1: { [key: string]: number, ... });
+      // $ExpectError
+      (result1: Array<number>);
+
+      const result2 = filter(x => x > 1)(readOnlyArrNumbers);
+
+      (result2: $ReadOnlyArray<number>);
+
+      // $ExpectError
+      (result2: { +[key: string]: number, ... });
+      // $ExpectError
+      (result2: { [key: string]: number, ... });
+      // $ExpectError
+      (result2: Array<number>);
+    });
+
+    it("should return readonly Object", () => {
+      type O = {| key: number |};
+      const readOnlyObj: { +[k: string]: O, ... } = Object.freeze({
+        a: { key: 1 },
+        c: { key: 2 },
+        d: { key: 3 }
+      });
+
+      (filter(
+        R.pipe(
+          R.prop("key"),
+          (v: number) => v === 0
+        ),
+        readOnlyObj
+      ): $ReadOnly<{ [k: string]: O, ... }>);
+
+      (filter(
+        R.pipe(
+          R.prop("key"),
+          (v: number) => v === 0
+        )
+      )(readOnlyObj): { +[k: string]: O, ... });
+    });
+  });
+});

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_functions.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_functions.js
@@ -1,0 +1,421 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+import _, { compose, pipe, uncurryN, curry, tryCatch, applyTo } from "ramda";
+// Function
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number, ... } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed, ... } = { a: 1, c: "d" };
+const os: Array<{ [k: string]: *, ... }> = [{ a: 1, c: "d" }, { b: 2 }];
+const str: string = "hello world";
+
+// TODO: "Gap" Functions: Started failing in v31...
+// const g = _.propIs
+// const __ = _.__
+// const g1: boolean = g(1, '2', {p: 3})
+// const g2: boolean = g(__, '2', {p: 3})(1)
+// const g3: boolean = g(__, __, {p: 3})(1)('2')
+// const g4: boolean = g(__, __, {p: 3})(1, '2')
+// const g5: boolean = g(__, '2', __)(1, {p: 3})
+// const g6: boolean = g(__, '2')(1)({p: 3})
+// const g7: boolean = g(__, '2')(1, {p: 3})
+// const g8: boolean = g(__, '2')(__, {p: 3})(1)
+
+type R = {
+  sum: number,
+  nested: { mul: number, ... },
+  ...
+};
+// TODO: "Gap" Functions: Started failing in v31...
+// const greet: string = _.replace('{name}', _.__, 'Hello, {name}!')('John')
+const truth: boolean = _.T("ddd");
+const lie: boolean = _.F("ddd");
+const mapIndexed = _.addIndex(_.map);
+
+const mi: Array<string> = mapIndexed((val, idx) => idx + "-" + val, [
+  "f",
+  "o",
+  "o",
+  "b",
+  "a",
+  "r"
+]);
+
+const t: string = _.always("Tee")();
+const app: Array<number> = _.ap([_.multiply(2), _.add(3)], [1, 2, 3]);
+const app1: Array<string | number> = _.ap([_.toString, _.add(3)], [1, 2, 3]);
+
+const nums = [1, 2, 3, -99, 42, 6, 7];
+const applied: number = _.apply(Math.max, nums);
+const spec = {
+  sum: _.add,
+  nested: { mul: _.multiply }
+};
+
+const applyToResult1 = applyTo(5, value => {
+  (value: number);
+  // $ExpectError
+  (value: string);
+  return String(value)
+});
+(applyToResult1: string);
+// $ExpectError
+(applyToResult1: number);
+
+const applyToResult2 = applyTo(5)(value => {
+  (value: number);
+  // $ExpectError
+  (value: string);
+  return String(value)
+});
+(applyToResult2: string);
+// $ExpectError
+(applyToResult2: number);
+
+const getMetrics = _.applySpec(spec);
+const apspec: $Shape<R> = getMetrics(2, 2);
+
+const applyToResult3 = _.applyTo(5, value => {
+  (value: number);
+  // $ExpectError
+  (value: string);
+  return String(value)
+});
+(applyToResult3: string);
+// $ExpectError
+(applyToResult3: number);
+
+const applyToResult4 = _.applyTo(5)(value => {
+  (value: number);
+  // $ExpectError
+  (value: string);
+  return String(value)
+});
+(applyToResult4: string);
+// $ExpectError
+(applyToResult4: number);
+
+const cmp: (x: Object, y: Object) => number = _.comparator(
+  (a, b) => a.age < b.age
+);
+const compf: number = _.compose(_.inc, _.negate)(2);
+
+const fn = compose(_.add);
+const fn1: (n: number) => number = fn(2);
+const add2 = _.compose(_.add(2));
+const four: number = add2(2);
+const str0: Array<string | void> = _.compose(_.match(/2/), _.toLower, _.trim)(
+  " 1,2,3 "
+);
+const str1: Array<string> = _.compose(_.split(","), _.toLower, _.trim)(
+  " 1,2,3 "
+);
+const str2: string = _.compose(_.replace("3", "4"), _.toLower, _.trim)(
+  " 1,2,3 "
+);
+
+const fn2: (n: number) => (n: number) => number = pipe(_.add);
+const fn3: (n: number) => number = fn2(2);
+const add2p = _.pipe(_.add(2));
+const b: number = add2p(2);
+const fail: string = _.pipe(_.trim)("h");
+const str3: Array<string | void> = _.pipe(_.toLower, _.trim, _.match(/2/))(
+  " 1,2,3 "
+);
+const str4: Array<string> = _.pipe(_.toLower, _.trim, _.split(","))(" 1,2,3 ");
+const str5: string = _.pipe(_.replace("3", "4"), _.toLower, _.trim)(" 1,2,3 ");
+
+// --- Curry ---
+declare var bar1: string => "bar1";
+declare var bar2: (string, number) => "bar2";
+declare var bar6: (string, number, boolean, null, {...}, []) => "bar6";
+
+const foo1 = curry(bar1);
+const foo2 = curry(bar2);
+const foo6 = curry(bar6);
+
+const foo1_1: "bar1" = foo1("");
+const foo2_1: "bar2" = foo2("", 0);
+const foo2_2: "bar2" = foo2("")(0);
+
+const foo6_1: "bar6" = foo6("", 0, true, null, {}, []);
+const foo6_2: "bar6" = foo6("")(0, true, null, {}, []);
+const foo6_3: "bar6" = foo6("", 0)(true, null, {}, []);
+const foo6_4: "bar6" = foo6("", 0, true)(null, {}, []);
+const foo6_5: "bar6" = foo6("", 0, true, null)({}, []);
+const foo6_6: "bar6" = foo6("", 0, true, null, {})([]);
+const foo6_7: "bar6" = foo6("")(0)(true, null, {}, []);
+const foo6_8: "bar6" = foo6("", 0)(true)(null, {}, []);
+const foo6_9: "bar6" = foo6("", 0, true)(null)({}, []);
+const foo6_10: "bar6" = foo6("", 0, true, null)({})([]);
+const foo6_11: "bar6" = foo6("")(0, true)(null, {}, []);
+const foo6_12: "bar6" = foo6("", 0)(true, null)({}, []);
+const foo6_13: "bar6" = foo6("", 0, true)(null, {})([]);
+const foo6_14: "bar6" = foo6("")(0, true, null)({}, []);
+const foo6_15: "bar6" = foo6("", 0)(true, null, {})([]);
+const foo6_16: "bar6" = foo6("")(0, true, null, {})([]);
+
+// $ExpectError
+const foo6_1_Error1: "bar6" = foo6(false, 0, true, null, {}, []);
+// $ExpectError
+const foo6_2_Error1: "bar6" = foo6(false)(0, true, null, {}, []);
+// $ExpectError
+const foo6_3_Error1: "bar6" = foo6(false, 0)(true, null, {}, []);
+// $ExpectError
+const foo6_4_Error1: "bar6" = foo6(false, 0, true)(null, {}, []);
+// $ExpectError
+const foo6_5_Error1: "bar6" = foo6(false, 0, true, null)({}, []);
+// $ExpectError
+const foo6_6_Error1: "bar6" = foo6(false, 0, true, null, {})([]);
+// $ExpectError
+const foo6_7_Error1: "bar6" = foo6(false)(0)(true, null, {}, []);
+// $ExpectError
+const foo6_8_Error1: "bar6" = foo6(false, 0)(true)(null, {}, []);
+// $ExpectError
+const foo6_9_Error1: "bar6" = foo6(false, 0, true)(null)({}, []);
+// $ExpectError
+const foo6_10_Error1: "bar6" = foo6(false, 0, true, null)({})([]);
+// $ExpectError
+const foo6_11_Error1: "bar6" = foo6(false)(0, true)(null, {}, []);
+// $ExpectError
+const foo6_12_Error1: "bar6" = foo6(false, 0)(true, null)({}, []);
+// $ExpectError
+const foo6_13_Error1: "bar6" = foo6(false, 0, true)(null, {})([]);
+// $ExpectError
+const foo6_14_Error1: "bar6" = foo6(false)(0, true, null)({}, []);
+// $ExpectError
+const foo6_15_Error1: "bar6" = foo6(false, 0)(true, null, {})([]);
+// $ExpectError
+const foo6_16_Error1: "bar6" = foo6(false)(0, true, null, {})([]);
+
+// $ExpectError
+const foo6_1_Error2: "bar6" = foo6("", 0, true, "", {}, []);
+// $ExpectError
+const foo6_2_Error2: "bar6" = foo6("")(0, true, "", {}, []);
+// $ExpectError
+const foo6_3_Error2: "bar6" = foo6("", 0)(true, "", {}, []);
+// $ExpectError
+const foo6_4_Error2: "bar6" = foo6("", 0, true)("", {}, []);
+// $ExpectError
+const foo6_5_Error2: "bar6" = foo6("", 0, true, "")({}, []);
+// $ExpectError
+const foo6_6_Error2: "bar6" = foo6("", 0, true, "", {})([]);
+// $ExpectError
+const foo6_7_Error2: "bar6" = foo6("")(0)(true, "", {}, []);
+// $ExpectError
+const foo6_8_Error2: "bar6" = foo6("", 0)(true)("", {}, []);
+// $ExpectError
+const foo6_9_Error2: "bar6" = foo6("", 0, true)("")({}, []);
+// $ExpectError
+const foo6_10_Error2: "bar6" = foo6("", 0, true, "")({})([]);
+// $ExpectError
+const foo6_11_Error2: "bar6" = foo6("")(0, true)("", {}, []);
+// $ExpectError
+const foo6_12_Error2: "bar6" = foo6("", 0)(true, "")({}, []);
+// $ExpectError
+const foo6_13_Error2: "bar6" = foo6("", 0, true)("", {})([]);
+// $ExpectError
+const foo6_14_Error2: "bar6" = foo6("")(0, true, "")({}, []);
+// $ExpectError
+const foo6_15_Error2: "bar6" = foo6("", 0)(true, "", {})([]);
+// $ExpectError
+const foo6_16_Error2: "bar6" = foo6("")(0, true, "", {})([]);
+
+// $ExpectError
+const foo6_1_Error3: "bar6" = foo6("", 0, true, null, {}, "");
+// $ExpectError
+const foo6_2_Error3: "bar6" = foo6("")(0, true, null, {}, "");
+// $ExpectError
+const foo6_3_Error3: "bar6" = foo6("", 0)(true, null, {}, "");
+// $ExpectError
+const foo6_4_Error3: "bar6" = foo6("", 0, true)(null, {}, "");
+// $ExpectError
+const foo6_5_Error3: "bar6" = foo6("", 0, true, null)({}, "");
+// $ExpectError
+const foo6_6_Error3: "bar6" = foo6("", 0, true, null, {})("");
+// $ExpectError
+const foo6_7_Error3: "bar6" = foo6("")(0)(true, null, {}, "");
+// $ExpectError
+const foo6_8_Error3: "bar6" = foo6("", 0)(true)(null, {}, "");
+// $ExpectError
+const foo6_9_Error3: "bar6" = foo6("", 0, true)(null)({}, "");
+// $ExpectError
+const foo6_10_Error3: "bar6" = foo6("", 0, true, null)({})("");
+// $ExpectError
+const foo6_11_Error3: "bar6" = foo6("")(0, true)(null, {}, "");
+// $ExpectError
+const foo6_12_Error3: "bar6" = foo6("", 0)(true, null)({}, "");
+// $ExpectError
+const foo6_13_Error3: "bar6" = foo6("", 0, true)(null, {})("");
+// $ExpectError
+const foo6_14_Error3: "bar6" = foo6("")(0, true, null)({}, "");
+// $ExpectError
+const foo6_15_Error3: "bar6" = foo6("", 0)(true, null, {})("");
+// $ExpectError
+const foo6_16_Error3: "bar6" = foo6("")(0, true, null, {})("");
+
+// $ExpectError
+const foo6_1_Error4: "error" = foo6("", 0, true, null, {}, []);
+// $ExpectError
+const foo6_2_Error4: "error" = foo6("")(0, true, null, {}, []);
+// $ExpectError
+const foo6_3_Error4: "error" = foo6("", 0)(true, null, {}, []);
+// $ExpectError
+const foo6_4_Error4: "error" = foo6("", 0, true)(null, {}, []);
+// $ExpectError
+const foo6_5_Error4: "error" = foo6("", 0, true, null)({}, []);
+// $ExpectError
+const foo6_6_Error4: "error" = foo6("", 0, true, null, {})([]);
+// $ExpectError
+const foo6_7_Error4: "error" = foo6("")(0)(true, null, {}, []);
+// $ExpectError
+const foo6_8_Error4: "error" = foo6("", 0)(true)(null, {}, []);
+// $ExpectError
+const foo6_9_Error4: "error" = foo6("", 0, true)(null)({}, []);
+// $ExpectError
+const foo6_10_Error4: "error" = foo6("", 0, true, null)({})([]);
+// $ExpectError
+const foo6_11_Error4: "error" = foo6("")(0, true)(null, {}, []);
+// $ExpectError
+const foo6_12_Error4: "error" = foo6("", 0)(true, null)({}, []);
+// $ExpectError
+const foo6_13_Error4: "error" = foo6("", 0, true)(null, {})([]);
+// $ExpectError
+const foo6_14_Error4: "error" = foo6("")(0, true, null)({}, []);
+// $ExpectError
+const foo6_15_Error4: "error" = foo6("", 0)(true, null, {})([]);
+// $ExpectError
+const foo6_16_Error4: "error" = foo6("")(0, true, null, {})([]);
+
+// -------------
+
+const currfn1: (y: number) => number = _.curryN(
+  2,
+  (x: number, y: number): number => x + y
+)(2);
+
+const flipped: (x: number, y: boolean, z: string) => number = _.flip(
+  (x: boolean, y: number, z: string) => 1
+);
+const flipped2: (x: number, y: boolean) => (z: string) => number = _.flip(
+  (x: boolean, y: number, z: string) => 1
+);
+const obb = {
+  doStuff(x: string, y: number, z: boolean) {
+    return 1;
+  },
+  doLessStuff(x: string, y: number) {
+    return "hello";
+  },
+  doEvenLessStuff(x: string) {
+    return true;
+  }
+};
+const doStuff: (
+  x: string,
+  y: number,
+  z: boolean,
+  obj: typeof obb
+) => number = _.invoker(3, "doStuff");
+//$ExpectError
+const doLessStuff: (
+  x: string,
+  y: number,
+  z: boolean,
+  obj: typeof obb
+) => number = _.invoker(3, "doLStuff");
+const stuffDone: number = doStuff("dd", 1, true, obb);
+
+const range = _.juxt([_.toString, Math.min, Math.max]);
+const ju: Array<number | string> = range(3, 4, 9, -3);
+
+
+let _memoizeWith = 0;
+const _memoizeWithFactorial = _.memoizeWith(_.identity, n => {
+  _memoizeWith += 1;
+  return _.product(_.range(1, n + 1));
+});
+const memWith: number = _memoizeWithFactorial(5);
+
+const narg: string | number = _.nthArg(1)(1, "b", "c");
+
+const nameIs = ({ first, last }) => `The name's ${last}, ${first} ${last}`;
+const o1: string = _.o(_.toUpper, nameIs)({ first: "James", last: "Bond" });
+const oNum: number = _.o(_.multiply(10), _.add(10))(-4);
+
+const oof: Array<Array<number>> = _.of([42]);
+
+const unap: string = _.unapply(JSON.stringify)(1, 2, 3);
+
+const greetName = name => "Hello " + name;
+
+// Uncurry
+const needs3: string => string => string => string = a => b => c => a + b + c;
+
+//$ExpectError
+const needs3_error1: number = uncurryN(3, needs3)("", "", "");
+
+//$ExpectError
+const needs3_error2: string => string = uncurryN(3, needs3)("", "", "");
+
+//$ExpectError
+const needs3_error3: string => string => string = uncurryN(3, needs3)(
+  "",
+  "",
+  ""
+);
+
+const needs3_no_error: string = uncurryN(3, needs3)("", "", "");
+
+// -------------
+
+// --- TryCatch ---
+const tryFn: boolean => string = a => String(a);
+
+const tryFn_2: boolean => boolean = a => a;
+
+const catchFn: (Error, boolean) => string = (e, a) => e.message;
+
+const catchFn_2: (Error, boolean) => boolean = (e, a) => a;
+
+const tc1: string = tryCatch(tryFn, catchFn, true);
+const tc2: boolean => string = tryCatch(tryFn, catchFn);
+const tc3: string = tc2(true);
+//const tc7: string = tryCatch(tryFn)(catchFn)(true);
+const tc4: string = tryCatch(tryFn)(catchFn, true);
+const tc5: string = tryCatch(tryFn)(catchFn)(true);
+
+//$ExpectError
+const tc_error1: boolean = tryCatch(tryFn, catchFn, true);
+//$ExpectError
+const tc_error2: boolean = tryCatch(tryFn, catchFn)(true);
+//$ExpectError
+const tc_error3: boolean = tryCatch(tryFn)(catchFn, true);
+//$ExpectError
+const tc_error4: boolean = tryCatch(tryFn)(catchFn)(true);
+//$ExpectError
+const tc_error5: string = tryCatch(tryFn_2, catchFn, "string");
+//$ExpectError
+const tc_error6: string = tryCatch(tryFn_2, catchFn)("string");
+//$ExpectError
+const tc_error7: string = tryCatch(tryFn_2)(catchFn, "string");
+//$ExpectError
+const tc_error8: string = tryCatch(tryFn_2)(catchFn)("string");
+//$ExpectError
+const tc_error9: string = tryCatch(tryFn_2, catchFn, true);
+//$ExpectError
+const tc_error10: string = tryCatch(tryFn_2, catchFn)(true);
+//$ExpectError
+const tc_error11: string = tryCatch(tryFn_2)(catchFn, true);
+//$ExpectError
+const tc_error12: string = tryCatch(tryFn_2)(catchFn)(true);
+//$ExpectError
+const tc_error13: string = tryCatch(tryFn, catchFn_2, true);
+//$ExpectError
+const tc_error14: string = tryCatch(tryFn, catchFn_2)(true);
+//$ExpectError
+const tc_error15: string = tryCatch(tryFn)(catchFn_2, true);
+//$ExpectError
+const tc_error16: string = tryCatch(tryFn)(catchFn_2)(true);
+
+// -------------

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_list.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_list.js
@@ -1,0 +1,896 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+import _, {
+  type RefineFilter,
+  adjust,
+  append,
+  chain,
+  compose,
+  concat,
+  curry,
+  filter,
+  find,
+  groupBy,
+  includes,
+  last,
+  length,
+  nth,
+  pipe,
+  reduce,
+  repeat,
+  subtract,
+  uniq,
+  without,
+  zipWith
+} from "ramda";
+import { describe, it } from 'flow-typed-test';
+
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number, ... } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed, ... } = { a: 1, c: "d" };
+const os: Array<{ [k: string]: number | string, ... }> = [
+  { a: 1, c: "d" },
+  { b: 2 }
+];
+const str: string = "hello world";
+
+// List
+{
+  const xs: Array<number> = _.adjust(2, x => x + 1, ns);
+  const xs1: Array<number> = _.adjust(2, x => x + 1)(ns);
+  //$ExpectError
+  const xs3: Array<string> = _.adjust(2)(x => x + 1)(ns);
+
+  const as: boolean = _.all(x => x > 1, ns);
+  const asf: (s: Array<string>) => boolean = _.any(x => x.length > 1);
+  const as1: boolean = asf(ss);
+
+  const aps: Array<Array<number>> = _.aperture(2, ns);
+  const aps2: Array<Array<string>> = _.aperture(2)(ss);
+
+  const newXs1: Array<number> = _.prepend(1)(ns);
+
+  describe('concat', () => {
+    it('should support array', () => {
+      const r1: Array<number> = concat([4, 5, 6], [1, 2, 3]);
+      const r2: Array<number> = concat([4, 5, 6])([1, 2, 3]);
+    });
+    it('should supports strings', () => {
+      const r1: string = concat("ABC", "DEF");
+      const r2: string = concat("ABC")("DEF");
+    });
+    it('should support readonly arrays', () => {
+      const arr1: $ReadOnlyArray<number> = [4, 5, 6];
+      const arr2: $ReadOnlyArray<string> = ['1', '2', '3'];
+      const r1: Array<number|string> = concat(arr1, arr2);
+      const r2: Array<number|string> = concat(arr1)(arr2);
+
+      // $ExpectError
+      const r3: Array<number> = concat(arr1)(arr2);
+      // $ExpectError
+      const r4: Array<string> = concat(arr1)(arr2);
+    });
+    it('should error when concat array with string', () => {
+      // $ExpectError
+      concat("ABC", ["DEF"]);
+    });
+  });
+
+  const dropxs: Array<string> = _.drop(4, ss);
+  const dropxs1: string = _.drop(3)(str);
+  const dropxs2: Array<string> = _.dropLast(4, ss);
+  const dropxs3: string = _.dropLast(3)(str);
+  const dropxs4: Array<number> = _.dropLastWhile(x => x <= 3, ns);
+  const dropxs5: Array<string> = _.dropRepeats(ss);
+  const dropxs6: Array<number> = _.dropRepeatsWith(_.eqBy(Math.abs), ns);
+  const dropxs7: Array<number> = _.dropWhile(x => x === 1, ns);
+
+  describe('includes', () => {
+    describe('uncurried form', () => {
+      it('returns a boolean for an Array and its element type', () => {
+        const xs: Array<number> = [1]
+        const result: boolean = includes(2, xs)
+      })
+
+      it('returns a boolean for a $ReadOnlyArray and its element type', () => {
+        const xs: $ReadOnlyArray<number> = [1]
+        const result: boolean = includes(2, xs)
+      })
+
+      it('does not allow a mismatched element type to the Array', () => {
+        const xs: Array<number> = [1]
+        // It is not understood why this fails to be flagged as an error when
+        // the 0.26.x libdef passes with the same declaration. The curried form
+        // works reliably though.
+        //
+        // $ShouldExpectErrorButInsteadWorksPleaseFix
+        const result: boolean = includes('foo', xs)
+      })
+
+      it('does not allow a mismatched element type to the $ReadOnlyArray', () => {
+        const xs: $ReadOnlyArray<string> = ['bar']
+        // It is not understood why this fails to be flagged as an error when
+        // the 0.26.x libdef passes with the same declaration. The curried form
+        // works reliably though.
+        //
+        // $ShouldExpectErrorButInsteadWorksPleaseFix
+        const result: boolean = includes(1, xs)
+      })
+
+      it('returns a boolean for two strings', () => {
+        const result: boolean = includes('foo', 'bar')
+      })
+
+      it('disallows a mismatched string and anything else', () => {
+        // $ExpectError
+        const result: boolean = includes(1, 'bar')
+      })
+    })
+
+    describe('1 arg curried form', () => {
+      it('returns a boolean for an Array and its element type', () => {
+        const xs: Array<number> = [1]
+        const result: boolean = includes(2)(xs)
+      })
+
+      it('returns a boolean for a $ReadOnlyArray and its element type', () => {
+        const xs: $ReadOnlyArray<number> = [1]
+        const result: boolean = includes(2)(xs)
+      })
+
+      it('does not allow a mismatched element type to the Array', () => {
+        const xs: Array<number> = [1]
+        // $ExpectError
+        const result: boolean = includes('foo')(xs)
+      })
+
+      it('does not allow a mismatched element type to the $ReadOnlyArray', () => {
+        const xs: $ReadOnlyArray<number> = [1]
+        // $ExpectError
+        const result: boolean = includes('foo')(xs)
+      })
+
+      it('returns a boolean for two strings', () => {
+        const result: boolean = includes('foo')('bar')
+      })
+
+      it('disallows a mismatched string and anything else', () => {
+        // $ExpectError
+        const result: boolean = includes(1)('bar')
+      })
+    })
+  })
+
+  describe('startsWith', () => {
+    it('checks to see if one string is inside of another', () => {
+      const result: boolean = _.startsWith("a")("abc");
+    })
+
+    it('checks to see if one element of an array is starting in another array', () => {
+      const result: boolean = _.startsWith(["a"], ["a", "b", "c"]);
+    })
+
+    // See https://ramdajs.com/repl/?v=0.25.0#?%2F%2F%20Works%20with%20more%20than%20just%20strings%3A%0AR.startsWith%28%5B1%5D%2C%20%5B1%2C%202%2C%203%5D%29%20%20%20%20%2F%2F%3D%3E%20true
+    // for a working example.
+    it('can check any type (not just strings) for the starting of an array', () => {
+      const result: boolean = _.startsWith([1], [1, 2, 3]);
+    })
+
+    // See https://ramdajs.com/repl/?v=0.25.0#?%2F%2F%20Works%20with%20multiple%20elements%20in%20the%20comparator%3A%0AR.startsWith%28%5B1%2C%202%5D%2C%20%5B1%2C%202%2C%203%5D%29%20%20%20%20%2F%2F%3D%3E%20true
+    // for a working example.
+    it('allows any number of elements to be used as the comparator', () => {
+      const result: boolean = _.startsWith([1, 2, 3], [1, 2, 3]);
+    })
+
+    it('catches mismatches between the first set and the second', () => {
+      // $ExpectError
+      _.startsWith("1", [1, 2, 3])
+    })
+
+    it('catches mismatches between the inner array elements', () => {
+      // It is not understood why this isn't flagged as an error.
+      // $ShouldExpectErrorButInsteadWorksPleaseFix
+      _.startsWith(["1"], [1, 2, 3])
+    })
+  })
+
+  describe('endsWith', () => {
+    it('checks to see if one string is inside of another', () => {
+      const result: boolean = _.endsWith("a")("abc");
+    })
+
+    it('checks to see if one element of an array is ending in another array', () => {
+      const result: boolean = _.endsWith(["a"], ["a", "b", "c"]);
+    })
+
+    // See https://ramdajs.com/repl/?v=0.25.0#?%2F%2F%20Works%20with%20more%20than%20just%20strings%3A%0AR.endsWith%28%5B3%5D%2C%20%5B1%2C%202%2C%203%5D%29%20%20%20%20%2F%2F%3D%3E%20true
+    // for a working example.
+    it('can check any type (not just strings) for the ending of an array', () => {
+      const result: boolean = _.endsWith([1], [1, 2, 3]);
+    })
+
+    // See https://ramdajs.com/repl/?v=0.25.0#?%2F%2F%20Works%20with%20multiple%20elements%20in%20the%20comparator%3A%0AR.endsWith%28%5B2%2C%203%5D%2C%20%5B1%2C%202%2C%203%5D%29%20%20%20%20%2F%2F%3D%3E%20true
+    // for a working example.
+    it('allows any number of elements to be used as the comparator', () => {
+      const result: boolean = _.endsWith([1, 2, 3], [1, 2, 3]);
+    })
+
+    it('catches mismatches between the first set and the second', () => {
+      // $ExpectError
+      _.endsWith("1", [1, 2, 3])
+    })
+
+    it('catches mismatches between the inner array elements', () => {
+      // It is not understood why this isn't flagged as an error.
+      // $ShouldExpectErrorButInsteadWorksPleaseFix
+      _.endsWith(["1"], [1, 2, 3])
+    })
+  })
+
+  const chainxs: number[] = _.chain((n) => [n, n], [1, 2])
+  const chainxs1: number[] = _.chain((n) => [n, n])([1, 2])
+
+  const findxs: ?{ [k: string]: number | string, ... } = _.find(
+    _.propEq("a", 2),
+    os
+  );
+  const findxs1: ?{ [k: string]: number | string, ... } = _.find(_.propEq("a", 4))(
+    os
+  );
+  // Ramda doesn't strictly break if you pass it an object, but it always
+  // returns undefined.
+  // $ExpectError
+  const findObj = find(o => o == "bar", { foo: "bar" });
+
+  const findxs2: ?{ [k: string]: number | string, ... } = _.findLast(
+    _.propEq("a", 2),
+    os
+  );
+  const findxs3: ?{ [k: string]: number | string, ... } = _.findLast(
+    _.propEq("a", 4)
+  )(os);
+  const findxs4: number = _.findIndex(_.propEq("a", 2), os);
+  const findxs5: number = _.findIndex(_.propEq("a", 4))(os);
+  const findxs6: number = _.findLastIndex(_.propEq("a", 2), os);
+  const findxs7: number = _.findLastIndex(_.propEq("a", 4))(os);
+
+
+  describe('length', () => {
+    describe('works on', () => {
+      it('empty array', () => {
+        length([])
+      })
+      it('simple array of strings', () => {
+        length(ss)
+      })
+      it('heterogeneous arrays', () => {
+        length([1, '', ss, true, ns])
+      })
+      it('strings', () => {
+        length(str)
+      })
+      it('objects defining numeric .length property', () => {
+        length({length: 12})
+      })
+    })
+    describe('fails on', () => {
+      it('null and undefined', () => {
+        // $ExpectError
+        length(null)
+        // $ExpectError
+        length()
+      })
+      it('types that has no length', () => {
+        // $ExpectError
+        length(123)
+      })
+      it('non-numeric .length property', () => {
+        // $ExpectError
+        length({length: 'size'})
+      })
+    })
+  })
+
+  const s4 = _.find(x => x === "2", ["1", "2"]);
+  //$ExpectError
+  const s5: ?{ [key: string]: string, ... } = _.find(x => x === "2", { a: 1, b: 2 });
+  const s6: number = _.findIndex(x => x === "2", ["1", "2"]);
+  const s7: number = _.findIndex(x => x === "2", { a: "1", b: "2" });
+  const forEachxs = _.forEach(x => console.log(x), ns);
+
+  const forEachObj = _.forEachObjIndexed((value, key) => {}, { x: 1, y: 2 });
+
+  describe('groupBy', () => {
+    it('should work with basic array', () => {
+      const fn = x => `${x}`;
+      const groupedBy: { [k: string]: Array<number>, ... } = groupBy(fn, [1, 2, 3]);
+      const groupedBy1: { [k: string]: Array<string>, ... } = groupBy(fn)(['one', 'two', 'three']);
+    });
+    it('group function should return string', () => {
+      const fn: number => number = x => x;
+
+      // $ExpectError
+      groupBy(fn, [1,2,3]);
+      // $ExpectError
+      groupBy(fn)([1,2,3]);
+    });
+    it('group function param should match array element', () => {
+      const fn: string => string = x => x;
+
+      // $ExpectError
+      groupBy(fn, [1,2,3]);
+      // $ExpectError
+      groupBy(fn)([1,2,3]);
+    });
+    it('should support readonly array', () => {
+      const fn: (number | string) => string = x => `${x}`;
+      const arr: $ReadOnlyArray<number> = [1, 2, 3];
+      const groupedBy: { [k: string]: Array<number>, ... } = groupBy(fn, arr);
+      const arr1: $ReadOnlyArray<number|string> = [1, 'two', 3];
+      const groupedBy1: { [k: string]: Array<number|string>, ... } = groupBy(fn)(arr1);
+
+      const fn1: number => string = x => `${x}`;
+      // $ExpectError
+      groupBy(fn1, arr1);
+      // $ExpectError
+      const groupedBy2: { [k: string]: Array<number> } = groupBy(fn)(arr1);
+    });
+  });
+
+  const groupedWith: Array<Array<number>> = _.groupWith(x => x > 1, ns);
+  const groupedWith1: Array<Array<string>> = _.groupWith(x => x === "one")(ss);
+
+  describe('head', () => {
+    describe('with array', () => {
+      it('should returns MaybeOf element type', () => {
+        const fn = (arr: number[]) => {
+          const xOfXs: ?number = _.head(arr);
+          //$ExpectError
+          const xOfXs: number = _.head(arr);
+        }
+      });
+      it('should works with refinement', () => {
+        const fn = (arr: number[]) => {
+          if (arr.length > 0) {
+            const xOfXs: number = _.head(arr);
+          }
+        }
+      });
+      it('should works with mixed-type arrays', () => {
+        const fn = (arr: Array<number|string>) => {
+          const xOfXs: ?(number|string) = _.head(arr);
+          //$ExpectError
+          const xOfXs: ?number = _.head(arr);
+          if (arr.length > 0) {
+            const xOfXs: number|string = _.head(arr);
+            //$ExpectError
+            const xOfXs: number = _.head(arr);
+          }
+        }
+      });
+    });
+    describe('with string', () => {
+      it('should works', () => {
+        const xOfStr: string = _.head(str);
+      });
+    })
+  });
+
+  const transducer = _.compose(_.map(_.add(1)), _.take(2));
+
+  const txs: Array<number> = _.into([], transducer, ns);
+  //$ExpectError
+  const txs1: string = _.into([], transducer, ns);
+  //$ExpectError
+  const txs2: string = _.into([], transducer, ss);
+
+  const ind: number = _.indexOf(1, ns);
+  const ind1: number = _.indexOf(str)(ss);
+  const ind2: { [key: string]: { [k: string]: number | string, ... }, ... } = _.indexBy(
+    x => "s",
+    os
+  );
+  const ind3: { [key: string]: { [k: string]: number | string, ... }, ... } = _.indexBy(
+    x => "s"
+  )(os);
+  const ind4: number = _.indexOf(null)(ss);
+
+  const insxs: Array<number> = _.insert(1, 2, ns);
+  const insxs2: Array<string> = _.insert(1, "2", ss);
+
+  const insxs3: Array<number> = _.insertAll(1, [2, 3], ns);
+  // this is disgusting — don't do this :)
+  // Technically it's a tuple with arbitrary size
+  const insxs4: Array<number | boolean | string> = _.insertAll(
+    1,
+    ["2", false],
+    ns
+  );
+  const insxs5: Array<string | number> = _.insertAll(1, [2], ss);
+
+  const joinxs: string = _.join("|", ns);
+
+  const lastxs: ?number = _.last(ns);
+  const laststr: string = _.last(str);
+
+  const lasti: number = _.lastIndexOf(3, [-1, 3, 3, 0, 1, 2, 3, 4]);
+
+  const mapxs: Array<number> = _.map(x => x + 1, ns);
+
+  const someObj: {
+    a: string,
+    b: number,
+    ...
+  } = { a: 'a', b: 2 }
+  const someMap: { [string]: {
+    a: string,
+    b: number,
+    ...
+  }, ... } = { so: someObj }
+  const mapObj: { [string]: string, ... } = _.map((x: {
+    a: string,
+    b: number,
+    ...
+  }): string => x.a)(someMap)
+  const mapObj2: { [string]: string, ... } = _.map((x: {
+    a: string,
+    b: number,
+    ...
+  }): string => x.a, someMap)
+
+  const functor = {
+    x: 1,
+    map(f) {
+      return f(this.x);
+    }
+  };
+
+  // Doesn't typecheck (yet) but at least doesn't break
+  const mapFxs = _.map(_.toString, functor);
+
+  const double = x => x * 2;
+  const dxs: Array<number> = _.map(double, [1, 2, 3]);
+  const dos: $Shape<typeof obj> = _.map(double, obj);
+
+  const appender = (a, b) => [a + b, a + b];
+  const mapacc: [number, Array<number>] = _.mapAccum(appender, 0, ns);
+  const mapacc1: [number, Array<number>] = _.mapAccumRight(appender, 0, ns);
+
+  const nxs: boolean = _.none(x => x > 1, ns);
+
+  describe('append', () => {
+    it('should supports arrays', () => {
+      const appendResult1: Array<number> = append(1, [1, 2, 3]);
+      const appendResult2: Array<string> = append('four')(['one', 'two', 'three']);
+    });
+    it('should works with read-only array', (readOnly: $ReadOnlyArray<number>) => {
+      const appendResult1: $ReadOnlyArray<number> = append(1, readOnly);
+      const appendResult2: $ReadOnlyArray<number> = append(1)(readOnly);
+    });
+    it('should result array element should be correct', () => {
+      const readOnly: $ReadOnlyArray<number> = [1, 2, 3];
+      const appendResult1: $ReadOnlyArray<number|string> = append('s', readOnly);
+      const appendResult2: $ReadOnlyArray<number|string> = append('s')(readOnly);
+
+      //$ExpectError
+      const appendResult3: $ReadOnlyArray<number|null> = append('s', readOnly);
+      //$ExpectError
+      const appendResult4: $ReadOnlyArray<number> = append('s')(readOnly);
+    });
+  });
+
+  const xxxs: Array<number> = _.intersperse(1, [1, 2, 3]);
+
+  const pairxs: [number, string] = _.pair(2, "str");
+
+  const partxs: [Array<string>, Array<string>] = _.partition(includes("s"), [
+    "sss",
+    "ttt",
+    "foo",
+    "bars"
+  ]);
+  const partxs1: [
+    { [k: string]: string, ... },
+    { [k: string]: string, ... }
+  ] = _.partition(includes("s"), { a: "sss", b: "ttt", foo: "bars" });
+
+  describe('pluck', () => {
+    it('should works on array of objects as maps', () => {
+      const arr: Array<{ [string]: number | string, ... }> = [{ a: "1" }, { a: 2 }];
+      const pl: Array<number | string> = _.pluck("a")(arr);
+      const p2: Array<number | string> = _.pluck("b")(arr);
+    });
+    it('should works on array of arrays', () => {
+      const pl: Array<number> = _.pluck(0)([[1, 2], [3, 4]]);
+    });
+    it('should works on array of objects', () => {
+      const arr: Array<{
+        key: number,
+        other?: string,
+        ...
+      }> = [{ key: 42 }, { key: 28, other: 'string' }];
+      const pl: number[] = _.pluck('key', arr);
+    });
+    it('should fails on non existing property', () => {
+      //$ExpectError
+      const pl = _.pluck('notExistingKey', [{ key: 42 }, { key: 28, other: 'string' }]);
+      //$ExpectError
+      const pl = _.pluck('other', [{ key: 42 }, { key: 28, other: 'string' }]);
+    });
+    it('should returns union type of selected property', () => {
+      const arr = [{ key: 42 }, { key: 'string', other: 'string' }];
+      const pl: Array<number | string> = _.pluck('key', arr);
+      //$ExpectError
+      const pl: number[] = _.pluck('key', arr);
+    });
+  });
+
+  const rxs: Array<number> = _.range(1, 10);
+
+  const remxs: Array<string> = _.remove(0, 2, ss);
+  const remxs1: Array<string> = _.remove(0, 2)(ss);
+  const remxs2: Array<string> = _.remove(0)(2)(ss);
+  const remxs3: Array<string> = _.remove(0)(2, ss);
+
+  const ys4: Array<string> = _.repeat("1", 10);
+  const ys5: Array<number> = _.repeat(1, 10);
+
+  // reduce
+  const redxs: number = reduce(_.add, 10, ns);
+  const redxs1: string = reduce(concat, "", ss);
+  const redxs2: Array<string> = reduce<string[], string[]>(concat, [])(_.map(x => [x], ss));
+  // Example used in docs: http://ramdajs.com/docs/#reduce
+  const redxs4: number = reduce(subtract, 0, [1, 2, 3, 4]);
+  // Using accumulator type that differs from the element type (A and B).
+  const redxs5: number = reduce((acc, s) => acc + parseInt(s), 0, [
+    "1",
+    "2",
+    "3"
+  ]);
+
+  const redux6a: number = reduce((acc, s) => _.reduced(acc), 0, ns)
+  const redux6b: number = reduce((acc: number, s: number) => _.reduced(acc), 0, ns)
+  const redxs7: number = reduce(
+    (acc, s) => acc < 4 ? acc + parseInt(s) : _.reduced(acc),
+    0,
+    ["1", "2", "3"]
+  );
+  // $ExpectError
+  const redxs8: number = reduce(
+    // $ExpectError
+    (acc, s) => acc < 4 ? acc + parseInt(s) : _.reduced(s),
+    0,
+    ["1", "2", "3"]
+  );
+
+  // Ramda works with $ReadOnlyArray as it is immutable.
+  const readOnlyArray: $ReadOnlyArray<number> = [1, 2, 3, 4];
+  // $ReadOnlyArray with curried permutations:
+  const redxsReadOnly3: number = reduce(subtract, 0, readOnlyArray);
+  const redxsReadOnly2_1: number = reduce(subtract, 0)(readOnlyArray);
+  const redxsReadOnly1_2: number = reduce<number, number>(subtract)(0, readOnlyArray);
+  const redxsReadOnly1_1_1: number = reduce(subtract)(0)(readOnlyArray);
+
+  // $ExpectError reduce will not work with an object.
+  reduce(subtract, 0, { foo: 1, bar: 2 });
+
+  // reduceRight
+  const redrxs1: number = _.reduceRight(_.add, 10, ns);
+  const redrxs2: string = _.reduceRight(concat, "", ss);
+  const redrxs3: Array<string> = _.reduceRight(concat, [])(
+    _.map(x => [x], ss)
+  );
+  const redrxs3a: string = _.reduceRight(
+    //$ExpectError
+    (acc: string, value: number): string => acc,
+    "",
+    ns
+  );
+  const redrxs3b: string = _.reduceRight(
+    (value: number, acc: string): string => acc,
+    "",
+    ns
+  );
+
+  // $ExpectError reduceRight does not support reduced.
+  const redrxs4: number = _.reduceRight(
+    // $ExpectError reduceRight does not support reduced.
+    (acc, n) => acc < 4 ? acc + n : _.reduced(acc),
+    0,
+    ns
+  );
+
+  const scanxs6: Array<number> = _.scan(_.add)(10)(ns);
+  const scanxs7: Array<number> = _.scan(_.add, 10)(ns);
+  const scanxs8: Array<number> = _.scan(_.add)(10, ns);
+  const scanxs9: Array<number> = _.scan(_.add, 10, ns);
+  const scanxs10: Array<string> = _.scan(concat)("")(ss);
+  const scanxs11: Array<string> = _.scan(concat, "")(ss);
+  const scanxs12: Array<string> = _.scan(concat)("", ss);
+  const scanxs13: Array<string> = _.scan(concat, "", ss);
+
+  const reduceToNamesBy = _.reduceBy(
+    (acc, student) => acc.concat(student.name),
+    []
+  );
+  const namesByGrade = reduceToNamesBy(student => {
+    const score = student.score;
+    return score < 65
+      ? "F"
+      : score < 70 ? "D" : score < 80 ? "C" : score < 90 ? "B" : "A";
+  });
+  const students = [
+    { name: "Lucy", score: 92 },
+    { name: "Drew", score: 85 },
+    { name: "Bart", score: 62 }
+  ];
+  const names1: { [k: string]: Array<string>, ... } = namesByGrade(students);
+
+  const isOdd = (acc, x) => x % 2 === 1;
+  const reduceWhile1: number = _.reduceWhile(isOdd, _.add, 0, [1, 3, 5, 60, 777, 800]);
+  const reduceWhile2: number = _.reduceWhile(isOdd, _.add, 111, [2, 4, 6]);
+
+  const spl: Array<string> = _.split(/\./, "a.b.c.xyz.d");
+
+  const spl1: [Array<number>, Array<number>] = _.splitAt(1, [1, 2, 3]);
+  const spl2: [string, string] = _.splitAt(5, "hello world");
+  const spl3: [string, string] = _.splitAt(-1, "foobar");
+  const spl4: Array<Array<number>> = _.splitEvery(3, [1, 2, 3, 4, 5, 6, 7]);
+  const spl5: Array<string> = _.splitEvery(3, "foobarbaz");
+  const spl6: [Array<number>, Array<number>] = _.splitWhen(_.equals(2))([
+    1,
+    2,
+    3,
+    1,
+    2,
+    3
+  ]);
+
+  const slixs: Array<string> = _.slice(0, 2, ss);
+  const slixs1: Array<string> = _.slice(0, 2)(ss);
+  const slixs2: Array<string> = _.slice(0)(2)(ss);
+  const slixs3: Array<string> = _.slice(0)(2, ss);
+
+  const diff = function(a, b) {
+    return a - b;
+  };
+  const sortxs: Array<number> = _.sort(diff, [4, 2, 7, 5]);
+
+  const timesxs: Array<number> = _.times(_.identity, 5);
+
+  const unf: (x: string) => Array<string> = _.unfold(
+    (x: string) => x.length > 10 || [x, x + "0"]
+  );
+  const unf1: Array<number> = _.unfold(x => x > 10 || [x, x + 1], 0);
+  const f = n => (n > 50 ? false : [-n, n + 10]);
+  const unf11: Array<number> = _.unfold(f, 10);
+
+  //$ExpectError
+  const unf2 = _.unfold(x => x.length > 10 || [x, x + "0"], 2);
+
+  const unby: Array<number> = _.uniqBy(Math.abs)([-1, -5, 2, 10, 1, 2]);
+
+  const strEq = _.eqBy(String);
+  const strEq2 = _.eqBy(String, 1, 2);
+  const unw = _.uniqWith(strEq)([1, "1", 2, 1]);
+  const unw1 = _.uniqWith(strEq)([{}, {}]);
+  const unw2 = _.uniqWith(strEq)([1, "1", 1]);
+  const unw3 = _.uniqWith(strEq)(["1", 1, 1]);
+
+  //$ExpectError
+  const ys6: { [key: string]: string, ... } = _.fromPairs([["h", 2]]);
+
+  describe('without', () => {
+    it('should work with basic array', () => {
+      const arr1: Array<number> = without([1, 2], [1, 2, 3, 4, 5]);
+      const arr2: Array<string> = without(['a'])(['a', 'b', 'c']);
+    });
+    it('should fail when first list does not match second list type', () => {
+      // $ExpectError
+      const arr1: Array<number> = without(['1', '2'], [1, 2, 3, 4, 5]);
+      // $ExpectError
+      const arr2: Array<string> = without([1])(['a', 'b', 'c']);
+    });
+    it('should work with readonly array', () => {
+      const list1: $ReadOnlyArray<number|string> =  [1, 'four', 5];
+      const list2: $ReadOnlyArray<number|string> =  [1, 'two', 3, 'four', 5];
+      const arr1: Array<number|string> = without(list1, list2);
+      const arr2: Array<number|string> = without(list1)(list2);
+    });
+    it('should list1 be a subset of list2', () => {
+      const list1: $ReadOnlyArray<number> =  [1, 3, 5];
+      const list2: $ReadOnlyArray<number|string> =  [1, 'four', 5];
+      const arr1: Array<number|string> = without(list1, list2);
+      // $ExpectError
+      const arr2: Array<number> = without(list2, list1);
+    });
+  });
+
+  const xprodxs: Array<[number, string]> = _.xprod([1, 2], ["a", "b", "c"]);
+  const xprodxs1: Array<[boolean, string]> = _.xprod([true, false])(["a", "b"]);
+
+  const zipxs: Array<[number, string]> = _.zip([1, 2, 3], ["a", "b", "c"]);
+
+  //$ExpectError
+  const zipxs1: Array<[number, string]> = _.zip([true, false])(["a", "b"]);
+
+  const zipos: { [k: string]: number, ... } = _.zipObj(["a", "b", "c"], [1, 2, 3]);
+
+  const ys9: { [k: string]: number, ... } = _.zipObj(["me", "you"], [1, 2]);
+  const zipped: Array<{
+    s: number,
+    y: string,
+    ...
+  }> = zipWith(
+    (a, b) => ({ s: a, y: b }),
+    [1, 2, 3],
+    ["1", "2", "3"]
+  );
+  const zipped2: Array<{
+    s: number,
+    y: string,
+    ...
+  }> = _.zipWith(
+    (a, b) => ({ s: a, y: b }),
+    [1, 2, 3]
+  )(["1", "2", "3"]);
+  const zipped3: Array<{
+    s: number,
+    y: string,
+    ...
+  }> = _.zipWith((a, b) => ({
+    s: a,
+    y: b
+  }))([1, 2, 3])(["1", "2", "3"]);
+
+  describe('chain', () => {
+    it('should accept read only list as input', () => {
+      const arr:$ReadOnlyArray<string> = ['1', '2', '3'];
+      const duplicate = n => [n, n];
+      const result1: Array<string> = chain(duplicate, arr);
+      const result2: Array<string> = chain(duplicate)(arr);
+    });
+
+    it('should fail when input out type mismatch', () => {
+      const arr:$ReadOnlyArray<string> = ['1', '2', '3'];
+      const castType = n => (parseInt(n): number);
+      //$ExpectError
+      const result: Array<string> = chain(castType, arr);
+    });
+
+    it('should take second argument as function', () => {
+      const arr:$ReadOnlyArray<string> = ['1', '2', '3'];
+      const result: Array<?string> = chain(append, x => x[x.length - 1])(arr)
+    });
+
+    it('should error out when second arugment is function but type mismatches', () => {
+      const arr:$ReadOnlyArray<string> = ['1', '2', '3'];
+      const castType = n => (parseInt(n): number);
+      //$ExpectError
+      const result: Array<string> = chain(append, castType)(arr)
+    });
+  });
+
+  describe('nth', () => {
+    it('should get a maybe type back on input is an array of given types', () => {
+      const nthxs1: ?number = nth(2, [1,2,3]);
+      const nthxs2: ?number = nth(2)([1,2]);
+      const nthxs3: ?number = nth(3)([1,2]);
+      const nthxs4: ?string = nth(2, ["curry"]);
+      const nthxs5: ?string = nth(2)(["curry", "bean"]);
+      const nthxs6: ?string = nth(3)(['foo', 'bar']);
+    });
+
+    it('should get a string back when input is string', () => {
+      const nthxs: string = nth(2)("curry");
+      const nthxs1: string = nth(2, "curry");
+    });
+
+    it('should take read only array as second argument', () => {
+      const readOnlyArray: $ReadOnlyArray<number>  = [1, 2, 3];
+      const nthxs = nth(2)(readOnlyArray)
+      const nthxs1 = nth(2, readOnlyArray)
+    });
+
+    it('should take a mutable array as second arugment', () => {
+      const array: Array<string> = ['foo', 'bar'];
+      const nthxs = nth(1)(array)
+      const nthxs1 = nth(1, array)
+      const nthxs2 = nth(1)(array)
+    });
+
+    it('should take tuple as second argument', () => {
+      const tuple:[number, boolean] = [1, true]
+      const n = nth(0, tuple)
+      const ns = nth(1)(tuple)
+    });
+
+    it('should fail on expecting return type to be a maybe type of the element of the input list', () => {
+      const arr: Array<number> = [1, 2, 3]
+      //$ExpectError
+      const nthxs: ?string = nth(2)(arr);
+      //$ExpectError
+      const nthxs1: ?boolean = nth(1)(arr);
+    });
+
+    it('should fail on expecting return type to mismatch the input array type', () => {
+      const arr: Array<number> = [1, 2, 3]
+      //$ExpectError
+      const nthxs: string = nth(2, arr);
+      //$ExpectError
+      const nthxs1: string = nth(2)(arr);
+      //$ExpectError
+      const nthxs2: string = nth(1, ['foo'])
+      //$ExpectError
+      const nthxs3: number = nth(1, arr);
+      //$ExpectError
+      const nthxs4: number = nth(1)(arr);
+      //$ExpectError
+      const nthxs5: number = nth(1, [1])
+      //$ExpectError
+      const nthxs: ?number = nth(2)(['foo']);
+    });
+
+    it('should fail on passing a non-number to first argument', () => {
+      //$ExpectError
+      const nthxs = nth('foo')(['foo', 'bar'])
+    });
+
+    it('should fail on passing a non-array to second argument', () => {
+      //$ExpectError
+      const nthxs = nth(2)({})
+    });
+  });
+
+  describe('adjust', () => {
+    it('should allow both Array and $ReadOnlyArray output', () => {
+      const arr: Array<number> = [1, 2, 3]
+      const ro: $ReadOnlyArray<number> = [1, 2, 3]
+      const result: $ReadOnlyArray<number> = adjust(1, x => x + 1, arr)
+      const result1: Array<number> = adjust(1, x => x + 1, arr)
+      const result2: $ReadOnlyArray<number> = adjust(1, x => x + 1, ro)
+      const result3: Array<number> = adjust(1, x => x + 1, ro)
+    });
+  });
+
+  describe('uniq', () => {
+    it('should accept read only array', () => {
+      const readOnlyNumbers: $ReadOnlyArray<number> = [1,1,2,3,4,3];
+      const result:$ReadOnlyArray<number> = uniq(readOnlyNumbers);
+    });
+
+    it('should fail when element type mismatches', () => {
+      const readOnlyNumbers: $ReadOnlyArray<number> = [1,1,2,3,4,3];
+      //$ExpectError
+      const result:$ReadOnlyArray<string> = uniq(readOnlyNumbers);
+
+      const mix = ['1', 2, true];
+      //$ExpectError
+      const result: $ReadOnlyArray<string> = uniq(mix);
+    });
+
+    it('should accept read only array when expecting mutable array as output', () => {
+      const readOnlyNumbers: $ReadOnlyArray<number> = [1,1,2,3,4,3];
+      const result: Array<number> = uniq(readOnlyNumbers);
+    });
+
+    it('should accept mutable array as input and read only array as output', () => {
+      const readOnlyStrings: Array<string> = ['foo', 'bar'];
+      const result1: $ReadOnlyArray<string> = uniq(readOnlyStrings)
+    });
+
+    it('should accept mutable array', () => {
+      const arr: Array<string> = ['1', '2', '3'];
+      const result: Array<string> = uniq(arr);
+    });
+
+    it('should accept a mixed element type array', () => {
+      const arr: Array<string|number|boolean> = ['foo', 1, false]
+      const result: Array<string|number|boolean> = uniq(arr)
+    });
+
+    //Reason not to test the other way around, namely, Array<A> to $ReadOnlyArray<A> is because
+    //$ReadOnlyArray is a supertype of Array https://flow.org/en/docs/types/arrays/#toc-readonlyarray
+  })
+}

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_logic.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_logic.js
@@ -1,0 +1,319 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+import { describe, it } from 'flow-typed-test';
+import _, {
+  complement,
+  compose,
+  curry,
+  filter,
+  find,
+  ifElse,
+  pipe,
+  repeat,
+  zipWith,
+} from 'ramda';
+
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ['one', 'two', 'three', 'four'];
+const obj: { [k: string]: number, ... } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed, ... } = { a: 1, c: 'd' };
+const os: Array<{ [k: string]: *, ... }> = [{ a: 1, c: 'd' }, { b: 2 }];
+const str: string = 'hello world';
+
+//Logic
+// TODO: Fix flow issues
+// const isQueen = _.propEq("rank", "Q");
+// const isSpade = _.propEq("suit", "♠︎");
+// const isQueenOfSpades = _.allPass([isQueen, isSpade]);
+
+//$ExpectError
+const allp: boolean = isQueenOfSpades(1);
+const allp1: boolean = isQueenOfSpades({ rank: 'Q', suit: '♣︎' });
+
+const a: boolean = _.and(true, true);
+const a_: (a: boolean) => boolean = _.and(true);
+
+const nonBooleanAnd: number = _.and(69, 42);
+const nonBooleanAnd_: (nonBooleanAnd: number) => * = _.and(69);
+
+const gte = _.anyPass([_.gt, _.equals]);
+const ge: boolean = gte(3, 2);
+
+//$ExpectError
+const gt10 = x => x > 10;
+//$ExpectError
+const even = x => x % 2 === 0;
+const f = _.both(gt10, even);
+
+const b: boolean = f('');
+const b_: boolean = f(100);
+
+const fn = _.cond([
+  [_.equals(0), _.always('water freezes at 0°C')],
+  [_.equals(100), _.always(1)],
+  [_.T, temp => 'nothing special happens at ' + temp + '°C'],
+]);
+const cond_: number | string = fn(0);
+
+// This is abit awkward — if a non-null value of type
+// differrent to number is passed flow will infer a union type
+// for all of them
+const defaultTo42 = _.defaultTo(42);
+const def: number = defaultTo42(null);
+const def1: number = defaultTo42(undefined);
+
+const feither = _.either(gt10, even);
+const feitherR: boolean = f(101);
+
+describe('complement', () => {
+  it('accepts a function that returns a boolean', () => {
+    complement(() => true)
+    complement(() => false)
+    // $ExpectError
+    complement(() => 'foo')
+    // $ExpectError
+    complement(() => 5)
+    // $ExpectError
+    complement(() => [])
+    // $ExpectError
+    complement(() => ({}))
+    // $ExpectError
+    complement(() => null)
+    // $ExpectError
+    complement(() => undefined)
+  })
+
+  it('returns a function that returns a boolean', () => {
+    const fn = complement(() => true)
+    const b: boolean = fn()
+    // $ExpectError
+    const s: string = fn()
+    // $ExpectError
+    const n: number = fn()
+    // $ExpectError
+    const xs: Array<mixed> = fn()
+    // $ExpectError
+    const obj: {[string]: mixed} = fn()
+    // $ExpectError
+    const v: void = fn()
+    // $ExpectError
+    const nil: null = fn()
+  })
+
+  // The following code is generated from
+  // https://github.com/LoganBarnett/typedef-gen due to Flow not being able to
+  // preserve the input function's form as a return type.
+  //
+  // Begin generated complement test cases.
+  it('returns a function whose parameters match the input function (0)', () => {
+    const fn = complement(() => true)
+    fn()
+    // Extra arguments are discarded, so there is no negative case here.
+  })
+
+  it('returns a function whose parameters match the input function (1)', () => {
+    const fn = complement((a: 'a',) => true)
+    fn('a',)
+    // $ExpectError
+    fn(0)
+  })
+
+  it('returns a function whose parameters match the input function (2)', () => {
+    const fn = complement((a: 'a', b: 'b',) => true)
+    fn('a', 'b',)
+    // $ExpectError
+    fn(0, 1)
+  })
+
+  it('returns a function whose parameters match the input function (3)', () => {
+    const fn = complement((a: 'a', b: 'b', c: 'c',) => true)
+    fn('a', 'b', 'c',)
+    // $ExpectError
+    fn(0, 1, 2)
+  })
+
+  it('returns a function whose parameters match the input function (4)', () => {
+    const fn = complement((a: 'a', b: 'b', c: 'c', d: 'd',) => true)
+    fn('a', 'b', 'c', 'd',)
+    // $ExpectError
+    fn(0, 1, 2, 3)
+  })
+
+  it('returns a function whose parameters match the input function (5)', () => {
+    const fn = complement((a: 'a', b: 'b', c: 'c', d: 'd', e: 'e',) => true)
+    fn('a', 'b', 'c', 'd', 'e',)
+    // $ExpectError
+    fn(0, 1, 2, 3, 4)
+  })
+
+  it('returns a function whose parameters match the input function (6)', () => {
+    const fn = complement((a: 'a', b: 'b', c: 'c', d: 'd', e: 'e', f: 'f',) => true)
+    fn('a', 'b', 'c', 'd', 'e', 'f',)
+    // $ExpectError
+    fn(0, 1, 2, 3, 4, 5)
+  })
+
+  it('returns a function whose parameters match the input function (7)', () => {
+    const fn = complement((a: 'a', b: 'b', c: 'c', d: 'd', e: 'e', f: 'f', g: 'g',) => true)
+    fn('a', 'b', 'c', 'd', 'e', 'f', 'g',)
+    // $ExpectError
+    fn(0, 1, 2, 3, 4, 5, 6)
+  })
+
+  it('returns a function whose parameters match the input function (8)', () => {
+    const fn = complement((a: 'a', b: 'b', c: 'c', d: 'd', e: 'e', f: 'f', g: 'g', h: 'h',) => true)
+    fn('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',)
+    // $ExpectError
+    fn(0, 1, 2, 3, 4, 5, 6, 7)
+  })
+
+  it('returns a function whose parameters match the input function (9)', () => {
+    const fn = complement((a: 'a', b: 'b', c: 'c', d: 'd', e: 'e', f: 'f', g: 'g', h: 'h', i: 'i',) => true)
+    fn('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',)
+    // $ExpectError
+    fn(0, 1, 2, 3, 4, 5, 6, 7, 8)
+  })
+
+  it('returns a function whose parameters match the input function (10)', () => {
+    const fn = complement((a: 'a', b: 'b', c: 'c', d: 'd', e: 'e', f: 'f', g: 'g', h: 'h', i: 'i', j: 'j',) => true)
+    fn('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',)
+    // $ExpectError
+    fn(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+  })
+
+  // End generated complement test cases.
+})
+
+
+describe('ifElse', () => {
+  it('uses a union of both branches as the return type', () => {
+    const incCount = ifElse(x => x % 2 == 0, x => x + 1, x => x.toString());
+    const ie: number | string = incCount(1);
+  })
+
+  it('checks the condition input matches the branch inputs', () => {
+    const incCount = ifElse(x => x % 2 == 0, x => x + 1, x => x.toString());
+    // Because the object literal ({}) isn't a number it
+    // $ExpectError
+    const ie: number | string = incCount({});
+  })
+
+  it('works with variadic arg inputs', () => {
+    const ifElseFn = ifElse(
+      // Without this test, variadic argument input functions will produce an
+      // error like this:
+      //
+      // Cannot call `ifElse` because rest array [1] has an unknown number of
+      // elements, so is incompatible with tuple type [2].
+      (...args: [string]): boolean => true,
+      (s: string) => s.toUpperCase(),
+      (s: string) => s.toLowerCase(),
+    );
+    const result: void | string = ifElseFn('input')
+  })
+
+  it('preserves the types used with variadic argument condition functions', () => {
+    const ifElseFn = ifElse(
+      (...args: [string]): boolean => true,
+      (s: string) => s.toUpperCase(),
+      (s: string) => s.toLowerCase(),
+    );
+    // $ExpectError
+    const result: void | string = ifElseFn(5)
+  })
+
+  // This was the original test for ifElse, which depends on the implementation
+  // of "is". "is" in its present form does not perform type refinement, so the
+  // stricter form of ifElse fails the check with this test. This test below
+  // captures the issue, and is left for reference and/or if some brave soul
+  // wishes to expand the definition of ifElse (and possibly also "is") to
+  // refine the predicate correctly. At time of writing, $Pred and $Refine are
+  // considered experimental/internal and abandoned:
+  // https://github.com/facebook/flow/issues/2464#issuecomment-471115953
+  //
+  // it('feeds a predicate-refined type to the branches', () => {
+  //   const incCount = ifElse(is(Number), x => x + 1, x => x.toString());
+  //   const ie: number | string = incCount(1);
+  // })
+})
+
+const em: boolean = _.isEmpty([1, 2, 3]);
+
+const n: boolean = _.not(true);
+//$ExpectError
+const n1: boolean = _.not(1);
+
+const oor: boolean = _.or(true, true);
+
+const nonBooleanOr: ?string = _.or('watskeburt', undefined);
+const nonBooleanOr_: (arg: { key: string, ... }) => string | { key: string, ... } = _.or(
+  'watskeburt'
+);
+
+// type refinement is important here
+// which might be awkward for some
+// but can actually catch some bugs statically
+
+const psatE: boolean = _.pathSatisfies(y => y > 0, ['x', 'y', 0], {
+  x: { y: [2] },
+});
+const psat: boolean = _.pathSatisfies(
+  y => typeof y === 'number' && y > 0,
+  ['x', 'y', 0],
+  { x: { y: [2] } }
+);
+const psatPart = _.pathSatisfies(y => typeof y === 'number' && y > 0);
+const psat2: boolean = psatPart(['x', 'y', 0])({ x: { y: 2 }, z: true });
+const psatPart2 = _.pathSatisfies(y => typeof y === 'number' && y > 0, [
+  'x',
+  'y',
+  0,
+]);
+const psat3: boolean = psatPart2({ x: { y: 2 }, z: true });
+
+describe('propSatisfies', () => {
+  describe('with object', () => {
+    it('should works with object', () => {
+      const propSat: boolean = _.propSatisfies(x => x > 0, 'x', { x: 1, y: 2 });
+    });
+    it('should works with object with properties of different types', () => {
+      const propSat: boolean = _.propSatisfies(x => x > 0, 'x', { x: 1, y: 2, str: 'different type' });
+      // same again but this time using a curried function
+      const propSatCurry: boolean = _.propSatisfies((x: number) => x > 0, 'x')({ x: 1, y: 2, str: 'different type' });
+    });
+    it('should error when property does not exist', () => {
+      //$ExpectError
+      const propSat3: boolean = _.propSatisfies((x: number) => x > 0, 'z', { x: 1, y: 2 });
+    });
+    it('should error when condition param does not match property type', () => {
+      //$ExpectError
+      const propSat: boolean = _.propSatisfies(x => x > 0, 'str', { x: 1, y: 2, str: 'different type' });
+      //$ExpectError
+      const propSatCurry: boolean = _.propSatisfies((x: number) => x > 0, 'str')({ x: 1, y: 2, str: 'different type' });
+    });
+  });
+  describe('with object as maps', () => {
+    const o: { [string]: number, ... } = { x: 1, y: 2 };
+    it('should works with object map', () => {
+      const propSat: boolean = _.propSatisfies((x: number) => x > 0, 'x', o);
+    });
+    it('should error when condition param does not match property type', () => {
+      //$ExpectError
+      const propSat2: boolean = _.propSatisfies((x: string) => x > 0, 'x', o);
+    });
+  });
+});
+
+const coerceArray = _.unless(_.is(Array), _.of);
+const coer: Array<number | Array<number>> | number = coerceArray([1, 2, 3]);
+const coer1: Array<number | Array<number>> | number = coerceArray(1);
+
+const coerceString = _.unless(_.is(String), _.toString);
+const coer2: string | Array<number> = coerceString([1, 2, 3]);
+const coer3: string | Array<number> = coerceString('s');
+
+const unlPrt = _.unless(_.is(Number), _.T);
+const unl: number | boolean | Array<number> = unlPrt([1, 2, 3]);
+const unl2: number | boolean | Array<number> = unlPrt(1);
+
+const un: number = _.until(_.gt(100), _.multiply(2))(1);

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_map.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_map.js
@@ -1,0 +1,97 @@
+// @flow
+import * as R from "ramda";
+import { it, describe } from "flow-typed-test";
+
+const NumberToString = (v: number): string => `${v}`;
+
+describe("R.map()", () => {
+  describe("Not read only", () => {
+    it("should return Array<string>", () => {
+      const ArrNumbers = Object.freeze([1, 2, 3]);
+
+      (R.map(NumberToString, ArrNumbers): Array<string>);
+
+      (R.map(NumberToString)(ArrNumbers): Array<string>);
+    });
+
+    it("should return Object {key: number}", () => {
+      const Obj = Object.freeze({
+        a: { key: 1 },
+        c: { key: 2 },
+        d: { key: 3 }
+      });
+
+      (R.map(R.prop("key"), Obj): { [key: string]: number, ... });
+
+      (R.map(R.prop("key"))(Obj): { [key: string]: number, ... });
+    });
+
+    describe("{}::map(fn)", () => {
+      class Index {
+        ids: Array<number>;
+
+        map<T>(fn: (e: number) => T): Array<T> {
+          return this.ids.map(e => fn(e));
+        }
+      }
+
+      it("should return array string", () => {
+        (R.map(NumberToString, new Index()): Array<string>);
+
+        (R.map(NumberToString)(new Index()): Array<string>);
+      });
+
+      it("raises an error when passed fn incompatible with Index map function", () => {
+        const fn = (s: string): string => "";
+
+        // $ExpectError
+        (R.map(fn, new Index()): Array<string>);
+      });
+    });
+  });
+
+  describe("Read Only", () => {
+    it("should return readonly Array", () => {
+      const readOnlyArrNumbers = Object.freeze([1, 2, 3]);
+
+      (R.map(NumberToString, readOnlyArrNumbers): $ReadOnlyArray<string>);
+
+      (R.map(NumberToString)(readOnlyArrNumbers): $ReadOnlyArray<string>);
+    });
+
+    it("should return readonly Object", () => {
+      const readOnlyObj = Object.freeze({
+        a: { key: 1 },
+        c: { key: 2 },
+        d: { key: 3 }
+      });
+
+      (R.map(R.prop("key"), readOnlyObj): $ReadOnly<{ [key: string]: number, ... }>);
+
+      (R.map(R.prop("key"))(readOnlyObj): $ReadOnly<{ [key: string]: number, ... }>);
+    });
+
+    describe("{}::map(fn)", () => {
+      class Index {
+        ids: $ReadOnlyArray<number>;
+
+        map<T>(fn: (e: number) => T): $ReadOnlyArray<T> {
+          return this.ids.map(e => fn(e));
+        }
+      }
+
+      it("should return read only Array<string>", () => {
+        (R.map(NumberToString, new Index()): $ReadOnlyArray<string>);
+
+        (R.map(NumberToString)(new Index()): $ReadOnlyArray<string>);
+      });
+
+      it("raises an error when passed fn incompatible with Index map function", () => {
+        const fn = (s: string): string => "";
+
+        // $ExpectError
+        (R.map(fn, new Index()): $ReadOnlyArray<string>);
+      });
+    });
+  });
+});

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_math.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_math.js
@@ -1,0 +1,32 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+
+import { describe, it } from 'flow-typed-test';
+import {
+  subtract,
+} from 'ramda'
+
+describe('subtract', () => {
+  it('works with two numbers', () => {
+    const result: number = subtract(1, 2)
+  })
+
+  // To see Ramda working with various date combinations, see:
+
+  it('works with dates to produce a number', () => {
+    const result: number = subtract(new Date(), new Date())
+  })
+
+  it('works with a date and a number to produce a number', () => {
+    const result: number = subtract(new Date(), 1000)
+  })
+
+  it('works with a number and a date to produce a number', () => {
+    const result: number = subtract(1000, new Date())
+  })
+
+  it('does not accept strings as inputs', () => {
+    // $ExpectError
+    const result: number = subtract('foo', 'o')
+  })
+})

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_misc.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_misc.js
@@ -1,0 +1,81 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+import _, {
+  compose,
+  pipe,
+  curry,
+  filter,
+  find,
+  isNil,
+  repeat,
+  replace,
+  zipWith
+} from "ramda";
+import { describe, it } from 'flow-typed-test';
+
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number, ... } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed, ... } = { a: 1, c: "d" };
+const os: Array<{ [k: string]: *, ... }> = [{ a: 1, c: "d" }, { b: 2 }];
+const str: string = "hello world";
+
+// Math
+{
+  const partDiv: (a: number) => number = _.divide(6);
+  const div: number = _.divide(6, 2);
+  //$ExpectError
+  const div2: number = _.divide(6, true);
+}
+
+// String
+{
+  const ss: Array<string | void> = _.match(/h/, "b");
+  describe('replace', () => {
+    it('should supports replace by string', () => {
+      const r1: string = replace(",", "|", "b,d,d");
+      const r2: string = replace(",")("|", "b,d,d");
+      const r3: string = replace(",")("|")("b,d,d");
+      const r4: string = replace(",", "|")("b,d,d");
+    });
+    it('should supports replace by RegExp', () => {
+      const r1: string = replace(/[,]/, "|", "b,d,d");
+      const r2: string = replace(/[,]/)("|", "b,d,d");
+      const r3: string = replace(/[,]/)("|")("b,d,d");
+      const r4: string = replace(/[,]/, "|")("b,d,d");
+    });
+    it('should supports replace by RegExp with replacement fn', () => {
+      const fn = (match: string, g1: string): string => g1;
+      const r1: string = replace(/([,])d/, fn, "b,d,d");
+      const r2: string = replace(/([,])d/)(fn, "b,d,d");
+      const r3: string = replace(/([,])d/)(fn)("b,d,d");
+      const r4: string = replace(/([,])d/, fn)("b,d,d");
+    });
+  });
+  const ss2: Array<string> = _.split(",", "b,d,d");
+  const ss1: boolean = _.test(/h/, "b");
+  const s: string = _.trim("s");
+  const x: string = _.head("one");
+  const sss: string = _.concat("H", "E");
+  const sss1: string = _.concat("H")("E");
+  const ssss: string = _.drop(1, "EF");
+  const ssss1: string = _.drop(1)("E");
+  const ssss2: string = _.dropLast(1, "EF");
+  const ys: string = _.nth(2, "curry");
+  const ys1: string = _.nth(2)("curry");
+}
+//Type
+{
+  const x: boolean = _.is(Number, 1);
+  const x1: boolean = isNil(1);
+
+  // should refine type
+  const x1a: ?{ a: number, ... } = { a: 1 };
+  //$ExpectError
+  x1a.a;
+  if (!isNil(x1a)) {
+    x1a.a;
+  }
+
+  const x2: boolean = _.propIs(1, "num", { num: 1 });
+}

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_object.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_object.js
@@ -10,6 +10,7 @@ import _, {
   lensProp,
   lensPath,
   lensIndex,
+  mergeRight,
   pipe,
   over,
   repeat,
@@ -440,23 +441,23 @@ const obI2: { [k: string]: number, ... } = _.mapObjIndexed(
 
 const ob1 = { a: 1 };
 const ob2 = { b: 3 };
-const ob3 = _.merge(ob1, ob2);
+const ob3 = mergeRight(ob1, ob2);
 //$ExpectError
 const propX = ob3.x;
 const propA = ob3.a;
 
-const mLeft: { name: string, age: number } = _.mergeLeft({ 'age': 40 }, { 'name': 'fred', 'age': 10 });
+const mLeft: Object = _.mergeLeft({ 'age': 40 }, { 'name': 'fred', 'age': 10 });
 const mLeftName: string = mLeft.name;
 const mLeftAge: number = mLeft.age;
-const mLeft2: { x: number, y: number } = _.mergeLeft({x: 0})({x: 5, y: 2});
+const mLeft2: Object = _.mergeLeft({x: 0})({x: 5, y: 2});
 const mLeftX: number = mLeft2.x;
 const mLeftY: number = mLeft2.y;
 
-const mRight: { name: string, age: number } = _.mergeRight({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
+const mRight: { name: string, age: number } = mergeRight({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
 const mRightName: string = mRight.name;
 // $ExpectError
 const mRightAge: number = mRight.name;
-const mRight2: { x: number, y: number } = _.mergeRight({x: 0, y: 0})({y: 2});
+const mRight2: {x: number, y: number } = mergeRight({x: 0, y: 0})({y: 2});
 const mRightX: number = mRight2.x;
 const mRightY: number = mRight2.y;
 

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_object.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_object.js
@@ -453,11 +453,21 @@ const mLeft2: Object = _.mergeLeft({x: 0})({x: 5, y: 2});
 const mLeftX: number = mLeft2.x;
 const mLeftY: number = mLeft2.y;
 
-const mRight: { name: string, age: number } = mergeRight({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
+type User = {
+  name: string,
+  age: number,
+  ...
+}
+const mRight: User = mergeRight({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
 const mRightName: string = mRight.name;
 // $ExpectError
 const mRightAge: number = mRight.name;
-const mRight2: {x: number, y: number } = mergeRight({x: 0, y: 0})({y: 2});
+type Point = {
+  x: number,
+  y: number,
+  ...
+}
+const mRight2: Point = mergeRight({x: 0, y: 0})({y: 2});
 const mRightX: number = mRight2.x;
 const mRightY: number = mRight2.y;
 

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_partial.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_partial.js
@@ -1,0 +1,17 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+import { partial } from "ramda";
+
+// --- Partial ---
+const method1 = (foo: string, bah: number, baz: boolean) => baz;
+
+const partial1: (number, boolean) => boolean = partial(method1, ["foo"]);
+const partial2: boolean = partial(method1, ["foo"])(4, true);
+// $ExpectError
+const partial3 = partial(method1, [4]);
+const partial4: boolean = partial(method1, ["foo", 4])(true);
+const partial5: boolean = partial(method1, ["foo", 4, true])();
+
+// Functions produced from partial are not curried.
+// $ExpectError
+const partial6 = partial(method1, ["foo"])(4);

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_pipe.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_pipe.js
@@ -1,0 +1,224 @@
+// @flow
+import { describe, it } from "flow-typed-test";
+import { pipe } from "ramda";
+
+// f - function
+// a - argument
+// unf - unary function
+function f1(a1: number): number {
+  return 69;
+}
+
+function f2(a1: number, a2: string): number {
+  return 69;
+}
+
+function f3(a1: number, a2: string, a3: boolean): number {
+  return 69;
+}
+
+function f4(a1: number, a2: string, a3: boolean, a4: number): number {
+  return 69;
+}
+
+function f5(a1: number, a2: string, a3: boolean, a4: number, a5: string): number {
+  return 69;
+}
+
+function unf1(a1: number): string {
+  return "69";
+}
+
+function unf2(a1: string): boolean {
+  return false;
+}
+
+function unf3(a1: boolean): number {
+  return 69;
+}
+
+function unf4(a1: number): string {
+  return "69";
+}
+
+function unf5(a1: string): boolean {
+  return true;
+}
+
+describe("pipe(...fn)", () => {
+  describe('call "pipe" with unary function', () => {
+    it("rises an error when function chain broken", () => {
+      // $ExpectError - unf1 return string but unf3 first argument boolean
+      pipe(f1, unf1, unf3, unf4, unf5)(1);
+    });
+
+    it("passes when used properly", () => {
+      (pipe(f1, unf1, unf2, unf3, unf4, unf5)(1): boolean);
+      (pipe(f1, unf1, unf2, unf3, unf4)(1): string);
+      (pipe(f1, unf1, unf2, unf3)(1): number);
+      (pipe(f1, unf1, unf2)(1): boolean);
+      (pipe(f1, unf1)(1): string);
+      (pipe(f1)(1): number);
+    });
+
+    it("raises an error when passed more arguments than it need", () => {
+      // $ExpectError - too many arguments
+      pipe(f1)(1, "1", true);
+    });
+
+    it("raises an error when passed too few arguments", () => {
+      // $ExpectError - too few arguments
+      pipe(f1)();
+    });
+
+    it("raises an error when passed an invalid argument", () => {
+      //$ExpectError - boolean  is incompatible with number
+      pipe(f1, unf1)(true);
+    });
+
+    it("raises an error when trying to recognize an unexpected type", () => {
+      //$ExpectError - boolean  is incompatible with string
+      (pipe(f1, unf1)(1): boolean);
+    });
+  });
+
+  describe('call "pipe" with double function', () => {
+    it("rises an error when function chain broken", () => {
+      // $ExpectError - unf1 return string but unf3 first argument boolean
+      pipe(f2, unf1, unf3, unf4, unf5)(1, "2");
+    });
+
+    it("passes when used properly", () => {
+      (pipe(f2, unf1, unf2, unf3, unf4, unf5)(1, "2"): boolean);
+      (pipe(f2, unf1, unf2, unf3, unf4)(1, "2"): string);
+      (pipe(f2, unf1, unf2, unf3)(1, "2"): number);
+      (pipe(f2, unf1, unf2)(1, "2"): boolean);
+      (pipe(f2, unf1)(1, "2"): string);
+    });
+
+    it("raises an error when passed more arguments than it need", () => {
+      // $ExpectError - too many arguments
+      pipe(f2)(1, "2", true, 4, "5");
+    });
+
+    it("raises an error when passed too few arguments", () => {
+      // $ExpectError - too few arguments
+      pipe(f2)(1);
+    });
+
+    it("raises an error when passed an invalid argument", () => {
+      //$ExpectError - boolean  is incompatible with string
+      pipe(f2, unf1)(1, true);
+    });
+
+    it("raises an error when trying to recognize an unexpected type", () => {
+      //$ExpectError - boolean  is incompatible with string
+      (pipe(f2, unf1)(1, "2"): boolean);
+    });
+  });
+
+  describe('call "pipe" with triple function', () => {
+    it("rises an error when function chain broken", () => {
+      // $ExpectError - unf1 return string but unf3 first argument boolean
+      pipe(f3, unf1, unf3, unf4, unf5)(1, "2", true);
+    });
+
+    it("passes when used properly", () => {
+      (pipe(f3, unf1, unf2, unf3, unf4, unf5)(1, "2", true): boolean);
+      (pipe(f3, unf1, unf2, unf3, unf4)(1, "2", true): string);
+      (pipe(f3, unf1, unf2, unf3)(1, "2", true): number);
+      (pipe(f3, unf1, unf2)(1, "2", true): boolean);
+      (pipe(f3, unf1)(1, "2", true): string);
+    });
+
+    it("raises an error when passed more arguments than it need", () => {
+      // $ExpectError - too many arguments
+      pipe(f3)(1, "2", true, 4, "5");
+    });
+
+    it("raises an error when passed too few arguments", () => {
+      // $ExpectError - too few arguments
+      pipe(f3)(1, "2");
+    });
+
+    it("raises an error when passed an invalid argument", () => {
+      //$ExpectError - number is incompatible with boolean
+      pipe(f3, unf1)(1, "2", 999);
+    });
+
+    it("raises an error when trying to recognize an unexpected type", () => {
+      //$ExpectError - boolean  is incompatible with string
+      (pipe(f3, unf1)(1, "2", true): boolean);
+    });
+  });
+
+  describe('call "pipe" with function that takes 4 arguments', () => {
+    it("rises an error when function chain broken", () => {
+      // $ExpectError - unf1 return string but unf3 first argument boolean
+      pipe(f4, unf1, unf3, unf4, unf5)(1, "2", true, 4);
+    });
+
+    it("passes when used properly", () => {
+      (pipe(f4, unf1, unf2, unf3, unf4, unf5)(1, "2", true, 4): boolean);
+      (pipe(f4, unf1, unf2, unf3, unf4)(1, "2", true, 4): string);
+      (pipe(f4, unf1, unf2, unf3)(1, "2", true, 4): number);
+      (pipe(f4, unf1, unf2)(1, "2", true, 4): boolean);
+      (pipe(f4, unf1)(1, "2", true, 4): string);
+    });
+
+    it("raises an error when passed more arguments than it need", () => {
+      // $ExpectError - too many arguments
+      pipe(f4)(1, "2", true, 4, "5", 6, false);
+    });
+
+    it("raises an error when passed too few arguments", () => {
+      // $ExpectError - too few arguments
+      pipe(f4)(1, "2", true);
+    });
+
+    it("raises an error when passed an invalid argument", () => {
+      //$ExpectError - string is incompatible with number
+      pipe(f4, unf1)(1, "2", true, "new number");
+    });
+
+    it("raises an error when trying to recognize an unexpected type", () => {
+      //$ExpectError - boolean  is incompatible with string
+      (pipe(f4, unf1)(1, "2", true, 4): boolean);
+    });
+  });
+
+  describe('call "pipe" with function that takes 5 arguments', () => {
+    it("rises an error when function chain broken", () => {
+      // $ExpectError - unf1 return string but unf3 first argument boolean
+      pipe(f5, unf1, unf3, unf4, unf5)(1, "2", true, 4, "5");
+    });
+
+    it("passes when used properly", () => {
+      (pipe(f5, unf1, unf2, unf3, unf4, unf5)(1, "2", true, 4, "5"): boolean);
+      (pipe(f5, unf1, unf2, unf3, unf4)(1, "2", true, 4, "5"): string);
+      (pipe(f5, unf1, unf2, unf3)(1, "2", true, 4, "5"): number);
+      (pipe(f5, unf1, unf2)(1, "2", true, 4, "5"): boolean);
+      (pipe(f5, unf1)(1, "2", true, 4, "5"): string);
+    });
+
+    it("raises an error when passed more arguments than it need", () => {
+      // $ExpectError - too many arguments
+      pipe(f5)(1, "2", true, 4, "5", 6, 7, 8);
+    });
+
+    it("raises an error when passed too few arguments", () => {
+      // $ExpectError - too few arguments
+      pipe(f5)(1, "2", true, 4);
+    });
+
+    it("raises an error when passed an invalid argument", () => {
+      //$ExpectError - boolean is incompatible with string
+      pipe(f5, unf1)(1, "2", true, 4, false);
+    });
+
+    it("raises an error when trying to recognize an unexpected type", () => {
+      //$ExpectError - boolean  is incompatible with string
+      (pipe(f5, unf1)(1, "2", true, 4, "5"): boolean);
+    });
+  });
+});

--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_relation.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/test_ramda_v0.27.x_relation.js
@@ -1,0 +1,334 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+import { it, describe } from "flow-typed-test";
+import _, {
+  ascend,
+  compose,
+  curry,
+  descend,
+  filter,
+  find,
+  gt,
+  gte,
+  intersection,
+  lt,
+  lte,
+  pipe,
+  prop,
+  repeat,
+  sort,
+  zipWith,
+} from "ramda";
+
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number, ... } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed, ... } = { a: 1, c: "d" };
+const objArr: { [k: string]: mixed, ... } = { a: 1, b: [1,2,3], c: "d"};
+const os: Array<{ [k: string]: *, ... }> = [{ a: 1, c: "d" }, { b: 2 }];
+const str: string = "hello world";
+
+const cl: number = _.clamp(1, 10, -1);
+const numbers = [1.0, 1.1, 1.2, 2.0, 3.0, 2.2];
+const letters = _.split("", "abcABCaaaBBc");
+// In ramda docs example it's just `Math.floor`
+// but we don't want the implicit number -> string
+const countB = _.countBy(_.compose(_.toString, Math.floor))(numbers);
+const countB1: { [k: string]: number, ... } = _.countBy(_.toLower)(letters);
+const diff: Array<number> = _.difference([1, 2, 3, 4], [7, 6, 5, 4, 3]);
+//$ExpectError
+const diff1: Array<string> = _.difference(
+  ["1", "2", "3", "4"],
+  [7, 6, 5, 4, 3]
+);
+
+const cmp = (x, y) => x.a === y.a;
+const l1 = [{ a: 1 }, { a: 2 }, { a: 3 }];
+const l2 = [{ a: 3 }, { a: 4 }];
+const diff2 = _.differenceWith(cmp, l1, l2);
+
+const eqb: boolean = _.eqBy(Math.abs, 5, -5);
+
+const es: boolean = _.equals([1, 2, 3], [1, 2, 3]);
+
+describe('ascend', () => {
+  /**
+   * In the examples for ascend, its result is plugged into sort. In order
+   * for this to function properly ascend needs to yield a function that can
+   * take two arguments.
+   */
+  it('works as an input to sort', () => {
+    const byAge = ascend(prop('age'));
+    const people = [
+      { name: 'Emma', age: 70 },
+      { name: 'Peter', age: 78 },
+      { name: 'Mikhail', age: 62 },
+    ];
+    const peopleByYoungestFirst = sort(byAge, people);
+  })
+
+  it('returns a curried function', () => {
+    const byAge = ascend(prop('age'))
+    byAge({ name: 'Emma', age: 70 })({ name: 'Peter', age: 78 })
+  })
+})
+
+describe('descend', () => {
+  /**
+   * In the examples for descend, its result is plugged into sort. In order
+   * for this to function properly descend needs to yield a function that can
+   * take two arguments.
+   */
+  it('works as an input to sort', () => {
+    const byAge = descend(prop('age'));
+    const people = [
+      { name: 'Emma', age: 70 },
+      { name: 'Peter', age: 78 },
+      { name: 'Mikhail', age: 62 },
+    ];
+    const peopleByYoungestFirst = sort(byAge, people);
+  })
+
+  it('returns a curried function', () => {
+    const byAge = descend(prop('age'))
+    byAge({ name: 'Emma', age: 70 })({ name: 'Peter', age: 78 })
+  })
+})
+
+describe('gt', () => {
+  it('works with two numbers and produces a bool', () => {
+    const result: bool = gt(2, 1)
+  })
+
+  it('works with two curried numbers and produces a bool', () => {
+    const result: bool = gt(2)(1)
+  })
+
+  it('works with two strings and produces a bool', () => {
+    const result: bool = gt('a', 'b')
+  })
+
+  it('works with two curried strings and produces a bool', () => {
+    const result: bool = gt('a')('b')
+  })
+
+  it('does not work with mixed numbers and strings', () => {
+    // $ExpectError
+    gt('a', 1)
+    // $ExpectError
+    gt(1, 'a')
+  })
+
+  it('does not work with functions', () => {
+    // $ExpectError
+    gt(() => 1, () => 2)
+  })
+})
+
+describe('gte', () => {
+  it('works with two numbers and produces a bool', () => {
+    const result: bool = gte(2, 1)
+  })
+
+  it('works with two curried numbers and produces a bool', () => {
+    const result: bool = gte(2)(1)
+  })
+
+  it('works with two strings and produces a bool', () => {
+    const result: bool = gte('a', 'b')
+  })
+
+  it('works with two curried strings and produces a bool', () => {
+    const result: bool = gte('a')('b')
+  })
+
+  it('does not work with mixed numbers and strings', () => {
+    // $ExpectError
+    gte('a', 1)
+    // $ExpectError
+    gte(1, 'a')
+  })
+
+  it('does not work with functions', () => {
+    // $ExpectError
+    gte(() => 1, () => 2)
+  })
+})
+
+describe('lt', () => {
+  it('works with two numbers and produces a bool', () => {
+    const result: bool = lt(2, 1)
+  })
+
+  it('works with two curried numbers and produces a bool', () => {
+    const result: bool = lt(2)(1)
+  })
+
+  it('works with two strings and produces a bool', () => {
+    const result: bool = lt('a', 'b')
+  })
+
+  it('works with two curried strings and produces a bool', () => {
+    const result: bool = lt('a')('b')
+  })
+
+  it('does not work with mixed numbers and strings', () => {
+    // $ExpectError
+    lt('a', 1)
+    // $ExpectError
+    lt(1, 'a')
+  })
+
+  it('does not work with functions', () => {
+    // $ExpectError
+    lt(() => 1, () => 2)
+  })
+})
+
+describe('lte', () => {
+  it('works with two numbers and produces a bool', () => {
+    const resulte: bool = lte(2, 1)
+  })
+
+  it('works with two curried numbers and produces a bool', () => {
+    const resulte: bool = lte(2)(1)
+  })
+
+  it('works with two strings and produces a bool', () => {
+    const resulte: bool = lte('a', 'b')
+  })
+
+  it('works with two curried strings and produces a bool', () => {
+    const resulte: bool = lte('a')('b')
+  })
+
+  it('does not work with mixed numbers and strings', () => {
+    // $ExpectError
+    lte('a', 1)
+    // $ExpectError
+    lte(1, 'a')
+  })
+
+  it('does not work with functions', () => {
+    // $ExpectError
+    lte(() => 1, () => 2)
+  })
+})
+
+const _max: number = _.max(2, 1);
+const _min: number = _.min(2, 1);
+
+const _maxBy: number = _.maxBy(Math.abs)(2, 1);
+const _minBy: number = _.minBy(Math.abs, 2, 1);
+
+const _identical: boolean = _.identical(2, 1);
+
+const _innerJoin: Array<{ [k: string]: mixed, ... }> = _.innerJoin(
+  (record, id) => record.id === id,
+  [{id: 824, name: 'Richie Furay'},
+   {id: 956, name: 'Dewey Martin'},
+   {id: 313, name: 'Bruce Palmer'},
+   {id: 456, name: 'Stephen Stills'},
+   {id: 177, name: 'Neil Young'}],
+  [177, 456, 999]
+);
+
+const pathEqObj: boolean = _.pathEq(["b", 1], 1, objArr);
+const pathEqObj2: boolean = _.pathEq(["b", 1])(1)(objArr);
+
+// It's good to test this with multiple params since $Keys<T> is a union.
+type PropEqObj = {
+  bar: number,
+  baz: string,
+  ...
+};
+const propEqObj: PropEqObj = { bar: 2, baz: "qux" };
+
+const isQueen = _.propEq("rank", "Q");
+
+const propEqResult1a: boolean = _.propEq("bar", 1, propEqObj);
+// Test curried versions.
+const propEqResult1b: boolean = _.propEq("bar")(1)(propEqObj);
+const propEqResult1c: boolean = _.propEq("bar")(1, propEqObj);
+const propEqResult1d: boolean = _.propEq("bar", 1)(propEqObj);
+
+// The type compared can be any type just like any other === comparison.
+// Also test the various arities.
+const propEqResult2a: boolean = _.propEq("bar", "always false", propEqObj);
+const propEqResult2b: boolean = _.propEq("bar")("always false")(propEqObj);
+const propEqResult2c: boolean = _.propEq("bar")("always false", propEqObj);
+const propEqResult2d: boolean = _.propEq("bar", "always false")(propEqObj);
+
+// The property name must be a property on the object supplied.
+// $ExpectError
+const propEqResultError: boolean = _.propEq("missing", 1, propEqObj);
+
+// propEq must work with key value pairs.
+const propEqKvp: { [string]: mixed, ... } = { foo: 1, bar: "2", baz: 3 };
+const propEqResult3a: boolean = _.propEq("qux", "value", propEqKvp);
+const propEqResult3b: boolean = _.propEq("qux")("value")(propEqKvp);
+const propEqResult3c: boolean = _.propEq("qux")("value", propEqKvp);
+const propEqResult3d: boolean = _.propEq("qux", "value")(propEqKvp);
+
+// propEq must work with arrays.
+const propEqArray = [1, 2, 3];
+const propEqResult4a: boolean = _.propEq(1, 2, propEqArray);
+const propEqResult4b: boolean = _.propEq(1)(2)(propEqArray);
+const propEqResult4c: boolean = _.propEq(1)(2, propEqArray);
+const propEqResult4d: boolean = _.propEq(1, 2)(propEqArray);
+
+const sortByFirstItem = _.sortBy(([first]) => first);
+const pairs = [[-1, 1], [-2, 2], [-3, 3]];
+const sorted: Array<[number, number]> = sortByFirstItem(pairs);
+
+const sortWithData = [
+  {name: 'alice', age: 40},
+  {name: 'bob', age: 30},
+  {name: 'clara', age: 40}
+];
+const descAge = (l, r) => l.age < r.age ? -1 : 1;
+const ascName = (l, r) => l.name < r.name ? -1 : 1;
+_.sortWith([descAge, ascName], sortWithData);
+_.sortWith([descAge, ascName])(sortWithData);
+
+const eqA = _.eqBy(prop("a"));
+const ls1: Array<{ [k: string]: number, ... }> = [
+  { a: 1 },
+  { a: 2 },
+  { a: 3 },
+  { a: 4 }
+];
+const ls2: Array<{ [k: string]: number, ... }> = [
+  { a: 3 },
+  { b: 4 },
+  { a: 5 },
+  { a: 6 }
+];
+const symW: Array<{ [k: string]: number, ... }> = _.symmetricDifferenceWith(
+  eqA,
+  ls1,
+  ls2
+);
+const sym: Array<number> = _.symmetricDifference([1, 2, 3, 4], [7, 6, 5, 4, 3]);
+
+const un: Array<number> = _.union([1, 2, 3])([2, 3, 4]);
+const un1: Array<{ [k: string]: number, ... }> = _.unionWith(eqA, ls1, ls2);
+
+// Given $ReadOnlyArray is super type of Array, no need to test Array -> $ReadOnlyArray case
+describe('intersection', () => {
+  it('should accept read only input', () => {
+    const readOnlyArray: $ReadOnlyArray<number> = [1, 2, 3]
+    const inters1: Array<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters2: Array<number> = intersection(readOnlyArray)(readOnlyArray)
+    const inters3: $ReadOnlyArray<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters4: $ReadOnlyArray<number> = intersection(readOnlyArray)(readOnlyArray)
+  });
+
+  it('should allow mutable array in and out', () => {
+    const readOnlyArray: Array<number> = [1, 2, 3]
+    const inters1: Array<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters2: Array<number> = intersection(readOnlyArray)(readOnlyArray)
+    const inters3: $ReadOnlyArray<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters4: $ReadOnlyArray<number> = intersection(readOnlyArray)(readOnlyArray)
+  });
+})

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/ramda_v0.27.x.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/ramda_v0.27.x.js
@@ -437,7 +437,82 @@ declare module ramda {
    * Type
    */
 
+  declare type Compose = (<A, B, C, D, E, F, G, H, I, J, K>(
+    jk: UnaryFn<J, K>,
+    ij: UnaryFn<I, J>,
+    hi: UnaryFn<H, I>,
+    gh: UnaryFn<G, H>,
+    fg: UnaryFn<F, G>,
+    ef: UnaryFn<E, F>,
+    de: UnaryFn<D, E>,
+    cd: UnaryFn<C, D>,
+    bc: UnaryFn<B, C>,
+    ab: UnaryFn<A, B>
+  ) => UnaryFn<A, K>) &
+    (<A, B, C, D, E, F, G, H, I, J>(
+      ij: UnaryFn<I, J>,
+      hi: UnaryFn<H, I>,
+      gh: UnaryFn<G, H>,
+      fg: UnaryFn<F, G>,
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>
+    ) => UnaryFn<A, J>) &
+    (<A, B, C, D, E, F, G, H, I>(
+      hi: UnaryFn<H, I>,
+      gh: UnaryFn<G, H>,
+      fg: UnaryFn<F, G>,
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>
+    ) => UnaryFn<A, I>) &
+    (<A, B, C, D, E, F, G, H>(
+      gh: UnaryFn<G, H>,
+      fg: UnaryFn<F, G>,
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>
+    ) => UnaryFn<A, H>) &
+    (<A, B, C, D, E, F, G>(
+      fg: UnaryFn<F, G>,
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>
+    ) => UnaryFn<A, G>) &
+    (<A, B, C, D, E, F>(
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+    ) => UnaryFn<A, F>) &
+    (<A, B, C, D, E>(
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+    ) => UnaryFn<A, E>) &
+    (<A, B, C, D>(
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+    ) => UnaryFn<A, D>) &
+    (<A, B, C>(
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+    ) => UnaryFn<A, C>) &
+    (<A, B>(ab: UnaryFn<A, B>) => UnaryFn<A, B>);
+
   declare var compose: Compose;
+
   declare function then<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>): CurriedFunction1<Promise<A>, Promise<R>>
   declare function then<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>, p: Promise<A>): Promise<R>;
   declare var curry: Curry;

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/ramda_v0.27.x.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/ramda_v0.27.x.js
@@ -393,72 +393,6 @@ declare module ramda {
 
   declare type Pipe = typeof pipe;
 
-  declare type PipeP = (<A, B, C, D, E, F, G>(
-    ab: UnaryPromiseFn<A, B>,
-    bc: UnaryPromiseFn<B, C>,
-    cd: UnaryPromiseFn<C, D>,
-    de: UnaryPromiseFn<D, E>,
-    ef: UnaryPromiseFn<E, F>,
-    fg: UnaryPromiseFn<F, G>,
-  ) => UnaryPromiseFn<A, G>) &
-    (<A, B, C, D, E, F>(
-      ab: UnaryPromiseFn<A, B>,
-      bc: UnaryPromiseFn<B, C>,
-      cd: UnaryPromiseFn<C, D>,
-      de: UnaryPromiseFn<D, E>,
-      ef: UnaryPromiseFn<E, F>,
-    ) => UnaryPromiseFn<A, F>) &
-    (<A, B, C, D, E>(
-      ab: UnaryPromiseFn<A, B>,
-      bc: UnaryPromiseFn<B, C>,
-      cd: UnaryPromiseFn<C, D>,
-      de: UnaryPromiseFn<D, E>,
-    ) => UnaryPromiseFn<A, E>) &
-    (<A, B, C, D>(
-      ab: UnaryPromiseFn<A, B>,
-      bc: UnaryPromiseFn<B, C>,
-      cd: UnaryPromiseFn<C, D>,
-    ) => UnaryPromiseFn<A, D>) &
-    (<A, B, C>(
-      ab: UnaryPromiseFn<A, B>,
-      bc: UnaryPromiseFn<B, C>,
-    ) => UnaryPromiseFn<A, C>) &
-    (<A, B>(
-      ab: UnaryPromiseFn<A, B>,
-    ) => UnaryPromiseFn<A, B>);
-
-  declare type Compose = (<A, B, C, D, E, F, G>(
-    fg: UnaryFn<F, G>,
-    ef: UnaryFn<E, F>,
-    de: UnaryFn<D, E>,
-    cd: UnaryFn<C, D>,
-    bc: UnaryFn<B, C>,
-    ab: UnaryFn<A, B>,
-  ) => UnaryFn<A, G>) &
-    (<A, B, C, D, E, F>(
-      ef: UnaryFn<E, F>,
-      de: UnaryFn<D, E>,
-      cd: UnaryFn<C, D>,
-      bc: UnaryFn<B, C>,
-      ab: UnaryFn<A, B>,
-    ) => UnaryFn<A, F>) &
-    (<A, B, C, D, E>(
-      de: UnaryFn<D, E>,
-      cd: UnaryFn<C, D>,
-      bc: UnaryFn<B, C>,
-      ab: UnaryFn<A, B>,
-    ) => UnaryFn<A, E>) &
-    (<A, B, C, D>(
-      cd: UnaryFn<C, D>,
-      bc: UnaryFn<B, C>,
-      ab: UnaryFn<A, B>,
-    ) => UnaryFn<A, D>) &
-    (<A, B, C>(
-      bc: UnaryFn<B, C>,
-      ab: UnaryFn<A, B>,
-    ) => UnaryFn<A, C>) &
-    (<A, B>(ab: UnaryFn<A, B>) => UnaryFn<A, B>);
-
   // This kind of filter allows us to do type refinement on the result, but we
   // still need Filter so that non-refining predicates still pass a type check.
   declare type RefineFilter =
@@ -503,9 +437,7 @@ declare module ramda {
    * Type
    */
 
-  // TODO: composeWith
   declare var compose: Compose;
-  // TODO: pipeWith
   declare function then<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>): CurriedFunction1<Promise<A>, Promise<R>>
   declare function then<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>, p: Promise<A>): Promise<R>;
   declare var curry: Curry;
@@ -1882,81 +1814,6 @@ declare module ramda {
   // TODO partialRight
 
   declare type UnaryMonadFn<A, R> = UnaryFn<A, Monad<R>>;
-  declare type PipeK = (<A, B, C, D, E, F, G, H, I, J, K, L: Monad<K>>(
-        ab: UnaryMonadFn<A, B>,
-        bc: UnaryMonadFn<B, C>,
-        cd: UnaryMonadFn<C, D>,
-        de: UnaryMonadFn<D, E>,
-        ef: UnaryMonadFn<E, F>,
-        fg: UnaryMonadFn<F, G>,
-        gh: UnaryMonadFn<G, H>,
-        hi: UnaryMonadFn<H, I>,
-        ij: UnaryMonadFn<I, J>,
-        jk: J => L,
-    ) => A => L) &
-    (<A, B, C, D, E, F, G, H, I, J, K: Monad<J>>(
-        ab: UnaryMonadFn<A, B>,
-        bc: UnaryMonadFn<B, C>,
-        cd: UnaryMonadFn<C, D>,
-        de: UnaryMonadFn<D, E>,
-        ef: UnaryMonadFn<E, F>,
-        fg: UnaryMonadFn<F, G>,
-        gh: UnaryMonadFn<G, H>,
-        hi: UnaryMonadFn<H, I>,
-        ij: I => K,
-    ) => A => K) &
-    (<A, B, C, D, E, F, G, H, I, J: Monad<I>>(
-        ab: UnaryMonadFn<A, B>,
-        bc: UnaryMonadFn<B, C>,
-        cd: UnaryMonadFn<C, D>,
-        de: UnaryMonadFn<D, E>,
-        ef: UnaryMonadFn<E, F>,
-        fg: UnaryMonadFn<F, G>,
-        gh: UnaryMonadFn<G, H>,
-        hi: H => J,
-    ) => A => J) &
-    (<A, B, C, D, E, F, G, H, I: Monad<H>>(
-        ab: UnaryMonadFn<A, B>,
-        bc: UnaryMonadFn<B, C>,
-        cd: UnaryMonadFn<C, D>,
-        de: UnaryMonadFn<D, E>,
-        ef: UnaryMonadFn<E, F>,
-        fg: UnaryMonadFn<F, G>,
-        gh: G => I,
-    ) => A => I) &
-    (<A, B, C, D, E, F, G, H: Monad<G>>(
-        ab: UnaryMonadFn<A, B>,
-        bc: UnaryMonadFn<B, C>,
-        cd: UnaryMonadFn<C, D>,
-        de: UnaryMonadFn<D, E>,
-        ef: UnaryMonadFn<E, F>,
-        fg: F => H,
-    ) => A => H) &
-    (<A, B, C, D, E, F, G: Monad<F>>(
-        ab: UnaryMonadFn<A, B>,
-        bc: UnaryMonadFn<B, C>,
-        cd: UnaryMonadFn<C, D>,
-        de: UnaryMonadFn<D, E>,
-        ef: E => G,
-    ) => A => G) &
-    (<A, B, C, D, E, F: Monad<E>>(
-        ab: UnaryMonadFn<A, B>,
-        bc: UnaryMonadFn<B, C>,
-        cd: UnaryMonadFn<C, D>,
-        de: D => F,
-    ) => A => F) &
-    (<A, B, C, D, E: Monad<D>>(
-        ab: UnaryMonadFn<A, B>,
-        bc: UnaryMonadFn<B, C>,
-        cd: C => E,
-    ) => A => E) &
-    (<A, B, C, D: Monad<C>>(
-        ab: UnaryMonadFn<A, B>,
-        bc: B => D,
-    ) => A => D) &
-    (<A, B, C: Monad<B>>(
-        ab: A => C
-    ) => A => C);
 
   declare function tap<T>(fn: (x: T) => any): (x: T) => T;
   declare function tap<T>(fn: (x: T) => any, x: T): T;

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/ramda_v0.27.x.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/ramda_v0.27.x.js
@@ -1,0 +1,2177 @@
+/* eslint-disable no-unused-vars, no-redeclare */
+
+type Transformer<A, B> = {
+  "@@transducer/step": <I, R>(r: A, a: *) => R,
+  "@@transducer/init": () => A,
+  "@@transducer/result": (result: *) => B
+};
+
+declare type $npm$ramda$Placeholder = { "@@functional/placeholder": true };
+
+declare opaque type $npm$ramda$Reduced<T>;
+
+declare module ramda {
+  declare type FunctorObj<A> = {
+    map: (<B>(A => B) => FunctorObj<B>),
+  }
+  declare type FunctorFantasyLand<A> = {
+    'fantasy-land/map': (<B>(A => B) => FunctorFantasyLand<B>),
+  }
+  declare type UnaryFn<A, R> = (a: A) => R;
+  declare type UnaryPromiseFn<A, R> = UnaryFn<A, Promise<R>>;
+  declare type BinaryFn<A, B, R> = ((a: A, b: B) => R) &
+    ((a: A) => (b: B) => R);
+  declare type UnarySameTypeFn<T> = UnaryFn<T, T>;
+  declare type BinarySameTypeFn<T> = BinaryFn<T, T, T>;
+  declare type NestedObject<T> = { [k: string]: T | NestedObject<T> };
+  declare type UnaryPredicateFn<T> = (x: T) => boolean;
+  declare type MapUnaryPredicateFn = <V>(V) => V => boolean;
+  declare type BinaryPredicateFn<T> = (x: T, y: T) => boolean;
+  declare type BinaryPredicateFn2<T, S> = (x: T, y: S) => boolean;
+
+  declare interface ObjPredicate {
+    (value: any, key: string): boolean;
+  }
+
+  declare type __CurriedFunction1<A, R, AA: A> = (...r: [AA]) => R;
+  declare type CurriedFunction1<A, R> = __CurriedFunction1<A, R, *>;
+
+  declare type __CurriedFunction2<A, B, R, AA: A, BB: B> = (
+    ((...r: [AA]) => CurriedFunction1<BB, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB]) => CurriedFunction1<AA, R>) &
+    ((...r: [AA, BB]) => R)
+  );
+  declare type CurriedFunction2<A, B, R> = __CurriedFunction2<A, B, R, *, *>;
+
+  declare type __CurriedFunction3<A, B, C, R, AA: A, BB: B, CC: C> = (
+    ((...r: [AA]) => CurriedFunction2<BB, CC, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB]) => CurriedFunction2<AA, CC, R>) &
+    ((...r: [AA, BB]) => CurriedFunction1<CC, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC]) => CurriedFunction1<AA, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC]) => CurriedFunction1<BB, R>) &
+    ((...r: [AA, BB, CC]) => R)
+  );
+  declare type CurriedFunction3<A, B, C, R> = __CurriedFunction3<
+    A,
+    B,
+    C,
+    R,
+    *,
+    *,
+    *
+  >;
+
+  declare type __CurriedFunction4<
+    A,
+    B,
+    C,
+    D,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D
+  > = ((...r: [AA]) => CurriedFunction3<BB, CC, DD, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB]) => CurriedFunction3<AA, CC, DD, R>) &
+    ((...r: [AA, BB]) => CurriedFunction2<CC, DD, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC]) => CurriedFunction2<AA, DD, R>) &
+    ((...r: [BB, $npm$ramda$Placeholder, CC]) => CurriedFunction2<BB, DD, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction1<DD, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC, DD]) => CurriedFunction1<AA, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC, DD]) => CurriedFunction1<BB, R>) &
+    ((...r: [AA, BB, $npm$ramda$Placeholder, DD]) => CurriedFunction1<CC, R>) &
+    ((...r: [AA, BB, CC, DD]) => R);
+  declare type CurriedFunction4<A, B, C, D, R> = __CurriedFunction4<
+    A,
+    B,
+    C,
+    D,
+    R,
+    *,
+    *,
+    *,
+    *
+  >;
+
+  declare type __CurriedFunction5<
+    A,
+    B,
+    C,
+    D,
+    E,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D,
+    EE: E
+  > = ((...r: [AA]) => CurriedFunction4<BB, CC, DD, EE, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB]) => CurriedFunction4<AA, CC, DD, EE, R>) &
+    ((...r: [AA, BB]) => CurriedFunction3<CC, DD, EE, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC]) => CurriedFunction3<AA, DD, EE, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC]) => CurriedFunction3<BB, DD, EE, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction2<DD, EE, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC, DD]) => CurriedFunction2<AA, EE, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC, DD]) => CurriedFunction2<BB, EE, R>) &
+    ((...r: [AA, BB, $npm$ramda$Placeholder, DD]) => CurriedFunction2<CC, EE, R>) &
+    ((...r: [AA, BB, CC, DD]) => CurriedFunction1<EE, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC, DD, EE]) => CurriedFunction1<AA, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC, DD, EE]) => CurriedFunction1<BB, R>) &
+    ((...r: [AA, BB, $npm$ramda$Placeholder, DD, EE]) => CurriedFunction1<CC, R>) &
+    ((...r: [AA, BB, CC, $npm$ramda$Placeholder, EE]) => CurriedFunction1<DD, R>) &
+    ((...r: [AA, BB, CC, DD, EE]) => R);
+  declare type CurriedFunction5<A, B, C, D, E, R> = __CurriedFunction5<
+    A,
+    B,
+    C,
+    D,
+    E,
+    R,
+    *,
+    *,
+    *,
+    *,
+    *
+  >;
+
+  declare type __CurriedFunction6<
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D,
+    EE: E,
+    FF: F
+  > = ((...r: [AA]) => CurriedFunction5<BB, CC, DD, EE, FF, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB]) => CurriedFunction5<AA, CC, DD, EE, FF, R>) &
+    ((...r: [AA, BB]) => CurriedFunction4<CC, DD, EE, FF, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC]) => CurriedFunction4<AA, DD, EE, FF, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC]) => CurriedFunction4<BB, DD, EE, FF, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction3<DD, EE, FF, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC, DD]) => CurriedFunction3<AA, EE, FF, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC, DD]) => CurriedFunction3<BB, EE, FF, R>) &
+    ((...r: [AA, BB, $npm$ramda$Placeholder, DD]) => CurriedFunction3<CC, EE, FF, R>) &
+    ((...r: [AA, BB, CC, DD]) => CurriedFunction2<EE, FF, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC, DD, EE]) => CurriedFunction2<AA, FF, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC, DD, EE]) => CurriedFunction2<BB, FF, R>) &
+    ((...r: [AA, BB, $npm$ramda$Placeholder, DD, EE]) => CurriedFunction2<CC, FF, R>) &
+    ((...r: [AA, BB, CC, $npm$ramda$Placeholder, EE]) => CurriedFunction2<DD, FF, R>) &
+    ((...r: [AA, BB, CC, DD, EE]) => CurriedFunction1<FF, R>) &
+    ((...r: [$npm$ramda$Placeholder, BB, CC, DD, EE, FF]) => CurriedFunction1<AA, R>) &
+    ((...r: [AA, $npm$ramda$Placeholder, CC, DD, EE, FF]) => CurriedFunction1<BB, R>) &
+    ((...r: [AA, BB, $npm$ramda$Placeholder, DD, EE, FF]) => CurriedFunction1<CC, R>) &
+    ((...r: [AA, BB, CC, $npm$ramda$Placeholder, EE, FF]) => CurriedFunction1<DD, R>) &
+    ((...r: [AA, BB, CC, DD, $npm$ramda$Placeholder, FF]) => CurriedFunction1<EE, R>) &
+    ((...r: [AA, BB, CC, DD, EE, FF]) => R);
+  declare type CurriedFunction6<A, B, C, D, E, F, R> = __CurriedFunction6<
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    R,
+    *,
+    *,
+    *,
+    *,
+    *,
+    *
+  >;
+
+  declare type Curry = (<A, R>((...r: [A]) => R) => CurriedFunction1<A, R>) &
+    (<A, B, R>((...r: [A, B]) => R) => CurriedFunction2<A, B, R>) &
+    (<A, B, C, R>((...r: [A, B, C]) => R) => CurriedFunction3<A, B, C, R>) &
+    (<A, B, C, D, R>(
+      (...r: [A, B, C, D]) => R
+    ) => CurriedFunction4<A, B, C, D, R>) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R
+    ) => CurriedFunction5<A, B, C, D, E, R>) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R
+    ) => CurriedFunction6<A, B, C, D, E, F, R>);
+
+  declare type Partial = (<A, R>((...r: [A]) => R, args: [A]) => () => R) &
+    (<A, B, R>((...r: [A, B]) => R, args: [A]) => B => R) &
+    (<A, B, R>((...r: [A, B]) => R, args: [A, B]) => () => R) &
+    (<A, B, C, R>((...r: [A, B, C]) => R, args: [A]) => (B, C) => R) &
+    (<A, B, C, R>((...r: [A, B, C]) => R, args: [A, B]) => C => R) &
+    (<A, B, C, R>((...r: [A, B, C]) => R, args: [A, B, C]) => () => R) &
+    (<A, B, C, D, R>((...r: [A, B, C, D]) => R, args: [A]) => (B, C, D) => R) &
+    (<A, B, C, D, R>((...r: [A, B, C, D]) => R, args: [A, B]) => (C, D) => R) &
+    (<A, B, C, D, R>((...r: [A, B, C, D]) => R, args: [A, B, C]) => D => R) &
+    (<A, B, C, D, R>(
+      (...r: [A, B, C, D]) => R,
+      args: [A, B, C, D]
+    ) => () => R) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A]
+    ) => (B, C, D, E) => R) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A, B]
+    ) => (C, D, E) => R) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A, B, C]
+    ) => (D, E) => R) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A, B, C, D]
+    ) => E => R) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A, B, C, D, E]
+    ) => () => R) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A]
+    ) => (B, C, D, E, F) => R) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B]
+    ) => (C, D, E, F) => R) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B, C]
+    ) => (D, E, F) => R) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B, C, D]
+    ) => (E, F) => R) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B, C, D, E]
+    ) => F => R) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B, C, D, E, F]
+    ) => () => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A]
+    ) => (B, C, D, E, F, G) => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B]
+    ) => (C, D, E, F, G) => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B, C]
+    ) => (D, E, F, G) => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B, C, D]
+    ) => (E, F, G) => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B, C, D, E]
+    ) => (F, G) => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B, C, D, E, F]
+    ) => G => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B, C, D, E, F, G]
+    ) => () => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A]
+    ) => (B, C, D, E, F, G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B]
+    ) => (C, D, E, F, G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C]
+    ) => (D, E, F, G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C, D]
+    ) => (E, F, G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C, D, E]
+    ) => (F, G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C, D, E, F]
+    ) => (G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C, D, E, F, G]
+    ) => H => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C, D, E, F, G, H]
+    ) => () => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A]
+    ) => (B, C, D, E, F, G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B]
+    ) => (C, D, E, F, G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C]
+    ) => (D, E, F, G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D]
+    ) => (E, F, G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D, E]
+    ) => (F, G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D, E, F]
+    ) => (G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D, E, F, G]
+    ) => (H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D, E, F, G, H]
+    ) => I => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D, E, F, G, H, I]
+    ) => () => R);
+
+  declare var pipe: {
+    <Args, Return, B, C, D, E, F>(
+      ab: (...a: Args) => B,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, D>,
+      de: UnaryFn<D, E>,
+      ef: UnaryFn<E, F>,
+      fg: UnaryFn<F, Return>,
+    ): (...a: Args) => Return,
+
+    <Args, Return, B, C, D, E,>(
+      ab: (...a: Args) => B,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, D>,
+      de: UnaryFn<D, E>,
+      ef: UnaryFn<E, Return>,
+    ): (...a: Args) => Return,
+
+    <Args, Return, B, C, D,>(
+      ab: (...a: Args) => B,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, D>,
+      de: UnaryFn<D, Return>,
+    ): (...a: Args) => Return,
+
+    <Args, Return, B, C,>(
+      ab: (...a: Args) => B,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, Return>,
+    ): (...a: Args) => Return,
+
+    <Args, Return, B,>(
+      ab: (...a: Args) => B,
+      bc: UnaryFn<B, Return>,
+    ): (...a: Args) => Return,
+
+    <A, B>(ab: UnaryFn<A, B>): UnaryFn<A, B>,
+  };
+
+  declare type Pipe = typeof pipe;
+
+  declare type PipeP = (<A, B, C, D, E, F, G>(
+    ab: UnaryPromiseFn<A, B>,
+    bc: UnaryPromiseFn<B, C>,
+    cd: UnaryPromiseFn<C, D>,
+    de: UnaryPromiseFn<D, E>,
+    ef: UnaryPromiseFn<E, F>,
+    fg: UnaryPromiseFn<F, G>,
+  ) => UnaryPromiseFn<A, G>) &
+    (<A, B, C, D, E, F>(
+      ab: UnaryPromiseFn<A, B>,
+      bc: UnaryPromiseFn<B, C>,
+      cd: UnaryPromiseFn<C, D>,
+      de: UnaryPromiseFn<D, E>,
+      ef: UnaryPromiseFn<E, F>,
+    ) => UnaryPromiseFn<A, F>) &
+    (<A, B, C, D, E>(
+      ab: UnaryPromiseFn<A, B>,
+      bc: UnaryPromiseFn<B, C>,
+      cd: UnaryPromiseFn<C, D>,
+      de: UnaryPromiseFn<D, E>,
+    ) => UnaryPromiseFn<A, E>) &
+    (<A, B, C, D>(
+      ab: UnaryPromiseFn<A, B>,
+      bc: UnaryPromiseFn<B, C>,
+      cd: UnaryPromiseFn<C, D>,
+    ) => UnaryPromiseFn<A, D>) &
+    (<A, B, C>(
+      ab: UnaryPromiseFn<A, B>,
+      bc: UnaryPromiseFn<B, C>,
+    ) => UnaryPromiseFn<A, C>) &
+    (<A, B>(
+      ab: UnaryPromiseFn<A, B>,
+    ) => UnaryPromiseFn<A, B>);
+
+  declare type Compose = (<A, B, C, D, E, F, G>(
+    fg: UnaryFn<F, G>,
+    ef: UnaryFn<E, F>,
+    de: UnaryFn<D, E>,
+    cd: UnaryFn<C, D>,
+    bc: UnaryFn<B, C>,
+    ab: UnaryFn<A, B>,
+  ) => UnaryFn<A, G>) &
+    (<A, B, C, D, E, F>(
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+    ) => UnaryFn<A, F>) &
+    (<A, B, C, D, E>(
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+    ) => UnaryFn<A, E>) &
+    (<A, B, C, D>(
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+    ) => UnaryFn<A, D>) &
+    (<A, B, C>(
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+    ) => UnaryFn<A, C>) &
+    (<A, B>(ab: UnaryFn<A, B>) => UnaryFn<A, B>);
+
+  // This kind of filter allows us to do type refinement on the result, but we
+  // still need Filter so that non-refining predicates still pass a type check.
+  declare type RefineFilter =
+    & (<K, V, P: $Pred<1>, T: Array<V> | $ReadOnlyArray<V>> (fn: P, xs: T) => Array<$Refine<V, P, 1>>)
+    & (<K, V, P: $Pred<1>, T: Array<V> | $ReadOnlyArray<V>> (fn: P) => (xs: T) => Array<$Refine<V, P, 1>>);
+
+  declare type Filter =
+    & (<K, V, T: $ReadOnlyArray<V> | { +[key: K]: V }>  (fn: UnaryPredicateFn<V>, xs: T) => T)
+    & (<K, V, T: { [key: K]: V } | Array<V>>   (fn: UnaryPredicateFn<V>, xs: T) => T)
+
+    & (<K, V, T: $ReadOnlyArray<V> | { +[key: K]: V }>  (fn: UnaryPredicateFn<V>) =>(xs: T) => T)
+    & (<K, V, T: Array<V> | { [key: K]: V }>   (fn: UnaryPredicateFn<V>) =>(xs: T) => T)
+
+  declare interface Monad<A> {
+    chain<B>(f: A => Monad<B>): Monad<B>;
+  }
+
+  declare class Semigroup<T> {}
+
+  declare class Chain {
+    chain<T, V: Monad<T> | Array<T>>(fn: (a: T) => V, x: V): V;
+    chain<T, V: Monad<T> | Array<T>>(fn: (a: T) => V): (x: V) => V;
+  }
+
+  declare class GenericContructor<T> {
+    constructor(x: T): GenericContructor<any>;
+  }
+
+  declare class GenericContructorMulti {
+    constructor(...args: Array<any>): GenericContructor<any>;
+  }
+
+  /**
+   * DONE:
+   * Function*
+   * List*
+   * Logic
+   * Math
+   * Object*
+   * Relation
+   * String
+   * Type
+   */
+
+  // TODO: composeWith
+  declare var compose: Compose;
+  // TODO: pipeWith
+  declare function then<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>): CurriedFunction1<Promise<A>, Promise<R>>
+  declare function then<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>, p: Promise<A>): Promise<R>;
+  declare var curry: Curry;
+  declare function curryN(
+    length: number,
+    fn: (...args: Array<any>) => any
+  ): Function;
+
+  // *Math
+  declare var add: CurriedFunction2<number, number, number>;
+  declare var inc: UnaryFn<number, number>;
+  declare var dec: UnaryFn<number, number>;
+  declare var mean: UnaryFn<Array<number>, number>;
+  declare var divide: CurriedFunction2<number, number, number>;
+  declare var mathMod: CurriedFunction2<number, number, number>;
+  declare var median: UnaryFn<Array<number>, number>;
+  declare var modulo: CurriedFunction2<number, number, number>;
+  declare var multiply: CurriedFunction2<number, number, number>;
+  declare var negate: UnaryFn<number, number>;
+  declare var product: UnaryFn<Array<number>, number>;
+  declare var subtract:
+    & CurriedFunction2<number, number, number>
+    & CurriedFunction2<Date, Date, number>
+    & CurriedFunction2<Date, number, number>
+    & CurriedFunction2<number, Date, number>;
+  declare var sum: UnaryFn<Array<number>, number>;
+
+  // Filter
+  // To refine with filter, be sure to import the RefineFilter type, and cast
+  // filter to a RefineFilter.
+  // ex:
+  // import { type RefineFilter, filter } from 'ramda'
+  // const notNull = (x): bool %checks => x != null
+  // const ns: Array<number> = (filter: RefineFilter)(notNull, [1, 2, null])
+  declare var filter: RefineFilter & Filter;
+  // reject doesn't get RefineFilter since it performs the opposite work of
+  // filter, and we don't have a kind of $NotPred type.
+  declare var reject: Filter;
+
+  // *String
+  declare var match: CurriedFunction2<RegExp, string, Array<string | void>>;
+  declare type ReplacementFn = (substring: string, ...args: Array<string>) => string;
+  declare function replace<A: RegExp | string, B: string | ReplacementFn>(A): CurriedFunction2<B, string, string>;
+  declare function replace<A: RegExp | string, B: string | ReplacementFn>(A, B): CurriedFunction1<string, string>;
+  declare function replace<A: RegExp | string, B: string | ReplacementFn>(A, B, string): string;
+  declare var split: CurriedFunction2<RegExp | string, string, Array<string>>;
+  declare var test: CurriedFunction2<RegExp, string, boolean>;
+  // startsWith and endsWith use the same signature:
+  declare type EdgeWith<A> =
+    & (
+        & ((Array<A>) => (Array<A>) => boolean)
+        & (Array<A>, Array<A>) => boolean
+    )
+    & (
+        & ((string) => (string) => boolean)
+        & (string, string) => boolean
+    )
+  ;
+  declare var startsWith: EdgeWith<*>;
+  declare var endsWith: EdgeWith<*>;
+  declare function toLower(a: string): string;
+  declare function toString(x: any): string;
+  declare function toUpper(a: string): string;
+  declare function trim(a: string): string;
+
+  // *Type
+  declare function is<T>(t: T): (v: any) => boolean;
+  declare function is<T>(t: T, v: any): boolean;
+  declare var propIs: CurriedFunction3<any, string, Object, boolean>;
+  declare function type(x: ?any): string;
+
+  declare function isNil(x: mixed): boolean %checks(x === undefined ||
+    x === null);
+
+  // *List
+  declare function adjust<A>(
+    index: number,
+  ): (fn: (a: A) => A) => (src: $ReadOnlyArray<A>) => Array<A>;
+  declare function adjust<A>(
+    index: number,
+    fn: (a: A) => A,
+  ): (src: $ReadOnlyArray<A>) => Array<A>;
+  declare function adjust<A>(
+    index: number,
+    fn: (a: A) => A,
+    src: $ReadOnlyArray<A>
+  ): Array<A>;
+
+  declare function all<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
+  declare function all<T>(
+    fn: UnaryPredicateFn<T>,
+  ): (xs: Array<T>) => boolean;
+
+  declare function any<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
+  declare function any<T>(
+    fn: UnaryPredicateFn<T>,
+  ): (xs: Array<T>) => boolean;
+
+  declare function aperture<T>(n: number, xs: Array<T>): Array<Array<T>>;
+  declare function aperture<T>(
+    n: number,
+  ): (xs: Array<T>) => Array<Array<T>>;
+
+  declare function append<A, E>(A, $ReadOnlyArray<E>): Array<E|A>;
+  declare function append<A, E>(A): CurriedFunction1<$ReadOnlyArray<E>, Array<E|A>>;
+
+  declare function prepend<E>(x: E, xs: Array<E>): Array<E>;
+  declare function prepend<E>(
+    x: E,
+  ): (xs: Array<E>) => Array<E>;
+
+  declare function chain<A, B>(f: (x: A) => Array<B>, xs: $ReadOnlyArray<A>): Array<B>
+  declare function chain<A, B>(f: (x: A) => Array<B>): (xs: $ReadOnlyArray<A>) => Array<B>
+
+  // Additional chain functionality documented at https://ramdajs.com/docs/#chain:
+  //
+  // Dispatches to the chain method of the second argument, if present, according to the FantasyLand Chain spec (https://github.com/fantasyland/fantasy-land#chain).
+  //
+  // If second argument is a function, chain(f, g)(x) is equivalent to f(g(x), x).
+  //
+  // Acts as a transducer if a transformer is given in list position.
+  declare function chain<A, B, R>(f: (x: A, y: B) => R, g: (y: B) => A):(y: B) => R;
+
+  declare function concat<A, B>(x: $ReadOnlyArray<A>, y: $ReadOnlyArray<B>): Array<A | B>;
+  declare function concat<A, B>(x: $ReadOnlyArray<A>): CurriedFunction1<$ReadOnlyArray<B>, Array<A | B>>;
+
+  declare function concat(x: string, y: string): string;
+  declare function concat(x: string): CurriedFunction1<string, string>;
+
+  declare type Includes =
+    & ((string, string) => boolean)
+    & ((string) => ((string => boolean)))
+    & (<A, T: $ReadOnlyArray<A> | Array<A>>(a: A) => (b: T) => boolean)
+    & (<A, T: $ReadOnlyArray<A> | Array<A>>(a: A, b: T) => boolean)
+
+  declare var includes: Includes;
+
+  declare function drop<V, T: Array<V> | string>(
+    n: number,
+  ): (xs: T) => T;
+  declare function drop<V, T: Array<V> | string>(n: number, xs: T): T;
+
+  declare function dropLast<V, T: Array<V> | string>(
+    n: number,
+  ): (xs: T) => T;
+  declare function dropLast<V, T: Array<V> | string>(n: number, xs: T): T;
+
+  declare function dropLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+  ): (xs: T) => T;
+  declare function dropLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): T;
+
+  declare function dropWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+  ): (xs: T) => T;
+  declare function dropWhile<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: T): T;
+
+  declare function dropRepeats<V, T: Array<V>>(xs: T): T;
+
+  declare function dropRepeatsWith<V, T: Array<V>>(
+    fn: BinaryPredicateFn<V>,
+  ): (xs: T) => T;
+  declare function dropRepeatsWith<V, T: Array<V>>(
+    fn: BinaryPredicateFn<V>,
+    xs: T
+  ): T;
+
+  declare function groupBy<T>(fn: (x: T) => string, xs: $ReadOnlyArray<T>): { [key: string]: Array<T> };
+  declare function groupBy<T>(fn: (x: T) => string): CurriedFunction1<$ReadOnlyArray<T>, { [string]: Array<T> }>;
+
+  declare function groupWith<T, V: Array<T> | string>(
+    fn: BinaryPredicateFn<T>,
+    xs: V
+  ): Array<V>;
+  declare function groupWith<T, V: Array<T> | string>(
+    fn: BinaryPredicateFn<T>,
+  ): (xs: V) => Array<V>;
+
+  declare function head<T, V: Array<T>>(xs: V): $ElementType<V, 0>;
+  declare function head<T, V: string>(xs: V): V;
+
+  declare function into<I, T, A: Array<T>, R: Array<*> | string | Object>(
+    accum: R,
+    xf: (a: A) => I,
+    input: A
+  ): R;
+  declare function into<I, T, A: Array<T>, R>(
+    accum: Transformer<I, R>,
+    xf: (a: A) => R,
+    input: A
+  ): R;
+
+  declare function indexOf<E>(x: ?E, xs: Array<E>): number;
+  declare function indexOf<E>(
+    x: ?E,
+  ): (xs: Array<E>) => number;
+
+  declare function indexBy<V, T: { [key: string]: * }>(
+    fn: (x: T) => string,
+  ): (xs: Array<T>) => { [key: string]: T };
+  declare function indexBy<V, T: { [key: string]: * }>(
+    fn: (x: T) => string,
+    xs: Array<T>
+  ): { [key: string]: T };
+
+  declare function insert<T>(
+    index: number,
+  ): (elem: T) => (src: Array<T>) => Array<T>;
+  declare function insert<T>(
+    index: number,
+    elem: T,
+  ): (src: Array<T>) => Array<T>;
+  declare function insert<T>(index: number, elem: T, src: Array<T>): Array<T>;
+
+  declare function insertAll<T, S>(
+    index: number,
+  ): (elem: Array<S>) => (src: Array<T>) => Array<S | T>;
+  declare function insertAll<T, S>(
+    index: number,
+    elems: Array<S>,
+  ): (src: Array<T>) => Array<S | T>;
+  declare function insertAll<T, S>(
+    index: number,
+    elems: Array<S>,
+    src: Array<T>
+  ): Array<S | T>;
+
+  declare function join(x: string, xs: Array<any>): string;
+  declare function join(
+    x: string,
+  ): (xs: Array<any>) => string;
+
+  declare function last<T, V: Array<T>>(xs: V): ?T;
+  declare function last<T, V: string>(xs: V): V;
+
+  declare function none<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
+  declare function none<T>(
+    fn: UnaryPredicateFn<T>,
+  ): (xs: Array<T>) => boolean;
+
+  declare var nth: {
+    <A, As: $ReadOnlyArray<A>>(n: number, xs: As): ?A,
+    <A, As: $ReadOnlyArray<A> | string>(
+      n: number,
+    ): ((xs: string) => string) & ((xs: As) => ?A),
+    (n: number, xs: string): string
+  }
+
+  declare type Find = (<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ) => (xs: T) => ?V) &
+    (<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: T) => ?V);
+
+  declare var find: Find;
+
+  declare function findLast<V, O: { [key: string]: * }, T: Array<V> | O>(
+    fn: UnaryPredicateFn<V>,
+  ): (xs: T | O) => ?V | O;
+  declare function findLast<V, O: { [key: string]: * }, T: Array<V> | O>(
+    fn: UnaryPredicateFn<V>,
+    xs: T | O
+  ): ?V | O;
+
+  declare function findIndex<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+  ): (xs: T) => number;
+  declare function findIndex<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): number;
+  declare function findLastIndex<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+  ): (xs: T) => number;
+  declare function findLastIndex<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): number;
+
+  declare function forEach<T, V>(fn: (x: T) => ?V, xs: Array<T>): Array<T>;
+  declare function forEach<T, V>(
+    fn: (x: T) => ?V,
+  ): (xs: Array<T>) => Array<T>;
+
+  declare function forEachObjIndexed<O: Object, A, B>(
+    fn: (val: A, key: string, o: O) => B,
+    o: { [key: string]: A }
+  ): O;
+
+  declare function forEachObjIndexed<O: Object, A, B>(
+    fn: (val: A, key: string, o: O) => B,
+    ...args: Array<void>
+  ): (o: { [key: string]: A }) => O;
+
+  declare function lastIndexOf<E>(x: E, xs: Array<E>): number;
+  declare function lastIndexOf<E>(
+    x: E,
+  ): (xs: Array<E>) => number;
+
+  declare var map: {
+    <T, R, R, FN: (x: T) => R, SR, S: { +map: FN => SR }>(fn: FN, xs: S): SR,
+
+    <T, R, FN: (x: T) => R>(fn: FN):
+      (<SR, S: { +map: FN => SR }>(xs: S) => SR) &
+      ((xs: { [key: string]: T }) => { [key: string]: R }) &
+      ((xs: { +[key: string]: T }) => { +[key: string]: R }) &
+      ((xs: Array<T>) => Array<R>) &
+      ((xs: $ReadOnlyArray<T>) => $ReadOnlyArray<R>),
+
+    <T, R>(fn: (x: T) => R, xs: Array<T>): Array<R>,
+    <T, R>(fn: (x: T) => R, xs: $ReadOnlyArray<T>): $ReadOnlyArray<R>,
+    <T, R>(fn: (x: T) => R, xs: { [key: string]: T }): { [key: string]: R },
+    <T, R>(fn: (x: T) => R, xs: { +[key: string]: T }): { +[key: string]: R }
+  };
+
+
+  declare type AccumIterator<A, B, R> = (acc: R, x: A) => [R, B];
+  declare function mapAccum<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+    acc: R,
+    xs: Array<A>
+  ): [R, Array<B>];
+  declare function mapAccum<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+  ): (acc: R, xs: Array<A>) => [R, Array<B>];
+
+  declare function mapAccumRight<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+    acc: R,
+    xs: Array<A>
+  ): [R, Array<B>];
+  declare function mapAccumRight<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+  ): (acc: R, xs: Array<A>) => [R, Array<B>];
+
+  declare function intersperse<E>(x: E, xs: Array<E>): Array<E>;
+  declare function intersperse<E>(
+    x: E,
+  ): (xs: Array<E>) => Array<E>;
+
+  declare function pair<A, B>(a: A, b: B): [A, B];
+  declare function pair<A, B>(a: A): (b: B) => [A, B];
+
+  declare function partition<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): [T, T];
+  declare function partition<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+  ): (xs: T) => [T, T];
+
+  declare function pluck<
+    V,
+    K: $Keys<V>,
+  >(key: K, list: V[]): Array<$ElementType<V, K>>;
+  declare function pluck<
+    V,
+    K: $Keys<V>,
+  >(key: K): (list: V[]) => Array<$ElementType<V, K>>;
+  declare function pluck<
+    T,
+    V: T[],
+  >(key: number, list: V[]): Array<$ElementType<V, number>>;
+  declare function pluck<
+    T,
+    V: T[],
+  >(key: number): (list: V[]) => Array<$ElementType<V, number>>;
+
+  declare var range: CurriedFunction2<number, number, Array<number>>;
+
+  declare function reduced<T>(x: T | $npm$ramda$Reduced<T>): $npm$ramda$Reduced<T>;
+
+  declare function remove<T>(
+    from: number,
+  ): ((to: number) => (src: Array<T>) => Array<T>) &
+    ((to: number, src: Array<T>) => Array<T>);
+  declare function remove<T>(
+    from: number,
+    to: number,
+  ): (src: Array<T>) => Array<T>;
+  declare function remove<T>(from: number, to: number, src: Array<T>): Array<T>;
+
+  declare function repeat<T>(x: T, times: number): Array<T>;
+  declare function repeat<T>(x: T): (times: number) => Array<T>;
+
+  declare function slice<V, T: Array<V> | string>(
+    from: number,
+  ): ((to: number) => (src: T) => T) &
+    ((to: number, src: T) => T);
+  declare function slice<V, T: Array<V> | string>(
+    from: number,
+    to: number,
+  ): (src: T) => T;
+  declare function slice<V, T: Array<V> | string>(
+    from: number,
+    to: number,
+    src: T
+  ): T;
+
+  declare function sort<V, T: Array<V>>(fn: (a: V, b: V) => number, xs: T): T;
+  declare function sort<V, T: Array<V>>(
+    fn: (a: V, b: V) => number,
+  ): (xs: T) => T;
+
+  declare function sortWith<V, T: Array<V>>(
+    fns: Array<(a: V, b: V) => number>,
+    xs: T
+  ): T;
+  declare function sortWith<V, T: Array<V>>(
+    fns: Array<(a: V, b: V) => number>,
+  ): (xs: T) => T;
+
+  /**
+   * In the examples for ascend and descend, its result is plugged into sort.
+   * In order for this to function properly ascend and descend need to yield a
+   * function that can take two arguments. In our case we'll declare the result
+   * function as curried, which matches the ramda behavior.
+   */
+  declare type MakeComparator = <A, B>(A => B) => CurriedFunction2<A, A, number>
+
+  declare var descend: MakeComparator
+  declare var ascend: MakeComparator
+
+  declare function times<T>(fn: (i: number) => T, n: number): Array<T>;
+  declare function times<T>(
+    fn: (i: number) => T,
+  ): (n: number) => Array<T>;
+
+  declare function take<V, T: Array<V> | string>(n: number, xs: T): T;
+  declare function take<V, T: Array<V> | string>(n: number): (xs: T) => T;
+
+  declare function takeLast<V, T: Array<V> | string>(n: number, xs: T): T;
+  declare function takeLast<V, T: Array<V> | string>(n: number): (xs: T) => T;
+
+  declare function takeLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): T;
+  declare function takeLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ): (xs: T) => T;
+
+  declare function takeWhile<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: T): T;
+  declare function takeWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ): (xs: T) => T;
+
+  declare function unfold<T, R>(
+    fn: (seed: T) => [R, T] | boolean,
+  ): (seed: T) => Array<R>;
+  declare function unfold<T, R>(
+    fn: (seed: T) => [R, T] | boolean,
+    seed: T
+  ): Array<R>;
+
+  declare function uniqBy<T, V>(
+    fn: (x: T) => V,
+  ): (xs: Array<T>) => Array<T>;
+  declare function uniqBy<T, V>(fn: (x: T) => V, xs: Array<T>): Array<T>;
+
+  declare function uniqWith<T>(
+    fn: BinaryPredicateFn<T>,
+  ): (xs: Array<T>) => Array<T>;
+  declare function uniqWith<T>(
+    fn: BinaryPredicateFn<T>,
+    xs: Array<T>
+  ): Array<T>;
+
+  declare function update<T>(
+    index: number,
+  ): ((elem: T) => (src: Array<T>) => Array<T>) &
+    ((elem: T, src: Array<T>) => Array<T>);
+  declare function update<T>(
+    index: number,
+    elem: T,
+  ): (src: Array<T>) => Array<T>;
+  declare function update<T>(index: number, elem: T, src: Array<T>): Array<T>;
+
+  // TODO `without` as a transducer
+  declare function without<T, E>($ReadOnlyArray<E>, $ReadOnlyArray<E|T>): Array<E|T>;
+  declare function without<T, E>($ReadOnlyArray<E>): CurriedFunction1<$ReadOnlyArray<E|T>, Array<E|T>>;
+
+  declare function xprod<T, S>(xs: Array<T>, ys: Array<S>): Array<[T, S]>;
+  declare function xprod<T, S>(
+    xs: Array<T>,
+  ): (ys: Array<S>) => Array<[T, S]>;
+
+  declare function zip<T, S>(xs: Array<T>, ys: Array<S>): Array<[T, S]>;
+  declare function zip<T, S>(
+    xs: Array<T>,
+  ): (ys: Array<S>) => Array<[T, S]>;
+
+  declare function zipObj<T: string, S>(
+    xs: Array<T>,
+    ys: Array<S>
+  ): { [key: T]: S };
+  declare function zipObj<T: string, S>(
+    xs: Array<T>,
+  ): (ys: Array<S>) => { [key: T]: S };
+
+  declare type NestedArray<T> = Array<T | NestedArray<T>>;
+  declare function flatten<T>(xs: NestedArray<T>): Array<T>;
+
+  declare function fromPairs<T, V>(pair: Array<[T, V]>): { [key: string]: V };
+
+  declare function init<T, V: Array<T> | string>(xs: V): V;
+
+  declare function length<T>(xs: Array<T> | string | {length: number}): number;
+
+  declare function reverse<T, V: Array<T> | string>(xs: V): V;
+
+  declare type Reduce = (<A, B>(
+    fn: (acc: A, elm: B) => $npm$ramda$Reduced<A> | A
+  ) => ((init: A) => (xs: Array<B> | $ReadOnlyArray<B>) => A) &
+    ((init: A, xs: Array<B> | $ReadOnlyArray<B>) => A)) &
+    (<A, B>(
+      fn: (acc: A, elm: B) => $npm$ramda$Reduced<A> | A,
+      init: A
+    ) => (xs: Array<B> | $ReadOnlyArray<B>) => A) &
+    (<A, B>(
+      fn: (acc: A, elm: B) => $npm$ramda$Reduced<A> | A,
+      init: A,
+      xs: Array<B> | $ReadOnlyArray<B>
+    ) => A);
+
+  declare var reduce: Reduce;
+
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+  ): ((acc: B) => ((
+    keyFn: (elem: A) => string,
+  ) => (xs: Array<A>) => { [key: string]: B }) &
+    ((keyFn: (elem: A) => string, xs: Array<A>) => { [key: string]: B })) &
+    ((
+      acc: B,
+      keyFn: (elem: A) => string,
+    ) => (xs: Array<A>) => { [key: string]: B }) &
+    ((
+      acc: B,
+      keyFn: (elem: A) => string,
+      xs: Array<A>
+    ) => { [key: string]: B });
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    acc: B,
+  ): ((
+    keyFn: (elem: A) => string,
+  ) => (xs: Array<A>) => { [key: string]: B }) &
+    ((keyFn: (elem: A) => string, xs: Array<A>) => { [key: string]: B });
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    acc: B,
+    keyFn: (elem: A) => string
+  ): (xs: Array<A>) => { [key: string]: B };
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    acc: B,
+    keyFn: (elem: A) => string,
+    xs: Array<A>
+  ): { [key: string]: B };
+
+  declare function reduceRight<A, B>(
+    fn: (elem: B, acc: A) => A,
+  ): ((init: A, xs: Array<B>) => A) &
+    ((init: A) => (xs: Array<B>) => A);
+  declare function reduceRight<A, B>(
+    fn: (elem: B, acc: A) => A,
+    init: A,
+  ): (xs: Array<B>) => A;
+  declare function reduceRight<A, B>(
+    fn: (elem: B, acc: A) => A,
+    init: A,
+    xs: Array<B>
+  ): A;
+
+  declare function reduceWhile<A, B>(pred: (acc: A, curr: B) => boolean): ((
+    fn: (a: A, b: B) => A,
+  ) => (init: A) => (
+    xs: Array<B>
+  ) => A &
+    ((
+      fn: (a: A, b: B) => A,
+    ) => (init: A, xs: Array<B>) => A)) &
+    ((
+      fn: (a: A, b: B) => A,
+      init: A,
+    ) => (xs: Array<B>) => A) &
+    ((fn: (a: A, b: B) => A, init: A, xs: Array<B>) => A);
+
+  declare function reduceWhile<A, B>(
+    pred: (acc: A, curr: B) => boolean,
+    fn: (a: A, b: B) => A,
+  ): ((init: A) => (xs: Array<B>) => A) &
+    ((init: A, xs: Array<B>) => A);
+
+  declare function reduceWhile<A, B>(
+    fn: (acc: A, curr: B) => boolean,
+    fn: (a: A, b: B) => A,
+    init: A,
+    xs: Array<B>
+  ): A;
+
+  declare function scan<A, B>(
+    fn: (acc: A, elem: B) => A,
+  ): ((init: A, xs: Array<B>) => Array<A>) &
+    ((init: A) => (xs: Array<B>) => Array<A>);
+  declare function scan<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+  ): (xs: Array<B>) => Array<A>;
+  declare function scan<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    xs: Array<B>
+  ): Array<A>;
+
+  declare function splitAt<V, T: Array<V> | string>(i: number, xs: T): [T, T];
+  declare function splitAt<V, T: Array<V> | string>(
+    i: number
+  ): (xs: T) => [T, T];
+  declare function splitEvery<V, T: Array<V> | string>(
+    i: number,
+    xs: T
+  ): Array<T>;
+  declare function splitEvery<V, T: Array<V> | string>(
+    i: number
+  ): (xs: T) => Array<T>;
+  declare function splitWhen<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): [T, T];
+  declare function splitWhen<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ): (xs: T) => [T, T];
+
+  declare function tail<T, V: Array<T> | string>(xs: V): V;
+
+  declare function transpose<T>(xs: Array<Array<T>>): Array<Array<T>>;
+
+  declare function uniq<T>(xs: $ReadOnlyArray<T>): Array<T>;
+
+  declare function unnest<T>(xs: NestedArray<T>): NestedArray<T>;
+
+  declare function zipWith<T, S, R>(
+    fn: (a: T, b: S) => R,
+  ): ((xs: Array<T>, ys: Array<S>) => Array<R>) &
+    ((xs: Array<T>) => (ys: Array<S>) => Array<R>);
+  declare function zipWith<T, S, R>(
+    fn: (a: T, b: S) => R,
+    xs: Array<T>,
+  ): (ys: Array<S>) => Array<R>;
+  declare function zipWith<T, S, R>(
+    fn: (a: T, b: S) => R,
+    xs: Array<T>,
+    ys: Array<S>
+  ): Array<R>;
+
+  // *Relation
+  declare function equals<T>(x: T): (y: T) => boolean;
+  declare function equals<T>(x: T, y: T): boolean;
+
+  declare function eqBy<A, B>(
+    fn: (x: A) => B,
+      ): ((x: A, y: A) => boolean) &
+    ((x: A) => (y: A) => boolean);
+  declare function eqBy<A, B>(
+    fn: (x: A) => B,
+    x: A,
+      ): (y: A) => boolean;
+  declare function eqBy<A, B>(fn: (x: A) => B, x: A, y: A): boolean;
+
+  // Flow cares about the order in which these appear. Generally function
+  // siguatures should go from smallest arity to largest arity.
+  declare type PropEq = (<T>(
+    prop: $Keys<T>
+  ) => ((val: mixed) => (obj: T) => boolean) &
+    ((val: mixed, obj: T) => boolean)) &
+    (<T>(prop: $Keys<T>, val: mixed) => (obj: T) => boolean) &
+    (<T>(prop: $Keys<T>, val: mixed, obj: T) => boolean) &
+    // Array variants.
+    (<T>(
+      prop: number
+    ) => ((val: mixed) => (obj: Array<*>) => boolean) &
+      ((val: mixed, obj: Array<*>) => boolean)) &
+    (<T>(prop: number, val: mixed) => (obj: Array<*>) => boolean) &
+    (<T>(prop: number, val: mixed, obj: Array<*>) => boolean);
+  declare var propEq: PropEq;
+
+  declare function pathEq<T: string | number>(
+    path: Array<T>,
+  ): ((val: mixed) => (o: Object) => boolean) &
+    ((val: mixed, o: Object) => boolean);
+  declare function pathEq<T: string | number>(
+    path: Array<T>,
+    val: mixed,
+  ): (o: Object) => boolean;
+  declare function pathEq<T: string | number>(path: Array<T>, val: mixed, o: Object): boolean;
+
+  declare function clamp<T: number | string | Date>(
+    min: T,
+  ): ((max: T) => (v: T) => T) & ((max: T, v: T) => T);
+  declare function clamp<T: number | string | Date>(
+    min: T,
+    max: T,
+  ): (v: T) => T;
+  declare function clamp<T: number | string | Date>(min: T, max: T, v: T): T;
+
+  declare function countBy<T>(
+    fn: (x: T) => string,
+  ): (list: Array<T>) => { [key: string]: number };
+  declare function countBy<T>(
+    fn: (x: T) => string,
+    list: Array<T>
+  ): { [key: string]: number };
+
+  declare function difference<T>(
+    xs1: Array<T>,
+  ): (xs2: Array<T>) => Array<T>;
+  declare function difference<T>(xs1: Array<T>, xs2: Array<T>): Array<T>;
+
+  declare function differenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+  ): ((xs1: Array<T>) => (xs2: Array<T>) => Array<T>) &
+    ((xs1: Array<T>, xs2: Array<T>) => Array<T>);
+  declare function differenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    xs1: Array<T>,
+  ): (xs2: Array<T>) => Array<T>;
+  declare function differenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    xs1: Array<T>,
+    xs2: Array<T>
+  ): Array<T>;
+
+  declare function eqBy<T>(fn: (x: T) => T, x: T, y: T): boolean;
+  declare function eqBy<T>(fn: (x: T) => T): (x: T, y: T) => boolean;
+  declare function eqBy<T>(fn: (x: T) => T, x: T): (y: T) => boolean;
+  declare function eqBy<T>(fn: (x: T) => T): (x: T) => (y: T) => boolean;
+
+  declare type RelationCompare =
+    & ((x: number) => (y: number) => bool)
+    & ((x: number, y: number) => bool)
+    & ((x: string) => (y: string) => bool)
+    & ((x: string, y: string) => bool)
+
+  declare var gt: RelationCompare
+  declare var gte: RelationCompare
+  declare var lt: RelationCompare
+  declare var lte: RelationCompare
+
+  declare function identical<T>(x: T): (y: T) => boolean;
+  declare function identical<T>(x: T, y: T): boolean;
+
+  declare function innerJoin<A, B>(
+    pred: (a: A, b: B) => boolean,
+  ): (
+    a: Array<A>,
+  ) => (b: Array<B>) => Array<A> & ((a: Array<A>, b: Array<B>) => Array<A>);
+  declare function innerJoin<A, B>(
+    pred: (a: A, b: B) => boolean,
+    a: Array<A>,
+  ): (b: Array<B>) => Array<A>;
+  declare function innerJoin<A, B>(
+    pred: (a: A, b: B) => boolean,
+    a: Array<A>,
+    b: Array<B>
+  ): Array<A>;
+
+  declare function intersection<T>(xs: $ReadOnlyArray<T>, ys: $ReadOnlyArray<T>): Array<T>;
+  declare function intersection<T>(xs: $ReadOnlyArray<T>): (ys: $ReadOnlyArray<T>) => Array<T>;
+
+  declare function max<T>(x: T): (y: T) => T;
+  declare function max<T>(x: T, y: T): T;
+
+  declare function maxBy<T, V>(
+    fn: (x: T) => V,
+  ): ((x: T, y: T) => T) & ((x: T) => (y: T) => T);
+  declare function maxBy<T, V>(
+    fn: (x: T) => V,
+    x: T,
+  ): (y: T) => T;
+  declare function maxBy<T, V>(fn: (x: T) => V, x: T, y: T): T;
+
+  declare function min<T>(x: T): (y: T) => T;
+  declare function min<T>(x: T, y: T): T;
+
+  declare function minBy<T, V>(
+    fn: (x: T) => V,
+  ): ((x: T, y: T) => T) & ((x: T) => (y: T) => T);
+  declare function minBy<T, V>(fn: (x: T) => V, x: T): (y: T) => T;
+  declare function minBy<T, V>(fn: (x: T) => V, x: T, y: T): T;
+
+  declare function sortBy<T, V>(
+    fn: (x: T) => V,
+  ): (x: Array<T>) => Array<T>;
+  declare function sortBy<T, V>(fn: (x: T) => V, x: Array<T>): Array<T>;
+
+  declare function symmetricDifference<T>(
+    x: Array<T>,
+  ): (y: Array<T>) => Array<T>;
+  declare function symmetricDifference<T>(x: Array<T>, y: Array<T>): Array<T>;
+
+  declare function symmetricDifferenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+  ): ((x: Array<T>) => (y: Array<T>) => Array<T>) &
+    ((x: Array<T>, y: Array<T>) => Array<T>);
+  declare function symmetricDifferenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+  ): (y: Array<T>) => Array<T>;
+  declare function symmetricDifferenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    y: Array<T>
+  ): Array<T>;
+
+  declare function union<T>(
+    x: Array<T>,
+  ): (y: Array<T>) => Array<T>;
+  declare function union<T>(x: Array<T>, y: Array<T>): Array<T>;
+
+  declare function unionWith<T>(
+    fn: BinaryPredicateFn<T>,
+  ): ((x: Array<T>) => (y: Array<T>) => Array<T>) &
+    ((x: Array<T>, y: Array<T>) => Array<T>);
+  declare function unionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+  ): (y: Array<T>) => Array<T>;
+  declare function unionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    y: Array<T>
+  ): Array<T>;
+
+  // *Object
+  declare var assoc: {
+    <T, S>(
+      key: string,
+      ...args: Array<void>
+    ):
+      & ((val: T) => (src: S) => ({ [k: string]: T }))
+      & ((val: T, src: S) => ({ [k: string]: T } & S)),
+    <T, S>(
+      key: string,
+      val: T,
+      ...args: Array<void>
+    ): (src: S) => ({ [k: string]: T } & S),
+    <T, S: Object, K: $Keys<S>> (key: K, val: T, src: S):      ({ [k: string]: T } & S),
+    <T, S: Object>              (key: string, val: T, src: S): ({ [k: string]: T, ...$Exact<S> })
+  };
+
+  declare function assocPath<T: string | number, S, V>(
+    key: Array<T>,
+    ...args: Array<void>
+  ): ((val: V) => (src: S) => { [k: string]: V }) &
+    ((val: V) => (src: S) => { [k: string]: V } & S);
+  declare function assocPath<T: string | number, S, V>(
+    key: Array<T>,
+    val: V,
+    ...args: Array<void>
+  ): (src: S) => { [k: string]: V } & S;
+  declare function assocPath<T: string | number, S, V>(
+    key: Array<T>,
+    val: V,
+    src: S
+  ): { [k: string]: V } & S;
+
+  declare function clone<T>(src: T): $Shape<T>;
+
+  declare function dissoc<T>(
+    key: string,
+    ...args: Array<void>
+  ): (src: { [k: string]: T }) => { [k: string]: T };
+  declare function dissoc<T>(
+    key: string,
+    src: { [k: string]: T }
+  ): { [k: string]: T };
+
+  declare function dissocPath<T: string | number, U>(
+    key: Array<T>,
+    ...args: Array<void>
+  ): (src: { [k: string]: U }) => { [k: string]: U };
+  declare function dissocPath<T: string | number, U>(
+    key: Array<T>,
+    src: { [k: string]: U }
+  ): { [k: string]: U };
+
+  declare function evolve<A: Object>(NestedObject<Function>): A => A;
+  declare function evolve<A: Object>(NestedObject<Function>, A): A;
+
+  declare function eqProps(
+    key: string,
+    ...args: Array<void>
+  ): ((o1: Object) => (o2: Object) => boolean) &
+    ((o1: Object, o2: Object) => boolean);
+  declare function eqProps(
+    key: string,
+    o1: Object,
+    ...args: Array<void>
+  ): (o2: Object) => boolean;
+  declare function eqProps(key: string, o1: Object, o2: Object): boolean;
+
+  declare function has(key: string): (o: Object) => boolean;
+  declare function has(key: string, o: Object): boolean;
+
+  declare function hasPath<T: string | number>(path: Array<T>): (o: Object) => boolean;
+  declare function hasPath<T: string | number>(path: Array<T>, o: Object): boolean;
+
+  declare function hasIn(key: string, o: Object): boolean;
+  declare function hasIn(key: string): (o: Object) => boolean;
+
+  declare function invert(o: Object): { [k: string]: Array<string> };
+  declare function invertObj(o: Object): { [k: string]: string };
+
+  declare function keys(o: ?Object): Array<string>;
+
+  declare type Lens<A, B, Fa: Functor<A>, Fb: Functor<B>> = (A => Fb) => Fb;
+  /**
+   * Because it is difficult to treat objects as if they are Functors, let's
+   * just have a lens type that works with objects, since Ramda supports objects
+   * as Functors in this context.
+   */
+  declare type LensObj<F, A, O> = (A => O) => O;
+
+  declare var lens:
+    & (<A, B, Fa, Fb>(
+      getter: (f: Fa) => A) => (
+      setter: (b: B, f: Fa) => Fb
+    ) => LensObj<Fa, A, Fb>)
+    & (<A, B, Fa, Fb>(
+      getter: (f: Fa) => A,
+      setter: (b: B, f: Fa) => Fb
+    ) => LensObj<Fa, A, Fb>)
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(
+      getter: (f: Fa) => A) => (
+      setter: (b: B, f: Fa) => Fb
+    ) => Lens<A, B, Fa, Fb>)
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(
+      getter: (f: Fa) => A,
+      setter: (b: B, f: Fa) => Fb
+    ) => Lens<A, B, Fa, Fb>)
+
+  declare function lensIndex<A, B, Fa: Functor<A>, Fb: Functor<B>, N: number, V: $ElementType<Fa, N>>(N): Lens<V, B, Fa, Fb>;
+
+  /**
+   * lensPath requires a tuple rather than an Array for its parameter. This
+   * allows us to make rested $ElementType uses in order to walk down the object
+   * hierarchy. This remains something TODO.
+   */
+  declare function lensPath<O, F, K: $Keys<F>>(p: [K]): LensObj<F, $ElementType<F, K>, O>;
+  declare function lensPath<
+    O, F,
+    K0: $Keys<F>, E0: $ElementType<F, K0>,
+    K1: $Keys<E0>
+  >(p: [K0, K1]): LensObj<F, $ElementType<E0, K1>, O>;
+  declare function lensPath<
+    O, F,
+    K0: $Keys<F>, E0: $ElementType<F, K0>,
+    K1: $Keys<E0>, E1: $ElementType<E0, K1>,
+    K2: $Keys<E1>
+  >(p: [K0, K1, K2]): LensObj<F, $ElementType<E1, K2>, O>;
+  declare function lensPath<
+    O, F,
+    K0: $Keys<F>, E0: $ElementType<F, K0>,
+    K1: $Keys<E0>, E1: $ElementType<E0, K1>,
+    K2: $Keys<E1>, E2: $ElementType<E1, K2>,
+    K3: $Keys<E2>
+  >(p: [K0, K1, K2, K3]): LensObj<F, $ElementType<E2, K3>, O>;
+  declare function lensPath<
+    O, F,
+    K0: $Keys<F>, E0: $ElementType<F, K0>,
+    K1: $Keys<E0>, E1: $ElementType<E0, K1>,
+    K2: $Keys<E1>, E2: $ElementType<E1, K2>,
+    K3: $Keys<E2>, E3: $ElementType<E2, K3>,
+    K4: $Keys<E3>
+  >(p: [K0, K1, K2, K3, K4]): LensObj<F, $ElementType<E3, K4>, O>;
+
+  // declare function lensProp(str: string): Lens;
+  declare function lensProp<O, F, K: $Keys<F>>(K): LensObj<F, $ElementType<F, K>, O>;
+
+  declare function mapObjIndexed<A, B>(
+    fn: (val: A, key: string, o: Object) => B,
+    o: { [key: string]: A }
+  ): { [key: string]: B };
+  declare function mapObjIndexed<A, B>(
+    fn: (val: A, key: string, o: Object) => B,
+    ...args: Array<void>
+  ): (o: { [key: string]: A }) => { [key: string]: B };
+
+  declare type Merge =
+    (<A, B>(a: A) => (b: B) => A & B) &
+    (<A, B>(a: A, b: B) => A & B);
+
+  declare var mergeLeft: Merge;
+  declare var mergeDeepLeft: Merge;
+  declare var mergeRight: Merge;
+
+  declare function mergeAll<T>(
+    os: Array<{ [k: string]: T }>
+  ): { [k: string]: T };
+
+  declare var mergeDeepRight: (<A, B>(a: A, b: B) => B & A) &
+    (<A, B>(a: A) => (b: B) => B & A);
+
+  declare type MergeWith = (<A, B, T: $Values<A> & $Values<B>>(
+    fn: (a: T, b: T) => T,
+    a: A,
+    b: B
+  ) => A & B) &
+    (<A, B, T>(
+      fn: (a: T, b: T) => T,
+    ) => (a: A) => (b: B) => A & B) &
+    (<A, B, T>(
+      fn: (a: T, b: T) => T,
+    ) => (a: A, b: B) => A & B) &
+    (<A, B, T>(
+      fn: (a: T, b: T) => T,
+      a: A,
+    ) => (b: B) => A & B);
+
+  declare type MergeWithKey = (<
+    A,
+    B,
+    S: $Keys<A> & $Keys<B>,
+    T: $ElementType<A, $Keys<A>> & $ElementType<B, $Keys<B>>,
+  >(
+    fn: (s: S, a: T, b: T) => T,
+    a: A,
+    b: B
+  ) => A & B) &
+    (<S, T, A, B>(
+      fn: (s: S, a: T, b: T) => T,
+    ) => (a: A, b: B) => A & B) &
+    (<S, T, A, B>(
+      fn: (s: S, a: T, b: T) => T,
+    ) => (a: A) => (b: B) => A & B) &
+    (<S, T, A, B>(
+      fn: (s: S, a: T, b: T) => T,
+      a: A,
+    ) => (b: B) => A & B);
+
+  declare var mergeDeepWith: MergeWith;
+
+  declare var mergeDeepWithKey: MergeWithKey;
+
+  declare var mergeWith: MergeWith;
+
+  declare var mergeWithKey: MergeWithKey;
+
+  declare function objOf<T>(
+    key: string,
+  ): (val: T) => { [key: string]: T };
+  declare function objOf<T>(key: string, val: T): { [key: string]: T };
+
+  declare function omit<T: Object>(
+    keys: Array<string>,
+  ): (val: T) => Object;
+  declare function omit<T: Object>(keys: Array<string>, val: T): Object;
+
+  declare type Functor<A> =
+    | { @@iterator(): Iterator<A> }
+    | FunctorObj<A>
+    | FunctorFantasyLand<A>
+    | Array<A>
+    | $ReadOnlyArray<A>
+
+  declare var over:
+    & (<A, B, Oa, Ob>(lens: LensObj<Oa, A, B>) => CurriedFunction2<A => B, Oa, Ob>)
+    & (<A, B, Oa, Ob>(lens: LensObj<Oa, A, B>, A => B) => CurriedFunction1<Oa, Ob>)
+    & (<A, B, Oa, Ob>(lens: LensObj<Oa, A, B>, A => B, Oa) => Ob)
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(lens: Lens<A, B, Fa, Fb>) => CurriedFunction2<A => B, Fa, Fb>)
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(lens: Lens<A, B, Fa, Fb>, A => B) => CurriedFunction1<Fa, Fb>)
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(lens: Lens<A, B, Fa, Fb>, A => B, Fa) => Fb)
+
+  declare function path<T: string | number, V>(
+    p: Array<T>,
+  ): (o: NestedObject<V>) => V;
+  declare function path<T: string | number, V>(
+    p: Array<T>,
+  ): (o: null | void) => void;
+  declare function path<T: string | number, V>(
+    p: Array<T>,
+  ): (o: mixed) => ?V;
+  declare function path<T: string | number, V, A: NestedObject<V>>(p: Array<T>, o: A): V;
+  declare function path<T: string | number, V, A: null | void>(p: Array<T>, o: A): void;
+  declare function path<T: string | number, V, A>(p: Array<T>, o: A): ?V;
+
+  declare function path<V>(
+    p: Array<string>,
+  ): (o: NestedObject<V>) => V;
+  declare function path<V>(
+    p: Array<string>,
+  ): (o: null | void) => void;
+  declare function path<V>(
+    p: Array<string>,
+  ): (o: mixed) => ?V;
+  declare function path<V, A: NestedObject<V>>(p: Array<string>, o: A): V;
+  declare function path<V, A: null | void>(p: Array<string>, o: A): void;
+  declare function path<V, A: mixed>(p: Array<string>, o: A): ?V;
+
+  declare function pathOr<T, U: string | number, V, A: NestedObject<V>>(
+    or: T,
+  ): ((p: Array<U>) => (o: ?A) => V | T) &
+    ((p: Array<U>, o: ?A) => V | T);
+  declare function pathOr<T, U: string | number, V, A: NestedObject<V>>(
+    or: T,
+    p: Array<U>,
+  ): (o: ?A) => V | T;
+  declare function pathOr<T, U: string | number, V, A: NestedObject<V>>(
+    or: T,
+    p: Array<U>,
+    o: ?A
+  ): V | T;
+
+  declare function pick<O, K: $ReadOnlyArray<$Keys<O>>>(
+    keys: K,
+  ): (val: O) => O;
+  declare function pick<O, K: $ReadOnlyArray<$Keys<O>>>(
+    keys: K,
+    val: O
+  ): O;
+
+  declare function pickAll<A>(
+    keys: Array<string>,
+  ): (val: { [key: string]: A }) => { [key: string]: ?A };
+  declare function pickAll<A>(
+    keys: Array<string>,
+    val: { [key: string]: A }
+  ): { [key: string]: ?A };
+
+  declare function pickBy<A>(
+    fn: BinaryPredicateFn2<A, string>,
+  ): (val: { [key: string]: A }) => { [key: string]: A };
+  declare function pickBy<A>(
+    fn: BinaryPredicateFn2<A, string>,
+    val: { [key: string]: A }
+  ): { [key: string]: A };
+
+  declare function project<T>(
+    keys: Array<string>,
+  ): (val: Array<{ [key: string]: T }>) => Array<{ [key: string]: T }>;
+  declare function project<T>(
+    keys: Array<string>,
+    val: Array<{ [key: string]: T }>
+  ): Array<{ [key: string]: T }>;
+
+  declare function prop<T: string, O>(
+    key: T,
+  ): (o: O) => $ElementType<O, T>;
+  declare function prop<T: string, O>(
+    __: $npm$ramda$Placeholder,
+    o: O
+  ): (key: T) => $ElementType<O, T>;
+  declare function prop<T: string, O>(key: T, o: O): $ElementType<O, T>;
+
+  declare function propOr<T, V, A: { [k: string]: V }>(
+    or: T,
+  ): ((p: string) => (o: A) => V | T) &
+    ((p: string, o: A) => V | T);
+  declare function propOr<T, V, A: { [k: string]: V }>(
+    or: T,
+    p: string,
+  ): (o: A) => V | T;
+  declare function propOr<T, V, A: { [k: string]: V }>(
+    or: T,
+    p: string,
+    o: A
+  ): V | T;
+
+  declare function keysIn(o: Object): Array<string>;
+
+  declare function props<T: string, O>(
+    keys: Array<T>,
+  ): (o: O) => Array<$ElementType<O, T>>;
+  declare function props<T: string, O>(
+    keys: Array<T>,
+    o: O
+  ): Array<$ElementType<O, T>>;
+
+  declare var set:
+    & (<A, B, Oa, Ob>(lens: LensObj<Oa, A, B>) => (
+      & (B => Oa => Ob)
+      & ((B, Oa) => Ob)
+    ))
+    & (<A, B, Oa, Ob>(lens: LensObj<Oa, A, B>, B, Oa) => Ob)
+    // NOTE: Other functor types might need to be directly supported here.
+    & (<A, B, Fa: Array<A>>(lens: Lens<A, B, Fa, Array<B>>) => (
+      & (B => Fa => Array<B>)
+      & ((B, Fa) => Array<B>)
+    ))
+    & (<A, B, Fa: Array<A>>(lens: Lens<A, B, Fa, Array<B>>, B, Fa) => Array<B>)
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(lens: Lens<A, B, Fa, Fb>) => (
+      & (B => Fa => Fb)
+      & ((B, Fa) => Fb)
+    ))
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(lens: Lens<A, B, Fa, Fb>, B, Fa) => Fb)
+
+  declare function toPairs<T, O: { [k: string]: T }>(
+    o: O
+  ): Array<[$Keys<O>, T]>;
+
+  declare function toPairsIn<T, O: { [k: string]: T }>(
+    o: O
+  ): Array<[string, T]>;
+
+  declare function values<T>(o: T): Array<$Values<T>>;
+
+  declare function valuesIn<T, O: { [k: string]: T }>(o: O): Array<T | any>;
+
+  declare function where<O>(
+    predObj: $ObjMap<O, MapUnaryPredicateFn>,
+    o: O
+  ): boolean;
+  declare function where<O>(
+    predObj: $ObjMap<O, MapUnaryPredicateFn>
+  ): O => boolean;
+
+  declare function whereEq<T, S, O: { [k: string]: T }, Q: { [k: string]: S }>(
+    predObj: O,
+  ): (o: $Shape<O & Q>) => boolean;
+  declare function whereEq<T, S, O: { [k: string]: T }, Q: { [k: string]: S }>(
+    predObj: O,
+    o: $Shape<O & Q>
+  ): boolean;
+
+  declare var view:
+    & (<A, B, Oa, Ob>(LensObj<Oa, A, B>) => Oa => A)
+    & (<A, B, Oa, Ob>(LensObj<Oa, A, B>, Oa) => A)
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(Lens<A, B, Fa, Fb>) => Fa => A)
+    & (<A, B, Fa: Functor<A>, Fb: Functor<B>>(Lens<A, B, Fa, Fb>, Fa) => A)
+
+  // *Function
+  declare var __: $npm$ramda$Placeholder;
+
+  declare var T: (_: any) => true;
+  declare var F: (_: any) => false;
+
+  declare function addIndex<A, B>(
+    iterFn: (fn: (x: A) => B, xs: Array<A>) => Array<B>
+  ): (fn: (x: A, idx: number, xs: Array<A>) => B, xs: Array<A>) => Array<B>;
+
+  declare function always<T>(x: T): (x: any) => T;
+
+  declare function ap<T, V>(
+    fns: Array<(x: T) => V>,
+  ): (xs: Array<T>) => Array<V>;
+  declare function ap<T, V>(fns: Array<(x: T) => V>, xs: Array<T>): Array<V>;
+
+  declare function apply<T, V>(
+    fn: (...args: Array<T>) => V,
+  ): (xs: Array<T>) => V;
+  declare function apply<T, V>(fn: (...args: Array<T>) => V, xs: Array<T>): V;
+
+  declare function applySpec<
+    V,
+    S,
+    A: Array<V>,
+    T: NestedObject<(...args: A) => S>
+  >(
+    spec: T
+  ): (...args: A) => NestedObject<S>;
+
+  declare function applyTo<A, B>(a: A): (fn: (x: A) => B) => B;
+  declare function applyTo<A, B>(a: A, fn: (x: A) => B): B;
+
+  declare function binary<T>(
+    fn: (...args: Array<any>) => T
+  ): (x: any, y: any) => T;
+
+  declare function bind<T>(
+    fn: (...args: Array<any>) => any,
+    thisObj: T
+  ): (...args: Array<any>) => any;
+
+  declare function call<T, V>(
+    fn: (...args: Array<V>) => T,
+    ...args: Array<V>
+  ): T;
+
+  declare function comparator<T>(
+    fn: BinaryPredicateFn<T>
+  ): (x: T, y: T) => number;
+
+  // TODO add tests
+  declare function construct<T>(
+    ctor: Class<GenericContructor<T>>
+  ): (x: T) => GenericContructor<T>;
+
+  // TODO add tests
+  declare function constructN<T>(
+    n: number,
+    ctor: Class<GenericContructorMulti<any>>
+  ): (...args: any) => GenericContructorMulti<any>;
+
+  // TODO make less generic
+  declare function converge(after: Function, fns: Array<Function>): Function;
+
+  declare function empty<T>(x: T): T;
+
+  declare function flip<A, B, TResult>(
+    fn: (arg0: A, arg1: B) => TResult
+  ): CurriedFunction2<B, A, TResult>;
+  declare function flip<A, B, C, TResult>(
+    fn: (arg0: A, arg1: B, arg2: C) => TResult
+  ): ((arg0: B, arg1: A) => (arg2: C) => TResult) &
+    ((arg0: B, arg1: A, arg2: C) => TResult);
+  declare function flip<A, B, C, D, TResult>(
+    fn: (arg0: A, arg1: B, arg2: C, arg3: D) => TResult
+  ): ((
+    arg1: B,
+    arg0: A,
+  ) => (arg2: C, arg3: D) => TResult) &
+    ((arg1: B, arg0: A, arg2: C, arg3: D) => TResult);
+  declare function flip<A, B, C, D, E, TResult>(
+    fn: (arg0: A, arg1: B, arg2: C, arg3: D, arg4: E) => TResult
+  ): ((
+    arg1: B,
+    arg0: A,
+  ) => (arg2: C, arg3: D, arg4: E) => TResult) &
+    ((arg1: B, arg0: A, arg2: C, arg3: D, arg4: E) => TResult);
+
+  declare function identity<T>(x: T): T;
+
+  declare function invoker<A, B, C, D, O: { [k: string]: Function }>(
+    arity: number,
+    name: $Keys<O>
+  ): CurriedFunction2<A, O, D> &
+    CurriedFunction3<A, B, O, D> &
+    CurriedFunction4<A, B, C, O, D>;
+
+  declare function juxt<T, S>(
+    fns: Array<(...args: Array<S>) => T>
+  ): (...args: Array<S>) => Array<T>;
+
+  // TODO lift
+
+  // TODO liftN
+
+  declare function memoizeWith<A, B, C>(
+    keyFn: (...args: Array<A>) => C
+  ): (...args: Array<A>) => (...args: Array<A>) => B;
+  declare function memoizeWith<A, B, C>(
+    keyFn: (...args: Array<A>) => C,
+    fn: (...args: Array<A>) => B
+  ): (...args: Array<A>) => B;
+
+  declare function nAry<T>(
+    arity: number,
+    fn: (...args: Array<any>) => T
+  ): (...args: Array<any>) => T;
+
+  declare function nthArg<T>(n: number): (...args: Array<T>) => T;
+
+  declare var o: (<A, B, C>(
+    fn1: (b: B) => C,
+    ...rest: void[]
+  ) => ((fn2: (a: A) => B, ...rest: void[]) => (x: A) => C) &
+    ((fn2: (a: A) => B, x: A) => C)) &
+    (<A, B, C>(
+      fn1: (b: B) => C,
+      fn2: (a: A) => B,
+      ...rest: void[]
+    ) => (x: A) => C) &
+    (<A, B, C>(fn1: (b: B) => C, fn2: (a: A) => B, x: A) => C);
+
+  declare function of<T>(x: T): Array<T>;
+
+  declare function once<A, B, T: (...args: Array<A>) => B>(fn: T): T;
+
+  declare var partial: Partial;
+  // TODO partialRight
+
+  declare type UnaryMonadFn<A, R> = UnaryFn<A, Monad<R>>;
+  declare type PipeK = (<A, B, C, D, E, F, G, H, I, J, K, L: Monad<K>>(
+        ab: UnaryMonadFn<A, B>,
+        bc: UnaryMonadFn<B, C>,
+        cd: UnaryMonadFn<C, D>,
+        de: UnaryMonadFn<D, E>,
+        ef: UnaryMonadFn<E, F>,
+        fg: UnaryMonadFn<F, G>,
+        gh: UnaryMonadFn<G, H>,
+        hi: UnaryMonadFn<H, I>,
+        ij: UnaryMonadFn<I, J>,
+        jk: J => L,
+    ) => A => L) &
+    (<A, B, C, D, E, F, G, H, I, J, K: Monad<J>>(
+        ab: UnaryMonadFn<A, B>,
+        bc: UnaryMonadFn<B, C>,
+        cd: UnaryMonadFn<C, D>,
+        de: UnaryMonadFn<D, E>,
+        ef: UnaryMonadFn<E, F>,
+        fg: UnaryMonadFn<F, G>,
+        gh: UnaryMonadFn<G, H>,
+        hi: UnaryMonadFn<H, I>,
+        ij: I => K,
+    ) => A => K) &
+    (<A, B, C, D, E, F, G, H, I, J: Monad<I>>(
+        ab: UnaryMonadFn<A, B>,
+        bc: UnaryMonadFn<B, C>,
+        cd: UnaryMonadFn<C, D>,
+        de: UnaryMonadFn<D, E>,
+        ef: UnaryMonadFn<E, F>,
+        fg: UnaryMonadFn<F, G>,
+        gh: UnaryMonadFn<G, H>,
+        hi: H => J,
+    ) => A => J) &
+    (<A, B, C, D, E, F, G, H, I: Monad<H>>(
+        ab: UnaryMonadFn<A, B>,
+        bc: UnaryMonadFn<B, C>,
+        cd: UnaryMonadFn<C, D>,
+        de: UnaryMonadFn<D, E>,
+        ef: UnaryMonadFn<E, F>,
+        fg: UnaryMonadFn<F, G>,
+        gh: G => I,
+    ) => A => I) &
+    (<A, B, C, D, E, F, G, H: Monad<G>>(
+        ab: UnaryMonadFn<A, B>,
+        bc: UnaryMonadFn<B, C>,
+        cd: UnaryMonadFn<C, D>,
+        de: UnaryMonadFn<D, E>,
+        ef: UnaryMonadFn<E, F>,
+        fg: F => H,
+    ) => A => H) &
+    (<A, B, C, D, E, F, G: Monad<F>>(
+        ab: UnaryMonadFn<A, B>,
+        bc: UnaryMonadFn<B, C>,
+        cd: UnaryMonadFn<C, D>,
+        de: UnaryMonadFn<D, E>,
+        ef: E => G,
+    ) => A => G) &
+    (<A, B, C, D, E, F: Monad<E>>(
+        ab: UnaryMonadFn<A, B>,
+        bc: UnaryMonadFn<B, C>,
+        cd: UnaryMonadFn<C, D>,
+        de: D => F,
+    ) => A => F) &
+    (<A, B, C, D, E: Monad<D>>(
+        ab: UnaryMonadFn<A, B>,
+        bc: UnaryMonadFn<B, C>,
+        cd: C => E,
+    ) => A => E) &
+    (<A, B, C, D: Monad<C>>(
+        ab: UnaryMonadFn<A, B>,
+        bc: B => D,
+    ) => A => D) &
+    (<A, B, C: Monad<B>>(
+        ab: A => C
+    ) => A => C);
+
+  declare function tap<T>(fn: (x: T) => any): (x: T) => T;
+  declare function tap<T>(fn: (x: T) => any, x: T): T;
+
+  declare function tryCatch<A, B, E>(
+    tryer: (a: A) => B
+  ): ((catcher: (e: E, a: A) => B) => (a: A) => B) &
+    ((catcher: (e: E, a: A) => B, a: A) => B);
+  declare function tryCatch<A, B, E>(
+    tryer: (a: A) => B,
+    catcher: (e: E, a: A) => B
+  ): (a: A) => B;
+  declare function tryCatch<A, B, E>(
+    tryer: (a: A) => B,
+    catcher: (e: E, a: A) => B,
+    a: A
+  ): B;
+
+  declare function unapply<T, V>(
+    fn: (xs: Array<T>) => V
+  ): (...args: Array<T>) => V;
+
+  declare function unary<T>(fn: (...args: Array<any>) => T): (x: any) => T;
+
+  declare var uncurryN: (<A, B, C>(2, (A) => B => C) => (A, B) => C) &
+    (<A, B, C, D>(3, (A) => B => C => D) => (A, B, C) => D) &
+    (<A, B, C, D, E>(4, (A) => B => C => D => E) => (A, B, C, D) => E) &
+    (<A, B, C, D, E, F>(
+      5,
+      (A) => B => C => D => E => F
+    ) => (A, B, C, D, E) => F) &
+    (<A, B, C, D, E, F, G>(
+      6,
+      (A) => B => C => D => E => F => G
+    ) => (A, B, C, D, E, F) => G) &
+    (<A, B, C, D, E, F, G, H>(
+      7,
+      (A) => B => C => D => E => F => G => H
+    ) => (A, B, C, D, E, F, G) => H) &
+    (<A, B, C, D, E, F, G, H, I>(
+      8,
+      (A) => B => C => D => E => F => G => H => I
+    ) => (A, B, C, D, E, F, G, H) => I);
+
+  //TODO useWith
+
+  // *Logic
+
+  declare function allPass<T>(
+    fns: Array<(...args: Array<T>) => boolean>
+  ): (...args: Array<T>) => boolean;
+
+  declare function and<X, Y>(x: X): (y: Y) => X | Y;
+  declare function and<X, Y>(x: X, y: Y): X | Y;
+
+  declare function anyPass<T>(
+    fns: Array<(...args: Array<T>) => boolean>
+  ): (...args: Array<T>) => boolean;
+
+  declare function both<T>(
+    x: (...args: Array<T>) => boolean,
+  ): (y: (...args: Array<T>) => boolean) => (...args: Array<T>) => boolean;
+  declare function both<T>(
+    x: (...args: Array<T>) => boolean,
+    y: (...args: Array<T>) => boolean
+  ): (...args: Array<T>) => boolean;
+
+  // The following code is generated from
+  // https://github.com/LoganBarnett/typedef-gen due to Flow not being able to
+  // preserve the input function's form as a return type.
+  //
+  // Begin generated complement declaration.
+
+  declare function complement< Fn: () => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, Fn: (A) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, Fn: (A, B) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, C, Fn: (A, B, C) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, C, D, Fn: (A, B, C, D) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, C, D, E, Fn: (A, B, C, D, E) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, C, D, E, F, Fn: (A, B, C, D, E, F) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, C, D, E, F, G, Fn: (A, B, C, D, E, F, G) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, C, D, E, F, G, H, Fn: (A, B, C, D, E, F, G, H) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, C, D, E, F, G, H, I, Fn: (A, B, C, D, E, F, G, H, I) => boolean>(
+    f: Fn
+  ): Fn;
+
+  declare function complement<A, B, C, D, E, F, G, H, I, J, Fn: (A, B, C, D, E, F, G, H, I, J) => boolean>(
+    f: Fn
+  ): Fn;
+  // End generated complement declaration.
+
+  declare function cond<A, B>(
+    fns: Array<[(...args: Array<A>) => boolean, (...args: Array<A>) => B]>
+  ): (...args: Array<A>) => B;
+
+  declare function defaultTo<T, V>(d: T): (x: ?V) => V | T;
+  declare function defaultTo<T, V>(d: T, x: ?V): V | T;
+
+  declare function either(
+    x: (...args: Array<any>) => *,
+  ): (y: (...args: Array<any>) => *) => (...args: Array<any>) => *;
+  declare function either(
+    x: (...args: Array<any>) => *,
+    y: (...args: Array<any>) => *
+  ): (...args: Array<any>) => *;
+
+  declare function ifElse<Args, B, C>(
+    cond: (...args: Args) => boolean
+  ): ((
+    f1: (...args: Args) => B
+  ) => (f2: (...args: Args) => C) => (...args: Args) => B | C) &
+    ((
+      f1: (...args: Args) => B,
+      f2: (...args: Args) => C
+    ) => (...args: Args) => B | C);
+  declare function ifElse<Args, B, C>(
+    cond: (...args: Args) => boolean,
+    f1: (...args: Args) => B,
+    f2: (...args: Args) => C
+  ): (...args: Args) => B | C;
+
+  declare function isEmpty(x: ?Array<any> | Object | string): boolean;
+
+  declare function not(x: boolean): boolean;
+
+  declare function or<X, Y>(x: X): (y: Y) => X | Y;
+  declare function or<X, Y>(x: X, y: Y): X | Y;
+
+  declare var pathSatisfies: CurriedFunction3<
+    UnaryPredicateFn<any>,
+    Array<string | number>,
+    Object,
+    boolean
+  >;
+
+  declare function propSatisfies<T, K>(
+    cond: (x: $ElementType<T, K>) => boolean,
+    prop: K,
+    o: T
+  ): boolean;
+  declare function propSatisfies<T, K>(
+    cond: (x: $ElementType<T, K>) => boolean,
+    prop: K,
+  ): (o: T) => boolean;
+  declare function propSatisfies<T, K>(
+    cond: (x: $ElementType<T, K>) => boolean,
+  ): ((prop:  K) => (o: T) => boolean) &
+    ((prop:  K, o: T) => boolean);
+
+  declare function unless<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+  ): ((fn: (x: S) => V) => (x: T | S) => T | V) &
+    ((fn: (x: S) => V, x: T | S) => T | V);
+  declare function unless<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+  ): (x: T | S) => V | T;
+  declare function unless<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+    x: T | S
+  ): T | V;
+
+  declare function until<T>(
+    pred: UnaryPredicateFn<T>,
+  ): ((fn: (x: T) => T) => (x: T) => T) &
+    ((fn: (x: T) => T, x: T) => T);
+  declare function until<T>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: T) => T,
+  ): (x: T) => T;
+  declare function until<T>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: T) => T,
+    x: T
+  ): T;
+
+  declare function when<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+  ): ((fn: (x: S) => V) => (x: T | S) => T | V) &
+    ((fn: (x: S) => V, x: T | S) => T | V);
+  declare function when<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+  ): (x: T | S) => V | T;
+  declare function when<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+    x: T | S
+  ): T | V;
+}

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.26.x_relation.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.26.x_relation.js
@@ -1,0 +1,330 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+import { it, describe } from "flow-typed-test";
+import _, {
+  ascend,
+  compose,
+  curry,
+  descend,
+  filter,
+  find,
+  gt,
+  gte,
+  intersection,
+  lt,
+  lte,
+  pipe,
+  prop,
+  repeat,
+  sort,
+  zipWith,
+} from "ramda";
+
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed } = { a: 1, c: "d" };
+const objArr: { [k: string]: mixed } = { a: 1, b: [1,2,3], c: "d"};
+const os: Array<{ [k: string]: * }> = [{ a: 1, c: "d" }, { b: 2 }];
+const str: string = "hello world";
+
+const cl: number = _.clamp(1, 10, -1);
+const numbers = [1.0, 1.1, 1.2, 2.0, 3.0, 2.2];
+const letters = _.split("", "abcABCaaaBBc");
+// In ramda docs example it's just `Math.floor`
+// but we don't want the implicit number -> string
+const countB = _.countBy(_.compose(_.toString, Math.floor))(numbers);
+const countB1: { [k: string]: number } = _.countBy(_.toLower)(letters);
+const diff: Array<number> = _.difference([1, 2, 3, 4], [7, 6, 5, 4, 3]);
+//$ExpectError
+const diff1: Array<string> = _.difference(
+  ["1", "2", "3", "4"],
+  [7, 6, 5, 4, 3]
+);
+
+const cmp = (x, y) => x.a === y.a;
+const l1 = [{ a: 1 }, { a: 2 }, { a: 3 }];
+const l2 = [{ a: 3 }, { a: 4 }];
+const diff2 = _.differenceWith(cmp, l1, l2);
+
+const eqb: boolean = _.eqBy(Math.abs, 5, -5);
+
+const es: boolean = _.equals([1, 2, 3], [1, 2, 3]);
+
+describe('ascend', () => {
+  /**
+   * In the examples for ascend, its result is plugged into sort. In order
+   * for this to function properly ascend needs to yield a function that can
+   * take two arguments.
+   */
+  it('works as an input to sort', () => {
+    const byAge = ascend(prop('age'));
+    const people = [
+      { name: 'Emma', age: 70 },
+      { name: 'Peter', age: 78 },
+      { name: 'Mikhail', age: 62 },
+    ];
+    const peopleByYoungestFirst = sort(byAge, people);
+  })
+
+  it('returns a curried function', () => {
+    const byAge = ascend(prop('age'))
+    byAge({ name: 'Emma', age: 70 })({ name: 'Peter', age: 78 })
+  })
+})
+
+describe('descend', () => {
+  /**
+   * In the examples for descend, its result is plugged into sort. In order
+   * for this to function properly descend needs to yield a function that can
+   * take two arguments.
+   */
+  it('works as an input to sort', () => {
+    const byAge = descend(prop('age'));
+    const people = [
+      { name: 'Emma', age: 70 },
+      { name: 'Peter', age: 78 },
+      { name: 'Mikhail', age: 62 },
+    ];
+    const peopleByYoungestFirst = sort(byAge, people);
+  })
+
+  it('returns a curried function', () => {
+    const byAge = descend(prop('age'))
+    byAge({ name: 'Emma', age: 70 })({ name: 'Peter', age: 78 })
+  })
+})
+
+describe('gt', () => {
+  it('works with two numbers and produces a bool', () => {
+    const result: bool = gt(2, 1)
+  })
+
+  it('works with two curried numbers and produces a bool', () => {
+    const result: bool = gt(2)(1)
+  })
+
+  it('works with two strings and produces a bool', () => {
+    const result: bool = gt('a', 'b')
+  })
+
+  it('works with two curried strings and produces a bool', () => {
+    const result: bool = gt('a')('b')
+  })
+
+  it('does not work with mixed numbers and strings', () => {
+    // $ExpectError
+    gt('a', 1)
+    // $ExpectError
+    gt(1, 'a')
+  })
+
+  it('does not work with functions', () => {
+    // $ExpectError
+    gt(() => 1, () => 2)
+  })
+})
+
+describe('gte', () => {
+  it('works with two numbers and produces a bool', () => {
+    const result: bool = gte(2, 1)
+  })
+
+  it('works with two curried numbers and produces a bool', () => {
+    const result: bool = gte(2)(1)
+  })
+
+  it('works with two strings and produces a bool', () => {
+    const result: bool = gte('a', 'b')
+  })
+
+  it('works with two curried strings and produces a bool', () => {
+    const result: bool = gte('a')('b')
+  })
+
+  it('does not work with mixed numbers and strings', () => {
+    // $ExpectError
+    gte('a', 1)
+    // $ExpectError
+    gte(1, 'a')
+  })
+
+  it('does not work with functions', () => {
+    // $ExpectError
+    gte(() => 1, () => 2)
+  })
+})
+
+describe('lt', () => {
+  it('works with two numbers and produces a bool', () => {
+    const result: bool = lt(2, 1)
+  })
+
+  it('works with two curried numbers and produces a bool', () => {
+    const result: bool = lt(2)(1)
+  })
+
+  it('works with two strings and produces a bool', () => {
+    const result: bool = lt('a', 'b')
+  })
+
+  it('works with two curried strings and produces a bool', () => {
+    const result: bool = lt('a')('b')
+  })
+
+  it('does not work with mixed numbers and strings', () => {
+    // $ExpectError
+    lt('a', 1)
+    // $ExpectError
+    lt(1, 'a')
+  })
+
+  it('does not work with functions', () => {
+    // $ExpectError
+    lt(() => 1, () => 2)
+  })
+})
+
+describe('lte', () => {
+  it('works with two numbers and produces a bool', () => {
+    const resulte: bool = lte(2, 1)
+  })
+
+  it('works with two curried numbers and produces a bool', () => {
+    const resulte: bool = lte(2)(1)
+  })
+
+  it('works with two strings and produces a bool', () => {
+    const resulte: bool = lte('a', 'b')
+  })
+
+  it('works with two curried strings and produces a bool', () => {
+    const resulte: bool = lte('a')('b')
+  })
+
+  it('does not work with mixed numbers and strings', () => {
+    // $ExpectError
+    lte('a', 1)
+    // $ExpectError
+    lte(1, 'a')
+  })
+
+  it('does not work with functions', () => {
+    // $ExpectError
+    lte(() => 1, () => 2)
+  })
+})
+
+const _max: number = _.max(2, 1);
+const _min: number = _.min(2, 1);
+
+const _maxBy: number = _.maxBy(Math.abs)(2, 1);
+const _minBy: number = _.minBy(Math.abs, 2, 1);
+
+const _identical: boolean = _.identical(2, 1);
+
+const _innerJoin: Array<{ [k: string]: mixed }> = _.innerJoin(
+  (record, id) => record.id === id,
+  [{id: 824, name: 'Richie Furay'},
+   {id: 956, name: 'Dewey Martin'},
+   {id: 313, name: 'Bruce Palmer'},
+   {id: 456, name: 'Stephen Stills'},
+   {id: 177, name: 'Neil Young'}],
+  [177, 456, 999]
+);
+
+const pathEqObj: boolean = _.pathEq(["b", 1], 1, objArr);
+const pathEqObj2: boolean = _.pathEq(["b", 1])(1)(objArr);
+
+// It's good to test this with multiple params since $Keys<T> is a union.
+type PropEqObj = { bar: number, baz: string };
+const propEqObj: PropEqObj = { bar: 2, baz: "qux" };
+
+const isQueen = _.propEq("rank", "Q");
+
+const propEqResult1a: boolean = _.propEq("bar", 1, propEqObj);
+// Test curried versions.
+const propEqResult1b: boolean = _.propEq("bar")(1)(propEqObj);
+const propEqResult1c: boolean = _.propEq("bar")(1, propEqObj);
+const propEqResult1d: boolean = _.propEq("bar", 1)(propEqObj);
+
+// The type compared can be any type just like any other === comparison.
+// Also test the various arities.
+const propEqResult2a: boolean = _.propEq("bar", "always false", propEqObj);
+const propEqResult2b: boolean = _.propEq("bar")("always false")(propEqObj);
+const propEqResult2c: boolean = _.propEq("bar")("always false", propEqObj);
+const propEqResult2d: boolean = _.propEq("bar", "always false")(propEqObj);
+
+// The property name must be a property on the object supplied.
+// $ExpectError
+const propEqResultError: boolean = _.propEq("missing", 1, propEqObj);
+
+// propEq must work with key value pairs.
+const propEqKvp: { [string]: mixed } = { foo: 1, bar: "2", baz: 3 };
+const propEqResult3a: boolean = _.propEq("qux", "value", propEqKvp);
+const propEqResult3b: boolean = _.propEq("qux")("value")(propEqKvp);
+const propEqResult3c: boolean = _.propEq("qux")("value", propEqKvp);
+const propEqResult3d: boolean = _.propEq("qux", "value")(propEqKvp);
+
+// propEq must work with arrays.
+const propEqArray = [1, 2, 3];
+const propEqResult4a: boolean = _.propEq(1, 2, propEqArray);
+const propEqResult4b: boolean = _.propEq(1)(2)(propEqArray);
+const propEqResult4c: boolean = _.propEq(1)(2, propEqArray);
+const propEqResult4d: boolean = _.propEq(1, 2)(propEqArray);
+
+const sortByFirstItem = _.sortBy(([first]) => first);
+const pairs = [[-1, 1], [-2, 2], [-3, 3]];
+const sorted: Array<[number, number]> = sortByFirstItem(pairs);
+
+const sortWithData = [
+  {name: 'alice', age: 40},
+  {name: 'bob', age: 30},
+  {name: 'clara', age: 40}
+];
+const descAge = (l, r) => l.age < r.age ? -1 : 1;
+const ascName = (l, r) => l.name < r.name ? -1 : 1;
+_.sortWith([descAge, ascName], sortWithData);
+_.sortWith([descAge, ascName])(sortWithData);
+
+const eqA = _.eqBy(prop("a"));
+const ls1: Array<{ [k: string]: number }> = [
+  { a: 1 },
+  { a: 2 },
+  { a: 3 },
+  { a: 4 }
+];
+const ls2: Array<{ [k: string]: number }> = [
+  { a: 3 },
+  { b: 4 },
+  { a: 5 },
+  { a: 6 }
+];
+const symW: Array<{ [k: string]: number }> = _.symmetricDifferenceWith(
+  eqA,
+  ls1,
+  ls2
+);
+const sym: Array<number> = _.symmetricDifference([1, 2, 3, 4], [7, 6, 5, 4, 3]);
+
+const un: Array<number> = _.union([1, 2, 3])([2, 3, 4]);
+const un1: Array<{ [k: string]: number }> = _.unionWith(eqA, ls1, ls2);
+
+// Given $ReadOnlyArray is super type of Array, no need to test Array -> $ReadOnlyArray case
+describe('intersection', () => {
+  it('should accept read only input', () => {
+    const readOnlyArray: $ReadOnlyArray<number> = [1, 2, 3]
+    const inters1: Array<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters2: Array<number> = intersection(readOnlyArray)(readOnlyArray)
+    const inters3: $ReadOnlyArray<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters4: $ReadOnlyArray<number> = intersection(readOnlyArray)(readOnlyArray)
+  });
+
+  it('should allow mutable array in and out', () => {
+    const readOnlyArray: Array<number> = [1, 2, 3]
+    const inters1: Array<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters2: Array<number> = intersection(readOnlyArray)(readOnlyArray)
+    const inters3: $ReadOnlyArray<number> = intersection(readOnlyArray, readOnlyArray)
+    const inters4: $ReadOnlyArray<number> = intersection(readOnlyArray)(readOnlyArray)
+  });
+})

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_cjs_modules.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_cjs_modules.js
@@ -1,0 +1,29 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+const _ = require("ramda");
+const { compose, match, toLower, trim, zipWith } = _;
+
+// $ExpectError
+inc();
+
+const str: Array<string | void> = compose(match(/2/), toLower, trim)(" 1,2,3 ");
+const str1: Array<string> = _.compose(_.split(","), _.toLower, _.trim)(
+  " 1,2,3 "
+);
+const str2: string = _.compose(_.replace("3", "4"), _.toLower, _.trim)(
+  " 1,2,3 "
+);
+
+const zipped: Array<{ s: number, y: string }> = _.zipWith(
+  (a, b) => ({ s: a, y: b }),
+  [1, 2, 3],
+  ["1", "2", "3"]
+);
+const zipped2: Array<{ s: number, y: string }> = zipWith(
+  (a, b) => ({ s: a, y: b }),
+  [1, 2, 3]
+)(["1", "2", "3"]);
+const zipped3: Array<{ s: number, y: string }> = _.zipWith((a, b) => ({
+  s: a,
+  y: b
+}))([1, 2, 3])(["1", "2", "3"]);

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_es_modules.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_es_modules.js
@@ -1,0 +1,14 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+import _, { compose, match, toLower, trim } from "ramda";
+
+//$ExpectError
+inc();
+
+const str: Array<string | void> = compose(match(/2/), toLower, trim)(" 1,2,3 ");
+const str1: Array<string> = _.compose(_.split(","), _.toLower, _.trim)(
+  " 1,2,3 "
+);
+const str2: string = _.compose(_.replace("3", "4"), _.toLower, _.trim)(
+  " 1,2,3 "
+);

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_filter.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_filter.js
@@ -1,0 +1,94 @@
+// @flow
+import R, { filter, type RefineFilter } from "ramda";
+import { it, describe } from "flow-typed-test";
+
+describe("filter", () => {
+  it("perserves the element type in the predicate and result array (number)", () => {
+    const s: Array<number> = filter(x => x > 1, [1, 2]);
+  });
+
+  it("perserves the element type in the predicate and result array (number)", () => {
+    const s: Array<string> = R.filter(x => x === "2", ["2", "3"]);
+  });
+
+  it("filters objects by passing the value to the predicate", () => {
+    const s: { [key: string]: string } = R.filter(x => x === "2", {
+      a: "2",
+      b: "3"
+    });
+  });
+
+  it("refines the element type using the predicate", () => {
+    const notNull = (x): boolean %checks => x != null;
+    const ns: Array<number> = (filter: RefineFilter)(notNull, [1, 2, null]);
+  });
+
+  it("fails when type refinement is incorrect", () => {
+    const isString = (x): boolean %checks => typeof x === "string";
+    // $ExpectError
+    const ns: Array<number> = (filter: RefineFilter)(isString, ["1", 2]);
+  });
+
+  it("fails when attempting to refine from a non $Pred predicate", () => {
+    const isNumber = x => typeof x === "number";
+    // $ExpectError
+    const ns: Array<number> = filter(isNumber, ["1", 2]);
+  });
+
+  it("does not accept predicates missing %checks when using RefineFilter", () => {
+    const isNumber = x => typeof x === "number";
+    // $ExpectError
+    const ns: Array<number> = (filter: RefineFilter)(isNumber, ["1", 2]);
+  });
+
+  describe("read only", () => {
+    it("should return readonly Array<number>", () => {
+      const readOnlyArrNumbers: $ReadOnlyArray<number> = Object.freeze([1, 2, 3]);
+
+      const result1 = filter(x => x > 1, readOnlyArrNumbers);
+      (result1: $ReadOnlyArray<number>);
+
+      // $ExpectError
+      (result1: { +[key: string]: number });
+      // $ExpectError
+      (result1: { [key: string]: number });
+      // $ExpectError
+      (result1: Array<number>);
+
+      const result2 = filter(x => x > 1)(readOnlyArrNumbers);
+
+      (result2: $ReadOnlyArray<number>);
+
+      // $ExpectError
+      (result2: { +[key: string]: number });
+      // $ExpectError
+      (result2: { [key: string]: number });
+      // $ExpectError
+      (result2: Array<number>);
+    });
+
+    it("should return readonly Object", () => {
+      type O = {| key: number |};
+      const readOnlyObj: { +[k: string]: O } = Object.freeze({
+        a: { key: 1 },
+        c: { key: 2 },
+        d: { key: 3 }
+      });
+
+      (filter(
+        R.pipe(
+          R.prop("key"),
+          (v: number) => v === 0
+        ),
+        readOnlyObj
+      ): $ReadOnly<{ [k: string]: O }>);
+
+      (filter(
+        R.pipe(
+          R.prop("key"),
+          (v: number) => v === 0
+        )
+      )(readOnlyObj): { +[k: string]: O });
+    });
+  });
+});

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_functions.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_functions.js
@@ -1,0 +1,420 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+import _, { compose, pipe, uncurryN, curry, tryCatch, applyTo } from "ramda";
+// Function
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed } = { a: 1, c: "d" };
+const os: Array<{ [k: string]: * }> = [{ a: 1, c: "d" }, { b: 2 }];
+const str: string = "hello world";
+
+// TODO: "Gap" Functions: Started failing in v31...
+// const g = _.propIs
+// const __ = _.__
+// const g1: boolean = g(1, '2', {p: 3})
+// const g2: boolean = g(__, '2', {p: 3})(1)
+// const g3: boolean = g(__, __, {p: 3})(1)('2')
+// const g4: boolean = g(__, __, {p: 3})(1, '2')
+// const g5: boolean = g(__, '2', __)(1, {p: 3})
+// const g6: boolean = g(__, '2')(1)({p: 3})
+// const g7: boolean = g(__, '2')(1, {p: 3})
+// const g8: boolean = g(__, '2')(__, {p: 3})(1)
+
+type R = {
+  sum: number,
+  nested: { mul: number }
+};
+// TODO: "Gap" Functions: Started failing in v31...
+// const greet: string = _.replace('{name}', _.__, 'Hello, {name}!')('John')
+const truth: boolean = _.T("ddd");
+const lie: boolean = _.F("ddd");
+const mapIndexed = _.addIndex(_.map);
+
+const mi: Array<string> = mapIndexed((val, idx) => idx + "-" + val, [
+  "f",
+  "o",
+  "o",
+  "b",
+  "a",
+  "r"
+]);
+
+const t: string = _.always("Tee")();
+const app: Array<number> = _.ap([_.multiply(2), _.add(3)], [1, 2, 3]);
+const app1: Array<string | number> = _.ap([_.toString, _.add(3)], [1, 2, 3]);
+
+const nums = [1, 2, 3, -99, 42, 6, 7];
+const applied: number = _.apply(Math.max, nums);
+const spec = {
+  sum: _.add,
+  nested: { mul: _.multiply }
+};
+
+const applyToResult1 = applyTo(5, value => {
+  (value: number);
+  // $ExpectError
+  (value: string);
+  return String(value)
+});
+(applyToResult1: string);
+// $ExpectError
+(applyToResult1: number);
+
+const applyToResult2 = applyTo(5)(value => {
+  (value: number);
+  // $ExpectError
+  (value: string);
+  return String(value)
+});
+(applyToResult2: string);
+// $ExpectError
+(applyToResult2: number);
+
+const getMetrics = _.applySpec(spec);
+const apspec: $Shape<R> = getMetrics(2, 2);
+
+const applyToResult3 = _.applyTo(5, value => {
+  (value: number);
+  // $ExpectError
+  (value: string);
+  return String(value)
+});
+(applyToResult3: string);
+// $ExpectError
+(applyToResult3: number);
+
+const applyToResult4 = _.applyTo(5)(value => {
+  (value: number);
+  // $ExpectError
+  (value: string);
+  return String(value)
+});
+(applyToResult4: string);
+// $ExpectError
+(applyToResult4: number);
+
+const cmp: (x: Object, y: Object) => number = _.comparator(
+  (a, b) => a.age < b.age
+);
+const compf: number = _.compose(_.inc, _.negate)(2);
+
+const fn = compose(_.add);
+const fn1: (n: number) => number = fn(2);
+const add2 = _.compose(_.add(2));
+const four: number = add2(2);
+const str0: Array<string | void> = _.compose(_.match(/2/), _.toLower, _.trim)(
+  " 1,2,3 "
+);
+const str1: Array<string> = _.compose(_.split(","), _.toLower, _.trim)(
+  " 1,2,3 "
+);
+const str2: string = _.compose(_.replace("3", "4"), _.toLower, _.trim)(
+  " 1,2,3 "
+);
+
+const fn2: (n: number) => (n: number) => number = pipe(_.add);
+const fn3: (n: number) => number = fn2(2);
+const add2p = _.pipe(_.add(2));
+const b: number = add2p(2);
+const fail: string = _.pipe(_.trim)("h");
+const str3: Array<string | void> = _.pipe(_.toLower, _.trim, _.match(/2/))(
+  " 1,2,3 "
+);
+const str4: Array<string> = _.pipe(_.toLower, _.trim, _.split(","))(" 1,2,3 ");
+const str5: string = _.pipe(_.replace("3", "4"), _.toLower, _.trim)(" 1,2,3 ");
+
+// --- Curry ---
+declare var bar1: string => "bar1";
+declare var bar2: (string, number) => "bar2";
+declare var bar6: (string, number, boolean, null, {}, []) => "bar6";
+
+const foo1 = curry(bar1);
+const foo2 = curry(bar2);
+const foo6 = curry(bar6);
+
+const foo1_1: "bar1" = foo1("");
+const foo2_1: "bar2" = foo2("", 0);
+const foo2_2: "bar2" = foo2("")(0);
+
+const foo6_1: "bar6" = foo6("", 0, true, null, {}, []);
+const foo6_2: "bar6" = foo6("")(0, true, null, {}, []);
+const foo6_3: "bar6" = foo6("", 0)(true, null, {}, []);
+const foo6_4: "bar6" = foo6("", 0, true)(null, {}, []);
+const foo6_5: "bar6" = foo6("", 0, true, null)({}, []);
+const foo6_6: "bar6" = foo6("", 0, true, null, {})([]);
+const foo6_7: "bar6" = foo6("")(0)(true, null, {}, []);
+const foo6_8: "bar6" = foo6("", 0)(true)(null, {}, []);
+const foo6_9: "bar6" = foo6("", 0, true)(null)({}, []);
+const foo6_10: "bar6" = foo6("", 0, true, null)({})([]);
+const foo6_11: "bar6" = foo6("")(0, true)(null, {}, []);
+const foo6_12: "bar6" = foo6("", 0)(true, null)({}, []);
+const foo6_13: "bar6" = foo6("", 0, true)(null, {})([]);
+const foo6_14: "bar6" = foo6("")(0, true, null)({}, []);
+const foo6_15: "bar6" = foo6("", 0)(true, null, {})([]);
+const foo6_16: "bar6" = foo6("")(0, true, null, {})([]);
+
+// $ExpectError
+const foo6_1_Error1: "bar6" = foo6(false, 0, true, null, {}, []);
+// $ExpectError
+const foo6_2_Error1: "bar6" = foo6(false)(0, true, null, {}, []);
+// $ExpectError
+const foo6_3_Error1: "bar6" = foo6(false, 0)(true, null, {}, []);
+// $ExpectError
+const foo6_4_Error1: "bar6" = foo6(false, 0, true)(null, {}, []);
+// $ExpectError
+const foo6_5_Error1: "bar6" = foo6(false, 0, true, null)({}, []);
+// $ExpectError
+const foo6_6_Error1: "bar6" = foo6(false, 0, true, null, {})([]);
+// $ExpectError
+const foo6_7_Error1: "bar6" = foo6(false)(0)(true, null, {}, []);
+// $ExpectError
+const foo6_8_Error1: "bar6" = foo6(false, 0)(true)(null, {}, []);
+// $ExpectError
+const foo6_9_Error1: "bar6" = foo6(false, 0, true)(null)({}, []);
+// $ExpectError
+const foo6_10_Error1: "bar6" = foo6(false, 0, true, null)({})([]);
+// $ExpectError
+const foo6_11_Error1: "bar6" = foo6(false)(0, true)(null, {}, []);
+// $ExpectError
+const foo6_12_Error1: "bar6" = foo6(false, 0)(true, null)({}, []);
+// $ExpectError
+const foo6_13_Error1: "bar6" = foo6(false, 0, true)(null, {})([]);
+// $ExpectError
+const foo6_14_Error1: "bar6" = foo6(false)(0, true, null)({}, []);
+// $ExpectError
+const foo6_15_Error1: "bar6" = foo6(false, 0)(true, null, {})([]);
+// $ExpectError
+const foo6_16_Error1: "bar6" = foo6(false)(0, true, null, {})([]);
+
+// $ExpectError
+const foo6_1_Error2: "bar6" = foo6("", 0, true, "", {}, []);
+// $ExpectError
+const foo6_2_Error2: "bar6" = foo6("")(0, true, "", {}, []);
+// $ExpectError
+const foo6_3_Error2: "bar6" = foo6("", 0)(true, "", {}, []);
+// $ExpectError
+const foo6_4_Error2: "bar6" = foo6("", 0, true)("", {}, []);
+// $ExpectError
+const foo6_5_Error2: "bar6" = foo6("", 0, true, "")({}, []);
+// $ExpectError
+const foo6_6_Error2: "bar6" = foo6("", 0, true, "", {})([]);
+// $ExpectError
+const foo6_7_Error2: "bar6" = foo6("")(0)(true, "", {}, []);
+// $ExpectError
+const foo6_8_Error2: "bar6" = foo6("", 0)(true)("", {}, []);
+// $ExpectError
+const foo6_9_Error2: "bar6" = foo6("", 0, true)("")({}, []);
+// $ExpectError
+const foo6_10_Error2: "bar6" = foo6("", 0, true, "")({})([]);
+// $ExpectError
+const foo6_11_Error2: "bar6" = foo6("")(0, true)("", {}, []);
+// $ExpectError
+const foo6_12_Error2: "bar6" = foo6("", 0)(true, "")({}, []);
+// $ExpectError
+const foo6_13_Error2: "bar6" = foo6("", 0, true)("", {})([]);
+// $ExpectError
+const foo6_14_Error2: "bar6" = foo6("")(0, true, "")({}, []);
+// $ExpectError
+const foo6_15_Error2: "bar6" = foo6("", 0)(true, "", {})([]);
+// $ExpectError
+const foo6_16_Error2: "bar6" = foo6("")(0, true, "", {})([]);
+
+// $ExpectError
+const foo6_1_Error3: "bar6" = foo6("", 0, true, null, {}, "");
+// $ExpectError
+const foo6_2_Error3: "bar6" = foo6("")(0, true, null, {}, "");
+// $ExpectError
+const foo6_3_Error3: "bar6" = foo6("", 0)(true, null, {}, "");
+// $ExpectError
+const foo6_4_Error3: "bar6" = foo6("", 0, true)(null, {}, "");
+// $ExpectError
+const foo6_5_Error3: "bar6" = foo6("", 0, true, null)({}, "");
+// $ExpectError
+const foo6_6_Error3: "bar6" = foo6("", 0, true, null, {})("");
+// $ExpectError
+const foo6_7_Error3: "bar6" = foo6("")(0)(true, null, {}, "");
+// $ExpectError
+const foo6_8_Error3: "bar6" = foo6("", 0)(true)(null, {}, "");
+// $ExpectError
+const foo6_9_Error3: "bar6" = foo6("", 0, true)(null)({}, "");
+// $ExpectError
+const foo6_10_Error3: "bar6" = foo6("", 0, true, null)({})("");
+// $ExpectError
+const foo6_11_Error3: "bar6" = foo6("")(0, true)(null, {}, "");
+// $ExpectError
+const foo6_12_Error3: "bar6" = foo6("", 0)(true, null)({}, "");
+// $ExpectError
+const foo6_13_Error3: "bar6" = foo6("", 0, true)(null, {})("");
+// $ExpectError
+const foo6_14_Error3: "bar6" = foo6("")(0, true, null)({}, "");
+// $ExpectError
+const foo6_15_Error3: "bar6" = foo6("", 0)(true, null, {})("");
+// $ExpectError
+const foo6_16_Error3: "bar6" = foo6("")(0, true, null, {})("");
+
+// $ExpectError
+const foo6_1_Error4: "error" = foo6("", 0, true, null, {}, []);
+// $ExpectError
+const foo6_2_Error4: "error" = foo6("")(0, true, null, {}, []);
+// $ExpectError
+const foo6_3_Error4: "error" = foo6("", 0)(true, null, {}, []);
+// $ExpectError
+const foo6_4_Error4: "error" = foo6("", 0, true)(null, {}, []);
+// $ExpectError
+const foo6_5_Error4: "error" = foo6("", 0, true, null)({}, []);
+// $ExpectError
+const foo6_6_Error4: "error" = foo6("", 0, true, null, {})([]);
+// $ExpectError
+const foo6_7_Error4: "error" = foo6("")(0)(true, null, {}, []);
+// $ExpectError
+const foo6_8_Error4: "error" = foo6("", 0)(true)(null, {}, []);
+// $ExpectError
+const foo6_9_Error4: "error" = foo6("", 0, true)(null)({}, []);
+// $ExpectError
+const foo6_10_Error4: "error" = foo6("", 0, true, null)({})([]);
+// $ExpectError
+const foo6_11_Error4: "error" = foo6("")(0, true)(null, {}, []);
+// $ExpectError
+const foo6_12_Error4: "error" = foo6("", 0)(true, null)({}, []);
+// $ExpectError
+const foo6_13_Error4: "error" = foo6("", 0, true)(null, {})([]);
+// $ExpectError
+const foo6_14_Error4: "error" = foo6("")(0, true, null)({}, []);
+// $ExpectError
+const foo6_15_Error4: "error" = foo6("", 0)(true, null, {})([]);
+// $ExpectError
+const foo6_16_Error4: "error" = foo6("")(0, true, null, {})([]);
+
+// -------------
+
+const currfn1: (y: number) => number = _.curryN(
+  2,
+  (x: number, y: number): number => x + y
+)(2);
+
+const flipped: (x: number, y: boolean, z: string) => number = _.flip(
+  (x: boolean, y: number, z: string) => 1
+);
+const flipped2: (x: number, y: boolean) => (z: string) => number = _.flip(
+  (x: boolean, y: number, z: string) => 1
+);
+const obb = {
+  doStuff(x: string, y: number, z: boolean) {
+    return 1;
+  },
+  doLessStuff(x: string, y: number) {
+    return "hello";
+  },
+  doEvenLessStuff(x: string) {
+    return true;
+  }
+};
+const doStuff: (
+  x: string,
+  y: number,
+  z: boolean,
+  obj: typeof obb
+) => number = _.invoker(3, "doStuff");
+//$ExpectError
+const doLessStuff: (
+  x: string,
+  y: number,
+  z: boolean,
+  obj: typeof obb
+) => number = _.invoker(3, "doLStuff");
+const stuffDone: number = doStuff("dd", 1, true, obb);
+
+const range = _.juxt([_.toString, Math.min, Math.max]);
+const ju: Array<number | string> = range(3, 4, 9, -3);
+
+
+let _memoizeWith = 0;
+const _memoizeWithFactorial = _.memoizeWith(_.identity, n => {
+  _memoizeWith += 1;
+  return _.product(_.range(1, n + 1));
+});
+const memWith: number = _memoizeWithFactorial(5);
+
+const narg: string | number = _.nthArg(1)(1, "b", "c");
+
+const nameIs = ({ first, last }) => `The name's ${last}, ${first} ${last}`;
+const o1: string = _.o(_.toUpper, nameIs)({ first: "James", last: "Bond" });
+const oNum: number = _.o(_.multiply(10), _.add(10))(-4);
+
+const oof: Array<Array<number>> = _.of([42]);
+
+const unap: string = _.unapply(JSON.stringify)(1, 2, 3);
+
+const greetName = name => "Hello " + name;
+
+// Uncurry
+const needs3: string => string => string => string = a => b => c => a + b + c;
+
+//$ExpectError
+const needs3_error1: number = uncurryN(3, needs3)("", "", "");
+
+//$ExpectError
+const needs3_error2: string => string = uncurryN(3, needs3)("", "", "");
+
+//$ExpectError
+const needs3_error3: string => string => string = uncurryN(3, needs3)(
+  "",
+  "",
+  ""
+);
+
+const needs3_no_error: string = uncurryN(3, needs3)("", "", "");
+
+// -------------
+
+// --- TyrCatch ---
+const tryFn: boolean => string = a => String(a);
+
+const tryFn_2: boolean => boolean = a => a;
+
+const catchFn: (Error, boolean) => string = (e, a) => e.message;
+
+const catchFn_2: (Error, boolean) => boolean = (e, a) => a;
+
+const tc1: string = tryCatch(tryFn, catchFn, true);
+const tc2: boolean => string = tryCatch(tryFn, catchFn);
+const tc3: string = tc2(true);
+//const tc7: string = tryCatch(tryFn)(catchFn)(true);
+const tc4: string = tryCatch(tryFn)(catchFn, true);
+const tc5: string = tryCatch(tryFn)(catchFn)(true);
+
+//$ExpectError
+const tc_error1: boolean = tryCatch(tryFn, catchFn, true);
+//$ExpectError
+const tc_error2: boolean = tryCatch(tryFn, catchFn)(true);
+//$ExpectError
+const tc_error3: boolean = tryCatch(tryFn)(catchFn, true);
+//$ExpectError
+const tc_error4: boolean = tryCatch(tryFn)(catchFn)(true);
+//$ExpectError
+const tc_error5: string = tryCatch(tryFn_2, catchFn, "string");
+//$ExpectError
+const tc_error6: string = tryCatch(tryFn_2, catchFn)("string");
+//$ExpectError
+const tc_error7: string = tryCatch(tryFn_2)(catchFn, "string");
+//$ExpectError
+const tc_error8: string = tryCatch(tryFn_2)(catchFn)("string");
+//$ExpectError
+const tc_error9: string = tryCatch(tryFn_2, catchFn, true);
+//$ExpectError
+const tc_error10: string = tryCatch(tryFn_2, catchFn)(true);
+//$ExpectError
+const tc_error11: string = tryCatch(tryFn_2)(catchFn, true);
+//$ExpectError
+const tc_error12: string = tryCatch(tryFn_2)(catchFn)(true);
+//$ExpectError
+const tc_error13: string = tryCatch(tryFn, catchFn_2, true);
+//$ExpectError
+const tc_error14: string = tryCatch(tryFn, catchFn_2)(true);
+//$ExpectError
+const tc_error15: string = tryCatch(tryFn)(catchFn_2, true);
+//$ExpectError
+const tc_error16: string = tryCatch(tryFn)(catchFn_2)(true);
+
+// -------------

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_list.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_list.js
@@ -1,0 +1,855 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+import _, {
+  type RefineFilter,
+  adjust,
+  append,
+  chain,
+  compose,
+  concat,
+  contains,
+  curry,
+  filter,
+  find,
+  groupBy,
+  includes,
+  last,
+  length,
+  nth,
+  pipe,
+  reduce,
+  repeat,
+  subtract,
+  without,
+  zipWith
+} from "ramda";
+import { describe, it } from 'flow-typed-test';
+
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed } = { a: 1, c: "d" };
+const os: Array<{ [k: string]: number | string }> = [
+  { a: 1, c: "d" },
+  { b: 2 }
+];
+const str: string = "hello world";
+
+// List
+{
+  const xs: Array<number> = _.adjust(2, x => x + 1, ns);
+  const xs1: Array<number> = _.adjust(2, x => x + 1)(ns);
+  //$ExpectError
+  const xs3: Array<string> = _.adjust(2)(x => x + 1)(ns);
+
+  const as: boolean = _.all(x => x > 1, ns);
+  const asf: (s: Array<string>) => boolean = _.any(x => x.length > 1);
+  const as1: boolean = asf(ss);
+
+  const aps: Array<Array<number>> = _.aperture(2, ns);
+  const aps2: Array<Array<string>> = _.aperture(2)(ss);
+
+  const newXs1: Array<number> = _.prepend(1)(ns);
+
+  describe('concat', () => {
+    it('should support array', () => {
+      const r1: Array<number> = concat([4, 5, 6], [1, 2, 3]);
+      const r2: Array<number> = concat([4, 5, 6])([1, 2, 3]);
+    });
+    it('should supports strings', () => {
+      const r1: string = concat("ABC", "DEF");
+      const r2: string = concat("ABC")("DEF");
+    });
+    it('should support readonly arrays', () => {
+      const arr1: $ReadOnlyArray<number> = [4, 5, 6];
+      const arr2: $ReadOnlyArray<string> = ['1', '2', '3'];
+      const r1: Array<number|string> = concat(arr1, arr2);
+      const r2: Array<number|string> = concat(arr1)(arr2);
+
+      // $ExpectError
+      const r3: Array<number> = concat(arr1)(arr2);
+      // $ExpectError
+      const r4: Array<string> = concat(arr1)(arr2);
+    });
+    it('should error when concat array with string', () => {
+      // $ExpectError
+      concat("ABC", ["DEF"]);
+    });
+  });
+
+  const dropxs: Array<string> = _.drop(4, ss);
+  const dropxs1: string = _.drop(3)(str);
+  const dropxs2: Array<string> = _.dropLast(4, ss);
+  const dropxs3: string = _.dropLast(3)(str);
+  const dropxs4: Array<number> = _.dropLastWhile(x => x <= 3, ns);
+  const dropxs5: Array<string> = _.dropRepeats(ss);
+  const dropxs6: Array<number> = _.dropRepeatsWith(_.eqBy(Math.abs), ns);
+  const dropxs7: Array<number> = _.dropWhile(x => x === 1, ns);
+
+  // The contains libdef is the same as includes, and tests should be duplicated
+  // across the two. As of 0.26.0 contains is deprecated, but still present.
+  describe('contains', () => {
+    describe('uncurried form', () => {
+      it('returns a boolean for an Array and its element type', () => {
+        const xs: Array<number> = [1]
+        const result: boolean = contains(2, xs)
+      })
+
+      it('returns a boolean for a $ReadOnlyArray and its element type', () => {
+        const xs: $ReadOnlyArray<number> = [1]
+        const result: boolean = contains(2, xs)
+      })
+
+      it('does not allow a mismatched element type to the Array', () => {
+        const xs: Array<number> = [1]
+        // It is not understood why this fails to be flagged as an error when
+        // the 0.26.x libdef passes with the same declaration. The curried form
+        // works reliably though.
+        //
+        // $ShouldExpectErrorButInsteadWorksPleaseFix
+        const result: boolean = contains('foo', xs)
+      })
+
+      it('does not allow a mismatched element type to the $ReadOnlyArray', () => {
+        const xs: $ReadOnlyArray<string> = ['bar']
+        // It is not understood why this fails to be flagged as an error when
+        // the 0.26.x libdef passes with the same declaration. The curried form
+        // works reliably though.
+        //
+        // $ShouldExpectErrorButInsteadWorksPleaseFix
+        const result: boolean = contains(1, xs)
+      })
+
+      it('returns a boolean for two strings', () => {
+        const result: boolean = contains('foo', 'bar')
+      })
+
+      it('disallows a mismatched string and anything else', () => {
+        // $ExpectError
+        const result: boolean = contains(1, 'bar')
+      })
+    })
+
+    describe('1 arg curried form', () => {
+      it('returns a boolean for an Array and its element type', () => {
+        const xs: Array<number> = [1]
+        const result: boolean = contains(2)(xs)
+      })
+
+      it('returns a boolean for a $ReadOnlyArray and its element type', () => {
+        const xs: $ReadOnlyArray<number> = [1]
+        const result: boolean = contains(2)(xs)
+      })
+
+      it('does not allow a mismatched element type to the Array', () => {
+        const xs: Array<number> = [1]
+        // $ExpectError
+        const result: boolean = contains('foo')(xs)
+      })
+
+      it('does not allow a mismatched element type to the $ReadOnlyArray', () => {
+        const xs: $ReadOnlyArray<number> = [1]
+        // $ExpectError
+        const result: boolean = contains('foo')(xs)
+      })
+
+      it('returns a boolean for two strings', () => {
+        const result: boolean = contains('foo')('bar')
+      })
+
+      it('disallows a mismatched string and anything else', () => {
+        // $ExpectError
+        const result: boolean = contains(1)('bar')
+      })
+    })
+  })
+
+  describe('startsWith', () => {
+    it('checks to see if one string is inside of another', () => {
+      const result: boolean = _.startsWith("a")("abc");
+    })
+
+    it('checks to see if one element of an array is starting in another array', () => {
+      const result: boolean = _.startsWith(["a"], ["a", "b", "c"]);
+    })
+
+    // See https://ramdajs.com/repl/?v=0.25.0#?%2F%2F%20Works%20with%20more%20than%20just%20strings%3A%0AR.startsWith%28%5B1%5D%2C%20%5B1%2C%202%2C%203%5D%29%20%20%20%20%2F%2F%3D%3E%20true
+    // for a working example.
+    it('can check any type (not just strings) for the starting of an array', () => {
+      const result: boolean = _.startsWith([1], [1, 2, 3]);
+    })
+
+    // See https://ramdajs.com/repl/?v=0.25.0#?%2F%2F%20Works%20with%20multiple%20elements%20in%20the%20comparator%3A%0AR.startsWith%28%5B1%2C%202%5D%2C%20%5B1%2C%202%2C%203%5D%29%20%20%20%20%2F%2F%3D%3E%20true
+    // for a working example.
+    it('allows any number of elements to be used as the comparator', () => {
+      const result: boolean = _.startsWith([1, 2, 3], [1, 2, 3]);
+    })
+
+    it('catches mismatches between the first set and the second', () => {
+      // $ExpectError
+      _.startsWith("1", [1, 2, 3])
+    })
+
+    it('catches mismatches between the inner array elements', () => {
+      // It is not understood why this isn't flagged as an error.
+      // $ShouldExpectErrorButInsteadWorksPleaseFix
+      _.startsWith(["1"], [1, 2, 3])
+    })
+  })
+
+  describe('endsWith', () => {
+    it('checks to see if one string is inside of another', () => {
+      const result: boolean = _.endsWith("a")("abc");
+    })
+
+    it('checks to see if one element of an array is ending in another array', () => {
+      const result: boolean = _.endsWith(["a"], ["a", "b", "c"]);
+    })
+
+    // See https://ramdajs.com/repl/?v=0.25.0#?%2F%2F%20Works%20with%20more%20than%20just%20strings%3A%0AR.endsWith%28%5B3%5D%2C%20%5B1%2C%202%2C%203%5D%29%20%20%20%20%2F%2F%3D%3E%20true
+    // for a working example.
+    it('can check any type (not just strings) for the ending of an array', () => {
+      const result: boolean = _.endsWith([1], [1, 2, 3]);
+    })
+
+    // See https://ramdajs.com/repl/?v=0.25.0#?%2F%2F%20Works%20with%20multiple%20elements%20in%20the%20comparator%3A%0AR.endsWith%28%5B2%2C%203%5D%2C%20%5B1%2C%202%2C%203%5D%29%20%20%20%20%2F%2F%3D%3E%20true
+    // for a working example.
+    it('allows any number of elements to be used as the comparator', () => {
+      const result: boolean = _.endsWith([1, 2, 3], [1, 2, 3]);
+    })
+
+    it('catches mismatches between the first set and the second', () => {
+      // $ExpectError
+      _.endsWith("1", [1, 2, 3])
+    })
+
+    it('catches mismatches between the inner array elements', () => {
+      // It is not understood why this isn't flagged as an error.
+      // $ShouldExpectErrorButInsteadWorksPleaseFix
+      _.endsWith(["1"], [1, 2, 3])
+    })
+  })
+
+  const chainxs: number[] = _.chain((n) => [n, n], [1, 2])
+  const chainxs1: number[] = _.chain((n) => [n, n])([1, 2])
+
+  const findxs: ?{ [k: string]: number | string } = _.find(
+    _.propEq("a", 2),
+    os
+  );
+  const findxs1: ?{ [k: string]: number | string } = _.find(_.propEq("a", 4))(
+    os
+  );
+  // Ramda doesn't strictly break if you pass it an object, but it always
+  // returns undefined.
+  // $ExpectError
+  const findObj = find(o => o == "bar", { foo: "bar" });
+
+  const findxs2: ?{ [k: string]: number | string } = _.findLast(
+    _.propEq("a", 2),
+    os
+  );
+  const findxs3: ?{ [k: string]: number | string } = _.findLast(
+    _.propEq("a", 4)
+  )(os);
+  const findxs4: number = _.findIndex(_.propEq("a", 2), os);
+  const findxs5: number = _.findIndex(_.propEq("a", 4))(os);
+  const findxs6: number = _.findLastIndex(_.propEq("a", 2), os);
+  const findxs7: number = _.findLastIndex(_.propEq("a", 4))(os);
+
+
+  describe('length', () => {
+    describe('works on', () => {
+      it('empty array', () => {
+        length([])
+      })
+      it('simple array of strings', () => {
+        length(ss)
+      })
+      it('heterogeneous arrays', () => {
+        length([1, '', ss, true, ns])
+      })
+      it('strings', () => {
+        length(str)
+      })
+      it('objects defining numeric .length property', () => {
+        length({length: 12})
+      })
+    })
+    describe('fails on', () => {
+      it('null and undefined', () => {
+        // $ExpectError
+        length(null)
+        // $ExpectError
+        length()
+      })
+      it('types that has no length', () => {
+        // $ExpectError
+        length(123)
+      })
+      it('non-numeric .length property', () => {
+        // $ExpectError
+        length({length: 'size'})
+      })
+    })
+  })
+
+  const s4 = _.find(x => x === "2", ["1", "2"]);
+  //$ExpectError
+  const s5: ?{ [key: string]: string } = _.find(x => x === "2", { a: 1, b: 2 });
+  const s6: number = _.findIndex(x => x === "2", ["1", "2"]);
+  const s7: number = _.findIndex(x => x === "2", { a: "1", b: "2" });
+  const forEachxs = _.forEach(x => console.log(x), ns);
+
+  const forEachObj = _.forEachObjIndexed((value, key) => {}, { x: 1, y: 2 });
+
+  describe('groupBy', () => {
+    it('should work with basic array', () => {
+      const fn = x => `${x}`;
+      const groupedBy: { [k: string]: Array<number> } = groupBy(fn, [1, 2, 3]);
+      const groupedBy1: { [k: string]: Array<string> } = groupBy(fn)(['one', 'two', 'three']);
+    });
+    it('group function should return string', () => {
+      const fn: number => number = x => x;
+
+      // $ExpectError
+      groupBy(fn, [1,2,3]);
+      // $ExpectError
+      groupBy(fn)([1,2,3]);
+    });
+    it('group function param should match array element', () => {
+      const fn: string => string = x => x;
+
+      // $ExpectError
+      groupBy(fn, [1,2,3]);
+      // $ExpectError
+      groupBy(fn)([1,2,3]);
+    });
+    it('should support readonly array', () => {
+      const fn: (number | string) => string = x => `${x}`;
+      const arr: $ReadOnlyArray<number> = [1, 2, 3];
+      const groupedBy: { [k: string]: Array<number> } = groupBy(fn, arr);
+      const arr1: $ReadOnlyArray<number|string> = [1, 'two', 3];
+      const groupedBy1: { [k: string]: Array<number|string> } = groupBy(fn)(arr1);
+
+      const fn1: number => string = x => `${x}`;
+      // $ExpectError
+      groupBy(fn1, arr1);
+      // $ExpectError
+      const groupedBy2: { [k: string]: Array<number> } = groupBy(fn)(arr1);
+    });
+  });
+
+  const groupedWith: Array<Array<number>> = _.groupWith(x => x > 1, ns);
+  const groupedWith1: Array<Array<string>> = _.groupWith(x => x === "one")(ss);
+
+  describe('head', () => {
+    describe('with array', () => {
+      it('should returns MaybeOf element type', () => {
+        const fn = (arr: number[]) => {
+          const xOfXs: ?number = _.head(arr);
+          //$ExpectError
+          const xOfXs: number = _.head(arr);
+        }
+      });
+      it('should works with refinement', () => {
+        const fn = (arr: number[]) => {
+          if (arr.length > 0) {
+            const xOfXs: number = _.head(arr);
+          }
+        }
+      });
+      it('should works with mixed-type arrays', () => {
+        const fn = (arr: Array<number|string>) => {
+          const xOfXs: ?(number|string) = _.head(arr);
+          //$ExpectError
+          const xOfXs: ?number = _.head(arr);
+          if (arr.length > 0) {
+            const xOfXs: number|string = _.head(arr);
+            //$ExpectError
+            const xOfXs: number = _.head(arr);
+          }
+        }
+      });
+    });
+    describe('with string', () => {
+      it('should works', () => {
+        const xOfStr: string = _.head(str);
+      });
+    })
+  });
+
+  const transducer = _.compose(_.map(_.add(1)), _.take(2));
+
+  const txs: Array<number> = _.into([], transducer, ns);
+  //$ExpectError
+  const txs1: string = _.into([], transducer, ns);
+  //$ExpectError
+  const txs2: string = _.into([], transducer, ss);
+
+  const ind: number = _.indexOf(1, ns);
+  const ind1: number = _.indexOf(str)(ss);
+  const ind2: { [key: string]: { [k: string]: number | string } } = _.indexBy(
+    x => "s",
+    os
+  );
+  const ind3: { [key: string]: { [k: string]: number | string } } = _.indexBy(
+    x => "s"
+  )(os);
+  const ind4: number = _.indexOf(null)(ss);
+
+  const insxs: Array<number> = _.insert(1, 2, ns);
+  const insxs2: Array<string> = _.insert(1, "2", ss);
+
+  const insxs3: Array<number> = _.insertAll(1, [2, 3], ns);
+  // this is disgusting — don't do this :)
+  // Technically it's a tuple with arbitrary size
+  const insxs4: Array<number | boolean | string> = _.insertAll(
+    1,
+    ["2", false],
+    ns
+  );
+  const insxs5: Array<string | number> = _.insertAll(1, [2], ss);
+
+  const joinxs: string = _.join("|", ns);
+
+  const lastxs: ?number = _.last(ns);
+  const laststr: string = _.last(str);
+
+  const lasti: number = _.lastIndexOf(3, [-1, 3, 3, 0, 1, 2, 3, 4]);
+
+  const mapxs: Array<number> = _.map(x => x + 1, ns);
+
+  const someObj: { a: string, b: number } = { a: 'a', b: 2 }
+  const someMap: { [string]: { a: string, b: number } } = { so: someObj }
+  const mapObj: { [string]: string } = _.map((x: { a: string, b: number }): string => x.a)(someMap)
+  const mapObj2: { [string]: string } = _.map((x: { a: string, b: number }): string => x.a, someMap)
+
+  const functor = {
+    x: 1,
+    map(f) {
+      return f(this.x);
+    }
+  };
+
+  // Doesn't typecheck (yet) but at least doesn't break
+  const mapFxs = _.map(_.toString, functor);
+
+  const double = x => x * 2;
+  const dxs: Array<number> = _.map(double, [1, 2, 3]);
+  const dos: $Shape<typeof obj> = _.map(double, obj);
+
+  const appender = (a, b) => [a + b, a + b];
+  const mapacc: [number, Array<number>] = _.mapAccum(appender, 0, ns);
+  const mapacc1: [number, Array<number>] = _.mapAccumRight(appender, 0, ns);
+
+  const nxs: boolean = _.none(x => x > 1, ns);
+
+  describe('append', () => {
+    it('should supports arrays', () => {
+      const appendResult1: Array<number> = append(1, [1, 2, 3]);
+      const appendResult2: Array<string> = append('four')(['one', 'two', 'three']);
+    });
+    it('should works with read-only array', (readOnly: $ReadOnlyArray<number>) => {
+      const appendResult1: $ReadOnlyArray<number> = append(1, readOnly);
+      const appendResult2: $ReadOnlyArray<number> = append(1)(readOnly);
+    });
+    it('should result array element should be correct', () => {
+      const readOnly: $ReadOnlyArray<number> = [1, 2, 3];
+      const appendResult1: $ReadOnlyArray<number|string> = append('s', readOnly);
+      const appendResult2: $ReadOnlyArray<number|string> = append('s')(readOnly);
+
+      //$ExpectError
+      const appendResult3: $ReadOnlyArray<number|null> = append('s', readOnly);
+      //$ExpectError
+      const appendResult4: $ReadOnlyArray<number> = append('s')(readOnly);
+    });
+  });
+
+  const xxxs: Array<number> = _.intersperse(1, [1, 2, 3]);
+
+  const pairxs: [number, string] = _.pair(2, "str");
+
+  describe('pluck', () => {
+    it('should works on array of objects as maps', () => {
+      const arr: Array<{ [string]: number | string }> = [{ a: "1" }, { a: 2 }];
+      const pl: Array<number | string> = _.pluck("a")(arr);
+      const p2: Array<number | string> = _.pluck("b")(arr);
+    });
+    it('should works on array of arrays', () => {
+      const pl: Array<number> = _.pluck(0)([[1, 2], [3, 4]]);
+    });
+    it('should works on array of objects', () => {
+      const arr: Array<{ key: number, other?: string }> = [{ key: 42 }, { key: 28, other: 'string' }];
+      const pl: number[] = _.pluck('key', arr);
+    });
+    it('should fails on non existing property', () => {
+      //$ExpectError
+      const pl = _.pluck('notExistingKey', [{ key: 42 }, { key: 28, other: 'string' }]);
+      //$ExpectError
+      const pl = _.pluck('other', [{ key: 42 }, { key: 28, other: 'string' }]);
+    });
+    it('should returns union type of selected property', () => {
+      const arr = [{ key: 42 }, { key: 'string', other: 'string' }];
+      const pl: Array<number | string> = _.pluck('key', arr);
+      //$ExpectError
+      const pl: number[] = _.pluck('key', arr);
+    });
+  });
+
+  const rxs: Array<number> = _.range(1, 10);
+
+  const remxs: Array<string> = _.remove(0, 2, ss);
+  const remxs1: Array<string> = _.remove(0, 2)(ss);
+  const remxs2: Array<string> = _.remove(0)(2)(ss);
+  const remxs3: Array<string> = _.remove(0)(2, ss);
+
+  const ys4: Array<string> = _.repeat("1", 10);
+  const ys5: Array<number> = _.repeat(1, 10);
+
+  // reduce
+  const redxs: number = reduce(_.add, 10, ns);
+  const redxs1: string = reduce(concat, "", ss);
+  const redxs2: Array<string> = reduce<string[], string[]>(concat, [])(_.map(x => [x], ss));
+  // Example used in docs: http://ramdajs.com/docs/#reduce
+  const redxs4: number = reduce(subtract, 0, [1, 2, 3, 4]);
+  // Using accumulator type that differs from the element type (A and B).
+  const redxs5: number = reduce((acc, s) => acc + parseInt(s), 0, [
+    "1",
+    "2",
+    "3"
+  ]);
+
+  const redux6a: number = reduce((acc, s) => _.reduced(acc), 0, ns)
+  const redux6b: number = reduce((acc: number, s: number) => _.reduced(acc), 0, ns)
+  const redxs7: number = reduce(
+    (acc, s) => acc < 4 ? acc + parseInt(s) : _.reduced(acc),
+    0,
+    ["1", "2", "3"]
+  );
+  // $ExpectError
+  const redxs8: number = reduce(
+    // $ExpectError
+    (acc, s) => acc < 4 ? acc + parseInt(s) : _.reduced(s),
+    0,
+    ["1", "2", "3"]
+  );
+
+  // Ramda works with $ReadOnlyArray as it is immutable.
+  const readOnlyArray: $ReadOnlyArray<number> = [1, 2, 3, 4];
+  // $ReadOnlyArray with curried permutations:
+  const redxsReadOnly3: number = reduce(subtract, 0, readOnlyArray);
+  const redxsReadOnly2_1: number = reduce(subtract, 0)(readOnlyArray);
+  const redxsReadOnly1_2: number = reduce<number, number>(subtract)(0, readOnlyArray);
+  const redxsReadOnly1_1_1: number = reduce(subtract)(0)(readOnlyArray);
+
+  // $ExpectError reduce will not work with an object.
+  reduce(subtract, 0, { foo: 1, bar: 2 });
+
+  // reduceRight
+  const redrxs1: number = _.reduceRight(_.add, 10, ns);
+  const redrxs2: string = _.reduceRight(concat, "", ss);
+  const redrxs3: Array<string> = _.reduceRight(concat, [])(
+    _.map(x => [x], ss)
+  );
+  const redrxs3a: string = _.reduceRight(
+    //$ExpectError
+    (acc: string, value: number): string => acc,
+    "",
+    ns
+  );
+  const redrxs3b: string = _.reduceRight(
+    (value: number, acc: string): string => acc,
+    "",
+    ns
+  );
+
+  // $ExpectError reduceRight does not support reduced.
+  const redrxs4: number = _.reduceRight(
+    // $ExpectError reduceRight does not support reduced.
+    (acc, n) => acc < 4 ? acc + n : _.reduced(acc),
+    0,
+    ns
+  );
+
+  const scanxs6: Array<number> = _.scan(_.add)(10)(ns);
+  const scanxs7: Array<number> = _.scan(_.add, 10)(ns);
+  const scanxs8: Array<number> = _.scan(_.add)(10, ns);
+  const scanxs9: Array<number> = _.scan(_.add, 10, ns);
+  const scanxs10: Array<string> = _.scan(concat)("")(ss);
+  const scanxs11: Array<string> = _.scan(concat, "")(ss);
+  const scanxs12: Array<string> = _.scan(concat)("", ss);
+  const scanxs13: Array<string> = _.scan(concat, "", ss);
+
+  const reduceToNamesBy = _.reduceBy(
+    (acc, student) => acc.concat(student.name),
+    []
+  );
+  const namesByGrade = reduceToNamesBy(student => {
+    const score = student.score;
+    return score < 65
+      ? "F"
+      : score < 70 ? "D" : score < 80 ? "C" : score < 90 ? "B" : "A";
+  });
+  const students = [
+    { name: "Lucy", score: 92 },
+    { name: "Drew", score: 85 },
+    { name: "Bart", score: 62 }
+  ];
+  const names1: { [k: string]: Array<string> } = namesByGrade(students);
+
+  const isOdd = (acc, x) => x % 2 === 1;
+  const reduceWhile1: number = _.reduceWhile(isOdd, _.add, 0, [1, 3, 5, 60, 777, 800]);
+  const reduceWhile2: number = _.reduceWhile(isOdd, _.add, 111, [2, 4, 6]);
+
+  const spl: Array<string> = _.split(/\./, "a.b.c.xyz.d");
+
+  const spl1: [Array<number>, Array<number>] = _.splitAt(1, [1, 2, 3]);
+  const spl2: [string, string] = _.splitAt(5, "hello world");
+  const spl3: [string, string] = _.splitAt(-1, "foobar");
+  const spl4: Array<Array<number>> = _.splitEvery(3, [1, 2, 3, 4, 5, 6, 7]);
+  const spl5: Array<string> = _.splitEvery(3, "foobarbaz");
+  const spl6: [Array<number>, Array<number>] = _.splitWhen(_.equals(2))([
+    1,
+    2,
+    3,
+    1,
+    2,
+    3
+  ]);
+
+  const slixs: Array<string> = _.slice(0, 2, ss);
+  const slixs1: Array<string> = _.slice(0, 2)(ss);
+  const slixs2: Array<string> = _.slice(0)(2)(ss);
+  const slixs3: Array<string> = _.slice(0)(2, ss);
+
+  const diff = function(a, b) {
+    return a - b;
+  };
+  const sortxs: Array<number> = _.sort(diff, [4, 2, 7, 5]);
+
+  const timesxs: Array<number> = _.times(_.identity, 5);
+
+  const unf: (x: string) => Array<string> = _.unfold(
+    (x: string) => x.length > 10 || [x, x + "0"]
+  );
+  const unf1: Array<number> = _.unfold(x => x > 10 || [x, x + 1], 0);
+  const f = n => (n > 50 ? false : [-n, n + 10]);
+  const unf11: Array<number> = _.unfold(f, 10);
+
+  //$ExpectError
+  const unf2 = _.unfold(x => x.length > 10 || [x, x + "0"], 2);
+
+  const unby: Array<number> = _.uniqBy(Math.abs)([-1, -5, 2, 10, 1, 2]);
+
+  const strEq = _.eqBy(String);
+  const strEq2 = _.eqBy(String, 1, 2);
+  const unw = _.uniqWith(strEq)([1, "1", 2, 1]);
+  const unw1 = _.uniqWith(strEq)([{}, {}]);
+  const unw2 = _.uniqWith(strEq)([1, "1", 1]);
+  const unw3 = _.uniqWith(strEq)(["1", 1, 1]);
+
+  //$ExpectError
+  const ys6: { [key: string]: string } = _.fromPairs([["h", 2]]);
+
+  describe('without', () => {
+    it('should work with basic array', () => {
+      const arr1: Array<number> = without([1, 2], [1, 2, 3, 4, 5]);
+      const arr2: Array<string> = without(['a'])(['a', 'b', 'c']);
+    });
+    it('should fail when first list does not match second list type', () => {
+      // $ExpectError
+      const arr1: Array<number> = without(['1', '2'], [1, 2, 3, 4, 5]);
+      // $ExpectError
+      const arr2: Array<string> = without([1])(['a', 'b', 'c']);
+    });
+    it('should work with readonly array', () => {
+      const list1: $ReadOnlyArray<number|string> =  [1, 'four', 5];
+      const list2: $ReadOnlyArray<number|string> =  [1, 'two', 3, 'four', 5];
+      const arr1: Array<number|string> = without(list1, list2);
+      const arr2: Array<number|string> = without(list1)(list2);
+    });
+    it('should list1 be a subset of list2', () => {
+      const list1: $ReadOnlyArray<number> =  [1, 3, 5];
+      const list2: $ReadOnlyArray<number|string> =  [1, 'four', 5];
+      const arr1: Array<number|string> = without(list1, list2);
+      // $ExpectError
+      const arr2: Array<number> = without(list2, list1);
+    });
+  });
+
+  const xprodxs: Array<[number, string]> = _.xprod([1, 2], ["a", "b", "c"]);
+  const xprodxs1: Array<[boolean, string]> = _.xprod([true, false])(["a", "b"]);
+
+  const zipxs: Array<[number, string]> = _.zip([1, 2, 3], ["a", "b", "c"]);
+
+  //$ExpectError
+  const zipxs1: Array<[number, string]> = _.zip([true, false])(["a", "b"]);
+
+  const zipos: { [k: string]: number } = _.zipObj(["a", "b", "c"], [1, 2, 3]);
+
+  const ys9: { [k: string]: number } = _.zipObj(["me", "you"], [1, 2]);
+  const zipped: Array<{ s: number, y: string }> = zipWith(
+    (a, b) => ({ s: a, y: b }),
+    [1, 2, 3],
+    ["1", "2", "3"]
+  );
+  const zipped2: Array<{ s: number, y: string }> = _.zipWith(
+    (a, b) => ({ s: a, y: b }),
+    [1, 2, 3]
+  )(["1", "2", "3"]);
+  const zipped3: Array<{ s: number, y: string }> = _.zipWith((a, b) => ({
+    s: a,
+    y: b
+  }))([1, 2, 3])(["1", "2", "3"]);
+
+  describe('chain', () => {
+    it('should accept read only list as input', () => {
+      const arr:$ReadOnlyArray<string> = ['1', '2', '3'];
+      const duplicate = n => [n, n];
+      const result1: Array<string> = chain(duplicate, arr);
+      const result2: Array<string> = chain(duplicate)(arr);
+    });
+
+    it('should fail when input out type mismatch', () => {
+      const arr:$ReadOnlyArray<string> = ['1', '2', '3'];
+      const castType = n => (parseInt(n): number);
+      //$ExpectError
+      const result: Array<string> = chain(castType, arr);
+    });
+
+    it('should take second argument as function', () => {
+      const arr:$ReadOnlyArray<string> = ['1', '2', '3'];
+      const result: Array<?string> = chain(append, x => x[x.length -1])(arr)
+    });
+
+    it('should error out when second arugment is function but type mismatches', () => {
+      const arr:$ReadOnlyArray<string> = ['1', '2', '3'];
+      const castType = n => (parseInt(n): number);
+      //$ExpectError
+      const result: Array<string> = chain(append, castType)(arr)
+    });
+  });
+                 
+  describe('nth', () => {
+    it('should get a maybe type back on input is an array of given types', () => {
+      const nthxs1: ?number = nth(2, [1,2,3]);
+      const nthxs2: ?number = nth(2)([1,2]);
+      const nthxs3: ?number = nth(3)([1,2]);
+      const nthxs4: ?string = nth(2, ["curry"]);
+      const nthxs5: ?string = nth(2)(["curry", "bean"]);
+      const nthxs6: ?string = nth(3)(['foo', 'bar']);
+    });
+
+    it('should get a string back when input is string', () => {
+      const nthxs: string = nth(2)("curry");
+      const nthxs1: string = nth(2, "curry");
+    });
+
+    it('should take read only array as second argument', () => {
+      const readOnlyArray: $ReadOnlyArray<number>  = [1, 2, 3];
+      const nthxs = nth(2)(readOnlyArray)
+      const nthxs1 = nth(2, readOnlyArray)
+    });
+
+    it('should take a mutable array as second arugment', () => {
+      const array: Array<string> = ['foo', 'bar'];
+      const nthxs = nth(1)(array)
+      const nthxs1 = nth(1, array)
+      const nthxs2 = nth(1)(array)
+    });
+
+    it('should take tuple as second argument', () => {
+      const tuple:[number, boolean] = [1, true]
+      const n  = nth(0, tuple)
+      cosnt ns = nth(1)(tuple)
+    });
+
+    it('should fail on expecting return type to be a maybe type of the element of the input list', () => {
+      const arr: Array<number> = [1, 2, 3]
+      //$ExpectError
+      const nthxs: ?string = nth(2)(arr);
+      //$ExpectError
+      const nthxs1: ?boolean = nth(1)(arr);
+    });
+
+    it('should fail on expecting return type to mismatch the input array type', () => {
+      const arr: Array<number> = [1, 2, 3]
+      //$ExpectError
+      const nthxs: string = nth(2, arr);
+      //$ExpectError
+      const nthxs1: string = nth(2)(arr);
+      //$ExpectError
+      const nthxs2: string = nth(1, ['foo'])
+      //$ExpectError
+      const nthxs3: number = nth(1, arr);
+      //$ExpectError
+      const nthxs4: number = nth(1)(arr);
+      //$ExpectError
+      const nthxs5: number = nth(1, [1])
+      //$ExpectError
+      const nthxs: ?number = nth(2)(['foo']);
+    });
+
+    it('should fail on passing a non-number to first argument', () => {
+      //$ExpectError
+      const nthxs = nth('foo')(['foo', 'bar'])
+    });
+
+    it('should fail on passing a non-array to second argument', () => {
+      //$ExpectError
+      const nthxs = nth(2)({})
+      });
+  });
+                 
+  describe('adjust', () => {
+    it('should allow both Array and $ReadOnlyArray output', () => {
+      const arr: Array<number> = [1, 2, 3]
+      const ro: $ReadOnlyArray<number> = [1, 2, 3]
+      const result: $ReadOnlyArray<number> = adjust(1, x => x + 1, arr)
+      const result1: Array<number> = adjust(1, x => x + 1, arr)
+      const result2: $ReadOnlyArray<number> = adjust(1, x => x + 1, ro)
+      const result3: Array<number> = adjust(1, x => x + 1, ro)
+    });
+  });
+
+  describe('uniq', () => {
+    it('should accept read only array', () => {
+      const readOnlyNumbers: $ReadOnlyArray<number> = [1,1,2,3,4,3];
+      const result:$ReadOnlyArray<number> = uniq(readOnlyNumbers);
+    });
+
+    it('should fail when element type mismatches', () => {
+      const readOnlyNumbers: $ReadOnlyArray<number> = [1,1,2,3,4,3];
+      //$ExpectError
+      const result:$ReadOnlyArray<string> = uniq(readOnlyNumbers);
+
+      const mix = ['1', 2, true];
+      //$ExpectError
+      const result: $ReadOnlyArray<string> = uniq(mix);
+    });
+
+    it('should accept read only array when expecting mutable array as output', () => {
+      const readOnlyNumbers: $ReadOnlyArray<number> = [1,1,2,3,4,3];
+      const result: Array<number> = uniq(readOnlyNumbers);
+    });
+
+    it('should accept mutable array as input and read only array as output', () => {
+      const readOnlyStrings: Array<string> = ['foo', 'bar'];
+      const result1: $ReadOnlyArray<string> = uniq(readOnlyStrings)
+    });
+
+    it('should accept mutable array', () => {
+      const arr: Array<string> = ['1', '2', '3'];
+      const result: Array<string> = uniq(arr);
+    });
+
+    it('should accept a mixed element type array', () => {
+      const arr: Array<string|number|boolean> = ['foo', 1, false]
+      const result: Array<string|number|boolean> = uniq(arr)
+    });
+
+    //Reason not to test the other way around, namely, Array<A> to $ReadOnlyArray<A> is because
+    //$ReadOnlyArray is a supertype of Array https://flow.org/en/docs/types/arrays/#toc-readonlyarray
+  })
+}

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_logic.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_logic.js
@@ -1,0 +1,205 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+import { describe, it } from 'flow-typed-test';
+import _, {
+  compose,
+  curry,
+  filter,
+  find,
+  ifElse,
+  pipe,
+  repeat,
+  zipWith,
+} from 'ramda';
+
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ['one', 'two', 'three', 'four'];
+const obj: { [k: string]: number } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed } = { a: 1, c: 'd' };
+const os: Array<{ [k: string]: * }> = [{ a: 1, c: 'd' }, { b: 2 }];
+const str: string = 'hello world';
+
+//Logic
+// TODO: Fix flow issues
+// const isQueen = _.propEq("rank", "Q");
+// const isSpade = _.propEq("suit", "♠︎");
+// const isQueenOfSpades = _.allPass([isQueen, isSpade]);
+
+//$ExpectError
+const allp: boolean = isQueenOfSpades(1);
+const allp1: boolean = isQueenOfSpades({ rank: 'Q', suit: '♣︎' });
+
+const a: boolean = _.and(true, true);
+const a_: (a: boolean) => boolean = _.and(true);
+
+const nonBooleanAnd: number = _.and(69, 42);
+const nonBooleanAnd_: (nonBooleanAnd: number) => * = _.and(69);
+
+const gte = _.anyPass([_.gt, _.equals]);
+const ge: boolean = gte(3, 2);
+
+//$ExpectError
+const gt10 = x => x > 10;
+//$ExpectError
+const even = x => x % 2 === 0;
+const f = _.both(gt10, even);
+
+const b: boolean = f('');
+const b_: boolean = f(100);
+
+//$ExpectError
+const isEven = n => n % 2 === 0;
+const isOdd = _.complement(isEven);
+
+const c: boolean = isOdd('');
+const c_: boolean = isOdd(2);
+
+const fn = _.cond([
+  [_.equals(0), _.always('water freezes at 0°C')],
+  [_.equals(100), _.always(1)],
+  [_.T, temp => 'nothing special happens at ' + temp + '°C'],
+]);
+const cond_: number | string = fn(0);
+
+// This is abit awkward — if a non-null value of type
+// differrent to number is passed flow will infer a union type
+// for all of them
+const defaultTo42 = _.defaultTo(42);
+const def: number = defaultTo42(null);
+const def1: number = defaultTo42(undefined);
+
+const feither = _.either(gt10, even);
+const feitherR: boolean = f(101);
+
+describe('ifElse', () => {
+  it('uses a union of both branches as the return type', () => {
+    const incCount = ifElse(x => x % 2 == 0, x => x + 1, x => x.toString());
+    const ie: number | string = incCount(1);
+  })
+
+  it('checks the condition input matches the branch inputs', () => {
+    const incCount = ifElse(x => x % 2 == 0, x => x + 1, x => x.toString());
+    // Because the object literal ({}) isn't a number it
+    // $ExpectError
+    const ie: number | string = incCount({});
+  })
+
+  it('works with variadic arg inputs', () => {
+    const ifElseFn = ifElse(
+      // Without this test, variadic argument input functions will produce an
+      // error like this:
+      //
+      // Cannot call `ifElse` because rest array [1] has an unknown number of
+      // elements, so is incompatible with tuple type [2].
+      (...args: [string]): boolean => true,
+      (s: string) => s.toUpperCase(),
+      (s: string) => s.toLowerCase(),
+    );
+    const result: void | string = ifElseFn('input')
+  })
+
+  it('preserves the types used with variadic argument condition functions', () => {
+    const ifElseFn = ifElse(
+      (...args: [string]): boolean => true,
+      (s: string) => s.toUpperCase(),
+      (s: string) => s.toLowerCase(),
+    );
+    // $ExpectError
+    const result: void | string = ifElseFn(5)
+  })
+
+  // This was the original test for ifElse, which depends on the implementation
+  // of "is". "is" in its present form does not perform type refinement, so the
+  // stricter form of ifElse fails the check with this test. This test below
+  // captures the issue, and is left for reference and/or if some brave soul
+  // wishes to expand the definition of ifElse (and possibly also "is") to
+  // refine the predicate correctly. At time of writing, $Pred and $Refine are
+  // considered experimental/internal and abandoned:
+  // https://github.com/facebook/flow/issues/2464#issuecomment-471115953
+  //
+  // it('feeds a predicate-refined type to the branches', () => {
+  //   const incCount = ifElse(is(Number), x => x + 1, x => x.toString());
+  //   const ie: number | string = incCount(1);
+  // })
+})
+
+const em: boolean = _.isEmpty([1, 2, 3]);
+
+const n: boolean = _.not(true);
+//$ExpectError
+const n1: boolean = _.not(1);
+
+const oor: boolean = _.or(true, true);
+
+const nonBooleanOr: ?string = _.or('watskeburt', undefined);
+const nonBooleanOr_: (arg: { key: string }) => string | { key: string } = _.or(
+  'watskeburt'
+);
+
+// type refinement is important here
+// which might be awkward for some
+// but can actually catch some bugs statically
+
+const psatE: boolean = _.pathSatisfies(y => y > 0, ['x', 'y', 0], {
+  x: { y: [2] },
+});
+const psat: boolean = _.pathSatisfies(
+  y => typeof y === 'number' && y > 0,
+  ['x', 'y', 0],
+  { x: { y: [2] } }
+);
+const psatPart = _.pathSatisfies(y => typeof y === 'number' && y > 0);
+const psat2: boolean = psatPart(['x', 'y', 0])({ x: { y: 2 }, z: true });
+const psatPart2 = _.pathSatisfies(y => typeof y === 'number' && y > 0, [
+  'x',
+  'y',
+  0,
+]);
+const psat3: boolean = psatPart2({ x: { y: 2 }, z: true });
+
+describe('propSatisfies', () => {
+  describe('with object', () => {
+    it('should works with object', () => {
+      const propSat: boolean = _.propSatisfies(x => x > 0, 'x', { x: 1, y: 2 });
+    });
+    it('should works with object with properties of different types', () => {
+      const propSat: boolean = _.propSatisfies(x => x > 0, 'x', { x: 1, y: 2, str: 'different type' });
+      // same again but this time using a curried function
+      const propSatCurry: boolean = _.propSatisfies((x: number) => x > 0, 'x')({ x: 1, y: 2, str: 'different type' });
+    });
+    it('should error when property does not exist', () => {
+      //$ExpectError
+      const propSat3: boolean = _.propSatisfies((x: number) => x > 0, 'z', { x: 1, y: 2 });
+    });
+    it('should error when condition param does not match property type', () => {
+      //$ExpectError
+      const propSat: boolean = _.propSatisfies(x => x > 0, 'str', { x: 1, y: 2, str: 'different type' });
+      //$ExpectError
+      const propSatCurry: boolean = _.propSatisfies((x: number) => x > 0, 'str')({ x: 1, y: 2, str: 'different type' });
+    });
+  });
+  describe('with object as maps', () => {
+    const o: { [string]: number } = { x: 1, y: 2 };
+    it('should works with object map', () => {
+      const propSat: boolean = _.propSatisfies((x: number) => x > 0, 'x', o);
+    });
+    it('should error when condition param does not match property type', () => {
+      //$ExpectError
+      const propSat2: boolean = _.propSatisfies((x: string) => x > 0, 'x', o);
+    });
+  });
+});
+
+const coerceArray = _.unless(_.is(Array), _.of);
+const coer: Array<number | Array<number>> | number = coerceArray([1, 2, 3]);
+const coer1: Array<number | Array<number>> | number = coerceArray(1);
+
+const coerceString = _.unless(_.is(String), _.toString);
+const coer2: string | Array<number> = coerceString([1, 2, 3]);
+const coer3: string | Array<number> = coerceString('s');
+
+const unlPrt = _.unless(_.is(Number), _.T);
+const unl: number | boolean | Array<number> = unlPrt([1, 2, 3]);
+const unl2: number | boolean | Array<number> = unlPrt(1);
+
+const un: number = _.until(_.gt(100), _.multiply(2))(1);

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_map.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_map.js
@@ -1,0 +1,97 @@
+// @flow
+import * as R from "ramda";
+import { it, describe } from "flow-typed-test";
+
+const NumberToString = (v: number): string => `${v}`;
+
+describe("R.map()", () => {
+  describe("Not read only", () => {
+    it("should return Array<string>", () => {
+      const ArrNumbers = Object.freeze([1, 2, 3]);
+
+      (R.map(NumberToString, ArrNumbers): Array<string>);
+
+      (R.map(NumberToString)(ArrNumbers): Array<string>);
+    });
+
+    it("should return Object {key: number}", () => {
+      const Obj = Object.freeze({
+        a: { key: 1 },
+        c: { key: 2 },
+        d: { key: 3 }
+      });
+
+      (R.map(R.prop("key"), Obj): { [key: string]: number });
+
+      (R.map(R.prop("key"))(Obj): { [key: string]: number });
+    });
+
+    describe("{}::map(fn)", () => {
+      class Index {
+        ids: Array<number>;
+
+        map<T>(fn: (e: number) => T): Array<T> {
+          return this.ids.map(e => fn(e));
+        }
+      }
+
+      it("should return array string", () => {
+        (R.map(NumberToString, new Index()): Array<string>);
+
+        (R.map(NumberToString)(new Index()): Array<string>);
+      });
+
+      it("raises an error when passed fn incompatible with Index map function", () => {
+        const fn = (s: string): string => "";
+
+        // $ExpectError
+        (R.map(fn, new Index()): Array<string>);
+      });
+    });
+  });
+
+  describe("Read Only", () => {
+    it("should return readonly Array", () => {
+      const readOnlyArrNumbers = Object.freeze([1, 2, 3]);
+
+      (R.map(NumberToString, readOnlyArrNumbers): $ReadOnlyArray<string>);
+
+      (R.map(NumberToString)(readOnlyArrNumbers): $ReadOnlyArray<string>);
+    });
+
+    it("should return readonly Object", () => {
+      const readOnlyObj = Object.freeze({
+        a: { key: 1 },
+        c: { key: 2 },
+        d: { key: 3 }
+      });
+
+      (R.map(R.prop("key"), readOnlyObj): $ReadOnly<{ [key: string]: number }>);
+
+      (R.map(R.prop("key"))(readOnlyObj): $ReadOnly<{ [key: string]: number }>);
+    });
+
+    describe("{}::map(fn)", () => {
+      class Index {
+        ids: $ReadOnlyArray<number>;
+
+        map<T>(fn: (e: number) => T): $ReadOnlyArray<T> {
+          return this.ids.map(e => fn(e));
+        }
+      }
+
+      it("should return read only Array<string>", () => {
+        (R.map(NumberToString, new Index()): $ReadOnlyArray<string>);
+
+        (R.map(NumberToString)(new Index()): $ReadOnlyArray<string>);
+      });
+
+      it("raises an error when passed fn incompatible with Index map function", () => {
+        const fn = (s: string): string => "";
+
+        // $ExpectError
+        (R.map(fn, new Index()): $ReadOnlyArray<string>);
+      });
+    });
+  });
+});

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_math.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_math.js
@@ -1,0 +1,32 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+
+import { describe, it } from 'flow-typed-test';
+import {
+  subtract,
+} from 'ramda'
+
+describe('subtract', () => {
+  it('works with two numbers', () => {
+    const result: number = subtract(1, 2)
+  })
+
+  // To see Ramda working with various date combinations, see:
+
+  it('works with dates to produce a number', () => {
+    const result: number = subtract(new Date(), new Date())
+  })
+
+  it('works with a date and a number to produce a number', () => {
+    const result: number = subtract(new Date(), 1000)
+  })
+
+  it('works with a number and a date to produce a number', () => {
+    const result: number = subtract(1000, new Date())
+  })
+
+  it('does not accept strings as inputs', () => {
+    // $ExpectError
+    const result: number = subtract('foo', 'o')
+  })
+})

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_misc.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_misc.js
@@ -1,0 +1,81 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+import _, {
+  compose,
+  pipe,
+  curry,
+  filter,
+  find,
+  isNil,
+  repeat,
+  replace,
+  zipWith
+} from "ramda";
+import { describe, it } from 'flow-typed-test';
+
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed } = { a: 1, c: "d" };
+const os: Array<{ [k: string]: * }> = [{ a: 1, c: "d" }, { b: 2 }];
+const str: string = "hello world";
+
+// Math
+{
+  const partDiv: (a: number) => number = _.divide(6);
+  const div: number = _.divide(6, 2);
+  //$ExpectError
+  const div2: number = _.divide(6, true);
+}
+
+// String
+{
+  const ss: Array<string | void> = _.match(/h/, "b");
+  describe('replace', () => {
+    it('should supports replace by string', () => {
+      const r1: string = replace(",", "|", "b,d,d");
+      const r2: string = replace(",")("|", "b,d,d");
+      const r3: string = replace(",")("|")("b,d,d");
+      const r4: string = replace(",", "|")("b,d,d");
+    });
+    it('should supports replace by RegExp', () => {
+      const r1: string = replace(/[,]/, "|", "b,d,d");
+      const r2: string = replace(/[,]/)("|", "b,d,d");
+      const r3: string = replace(/[,]/)("|")("b,d,d");
+      const r4: string = replace(/[,]/, "|")("b,d,d");
+    });
+    it('should supports replace by RegExp with replacement fn', () => {
+      const fn = (match: string, g1: string): string => g1;
+      const r1: string = replace(/([,])d/, fn, "b,d,d");
+      const r2: string = replace(/([,])d/)(fn, "b,d,d");
+      const r3: string = replace(/([,])d/)(fn)("b,d,d");
+      const r4: string = replace(/([,])d/, fn)("b,d,d");
+    });
+  });
+  const ss2: Array<string> = _.split(",", "b,d,d");
+  const ss1: boolean = _.test(/h/, "b");
+  const s: string = _.trim("s");
+  const x: string = _.head("one");
+  const sss: string = _.concat("H", "E");
+  const sss1: string = _.concat("H")("E");
+  const ssss: string = _.drop(1, "EF");
+  const ssss1: string = _.drop(1)("E");
+  const ssss2: string = _.dropLast(1, "EF");
+  const ys: string = _.nth(2, "curry");
+  const ys1: string = _.nth(2)("curry");
+}
+//Type
+{
+  const x: boolean = _.is(Number, 1);
+  const x1: boolean = isNil(1);
+
+  // should refine type
+  const x1a: ?{ a: number } = { a: 1 };
+  //$ExpectError
+  x1a.a;
+  if (!isNil(x1a)) {
+    x1a.a;
+  }
+
+  const x2: boolean = _.propIs(1, "num", { num: 1 });
+}

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_object.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_object.js
@@ -21,9 +21,9 @@ import _, {
 
 const ns: Array<number> = [1, 2, 3, 4, 5];
 const ss: Array<string> = ["one", "two", "three", "four"];
-const obj: { [k: string]: number, ... } = { a: 1, c: 2 };
-const objMixed: { [k: string]: mixed, ... } = { a: 1, c: "d" };
-const os: Array<{ [k: string]: *, ... }> = [{ a: 1, c: "d" }, { b: 2 }];
+const obj: { [k: string]: number } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed } = { a: 1, c: "d" };
+const os: Array<{ [k: string]: * }> = [{ a: 1, c: "d" }, { b: 2 }];
 const str: string = "hello world";
 
 describe("Object", () => {
@@ -32,22 +32,19 @@ describe("Object", () => {
       (_.assoc("c", "s", { a: 1, b: 2 }): {
         a: number,
         b: number,
-        c: string,
-        ...
+        c: string
       });
 
       (_.assoc("x", { x1: 11 }, { y: ["y1"] }): {
-        x: { [string]: number, ... },
-        y: Array<string>,
-        ...
+        x: { [string]: number },
+        y: Array<string>
       });
     });
 
     it("should return sum types when passed key already has in passed object", () => {
       (_.assoc("a", "s", { a: 1, b: 2 }): {
         a: number | string,
-        b: number | string,
-        ...
+        b: number | string
       });
     });
   });
@@ -105,7 +102,7 @@ describe("Object", () => {
     })
 
     it('works with lensPath down to level 5', () => {
-      type NestedData = { a: { b: { c: { d: { e: string, ... }, ... }, ... }, ... }, ... };
+      type NestedData = { a: { b: { c: { d: { e: string } } } } };
       const nestedData: NestedData = {
         a: {
           b: {
@@ -122,7 +119,9 @@ describe("Object", () => {
     })
 
     it('produces an output type that results from the mapping function and input (object)', () => {
-      type TransformedData = { a: number, ... }
+      type TransformedData = {
+        a: number,
+      }
       const data = {
         a: 'foo',
       }
@@ -131,7 +130,7 @@ describe("Object", () => {
     })
 
     it('requires the lens works with the functor provided (object)', () => {
-      type Data = { a: string, ... }
+      type Data = { a: string }
       const data: Data = {
         a: 'foo',
       }
@@ -216,7 +215,7 @@ describe("Object", () => {
     })
 
     it('requires the lens works with the functor provided (object)', () => {
-      type Data = { a: string, ... }
+      type Data = { a: string }
       const data: Data = {
         a: 'foo',
       }
@@ -236,12 +235,7 @@ describe("Object", () => {
    */
   describe('view', () => {
     it('works with lens', () => {
-      type Data = {
-        a: string,
-        b: number,
-        c: boolean,
-        ...
-      }
+      type Data = { a: string, b: number, c: boolean }
       const data = {
         a: 'foo',
         b: 4,
@@ -257,26 +251,26 @@ describe("Object", () => {
     })
 
     it('works with lensIndex', () => {
-      type Data = { a: string, ... }
+      type Data = { a: string }
       const xs: Array<number> = [1, 2, 3]
       const result: number = view(lensIndex(0), xs)
     })
 
     it('works with lensProp', () => {
-      type Data = { a: string, ... }
+      type Data = { a: string }
       const data = { a: 'foo' }
       const result: string = view(lensProp('a'), data)
     })
 
     it('fails when the lensProp refers to a non-existent field', () => {
-      type Data = { a: string, ... }
+      type Data = { a: string }
       const data = { a: 'foo' }
       // $ExpectError
       const result: string = view(lensProp('b'), data)
     })
 
     it('produces the correct result type', () => {
-      type Data = { a: string, ... }
+      type Data = { a: string }
       const data = { a: 'foo' }
       // $ExpectError
       const result: number = view(lensProp('a'), data)
@@ -284,7 +278,7 @@ describe("Object", () => {
   })
 });
 
-const apath: { [k: string]: number | string | Object, ... } = _.assocPath(
+const apath: { [k: string]: number | string | Object } = _.assocPath(
   ["a", 0, "c"],
   "s",
   { a: [ { c: 0 } ] }
@@ -323,28 +317,28 @@ const id = objectsClone2.id;
 //$ExpectError
 const idE = objectsClone4.id;
 
-const dissocd: { a: number, ... } = _.dissoc("b", { a: 1, b: 2 });
-const dissocd2: { a: number, ... } = _.dissoc("b")({ a: 1, b: 2 });
+const dissocd: { a: number } = _.dissoc("b", { a: 1, b: 2 });
+const dissocd2: { a: number } = _.dissoc("b")({ a: 1, b: 2 });
 //$ExpectError
-const dissocd3: { a: string, ... } = _.dissoc("b", { a: 1, b: 2 });
+const dissocd3: { a: string } = _.dissoc("b", { a: 1, b: 2 });
 //$ExpectError
-const dissocd4: { a: string, ... } = _.dissoc("b")({ a: 1, b: 2 });
+const dissocd4: { a: string } = _.dissoc("b")({ a: 1, b: 2 });
 
-const dissocPathd: { a: { b: number, ... }, ... } = _.dissocPath(["a", "c"], {
+const dissocPathd: { a: { b: number } } = _.dissocPath(["a", "c"], {
   a: { b: 1, c: 2 }
 });
-const dissocPathd2: { a: { b: number, ... }, ... } = _.dissocPath(["a", "c"])({
+const dissocPathd2: { a: { b: number } } = _.dissocPath(["a", "c"])({
   a: { b: 1, c: 2 }
 });
-const dissocPathd3: { a: { b: number, ... }, ... } = _.dissocPath(["a", "c", 0])({
+const dissocPathd3: { a: { b: number } } = _.dissocPath(["a", "c", 0])({
   a: { b: 1, c: [2] }
 });
 //$ExpectError
-const dissocPathd4: { a: { b: string, ... }, ... } = _.dissocPath(["a", "c"], {
+const dissocPathd4: { a: { b: string } } = _.dissocPath(["a", "c"], {
   a: { b: 1, c: 2 }
 });
 //$ExpectError
-const dissocPathd5: { a: { b: string, ... }, ... } = _.dissocPath(["a", "c"])({
+const dissocPathd5: { a: { b: string } } = _.dissocPath(["a", "c"])({
   a: { b: 1, c: 2 }
 });
 
@@ -416,10 +410,10 @@ const raceResultsByFirstName = {
   second: "jake",
   third: "alice"
 };
-const inverted: { [k: string]: Array<string>, ... } = _.invert(
+const inverted: { [k: string]: Array<string> } = _.invert(
   raceResultsByFirstName
 );
-const inverted1: { [k: string]: string, ... } = _.invertObj(raceResultsByFirstName);
+const inverted1: { [k: string]: string } = _.invertObj(raceResultsByFirstName);
 
 const ks: Array<string> = _.keys(raceResultsByFirstName);
 const ksMaybe: Array<string> = _.keys(null)
@@ -428,19 +422,19 @@ const ksi: Array<string> = _.keysIn(square);
 const xs = { x: 1, y: 2, z: 3 };
 const prependKeyAndDouble = (num, key, obj) => key + num * 2;
 
-const obI: { [k: string]: string, ... } = _.mapObjIndexed(
+const obI: { [k: string]: string } = _.mapObjIndexed(
   prependKeyAndDouble,
   xs
 );
 //$ExpectError
-const obI2: { [k: string]: number, ... } = _.mapObjIndexed(
+const obI2: { [k: string]: number } = _.mapObjIndexed(
   prependKeyAndDouble,
   xs
 );
 
 const ob1 = { a: 1 };
 const ob2 = { b: 3 };
-const ob3 = _.merge(ob1, ob2);
+const ob3 = _.mergeRight(ob1, ob2);
 //$ExpectError
 const propX = ob3.x;
 const propA = ob3.a;
@@ -551,14 +545,10 @@ const ppp3: string = _.prop("x", { x: 100 });
 const ppp4: number = _.prop(_.__, { x: 100 })("x");
 //$ExpectError
 const ppp5: number = _.prop(_.__, { x: 100 })("y");
-const ppp6: number = _.prop("x", ({ x: 1, y: "a" }: {
-  x: number,
-  y: string,
-  ...
-}));
-const ppp7: number = _.prop("x", ({ x: 1 }: { [string]: number, ... }));
+const ppp6: number = _.prop("x", ({ x: 1, y: "a" }: { x: number, y: string }));
+const ppp7: number = _.prop("x", ({ x: 1 }: { [string]: number }));
 //$ExpectError
-const ppp8: string = _.prop("x", ({ x: 1 }: { [string]: number, ... }));
+const ppp8: string = _.prop("x", ({ x: 1 }: { [string]: number }));
 
 const alice = {
   name: "ALICE",
@@ -578,14 +568,10 @@ const pss1: Array<number | boolean> = _.props(["x", "y"], {
 });
 const pss2: Array<number | boolean> = _.props(
   ["x", "y"],
-  ({ x: true, y: 2, z: "foo" }: {
-  x: boolean,
-  y: number,
-  ...
-})
+  ({ x: true, y: 2, z: "foo" }: { x: boolean, y: number })
 );
 const pss3: Array<number> = _.props(["y"], { x: true, y: 2, z: "foo" });
-const pss4: Array<number> = _.props(["y"], ({ y: 2 }: { [string]: number, ... }));
+const pss4: Array<number> = _.props(["y"], ({ y: 2 }: { [string]: number }));
 //$ExpectError -- wrong key
 const pssE1: Array<number | boolean> = _.props(["d", "y"], {
   x: true,
@@ -599,7 +585,7 @@ const pssE2: Array<string | boolean> = _.props(["x", "y"], {
   z: "foo"
 });
 //$ExpectError -- wrong type on indexer value
-const pssE3: Array<string> = _.props(["y"], ({ y: 2 }: { [string]: number, ... }));
+const pssE3: Array<string> = _.props(["y"], ({ y: 2 }: { [string]: number }));
 
 const top: Array<["a" | "b" | "c", number]> = _.toPairs({ a: 1, b: 2, c: 3 });
 

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_object.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_object.js
@@ -446,11 +446,21 @@ const mLeft2: { x: number, y: number } = _.mergeLeft({x: 0})({x: 5, y: 2});
 const mLeftX: number = mLeft2.x;
 const mLeftY: number = mLeft2.y;
 
-const mRight: { name: string, age: number } = _.mergeRight({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
+type User = {
+  name: string,
+  age: number,
+  ...
+}
+const mRight: User = _.mergeRight({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
 const mRightName: string = mRight.name;
 // $ExpectError
 const mRightAge: number = mRight.name;
-const mRight2: { x: number, y: number } = _.mergeRight({x: 0, y: 0})({y: 2});
+type Point = {
+  x: number,
+  y: number,
+  ...
+}
+const mRight2: Point = _.mergeRight({x: 0, y: 0})({y: 2});
 const mRightX: number = mRight2.x;
 const mRightY: number = mRight2.y;
 

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_partial.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_partial.js
@@ -1,0 +1,17 @@
+/* @flow */
+/*eslint-disable no-undef, no-unused-vars, no-console*/
+import { partial } from "ramda";
+
+// --- Partial ---
+const method1 = (foo: string, bah: number, baz: boolean) => baz;
+
+const partial1: (number, boolean) => boolean = partial(method1, ["foo"]);
+const partial2: boolean = partial(method1, ["foo"])(4, true);
+// $ExpectError
+const partial3 = partial(method1, [4]);
+const partial4: boolean = partial(method1, ["foo", 4])(true);
+const partial5: boolean = partial(method1, ["foo", 4, true])();
+
+// Functions produced from partial are not curried.
+// $ExpectError
+const partial6 = partial(method1, ["foo"])(4);

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_pipe.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/test_ramda_v0.27.x_pipe.js
@@ -1,0 +1,224 @@
+// @flow
+import { describe, it } from "flow-typed-test";
+import { pipe } from "ramda";
+
+// f - function
+// a - argument
+// unf - unary function
+function f1(a1: number): number {
+  return 69;
+}
+
+function f2(a1: number, a2: string): number {
+  return 69;
+}
+
+function f3(a1: number, a2: string, a3: boolean): number {
+  return 69;
+}
+
+function f4(a1: number, a2: string, a3: boolean, a4: number): number {
+  return 69;
+}
+
+function f5(a1: number, a2: string, a3: boolean, a4: number, a5: string): number {
+  return 69;
+}
+
+function unf1(a1: number): string {
+  return "69";
+}
+
+function unf2(a1: string): boolean {
+  return false;
+}
+
+function unf3(a1: boolean): number {
+  return 69;
+}
+
+function unf4(a1: number): string {
+  return "69";
+}
+
+function unf5(a1: string): boolean {
+  return true;
+}
+
+describe("pipe(...fn)", () => {
+  describe('call "pipe" with unary function', () => {
+    it("rises an error when function chain broken", () => {
+      // $ExpectError - unf1 return string but unf3 first argument boolean
+      pipe(f1, unf1, unf3, unf4, unf5)(1);
+    });
+
+    it("passes when used properly", () => {
+      (pipe(f1, unf1, unf2, unf3, unf4, unf5)(1): boolean);
+      (pipe(f1, unf1, unf2, unf3, unf4)(1): string);
+      (pipe(f1, unf1, unf2, unf3)(1): number);
+      (pipe(f1, unf1, unf2)(1): boolean);
+      (pipe(f1, unf1)(1): string);
+      (pipe(f1)(1): number);
+    });
+
+    it("raises an error when passed more arguments than it need", () => {
+      // $ExpectError - too many arguments
+      pipe(f1)(1, "1", true);
+    });
+
+    it("raises an error when passed too few arguments", () => {
+      // $ExpectError - too few arguments
+      pipe(f1)();
+    });
+
+    it("raises an error when passed an invalid argument", () => {
+      //$ExpectError - boolean  is incompatible with number
+      pipe(f1, unf1)(true);
+    });
+
+    it("raises an error when trying to recognize an unexpected type", () => {
+      //$ExpectError - boolean  is incompatible with string
+      (pipe(f1, unf1)(1): boolean);
+    });
+  });
+
+  describe('call "pipe" with double function', () => {
+    it("rises an error when function chain broken", () => {
+      // $ExpectError - unf1 return string but unf3 first argument boolean
+      pipe(f2, unf1, unf3, unf4, unf5)(1, "2");
+    });
+
+    it("passes when used properly", () => {
+      (pipe(f2, unf1, unf2, unf3, unf4, unf5)(1, "2"): boolean);
+      (pipe(f2, unf1, unf2, unf3, unf4)(1, "2"): string);
+      (pipe(f2, unf1, unf2, unf3)(1, "2"): number);
+      (pipe(f2, unf1, unf2)(1, "2"): boolean);
+      (pipe(f2, unf1)(1, "2"): string);
+    });
+
+    it("raises an error when passed more arguments than it need", () => {
+      // $ExpectError - too many arguments
+      pipe(f2)(1, "2", true, 4, "5");
+    });
+
+    it("raises an error when passed too few arguments", () => {
+      // $ExpectError - too few arguments
+      pipe(f2)(1);
+    });
+
+    it("raises an error when passed an invalid argument", () => {
+      //$ExpectError - boolean  is incompatible with string
+      pipe(f2, unf1)(1, true);
+    });
+
+    it("raises an error when trying to recognize an unexpected type", () => {
+      //$ExpectError - boolean  is incompatible with string
+      (pipe(f2, unf1)(1, "2"): boolean);
+    });
+  });
+
+  describe('call "pipe" with triple function', () => {
+    it("rises an error when function chain broken", () => {
+      // $ExpectError - unf1 return string but unf3 first argument boolean
+      pipe(f3, unf1, unf3, unf4, unf5)(1, "2", true);
+    });
+
+    it("passes when used properly", () => {
+      (pipe(f3, unf1, unf2, unf3, unf4, unf5)(1, "2", true): boolean);
+      (pipe(f3, unf1, unf2, unf3, unf4)(1, "2", true): string);
+      (pipe(f3, unf1, unf2, unf3)(1, "2", true): number);
+      (pipe(f3, unf1, unf2)(1, "2", true): boolean);
+      (pipe(f3, unf1)(1, "2", true): string);
+    });
+
+    it("raises an error when passed more arguments than it need", () => {
+      // $ExpectError - too many arguments
+      pipe(f3)(1, "2", true, 4, "5");
+    });
+
+    it("raises an error when passed too few arguments", () => {
+      // $ExpectError - too few arguments
+      pipe(f3)(1, "2");
+    });
+
+    it("raises an error when passed an invalid argument", () => {
+      //$ExpectError - number is incompatible with boolean
+      pipe(f3, unf1)(1, "2", 999);
+    });
+
+    it("raises an error when trying to recognize an unexpected type", () => {
+      //$ExpectError - boolean  is incompatible with string
+      (pipe(f3, unf1)(1, "2", true): boolean);
+    });
+  });
+
+  describe('call "pipe" with function that takes 4 arguments', () => {
+    it("rises an error when function chain broken", () => {
+      // $ExpectError - unf1 return string but unf3 first argument boolean
+      pipe(f4, unf1, unf3, unf4, unf5)(1, "2", true, 4);
+    });
+
+    it("passes when used properly", () => {
+      (pipe(f4, unf1, unf2, unf3, unf4, unf5)(1, "2", true, 4): boolean);
+      (pipe(f4, unf1, unf2, unf3, unf4)(1, "2", true, 4): string);
+      (pipe(f4, unf1, unf2, unf3)(1, "2", true, 4): number);
+      (pipe(f4, unf1, unf2)(1, "2", true, 4): boolean);
+      (pipe(f4, unf1)(1, "2", true, 4): string);
+    });
+
+    it("raises an error when passed more arguments than it need", () => {
+      // $ExpectError - too many arguments
+      pipe(f4)(1, "2", true, 4, "5", 6, false);
+    });
+
+    it("raises an error when passed too few arguments", () => {
+      // $ExpectError - too few arguments
+      pipe(f4)(1, "2", true);
+    });
+
+    it("raises an error when passed an invalid argument", () => {
+      //$ExpectError - string is incompatible with number
+      pipe(f4, unf1)(1, "2", true, "new number");
+    });
+
+    it("raises an error when trying to recognize an unexpected type", () => {
+      //$ExpectError - boolean  is incompatible with string
+      (pipe(f4, unf1)(1, "2", true, 4): boolean);
+    });
+  });
+
+  describe('call "pipe" with function that takes 5 arguments', () => {
+    it("rises an error when function chain broken", () => {
+      // $ExpectError - unf1 return string but unf3 first argument boolean
+      pipe(f5, unf1, unf3, unf4, unf5)(1, "2", true, 4, "5");
+    });
+
+    it("passes when used properly", () => {
+      (pipe(f5, unf1, unf2, unf3, unf4, unf5)(1, "2", true, 4, "5"): boolean);
+      (pipe(f5, unf1, unf2, unf3, unf4)(1, "2", true, 4, "5"): string);
+      (pipe(f5, unf1, unf2, unf3)(1, "2", true, 4, "5"): number);
+      (pipe(f5, unf1, unf2)(1, "2", true, 4, "5"): boolean);
+      (pipe(f5, unf1)(1, "2", true, 4, "5"): string);
+    });
+
+    it("raises an error when passed more arguments than it need", () => {
+      // $ExpectError - too many arguments
+      pipe(f5)(1, "2", true, 4, "5", 6, 7, 8);
+    });
+
+    it("raises an error when passed too few arguments", () => {
+      // $ExpectError - too few arguments
+      pipe(f5)(1, "2", true, 4);
+    });
+
+    it("raises an error when passed an invalid argument", () => {
+      //$ExpectError - boolean is incompatible with string
+      pipe(f5, unf1)(1, "2", true, 4, false);
+    });
+
+    it("raises an error when trying to recognize an unexpected type", () => {
+      //$ExpectError - boolean  is incompatible with string
+      (pipe(f5, unf1)(1, "2", true, 4, "5"): boolean);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #3729.
- Links to documentation: https://github.com/ramda/ramda/pull/2835 (never made it to official release notes)
- Link to GitHub or NPM: https://ramdajs.com/ https://github.com/ramda/ramda
- Type of contribution: new definition

Other notes:

These definitions are a copy of `0.26.x` but with removed functions... removed. Some corrections were copied back to `0.26.x` - namely tests using `Object`.

