### PR TITLE
[@sentry/browser] Add Integrations and Transports, fix extras

### DIFF
--- a/definitions/npm/@sentry/browser_v5.x.x/flow_v0.84.x-/browser_v5.x.x.js
+++ b/definitions/npm/@sentry/browser_v5.x.x/flow_v0.84.x-/browser_v5.x.x.js
@@ -356,9 +356,14 @@ declare module '@sentry/browser' {
 
         +blacklistUrls?: $ReadOnlyArray<string | RegExp>,
         +whitelistUrls?: $ReadOnlyArray<string | RegExp>,
-        +integrations?:
-            | $ReadOnlyArray<Integration<any>>
-            | (($ReadOnlyArray<Integration<any>>) => $ReadOnlyArray<Integration<any>>),
+        // This really should be typed as:
+        //    | $ReadOnlyArray<Integration<any>>
+        //    | (($ReadOnlyArray<Integration<any>>) => $ReadOnlyArray<Integration<any>>)
+        // but we must support integrations from @sentry/integrations as well
+        // as custom integrations. Since cross-package imports aren't allowed
+        // and classes are nominally typed, using `any` seems like our only
+        // option here.
+        +integrations?: any,
         +beforeBreadcrumb?: (breadcrumb: Breadcrumb, hint?: BreadcrumbHint) => Breadcrumb | void,
         +_experiments?: { [key: string]: mixed, ... },
     |};

