### PR TITLE
qs: Make stringify 'obj' param $ReadOnly

### DIFF
--- a/definitions/npm/qs_v6.5.x/flow_v0.104.x-/qs_v6.5.x.js
+++ b/definitions/npm/qs_v6.5.x/flow_v0.104.x-/qs_v6.5.x.js
@@ -53,7 +53,10 @@ declare module "qs" {
 
   declare module.exports: {
     parse(str: string, opts?: ParseOptions): mixed,
-    stringify(obj: {[string]: mixed, ...} | Array<mixed>, opts?: StringifyOptions): string,
+    stringify(
+      obj: $ReadOnly<{ [string]: mixed, ... }> | $ReadOnlyArray<mixed>,
+      opts?: StringifyOptions
+    ): string,
     formats: Formats,
     ...
   };

--- a/definitions/npm/qs_v6.5.x/flow_v0.45.x-v0.103.x/qs_v6.5.x.js
+++ b/definitions/npm/qs_v6.5.x/flow_v0.45.x-v0.103.x/qs_v6.5.x.js
@@ -49,7 +49,10 @@ declare module "qs" {
 
   declare module.exports: {
     parse(str: string, opts?: ParseOptions): mixed,
-    stringify(obj: {[string]: mixed, ...} | Array<mixed>, opts?: StringifyOptions): string,
-    formats: Formats
+    stringify(
+      obj: $ReadOnly<{ [string]: mixed, ... }> | $ReadOnlyArray<mixed>,
+      opts?: StringifyOptions
+    ): string,
+    formats: Formats,
   };
 }

--- a/definitions/npm/qs_v6.9.x/flow_v0.104.x-/qs_v6.9.x.js
+++ b/definitions/npm/qs_v6.9.x/flow_v0.104.x-/qs_v6.9.x.js
@@ -61,8 +61,11 @@ declare module "qs" {
   };
 
   declare module.exports: {|
-    parse(str: string, opts?: ParseOptions): {[string]: mixed, ...},
-    stringify(obj: {[string]: mixed, ...} | Array<mixed>, opts?: StringifyOptions): string,
+    parse(str: string, opts?: ParseOptions): { [string]: mixed, ... },
+    stringify(
+      obj: $ReadOnly<{ [string]: mixed, ... }> | $ReadOnlyArray<mixed>,
+      opts?: StringifyOptions
+    ): string,
     formats: Formats,
   |};
 }

--- a/definitions/npm/qs_v6.9.x/flow_v0.45.x-v0.103.x/qs_v6.9.x.js
+++ b/definitions/npm/qs_v6.9.x/flow_v0.45.x-v0.103.x/qs_v6.9.x.js
@@ -59,8 +59,11 @@ declare module "qs" {
   };
 
   declare module.exports: {
-    parse(str: string, opts?: ParseOptions): {[string]: mixed},
-    stringify(obj: {[string]: mixed} | Array<any>, opts?: StringifyOptions): string,
-    formats: Formats
+    parse(str: string, opts?: ParseOptions): { [string]: mixed },
+    stringify(
+      obj: $ReadOnly<{ [string]: mixed, ... }> | $ReadOnlyArray<mixed>,
+      opts?: StringifyOptions
+    ): string,
+    formats: Formats,
   };
 }

--- a/definitions/npm/qs_v6.9.x/test_qs.js
+++ b/definitions/npm/qs_v6.9.x/test_qs.js
@@ -36,7 +36,7 @@ describe('parse', () => {
   it('returns an inert object', () => {
     // This assertion isn't great because the any (Object) can be cast without
     // issue.
-    const obj: { [string]: mixed, ... } = parse("test")
+    const obj: $ReadOnly<{ [string]: mixed, ... }> = parse("test")
 
     // This combined with the positive assertion above should make for a robust
     // enforcement of the return type, immune to Object/any's type coverage


### PR DESCRIPTION
- Make qs.stringify obj param $ReadOnly

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation:
https://flow.org/en/docs/types/arrays/#toc-readonlyarray
https://flow.org/en/docs/types/utilities/#toc-readonly
- Type of contribution: fix

Other notes:
Resolve Flow errors for qs.stringify object param by making obj read only.

