### PR TITLE
[styled-components v5] add libdefs

### DIFF
--- a/definitions/npm/styled-components_v5.x.x/flow_v0.104.x-/styled-components_v5.x.x.js
+++ b/definitions/npm/styled-components_v5.x.x/flow_v0.104.x-/styled-components_v5.x.x.js
@@ -1,0 +1,548 @@
+// @flow
+
+declare module 'styled-components' {
+  declare class InterpolatableComponent<P> extends React$Component<P> {
+    static +styledComponentId: string;
+  }
+
+  declare export type Styles = {
+    [ruleOrSelector: string]: string | number, // | Styles,
+    ...,
+  };
+
+  declare export type Interpolation<P> =
+    | ((
+        executionContext: P
+      ) => ((executionContext: P) => InterpolationBase) | InterpolationBase)
+    | InterpolationBase;
+
+  declare export type InterpolationBase =
+    | CSSRules
+    | KeyFrames
+    | string
+    | number
+    | false // falsy values are OK, true is the only one not allowed, because it renders as "true"
+    | null
+    | void
+    | Styles
+    | Class<InterpolatableComponent<any>>; // CSS-in-JS object returned by polished are also supported, partially
+
+  declare export type TaggedTemplateLiteral<I, R> = (
+    strings: string[],
+    ...interpolations: Interpolation<I>[]
+  ) => R;
+
+  // Should this be `mixed` perhaps?
+  declare export type CSSRules = Interpolation<any>[]; // eslint-disable-line flowtype/no-weak-types
+
+  declare export type CSSConstructor = TaggedTemplateLiteral<any, CSSRules>; // eslint-disable-line flowtype/no-weak-types
+  declare export type KeyFramesConstructor = TaggedTemplateLiteral<
+    any,
+    KeyFrames
+  >; // eslint-disable-line flowtype/no-weak-types
+  declare export type CreateGlobalStyleConstructor = TaggedTemplateLiteral<
+    any,
+    React$ComponentType<*>
+  >; // eslint-disable-line flowtype/no-weak-types
+
+  declare interface Tag<T> {
+    styleTag: HTMLStyleElement | null;
+    getIds(): string[];
+    hasNameForId(id: string, name: string): boolean;
+    insertMarker(id: string): T;
+    insertRules(id: string, cssRules: string[], name: ?string): void;
+    removeRules(id: string): void;
+    css(): string;
+    toHTML(additionalAttrs: ?string): string;
+    toElement(): React$Element<*>;
+    clone(): Tag<T>;
+    sealed: boolean;
+  }
+
+  // The `any`/weak types in here all come from `styled-components` directly, since those definitions were just copied over
+  declare export class StyleSheet {
+    static get master(): StyleSheet;
+    static get instance(): StyleSheet;
+    static reset(forceServer?: boolean): void;
+
+    id: number;
+    forceServer: boolean;
+    target: ?HTMLElement;
+    tagMap: { [string]: Tag<any>, ... }; // eslint-disable-line flowtype/no-weak-types
+    deferred: { [string]: string[] | void, ... };
+    rehydratedNames: { [string]: boolean, ... };
+    ignoreRehydratedNames: { [string]: boolean, ... };
+    tags: Tag<any>[]; // eslint-disable-line flowtype/no-weak-types
+    importRuleTag: Tag<any>; // eslint-disable-line flowtype/no-weak-types
+    capacity: number;
+    clones: StyleSheet[];
+
+    constructor(?HTMLElement): this;
+    rehydrate(): this;
+    clone(): StyleSheet;
+    sealAllTags(): void;
+    makeTag(tag: ?Tag<any>): Tag<any>; // eslint-disable-line flowtype/no-weak-types
+    getImportRuleTag(): Tag<any>; // eslint-disable-line flowtype/no-weak-types
+    getTagForId(id: string): Tag<any>; // eslint-disable-line flowtype/no-weak-types
+    hasId(id: string): boolean;
+    hasNameForId(id: string, name: string): boolean;
+    deferredInject(id: string, cssRules: string[]): void;
+    inject(id: string, cssRules: string[], name?: string): void;
+    remove(id: string): void;
+    toHtml(): string;
+    toReactElements(): React$ElementType[];
+  }
+
+  declare export function isStyledComponent(target: any): boolean;
+
+  declare type SCMProps = {
+    children?: React$Element<any>,
+    sheet?: StyleSheet,
+    target?: HTMLElement,
+    ...
+  };
+
+  declare export var StyleSheetContext: React$Context<StyleSheet>;
+  declare export var StyleSheetConsumer: React$ComponentType<{|
+    children: (value: StyleSheet) => ?React$Node,
+  |}>;
+  declare var StyleSheetProvider: React$ComponentType<{|
+    children?: React$Node,
+    value: StyleSheet,
+  |}>;
+
+  /**
+   * plugin
+   *
+   * @param  {number} context
+   * @param  {Array<string>} selector
+   * @param  {Array<string>} parent
+   * @param  {string} content
+   * @param  {number} line
+   * @param  {number} column
+   * @param  {number} length
+   * @return {(string|void)?}
+   */
+
+  declare type StylisPluginSignature = (
+    context: number,
+    selector: string[],
+    parent: string[],
+    content: string,
+    line: number,
+    column: number,
+    length: number
+  ) => string | void;
+
+  declare export class StyleSheetManager extends React$Component<SCMProps> {
+    getContext(sheet: ?StyleSheet, target: ?HTMLElement): StyleSheet;
+    render(): React$Element<typeof StyleSheetProvider>;
+    stylisPlugins?: StylisPluginSignature[];
+    disableVendorPrefixes?: boolean;
+    disableCSSOMInjection?: boolean;
+  }
+
+  declare export class ServerStyleSheet {
+    instance: StyleSheet;
+    masterSheet: StyleSheet;
+    sealed: boolean;
+
+    seal(): void;
+    collectStyles(children: any): React$Element<StyleSheetManager>;
+    getStyleTags(): string;
+    toReactElements(): React$ElementType[];
+    // This seems to be use a port of node streams in the Browsers. Not gonna type this for now
+    // eslint-disable-next-line flowtype/no-weak-types
+    interleaveWithNodeStream(stream: any): any;
+  }
+
+  declare export class KeyFrames {
+    id: string;
+    name: string;
+    rules: string[];
+
+    constructor(name: string, rules: string[]): this;
+    inject(StyleSheet): void;
+    toString(): string;
+    getName(): string;
+  }
+
+  // I think any is appropriate here?
+  // eslint-disable-next-line flowtype/no-weak-types
+  declare export var css: CSSConstructor;
+  declare export var keyframes: KeyFramesConstructor;
+  declare export var createGlobalStyle: CreateGlobalStyleConstructor;
+  declare export var ThemeConsumer: React$ComponentType<{|
+    children: (value: mixed) => ?React$Node,
+  |}>;
+  declare export var ThemeProvider: React$ComponentType<{|
+    children?: ?React$Node,
+    theme: mixed | (mixed => mixed),
+  |}>;
+
+  /**
+    Any because the intended use-case is for users to do:
+
+        import {ThemeContext} from 'styled-components';
+        ...
+        const theme = React.useContext<MyTheme>(ThemeContext);
+
+    If they want DRY-er code, they could declare their own version of this via something like
+
+        import { ThemeContext as SCThemeContext } from 'styled-components';
+        export const ThemeContext: React$Context<MyTheme> = SCThemeContext;
+
+    and then
+
+        import {ThemeContext} from './theme';
+  */
+  // eslint-disable-next-line flowtype/no-weak-types
+  declare export var ThemeContext: React$Context<any>;
+
+  declare export type ThemeProps<T> = {|
+    theme: T,
+  |};
+
+  declare type CommonSCProps = {|
+    children?: React$Node,
+    className?: ?string,
+    style?: { [string]: string | number, ... },
+    ref?: React$Ref<any>,
+  |};
+
+  declare export type PropsWithTheme<Props, T> = {|
+    ...ThemeProps<T>,
+    ...CommonSCProps, // Not sure how useful this is here, but it's technically correct to have it
+    ...$Exact<Props>,
+  |};
+
+  declare export function withTheme<Theme, Config: { ... }, Instance>(
+    Component: React$AbstractComponent<Config, Instance>
+  ): React$AbstractComponent<$Diff<Config, ThemeProps<Theme | void>>, Instance>;
+
+  declare export function useTheme<Theme>(): Theme;
+
+  declare export type StyledComponent<
+    Props,
+    Theme,
+    Instance,
+    MergedProps = { ...$Exact<Props>, ...CommonSCProps, ... }
+  > = React$AbstractComponent<MergedProps, Instance> &
+    Class<InterpolatableComponent<MergedProps>>;
+
+  declare export type StyledFactory<StyleProps, Theme, Instance> = {|
+    [[call]]: TaggedTemplateLiteral<
+      PropsWithTheme<StyleProps, Theme>,
+      StyledComponent<StyleProps, Theme, Instance>
+    >,
+    +attrs: <A: { ... }>(
+      (StyleProps => A) | A
+    ) => TaggedTemplateLiteral<
+      PropsWithTheme<{| ...$Exact<StyleProps>, ...$Exact<A> |}, Theme>,
+      StyledComponent<
+        React$Config<{| ...$Exact<StyleProps>, ...$Exact<A> |}, $Exact<A>>,
+        Theme,
+        Instance
+      >
+    >,
+  |};
+
+  declare export type StyledShorthandFactory<V> = {|
+    [[call]]: <StyleProps, Theme>(
+      string[],
+      ...Interpolation<PropsWithTheme<StyleProps, Theme>>[]
+    ) => StyledComponent<StyleProps, Theme, V>,
+    [[call]]: <StyleProps, Theme>(
+      (props: PropsWithTheme<StyleProps, Theme>) => Interpolation<any>
+    ) => StyledComponent<StyleProps, Theme, V>,
+    +attrs: <A: { ... }, StyleProps = {||}, Theme = {||}>(
+      (StyleProps => A) | A
+    ) => TaggedTemplateLiteral<
+      PropsWithTheme<{| ...$Exact<StyleProps>, ...$Exact<A> |}, Theme>,
+      StyledComponent<
+        React$Config<{| ...$Exact<StyleProps>, ...$Exact<A> |}, $Exact<A>>,
+        Theme,
+        V
+      >
+    >,
+  |};
+
+  declare type BuiltinElementInstances = {
+    a: React$ElementRef<'a'>,
+    abbr: React$ElementRef<'abbr'>,
+    address: React$ElementRef<'address'>,
+    area: React$ElementRef<'area'>,
+    article: React$ElementRef<'article'>,
+    aside: React$ElementRef<'aside'>,
+    audio: React$ElementRef<'audio'>,
+    b: React$ElementRef<'b'>,
+    base: React$ElementRef<'base'>,
+    bdi: React$ElementRef<'bdi'>,
+    bdo: React$ElementRef<'bdo'>,
+    big: React$ElementRef<'big'>,
+    blockquote: React$ElementRef<'blockquote'>,
+    body: React$ElementRef<'body'>,
+    br: React$ElementRef<'br'>,
+    button: React$ElementRef<'button'>,
+    canvas: React$ElementRef<'canvas'>,
+    caption: React$ElementRef<'caption'>,
+    cite: React$ElementRef<'cite'>,
+    code: React$ElementRef<'code'>,
+    col: React$ElementRef<'col'>,
+    colgroup: React$ElementRef<'colgroup'>,
+    data: React$ElementRef<'data'>,
+    datalist: React$ElementRef<'datalist'>,
+    dd: React$ElementRef<'dd'>,
+    del: React$ElementRef<'del'>,
+    details: React$ElementRef<'details'>,
+    dfn: React$ElementRef<'dfn'>,
+    dialog: React$ElementRef<'dialog'>,
+    div: React$ElementRef<'div'>,
+    dl: React$ElementRef<'dl'>,
+    dt: React$ElementRef<'dt'>,
+    em: React$ElementRef<'em'>,
+    embed: React$ElementRef<'embed'>,
+    fieldset: React$ElementRef<'fieldset'>,
+    figcaption: React$ElementRef<'figcaption'>,
+    figure: React$ElementRef<'figure'>,
+    footer: React$ElementRef<'footer'>,
+    form: React$ElementRef<'form'>,
+    h1: React$ElementRef<'h1'>,
+    h2: React$ElementRef<'h2'>,
+    h3: React$ElementRef<'h3'>,
+    h4: React$ElementRef<'h4'>,
+    h5: React$ElementRef<'h5'>,
+    h6: React$ElementRef<'h6'>,
+    head: React$ElementRef<'head'>,
+    header: React$ElementRef<'header'>,
+    hgroup: React$ElementRef<'hgroup'>,
+    hr: React$ElementRef<'hr'>,
+    html: React$ElementRef<'html'>,
+    i: React$ElementRef<'i'>,
+    iframe: React$ElementRef<'iframe'>,
+    img: React$ElementRef<'img'>,
+    input: React$ElementRef<'input'>,
+    ins: React$ElementRef<'ins'>,
+    kbd: React$ElementRef<'kbd'>,
+    label: React$ElementRef<'label'>,
+    legend: React$ElementRef<'legend'>,
+    li: React$ElementRef<'li'>,
+    link: React$ElementRef<'link'>,
+    main: React$ElementRef<'main'>,
+    map: React$ElementRef<'map'>,
+    mark: React$ElementRef<'mark'>,
+    menu: React$ElementRef<'menu'>,
+    meta: React$ElementRef<'meta'>,
+    meter: React$ElementRef<'meter'>,
+    nav: React$ElementRef<'nav'>,
+    noscript: React$ElementRef<'noscript'>,
+    object: React$ElementRef<'object'>,
+    ol: React$ElementRef<'ol'>,
+    optgroup: React$ElementRef<'optgroup'>,
+    option: React$ElementRef<'option'>,
+    output: React$ElementRef<'output'>,
+    p: React$ElementRef<'p'>,
+    param: React$ElementRef<'param'>,
+    picture: React$ElementRef<'picture'>,
+    pre: React$ElementRef<'pre'>,
+    progress: React$ElementRef<'progress'>,
+    q: React$ElementRef<'q'>,
+    rp: React$ElementRef<'rp'>,
+    rt: React$ElementRef<'rt'>,
+    ruby: React$ElementRef<'ruby'>,
+    s: React$ElementRef<'s'>,
+    samp: React$ElementRef<'samp'>,
+    script: React$ElementRef<'script'>,
+    section: React$ElementRef<'section'>,
+    select: React$ElementRef<'select'>,
+    small: React$ElementRef<'small'>,
+    source: React$ElementRef<'source'>,
+    span: React$ElementRef<'span'>,
+    strong: React$ElementRef<'strong'>,
+    style: React$ElementRef<'style'>,
+    sub: React$ElementRef<'sub'>,
+    summary: React$ElementRef<'summary'>,
+    sup: React$ElementRef<'sup'>,
+    table: React$ElementRef<'table'>,
+    tbody: React$ElementRef<'tbody'>,
+    td: React$ElementRef<'td'>,
+    textarea: React$ElementRef<'textarea'>,
+    tfoot: React$ElementRef<'tfoot'>,
+    th: React$ElementRef<'th'>,
+    thead: React$ElementRef<'thead'>,
+    time: React$ElementRef<'time'>,
+    title: React$ElementRef<'title'>,
+    tr: React$ElementRef<'tr'>,
+    track: React$ElementRef<'track'>,
+    u: React$ElementRef<'u'>,
+    ul: React$ElementRef<'ul'>,
+    var: React$ElementRef<'var'>,
+    video: React$ElementRef<'video'>,
+    wbr: React$ElementRef<'wbr'>,
+    // SVG
+    circle: React$ElementRef<'circle'>,
+    clipPath: React$ElementRef<'clipPath'>,
+    defs: React$ElementRef<'defs'>,
+    ellipse: React$ElementRef<'ellipse'>,
+    g: React$ElementRef<'g'>,
+    image: React$ElementRef<'image'>,
+    line: React$ElementRef<'line'>,
+    linearGradient: React$ElementRef<'linearGradient'>,
+    mask: React$ElementRef<'mask'>,
+    path: React$ElementRef<'path'>,
+    pattern: React$ElementRef<'pattern'>,
+    polygon: React$ElementRef<'polygon'>,
+    polyline: React$ElementRef<'polyline'>,
+    radialGradient: React$ElementRef<'radialGradient'>,
+    rect: React$ElementRef<'rect'>,
+    stop: React$ElementRef<'stop'>,
+    svg: React$ElementRef<'svg'>,
+    text: React$ElementRef<'text'>,
+    tspan: React$ElementRef<'tspan'>,
+    // Deprecated, should be HTMLUnknownElement, but Flow doesn't support it
+    keygen: React$ElementRef<'keygen'>,
+    menuitem: React$ElementRef<'menuitem'>,
+    ...
+  };
+
+  declare type BuiltinElementType<ElementName: string> = $ElementType<
+    BuiltinElementInstances,
+    ElementName
+  >;
+
+  declare type ConvenientShorthands = $ObjMap<
+    BuiltinElementInstances,
+    <V>(V) => StyledShorthandFactory<V>
+  >;
+
+  declare type ExtractProps<O> = $Call<
+    <T>(StyledComponent<T, any, any>) => T,
+    O
+  >;
+  declare type ExtractTheme<O> = $Call<
+    <T>(StyledComponent<any, T, any>) => T,
+    O
+  >;
+  declare type ExtractInstance<O> = $Call<
+    <T>(StyledComponent<any, any, T>) => T,
+    O
+  >;
+
+  declare interface Styled {
+    <
+      Comp: StyledComponent<P, T, I>,
+      Theme: ExtractTheme<Comp>,
+      +Instance: ExtractInstance<Comp>,
+      OwnProps = ExtractProps<Comp>
+    >(
+      Comp
+    ): StyledFactory<{| ...$Exact<OwnProps> |}, Theme, Instance>;
+    <StyleProps, Theme, ElementName: $Keys<BuiltinElementInstances>>(
+      ElementName
+    ): StyledFactory<StyleProps, Theme, BuiltinElementType<ElementName>>;
+    <
+      Comp: React$ComponentType<any>,
+      Theme,
+      OwnProps = React$ElementConfig<Comp>
+    >(
+      Comp
+    ): StyledFactory<{| ...$Exact<OwnProps> |}, Theme, Comp>;
+  }
+
+  declare export default Styled & ConvenientShorthands;
+}
+
+declare module 'styled-components/native' {
+  import type {
+    CSSRules,
+    CSSConstructor,
+    KeyFramesConstructor,
+    CreateGlobalStyleConstructor,
+    StyledComponent,
+    Interpolation,
+
+    // "private" types
+    TaggedTemplateLiteral,
+    StyledFactory,
+    StyledShorthandFactory,
+    ThemeProps,
+    PropsWithTheme,
+  } from 'styled-components';
+
+  declare type BuiltinElementInstances = {
+    ActivityIndicator: React$ComponentType<{ ... }>,
+    ActivityIndicatorIOS: React$ComponentType<{ ... }>,
+    ART: React$ComponentType<{ ... }>,
+    Button: React$ComponentType<{ ... }>,
+    DatePickerIOS: React$ComponentType<{ ... }>,
+    DrawerLayoutAndroid: React$ComponentType<{ ... }>,
+    Image: React$ComponentType<{ ... }>,
+    ImageBackground: React$ComponentType<{ ... }>,
+    ImageEditor: React$ComponentType<{ ... }>,
+    ImageStore: React$ComponentType<{ ... }>,
+    KeyboardAvoidingView: React$ComponentType<{ ... }>,
+    ListView: React$ComponentType<{ ... }>,
+    MapView: React$ComponentType<{ ... }>,
+    Modal: React$ComponentType<{ ... }>,
+    NavigatorIOS: React$ComponentType<{ ... }>,
+    Picker: React$ComponentType<{ ... }>,
+    PickerIOS: React$ComponentType<{ ... }>,
+    ProgressBarAndroid: React$ComponentType<{ ... }>,
+    ProgressViewIOS: React$ComponentType<{ ... }>,
+    ScrollView: React$ComponentType<{ ... }>,
+    SegmentedControlIOS: React$ComponentType<{ ... }>,
+    Slider: React$ComponentType<{ ... }>,
+    SliderIOS: React$ComponentType<{ ... }>,
+    SnapshotViewIOS: React$ComponentType<{ ... }>,
+    Switch: React$ComponentType<{ ... }>,
+    RecyclerViewBackedScrollView: React$ComponentType<{ ... }>,
+    RefreshControl: React$ComponentType<{ ... }>,
+    SafeAreaView: React$ComponentType<{ ... }>,
+    StatusBar: React$ComponentType<{ ... }>,
+    SwipeableListView: React$ComponentType<{ ... }>,
+    SwitchAndroid: React$ComponentType<{ ... }>,
+    SwitchIOS: React$ComponentType<{ ... }>,
+    TabBarIOS: React$ComponentType<{ ... }>,
+    Text: React$ComponentType<{ ... }>,
+    TextInput: React$ComponentType<{ ... }>,
+    ToastAndroid: React$ComponentType<{ ... }>,
+    ToolbarAndroid: React$ComponentType<{ ... }>,
+    Touchable: React$ComponentType<{ ... }>,
+    TouchableHighlight: React$ComponentType<{ ... }>,
+    TouchableNativeFeedback: React$ComponentType<{ ... }>,
+    TouchableOpacity: React$ComponentType<{ ... }>,
+    TouchableWithoutFeedback: React$ComponentType<{ ... }>,
+    View: React$ComponentType<{ ... }>,
+    ViewPagerAndroid: React$ComponentType<{ ... }>,
+    WebView: React$ComponentType<{ ... }>,
+    FlatList: React$ComponentType<{ ... }>,
+    SectionList: React$ComponentType<{ ... }>,
+    VirtualizedList: React$ComponentType<{ ... }>,
+    ...
+  };
+
+  declare type BuiltinElementType<ElementName: string> = $ElementType<
+    BuiltinElementInstances,
+    ElementName
+  >;
+
+  declare type ConvenientShorthands = $ObjMap<
+    BuiltinElementInstances,
+    <V>(V) => StyledShorthandFactory<V>
+  >;
+
+  declare interface Styled {
+    <StyleProps, Theme, ElementName: $Keys<BuiltinElementInstances>>(
+      ElementName
+    ): StyledFactory<StyleProps, Theme, BuiltinElementType<ElementName>>;
+    <
+      Comp: React$ComponentType<any>,
+      Theme,
+      OwnProps = React$ElementConfig<Comp>
+    >(
+      Comp
+    ): StyledFactory<{| ...$Exact<OwnProps> |}, Theme, Comp>;
+  }
+
+  declare export default Styled & ConvenientShorthands;
+}

