### PR TITLE
Fix qs compatability with older versions of Flow

### DIFF
--- a/definitions/npm/qs_v6.5.x/flow_v0.45.x-v0.103.x/qs_v6.5.x.js
+++ b/definitions/npm/qs_v6.5.x/flow_v0.45.x-v0.103.x/qs_v6.5.x.js
@@ -50,7 +50,7 @@ declare module "qs" {
   declare module.exports: {
     parse(str: string, opts?: ParseOptions): mixed,
     stringify(
-      obj: $ReadOnly<{ [string]: mixed, ... }> | $ReadOnlyArray<mixed>,
+      obj: $ReadOnly<{ [string]: mixed }> | $ReadOnlyArray<mixed>,
       opts?: StringifyOptions
     ): string,
     formats: Formats,

--- a/definitions/npm/qs_v6.9.x/flow_v0.45.x-v0.103.x/qs_v6.9.x.js
+++ b/definitions/npm/qs_v6.9.x/flow_v0.45.x-v0.103.x/qs_v6.9.x.js
@@ -61,7 +61,7 @@ declare module "qs" {
   declare module.exports: {
     parse(str: string, opts?: ParseOptions): { [string]: mixed },
     stringify(
-      obj: $ReadOnly<{ [string]: mixed, ... }> | $ReadOnlyArray<mixed>,
+      obj: $ReadOnly<{ [string]: mixed }> | $ReadOnlyArray<mixed>,
       opts?: StringifyOptions
     ): string,
     formats: Formats,


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
- Links to documentation: N/A
- Link to GitHub or NPM: N/A
- Type of contribution: fix

Other notes:
https://github.com/flow-typed/flow-typed/pull/3737#issuecomment-590247801 Resolves the issue mentioned here

