### PR TITLE
Remove react-dom from built-in flow libdefs

### DIFF
--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -214,7 +214,7 @@ async function installCoreLibDefs(): Promise<number> {
   return 0;
 }
 
-const FLOW_BUILT_IN_NPM_LIBS = ['react', 'react-dom'];
+const FLOW_BUILT_IN_NPM_LIBS = ['react'];
 type installNpmLibDefsArgs = {|
   cwd: string,
   flowVersion: FlowVersion,


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Type of contribution: fix

Other notes:
Fixes https://github.com/flow-typed/flow-typed/issues/3726. We are moving react-dom out of Flow. It is already in flow-typed!
