### PR TITLE
[reselect_v4.x.x.js] Redefine OutputSelector type as a callable object

### DIFF
--- a/definitions/npm/reselect_v4.x.x/flow_v0.104.x-/reselect_v4.x.x.js
+++ b/definitions/npm/reselect_v4.x.x/flow_v0.104.x-/reselect_v4.x.x.js
@@ -4,14 +4,12 @@ declare module "reselect" {
   declare type InputSelector<-TState, TProps, TResult> =
     (state: TState, props: TProps, ...rest: any[]) => TResult
 
-  declare type OutputSelector<-TState, TProps, TResult> =
-    & InputSelector<TState, TProps, TResult>
-    & {
+  declare type OutputSelector<-TState, TProps, TResult> = {|
+    (state: TState, props: TProps, ...rest: any[]): TResult,
     recomputations(): number,
     resetRecomputations(): number,
     resultFunc(...args: any[]): TResult,
-    ...
-  };
+  |}
 
   declare type SelectorCreator = {
     <TState, TProps, TResult, T1>(


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/reduxjs/reselect/blob/master/README.md
- Link to GitHub or NPM: https://github.com/reduxjs/reselect
- Type of contribution: fix

Other notes: This is a very simple change and is backward compatible so I didn't need to write any new tests. I am just redefining the `OutputSelector` type to a callable object since it achieves a more accurate typing (closer to the real api). The previous definition was an intersection between an `InputSelector` (function) and an object containing the rest of the api.
This also seems to fix [this issue](https://github.com/flow-typed/flow-typed/issues/3127), which happens to be really hard to reproduce. After applying the proposed change locally in one of the projects where I have encountered the issue it was properly fixed.