--- a/definitions/npm/@sentry/browser_v5.x.x/flow_v0.84.x-/browser_v5.x.x.js
+++ b/definitions/npm/@sentry/browser_v5.x.x/flow_v0.84.x-/browser_v5.x.x.js
@@ -31,8 +31,8 @@ declare module '@sentry/browser' {
         setUser(user: User | null): void;
         setTags(tags: { [key: string]: string, ... }): void;
         setTag(key: string, value: string): void;
-        setExtra(key: string, extra: mixed): void;
-        setExtras(extras: { [key: string]: mixed, ... }): void;
+        setExtra(key: string, extra: any): void;
+        setExtras(extras: { [key: string]: any, ... }): void;
         setContext(name: string, context: { [key: string]: mixed, ... } | null): void;
         configureScope(callback: (scope: Scope) => void): void;
         run(callback: (hub: Hub) => void): void;
@@ -46,8 +46,8 @@ declare module '@sentry/browser' {
         setUser(user: User | null): void;
         setTags(tags: {| [key: string]: string |}): void;
         setTag(key: string, value: string): void;
-        setExtras(extras: {| [key: string]: string |}): void;
-        setExtra(key: string, extra: mixed): void;
+        setExtras(extras: { [key: string]: any, ... }): void;
+        setExtra(key: string, extra: any): void;
         setFingerprint(fingerprint: $ReadOnlyArray<string>): void;
         setLevel(level: $Values<typeof Severity>): void;
         setTransaction(transaction?: string): void;
@@ -62,8 +62,8 @@ declare module '@sentry/browser' {
         name: string,
         context: {| [key: string]: mixed |} | null,
     ): void;
-    declare export function setExtra(key: string, extra: mixed): void;
-    declare export function setExtras(extras: {| [key: string]: mixed |}): void;
+    declare export function setExtra(key: string, extra: any): void;
+    declare export function setExtras(extras: { [key: string]: any, ... }): void;
     declare export function setTag(key: string, value: string): void;
     declare export function setTags(tags: {| [key: string]: string |}): void;
     declare export function setUser(user: User): void;
@@ -300,7 +300,7 @@ declare module '@sentry/browser' {
         +breadcrumbs?: $ReadOnlyArray<Breadcrumb>,
         +contexts?: {| [key: string]: { ... } |},
         +tags?: {| [key: string]: string |},
-        +extra?: {| [key: string]: mixed |},
+        +extra?: {| [key: string]: any |},
         +user?: User,
         +type?: EventType,
         +spans?: $ReadOnlyArray<Span>,

--- a/definitions/npm/@sentry/browser_v5.x.x/flow_v0.84.x-/browser_v5.x.x.js
+++ b/definitions/npm/@sentry/browser_v5.x.x/flow_v0.84.x-/browser_v5.x.x.js
@@ -36,7 +36,7 @@ declare module '@sentry/browser' {
         setContext(name: string, context: { [key: string]: mixed, ... } | null): void;
         configureScope(callback: (scope: Scope) => void): void;
         run(callback: (hub: Hub) => void): void;
-        getIntegration<T: Integration<>>(integration: IntegrationClass<T>): T | null;
+        getIntegration<T>(integration: Class<Integration<T>>): Integration<T> | null;
         traceHeaders(): { [key: string]: string, ... };
         startSpan(span?: Span | SpanContext, forceNoChild?: boolean): Span;
     }
@@ -83,10 +83,10 @@ declare module '@sentry/browser' {
         getOptions(): O;
         close(timeout?: number): Promise<boolean>;
         flush(timeout?: number): Promise<boolean>;
-        getIntegration<T: Integration<>>(integration: IntegrationClass<T>): T | null;
+        getIntegration<T>(integration: Class<Integration<T>>): Integration<T> | null;
     }
 
-    declare export var defaultIntegrations: $ReadOnlyArray<Integration<>>;
+    declare export var defaultIntegrations: $ReadOnlyArray<Integration<any>>;
     declare export function forceLoad(): void;
     declare export function init(Options): void;
     declare export function lastEventId(): string | void;
@@ -108,12 +108,39 @@ declare module '@sentry/browser' {
         +Debug: 'debug',
         +Critical: 'critical',
     |};
+    declare export var Integrations: {|
+        // Core
+        +InboundFilters: Class<Integration<>>,
+        +FunctionToString: Class<Integration<>>,
 
-    declare class IntegrationClass<T> {
-        constructor(...args: $ReadOnlyArray<mixed>): T;
-        id: string;
-    }
-    declare class Integration<O = { ... }> {
+        // Browser
+        +GlobalHandlers: Class<Integration<{|
+            onerror?: boolean,
+            onunhandledrejection?: boolean,
+        |}>>,
+        +TryCatch: Class<Integration<>>,
+        +Breadcrumbs: Class<Integration<{|
+            beacon?: boolean,
+            console?: boolean,
+            dom?: boolean,
+            fetch?: boolean,
+            history?: boolean,
+            sentry?: boolean,
+            xhr?: boolean,
+        |}>>,
+        +LinkedErrors: Class<Integration<{|
+            key?: string,
+            limit?: number,
+        |}>>,
+        +UserAgent: Class<Integration<>>,
+    |};
+    declare export var Transports: {|
+        +BaseTransport: Class<Transport>,
+        +FetchTransport: Class<Transport>,
+        +XHRTransport: Class<Transport>,
+    |};
+
+    declare class Integration<O = {||}> {
         constructor(options?: O): Integration<O>;
         name: string;
         setupOnce(
@@ -223,11 +250,11 @@ declare module '@sentry/browser' {
     |};
     declare type DsnLike = string | DsnComponents;
     declare type Dsn = { toString(withPassword: boolean): string, ...DsnComponents, ... };
-    declare type Transport = {|
-        sendEvent(event: Event): Promise<SentryResponse>,
-        close(timeout?: number): Promise<boolean>,
-    |};
-    declare type TransportClass<T: Transport> = (options: TransportOptions) => T;
+    declare class Transport {
+        constructor(options: TransportOptions): Transport;
+        sendEvent(event: Event): Promise<SentryResponse>;
+        close(timeout?: number): Promise<boolean>;
+    }
     declare type TransportOptions = {|
         +dsn: DsnLike,
         +headers?: { [key: string]: string, ... },
@@ -311,7 +338,7 @@ declare module '@sentry/browser' {
         +dsn?: string,
         +defaultIntegrations?: false,
         +ignoreErrors?: $ReadOnlyArray<string | RegExp>,
-        +transport?: TransportClass<Transport>,
+        +transport?: Class<Transport>,
         +transportOptions?: TransportOptions,
         +release?: string,
         +environment?: string,
@@ -330,8 +357,8 @@ declare module '@sentry/browser' {
         +blacklistUrls?: $ReadOnlyArray<string | RegExp>,
         +whitelistUrls?: $ReadOnlyArray<string | RegExp>,
         +integrations?:
-            | $ReadOnlyArray<Integration<>>
-            | (($ReadOnlyArray<Integration<>>) => $ReadOnlyArray<Integration<>>),
+            | $ReadOnlyArray<Integration<any>>
+            | (($ReadOnlyArray<Integration<any>>) => $ReadOnlyArray<Integration<any>>),
         +beforeBreadcrumb?: (breadcrumb: Breadcrumb, hint?: BreadcrumbHint) => Breadcrumb | void,
         +_experiments?: { [key: string]: mixed, ... },
     |};
@@ -359,4 +386,3 @@ declare module '@sentry/browser' {
         +onLoad?: () => void,
     |};
 }
-

--- a/definitions/npm/@sentry/browser_v5.x.x/test_browser_v5.x.x.js
+++ b/definitions/npm/@sentry/browser_v5.x.x/test_browser_v5.x.x.js
@@ -37,6 +37,14 @@ describe('@sentry/browser', () => {
       Sentry.setExtra(null, 'foo');
     });
 
+    it('Sentry.setExtras', () => {
+      const narrowerType: { [string]: string, ... } = { narrower: 'type' };
+      Sentry.setExtras(narrowerType);
+
+      // $ExpectError
+      Sentry.setExtras(null);
+    });
+
     it('Sentry.setUser', () => {
       Sentry.setUser({ email: 'john.doe@example.com' });
       Sentry.setUser({ email: 'john.doe@example.com', arbitrary: 'value' });

--- a/definitions/npm/@sentry/browser_v5.x.x/test_browser_v5.x.x.js
+++ b/definitions/npm/@sentry/browser_v5.x.x/test_browser_v5.x.x.js
@@ -134,5 +134,36 @@ describe('@sentry/browser', () => {
       new Sentry.Hub();
     });
   });
-});
 
+  describe('Integrations', () => {
+    it('Includes Core integrations', () => {
+      new Sentry.Integrations.FunctionToString();
+
+      // $ExpectError
+      new Sentry.Integrations.OnUnhandledRejection(); // Node-specific integration, not in Browser
+    });
+
+    it('Includes Browser-specific integrations', () => {
+      new Sentry.Integrations.UserAgent();
+      new Sentry.Integrations.Breadcrumbs({ console: false });
+
+      // $ExpectError
+      new Sentry.Integrations.OnUnhandledRejection(); // Node-specific integration, not in Browser
+    });
+  });
+
+  describe('Transports', () => {
+    it('Includes transports', () => {
+      new Sentry.Transports.FetchTransport({ dsn: 'dsn_value' });
+      new Sentry.Transports.XHRTransport({
+        dsn: 'dsn_value',
+        headers: { foo: 'bar' },
+      });
+
+      // $ExpectError
+      new Sentry.Transports.InvalidTransport({ dsn: 'dsn_value' });
+      // $ExpectError
+      new Sentry.Transports.FetchTransport({}); // Missing `dsn` option
+    });
+  });
+});

--- a/definitions/npm/@sentry/browser_v5.x.x/test_browser_v5.x.x.js
+++ b/definitions/npm/@sentry/browser_v5.x.x/test_browser_v5.x.x.js
@@ -150,6 +150,17 @@ describe('@sentry/browser', () => {
       // $ExpectError
       new Sentry.Integrations.OnUnhandledRejection(); // Node-specific integration, not in Browser
     });
+
+    it('Accepts custom integrations', () => {
+      class CustomIntegration {
+        constructor() {}
+        name = 'CustomIntegration';
+        setupOnce(addGlobalEventProcessor, getCurrentHub) {}
+      }
+
+      new Sentry.init({ integrations: [new CustomIntegration()] });
+    });
+
   });
 
   describe('Transports', () => {


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
In #3723, I added libdefs for @sentry/browser. I forgot to add types for two additional exports: Integrations and Transports. This PR adds them.

- Links to documentation:
https://docs.sentry.io/platforms/javascript/#sdk-integrations
- Link to GitHub or NPM:
https://github.com/getsentry/sentry-javascript/blob/5.12.3/packages/browser/src/index.ts
- Type of contribution: addition

