### PR TITLE
Fix luxon diff / diffnow

### DIFF
--- a/definitions/npm/luxon_v0.2.x/flow_v0.104.x-/luxon_v0.2.x.js
+++ b/definitions/npm/luxon_v0.2.x/flow_v0.104.x-/luxon_v0.2.x.js
@@ -480,11 +480,11 @@ declare module "luxon" {
     zoneName: string;
     diff(
       otherDateTime: DateTime,
-      unit: DateTimeUnit | Array<DateTimeUnit>,
+      unit?: DateTimeUnit | Array<DateTimeUnit>,
       options?: DateTimeDiffOptions
     ): Duration;
     diffNow(
-      unit: DateTimeUnit | Array<DateTimeUnit>,
+      unit?: DateTimeUnit | Array<DateTimeUnit>,
       options?: DateTimeDiffOptions
     ): Duration;
     endOf(unit: DateTimeUnit): DateTime;

--- a/definitions/npm/luxon_v0.2.x/flow_v0.104.x-/test_luxon.js
+++ b/definitions/npm/luxon_v0.2.x/flow_v0.104.x-/test_luxon.js
@@ -405,7 +405,6 @@ var date = DateTime.min(DateTime.local(), null, DateTime.utc());
 }): Duration);
 // $ExpectError
 (date.diff(new Date()): Duration);
-// $ExpectError
 (date.diff(DateTime.utc()): Duration);
 // $ExpectError
 (date.diff(DateTime.utc(), "glom"): Duration);
@@ -414,13 +413,13 @@ var date = DateTime.min(DateTime.local(), null, DateTime.utc());
 // $ExpectError
 (date.diff(DateTime.utc(), ["year", "month"], { foo: "bar" }): Duration);
 
+(date.diffNow(): Duration);
 (date.diffNow("year"): Duration);
 (date.diffNow(["year", "month"]): Duration);
 (date.diffNow(["year", "month"], {}): Duration);
 (date.diffNow(["year", "month"], { conversionAccuracy: "longterm" }): Duration);
 // $ExpectError
 (date.diff(new Date()): Duration);
-// $ExpectError
 (date.diff(DateTime.utc()): Duration);
 // $ExpectError
 (date.diffNow("glom"): Duration);

--- a/definitions/npm/luxon_v0.2.x/flow_v0.32.0-v0.103.x/luxon_v0.2.x.js
+++ b/definitions/npm/luxon_v0.2.x/flow_v0.32.0-v0.103.x/luxon_v0.2.x.js
@@ -468,11 +468,11 @@ declare module "luxon" {
     zoneName: string;
     diff(
       otherDateTime: DateTime,
-      unit: DateTimeUnit | Array<DateTimeUnit>,
+      unit?: DateTimeUnit | Array<DateTimeUnit>,
       options?: DateTimeDiffOptions
     ): Duration;
     diffNow(
-      unit: DateTimeUnit | Array<DateTimeUnit>,
+      unit?: DateTimeUnit | Array<DateTimeUnit>,
       options?: DateTimeDiffOptions
     ): Duration;
     endOf(unit: DateTimeUnit): DateTime;

--- a/definitions/npm/luxon_v0.4.x/flow_v0.104.x-/luxon_v0.4.x.js
+++ b/definitions/npm/luxon_v0.4.x/flow_v0.104.x-/luxon_v0.4.x.js
@@ -481,11 +481,11 @@ declare module "luxon" {
     zoneName: string;
     diff(
       otherDateTime: DateTime,
-      unit: DateTimeUnit | Array<DateTimeUnit>,
+      unit?: DateTimeUnit | Array<DateTimeUnit>,
       options?: DateTimeDiffOptions
     ): Duration;
     diffNow(
-      unit: DateTimeUnit | Array<DateTimeUnit>,
+      unit?: DateTimeUnit | Array<DateTimeUnit>,
       options?: DateTimeDiffOptions
     ): Duration;
     endOf(unit: DateTimeUnit): DateTime;

--- a/definitions/npm/luxon_v0.4.x/flow_v0.104.x-/test_luxon.js
+++ b/definitions/npm/luxon_v0.4.x/flow_v0.104.x-/test_luxon.js
@@ -405,7 +405,6 @@ var date = DateTime.min(DateTime.local(), null, DateTime.utc());
 }): Duration);
 // $ExpectError
 (date.diff(new Date()): Duration);
-// $ExpectError
 (date.diff(DateTime.utc()): Duration);
 // $ExpectError
 (date.diff(DateTime.utc(), "glom"): Duration);