--- a/definitions/npm/styled-components_v5.x.x/flow_v0.104.x-/test_styled-components-native.js
+++ b/definitions/npm/styled-components_v5.x.x/flow_v0.104.x-/test_styled-components-native.js
@@ -1,0 +1,24 @@
+// @flow
+import * as React from 'react';
+// import * as ReactNative from 'react-native'
+import styled from 'styled-components/native';
+
+// Test that we can create native components
+const Text1 = styled.Text``;
+const Text2 = styled('Text')``;
+
+// $ExpectError - test for non-existent element
+const derp1 = styled.derp``;
+
+// $ExpectError - test for non-existent element
+const derp2 = styled('derp')``;
+
+// Test we don't "accidentally style" something else:
+// $ExpectError
+const derp3 = styled(null)``;
+
+// $ExpectError
+const derp4 = styled({})``;
+
+// $ExpectError
+const derp5 = styled(1)``;

--- a/definitions/npm/styled-components_v5.x.x/flow_v0.104.x-/test_styled-components_v5.x.x.js
+++ b/definitions/npm/styled-components_v5.x.x/flow_v0.104.x-/test_styled-components_v5.x.x.js
@@ -1,0 +1,497 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+
+import * as React from 'react';
+import styled, {
+  createGlobalStyle,
+  css,
+  keyframes,
+  withTheme,
+  useTheme,
+  ThemeContext,
+  type CSSRules,
+  type KeyFrames,
+  type StyledComponent,
+} from 'styled-components';
+
+describe('styled builtins', () => {
+  it('should map to correct element', () => {
+    const Span1: StyledComponent<
+      { ... },
+      { ... },
+      HTMLSpanElement
+    > = styled.span``;
+    const Div1: StyledComponent<
+      { ... },
+      { ... },
+      HTMLDivElement
+    > = styled.div``;
+
+    const Span2: StyledComponent<{ ... }, { ... }, HTMLSpanElement> = styled(
+      'span'
+    )``;
+    const Div2: StyledComponent<{ ... }, { ... }, HTMLDivElement> = styled(
+      'div'
+    )``;
+  });
+
+  it('should not map to incorrect element', () => {
+    const Span1: StyledComponent<
+      { ... },
+      { ... },
+      // $ExpectError - should be HTMLSpanElement
+      HTMLDivElement
+    > = styled.span``;
+
+    const Div1: StyledComponent<
+      { ... },
+      { ... },
+      // $ExpectError - should be HTMLDivElement
+      HTMLSpanElement
+    > = styled.div``;
+
+    // $ExpectError - Should be HTMLSpanElement
+    const Span2: StyledComponent<{ ... }, { ... }, HTMLDivElement> = styled(
+      'span'
+    )``;
+
+    // $ExpectError - should be HTMLDivElement
+    const Div2: StyledComponent<{ ... }, { ... }, HTMLSpanElement> = styled(
+      'div'
+    )``;
+  });
+
+  it('should render as the correct element', () => {
+    const Span: StyledComponent<
+      { ... },
+      { ... },
+      HTMLSpanElement
+    > = styled.span``;
+    const Div: StyledComponent<{ ... }, { ... }, HTMLDivElement> = styled.div``;
+
+    const span1: React.Element<
+      React.AbstractComponent<{ ... }, HTMLSpanElement>
+    > = <Span />;
+
+    const div1: React.Element<
+      // noExpectError - should be HTMLDivElement
+      React.AbstractComponent<{ ... }, HTMLSpanElement>
+    > = <Div />;
+  });
+
+  it("shouldn't style something impossible", () => {
+    // $ExpectError
+    const derp1 = styled(null)``;
+
+    // $ExpectError
+    const derp2 = styled({})``;
+
+    // $ExpectError
+    const derp3 = styled(1)``;
+
+    // $ExpectError
+    const derp4 = styled.derp``;
+
+    // $ExpectError
+    const derp5 = styled('derp')``;
+  });
+
+  it('should accept style props', () => {
+    const Span: StyledComponent<{ color: string, ... }, *, *> = styled.span`
+      color: ${props => props.color};
+    `;
+
+    const span1 = <Span color="maroon" />;
+
+    const Div: StyledComponent<
+      {
+        color: string,
+        background?: string,
+        ...
+      },
+      *,
+      *
+    > = styled.div`
+      color: ${props => props.color};
+    `;
+
+    const div1 = <Div color="maroon" />;
+    const div2 = <Div color="maroon" background="salmon" />;
+  });
+
+  it('should validate template props', () => {
+    const Span: StyledComponent<{ color: string, ... }, *, *> = styled.span`
+      color: ${// $ExpectError - background is not in props
+      props => props.background};
+    `;
+  });
+
+  it('should inject theme', () => {
+    const Span: StyledComponent<
+      { color?: string, ... },
+      { accent: string, ... },
+      *
+    > = styled.span`
+      color: ${props => props.color || props.theme.accent};
+    `;
+  });
+
+  it('supports common props that styled components accept', () => {
+    const Span: StyledComponent<{ color: string, ... }, *, *> = styled.span`
+      color: ${props => props.color};
+    `;
+
+    const span1 = <Span color="maroon" className="marooned" />;
+    const span2 = <Span color="maroon" style={{ padding: 5 }} />;
+
+    // $ExpectError - Make sure we don't break soundness when props are missing!
+    const span3 = <Span style={{ padding: 5 }} />;
+  });
+
+  it('exposes common props inside interpolations', () => {
+    const Span: StyledComponent<{ color: string, ... }, *, *> = styled.span`
+      color: ${props => props.color};
+      /* People reading this test: this is a horrible way to dynamically scale your component! */
+      height: calc(${props => React.Children.count(props.children)} * 20px);
+    `;
+  });
+
+  it('should validate theme', () => {
+    const Span: StyledComponent<
+      { color?: string, ... },
+      { accent: string, ... },
+      *
+    > = styled.span`
+      color: ${// $ExpectError - oops, someone meant accent, not primary
+      props => props.color || props.theme.primary};
+    `;
+  });
+
+  it('should support .attrs', () => {
+    const AttrsInput = styled.input.attrs<_, {| size: string |}>({
+      // we can define static props
+      type: 'password',
+      // or we can define dynamic ones
+      margin: props => {
+        (props.size: string);
+        return props.size;
+      },
+      padding: props => {
+        (props.size: string);
+        return props.size;
+      },
+    })`
+      color: palevioletred;
+      font-size: 1em;
+      border: 2px solid palevioletred;
+      border-radius: 3px;
+      margin: ${props => props.margin};
+      padding: ${props => props.padding};
+    `;
+
+    const AttrsInputExtra = styled<_, _>(AttrsInput).attrs<{|
+      autoComplete: string,
+    |}>(props => ({ autoComplete: 'off' }))``;
+
+    // $ExpectError
+    const test1 = <AttrsInputExtra size="2em" autoComplete={1} type={1} />; // error
+    const test2 = <AttrsInputExtra size="2em" autoComplete="on" type="text" />; // ok
+    // $ExpectError
+    const test3 = <AttrsInputExtra size="2em" type={1} />; // error
+  });
+});
+
+// @NOTE: Not sure how to better test this
+describe('createGlobalStyle & GlobalStyles', () => {
+  it('can be created and rendered', () => {
+    const GlobalStyles: React.ComponentType<*> = createGlobalStyle``;
+
+    const App = () => (
+      <div>
+        <GlobalStyles />
+      </div>
+    );
+  });
+});
+
+describe('ThemeContext', () => {
+  type MyTheme = {|
+    primaryColor: string,
+  |};
+
+  it('allows refining the theme', () => {
+    const theme = React.useContext<MyTheme>(ThemeContext);
+
+    theme.primaryColor;
+  });
+
+  it('typechecks the theme', () => {
+    const theme = React.useContext<MyTheme>(ThemeContext);
+
+    // $ExpectError
+    theme.primaryColot;
+  });
+
+  it('allows aliasing the context with the Theme refined', () => {
+    const MyThemeContext: React.Context<MyTheme> = ThemeContext;
+    const theme = React.useContext(MyThemeContext);
+
+    theme.primaryColor;
+
+    // $ExpectError
+    theme.primaryColot;
+  });
+});
+
+describe('css generator', () => {
+  it('can be used', () => {
+    const styles: CSSRules = css`
+      color: pink;
+    `;
+  });
+
+  it('accepts strings', () => {
+    const str = 'pink';
+
+    const styles = css`
+      color: ${str};
+    `;
+  });
+
+  it('accepts functions', () => {
+    const fun = (): string => 'pink';
+
+    const styles = css`
+      color: ${fun};
+    `;
+  });
+
+  it('accepts void/undefined', () => {
+    const styles = css`
+      ${undefined};
+    `;
+  });
+
+  it('accepts false', () => {
+    const styles = css`
+      ${false};
+    `;
+  });
+
+  // Technically styled-components _does_ accept true, _but_ it usually generates wrong/nonsensical and unexpected output.
+  it("doesn't accept true", () => {
+    // $ExpectError - lies!
+    const styles = css`
+      ${true};
+    `;
+  });
+
+  it('accepts null', () => {
+    const styles = css`
+      ${null};
+    `;
+  });
+
+  it('accepts style objects', () => {
+    const styles = css`
+      ${{
+        color: 'red',
+      }};
+    `;
+  });
+
+  it("doesn't accept exotic/non-style objects", () => {
+    // $ExpectError - don't accept non-style objects
+    const styles = css`
+      ${{ fun: () => null }};
+    `;
+  });
+
+  it('accepts feyframes', () => {
+    const anim = keyframes`
+      from {}
+      to {}
+    `;
+
+    const styles = css`
+      animation: ${anim};
+    `;
+  });
+
+  it('it accepts CSSRules', () => {
+    const additonalStyles = css`
+      background: ${'salmon'};
+    `;
+
+    const styles = css`
+      color: maroon;
+      ${additonalStyles};
+    `;
+  });
+
+  it('accepts styled-components in interpolations', () => {
+    const SComp1 = styled.div``;
+
+    const SComp2 = styled.div`
+      ${SComp1} {
+        color: pink;
+      }
+    `;
+  });
+
+  it("doen't accept any component in interpolations", () => {
+    class ClassComp extends React.Component<{ ... }> {
+      render() {
+        return null;
+      }
+    }
+
+    const FuncComp: React.ComponentType<*> = () => null;
+
+    // $ExpectError - we don't know how to interpolate non-styled-components components
+    const SComp1 = styled.div`
+      ${ClassComp} {
+        color: pink;
+      }
+    `;
+
+    // $ExpectError - we don't know how to interpolate non-styled-components components
+    const SComp2 = styled.div`
+      ${FuncComp} {
+        color: pink;
+      }
+    `;
+  });
+});
+
+// @NOTE: Not sure how to better test this
+describe('keyframes generator', () => {
+  it('can be created', () => {
+    const animation: KeyFrames = keyframes``;
+  });
+});
+
+describe('refs', () => {
+  it('correctly detects the component type', () => {
+    const ref1: { current: HTMLInputElement | null, ... } = React.createRef();
+    const Input = styled.input``;
+    const input = <Input ref={ref1} />;
+  });
+
+  it('errors on wrong component type', () => {
+    const ref1: { current: HTMLInputElement | null, ... } = React.createRef();
+    const Section = styled.section``;
+    // $ExpectError - Complain about HTMLElement not being compatible wiht HTMLInputElement
+    const section = <Section ref={ref1} />;
+  });
+
+  // Commented this test, because it also generates an error on line 21
+  // When the reference type is wrong.
+  // I think because Flow is trying to some inference crazyness
+  // it('errors on wrong component type', () => {
+  //   const ref1: {current: HTMLInputElement | null} = React.createRef()
+  //   const Span = styled.span``
+
+  // Used £ instead of $ so it doesn't trigger supression warnings
+  //   // £ExpectError - Complain about HTMLSpanElement not being compatible wiht HTMLInputElement
+  //   const span = <Span ref={ref1} />
+  // })
+});
+
+describe('withTheme', () => {
+  type Theme = { accent: string, ... };
+
+  type Props = {
+    ownProp: string,
+    theme: Theme,
+    ...
+  };
+
+  // Explicit annotation until we see what happens to https://github.com/facebook/flow/issues/7774
+  // This appears to be a regression in flow
+  const MyComp: React.ComponentType<Props> = (props: Props) => (
+    <div>{props.ownProp}</div>
+  );
+
+  const MyCompWT = withTheme(MyComp);
+  const MyCompWT2 = withTheme(MyCompWT);
+
+  it("doesn't interfere with component's own props", () => {
+    // $ExpectError - wrong prop
+    const mcwt2 = <MyCompWT ownProp={0} />;
+  });
+
+  it("errors when theme should be there but isn't", () => {
+    // $ExpectError - missing theme prop
+    const mc = <MyComp ownProp="own prop" />;
+  });
+
+  it('detects theme is passed in', () => {
+    const mcwt = <MyCompWT ownProp="own prop" />;
+  });
+
+  // I think this is no longer relevant probably, since Flow has
+  // deperacted $Supertype and $Subtype, but it can't hurt to have them
+  it('preserves props when wrapped in two HOCs', () => {
+    const mcwt1 = <MyCompWT2 ownProp="own prop" />;
+
+    // $ExpectError - wrong prop
+    const mcwt2 = <MyCompWT2 ownProp={0} />;
+  });
+});
+
+describe('useTheme', () => {
+  type Theme1 = {|
+    accent: string,
+  |};
+
+  type Theme2 = {|
+    primary: string,
+  |};
+
+  it('returns Theme', () => {
+    const theme1: Theme1 = useTheme<Theme1>();
+
+    // $ExpectError - Theme1 !== Theme2
+    const theme2: Theme2 = useTheme<Theme1>();
+  });
+});
+
+describe('wrapping components', () => {
+  type Props = {|
+    name: string,
+  |};
+
+  type StyleProps = {|
+    ...Props,
+    color?: string,
+  |};
+
+  type Theme = { accent: string, ... };
+
+  const Hello: React.ComponentType<Props> = (p: Props) => (
+    <div>Hello {p.name}</div>
+  );
+
+  const StyledHello = styled<_, Theme, StyleProps>(Hello)`
+    color: ${props => props.color || props.theme.accent};
+  `;
+
+  it('understands props that the wrapped component wants', () => {
+    const hello1 = <StyledHello name="World" />;
+    const hello2 = <StyledHello name="World" color="maroon" />;
+
+    // $ExpectError - Invalid prop type
+    const hello3 = <StyledHello name={3} />;
+  });
+
+  // defaultProps doesn't work with React.AbstractComponent "by design"
+  // see https://github.com/flow-typed/flow-typed/pull/3228#issuecomment-509016680
+  // and the linked issue for a slightly longer explanation
+  // it('allows default props to be defined', () => {
+  //   StyledHello.defaultProps = {
+  //     name: "me"
+  //   }
+  // })
+});


### PR DESCRIPTION
# < :nail_care: >

Adds libdefs for v5 of styled-components. Mostly it's the same as libdefs for v4, but with the following non-breaking changes (copied from the [release notes]):

 - adds `useTheme` hook
 - adds `stylisPlugins` prop to `StyleSheetManager`
 - adds `disableVendorPrefixes` prop to `StyleSheetManager`
 - adds `disableCSSOMInjection` prop to `StyleSheetManager`

The *"subfunction" attrs syntax that was deprecated in v4* which is removed in v5 was never supported in v4 libdefs (because it was deprecated), so nothing to do here.

---

I also took the opportunity to fix some type issues I encountered in the v4 libdefs. Interpolations should be more reliable and error in fewer cases (still doesn't support Polished's `Styles`).

In some cases Flow would claim that `React$AbstractComponent` wasn't compatible with `StyledComponent`; I am not sure where that comes from since (maybe the intersection with `InterpolatableComponent` causes a bug). I couldn't manage to make a small reproducible case, and I couldn't see anything that triggered it specifically. Two other similar components didn't have this issue within the same codebase. I added this on a hunch and it fixes it, but it's not very versatile:

~~~js
    <
      Comp: StyledComponent<P, T, I>,
      Theme: ExtractTheme<Comp>,
      +Instance: ExtractInstance<Comp>,
      OwnProps = ExtractProps<Comp>
    >(
      Comp
    ): StyledFactory<
      {| ...$Exact<OwnProps> |},
      Theme,
      Instance
    >;
~~~

Additionally these libdefs are now styled with prettier.

[release notes]: https://styled-components.com/releases#v5.0.0