@@ -414,20 +413,11 @@ var date = DateTime.min(DateTime.local(), null, DateTime.utc());
 // $ExpectError
 (date.diff(DateTime.utc(), ["year", "month"], { foo: "bar" }): Duration);
 
+(date.diffNow(): Duration);
 (date.diffNow("year"): Duration);
 (date.diffNow(["year", "month"]): Duration);
 (date.diffNow(["year", "month"], {}): Duration);
 (date.diffNow(["year", "month"], { conversionAccuracy: "longterm" }): Duration);
-// $ExpectError
-(date.diff(new Date()): Duration);
-// $ExpectError
-(date.diff(DateTime.utc()): Duration);
-// $ExpectError
-(date.diffNow("glom"): Duration);
-// $ExpectError
-(date.diffNow(["year", "glom"]): Duration);
-// $ExpectError
-(date.diffNow(["year", "month"], { foo: "bar" }): Duration);
 
 (date.startOf("year"): DateTime);
 (date.startOf("month"): DateTime);

--- a/definitions/npm/luxon_v1.x.x/flow_v0.104.x-/luxon_v1.x.x.js
+++ b/definitions/npm/luxon_v1.x.x/flow_v0.104.x-/luxon_v1.x.x.js
@@ -488,11 +488,11 @@ declare module "luxon" {
     zoneName: string;
     diff(
       otherDateTime: DateTime,
-      unit: DateTimeUnit | Array<DateTimeUnit>,
+      unit?: DateTimeUnit | Array<DateTimeUnit>,
       options?: DateTimeDiffOptions
     ): Duration;
     diffNow(
-      unit: DateTimeUnit | Array<DateTimeUnit>,
+      unit?: DateTimeUnit | Array<DateTimeUnit>,
       options?: DateTimeDiffOptions
     ): Duration;
     endOf(unit: DateTimeUnit): DateTime;

--- a/definitions/npm/luxon_v1.x.x/flow_v0.104.x-/test_luxon.js
+++ b/definitions/npm/luxon_v1.x.x/flow_v0.104.x-/test_luxon.js
@@ -435,7 +435,6 @@ var date = DateTime.min(DateTime.local(), null, DateTime.utc());
 }): Duration);
 // $ExpectError
 (date.diff(new Date()): Duration);
-// $ExpectError
 (date.diff(DateTime.utc()): Duration);
 // $ExpectError
 (date.diff(DateTime.utc(), "glom"): Duration);
@@ -444,13 +443,13 @@ var date = DateTime.min(DateTime.local(), null, DateTime.utc());
 // $ExpectError
 (date.diff(DateTime.utc(), ["year", "month"], { foo: "bar" }): Duration);
 
+(date.diffNow(): Duration);
 (date.diffNow("year"): Duration);
 (date.diffNow(["year", "month"]): Duration);
 (date.diffNow(["year", "month"], {}): Duration);
 (date.diffNow(["year", "month"], { conversionAccuracy: "longterm" }): Duration);
 // $ExpectError
 (date.diff(new Date()): Duration);
-// $ExpectError
 (date.diff(DateTime.utc()): Duration);
 // $ExpectError
 (date.diffNow("glom"): Duration);

--- a/definitions/npm/luxon_v1.x.x/flow_v0.32.0-v0.103.x/luxon_v1.x.x.js
+++ b/definitions/npm/luxon_v1.x.x/flow_v0.32.0-v0.103.x/luxon_v1.x.x.js
@@ -476,11 +476,11 @@ declare module "luxon" {
     zoneName: string;
     diff(
       otherDateTime: DateTime,
-      unit: DateTimeUnit | Array<DateTimeUnit>,
+      unit?: DateTimeUnit | Array<DateTimeUnit>,
       options?: DateTimeDiffOptions
     ): Duration;
     diffNow(
-      unit: DateTimeUnit | Array<DateTimeUnit>,
+      unit?: DateTimeUnit | Array<DateTimeUnit>,
       options?: DateTimeDiffOptions
     ): Duration;
     endOf(unit: DateTimeUnit): DateTime;


### PR DESCRIPTION
- Links to documentation: https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#instance-method-diff
- Link to GitHub or NPM: https://github.com/moment/luxon/blob/0.0.18/src/datetime.js#L1450
- Type of contribution: fix

Other notes:
Luxon methods `diff` and `diffNow` both have default args for the `unit` parameter (looks like since v0.18.0). Fixing the type