### PR TITLE
feat(express): support more comprehensive types for Router#use

### DIFF
--- a/definitions/npm/express_v4.17.x/flow_v0.104.x-/express_v4.17.x.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.104.x-/express_v4.17.x.js
@@ -195,6 +195,11 @@ declare class express$Route<
   connect: express$RouteMethodType<this, Req, Res>;
 }
 
+declare type express$RouterUseable<Req: express$Request, Res: express$Response> =
+  | express$Middleware<Req, Res>
+  | express$Router<Req, Res>
+  | $ReadOnlyArray<express$Path | express$Middleware<Req, Res> | express$Router<Req, Res>>;
+
 declare class express$Router<
   Req: express$Request = express$Request,
   Res: express$Response = express$Response,
@@ -204,13 +209,8 @@ declare class express$Router<
   static <Req2: express$Request, Res2: express$Response>(
     options?: express$RouterOptions,
   ): express$Router<Req2, Res2>;
-  use(middleware: express$Middleware<Req, Res>): this;
-  use(...middleware: Array<express$Middleware<Req, Res>>): this;
-  use(
-    path: express$Path | $ReadOnlyArray<express$Path>,
-    ...middleware: Array<express$Middleware<Req, Res>>
-  ): this;
-  use(path: string, router: express$Router<Req, Res>): this;
+  use(express$RouterUseable<Req, Res>, ...express$RouterUseable<Req, Res>[]): this;
+  use(express$Path, express$RouterUseable<Req, Res>, ...express$RouterUseable<Req, Res>[]): this;
   handle(
     req: http$IncomingMessage<>,
     res: http$ServerResponse,

--- a/definitions/npm/express_v4.17.x/flow_v0.104.x-/express_v4.17.x.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.104.x-/express_v4.17.x.js
@@ -198,7 +198,7 @@ declare class express$Route<
 declare type express$RouterUseable<Req: express$Request, Res: express$Response> =
   | express$Middleware<Req, Res>
   | express$Router<Req, Res>
-  | $ReadOnlyArray<express$Path | express$Middleware<Req, Res> | express$Router<Req, Res>>;
+  | $ReadOnlyArray<express$Middleware<Req, Res> | express$Router<Req, Res>>;
 
 declare class express$Router<
   Req: express$Request = express$Request,

--- a/definitions/npm/express_v4.17.x/flow_v0.104.x-/test_useMethod.js
+++ b/definitions/npm/express_v4.17.x/flow_v0.104.x-/test_useMethod.js
@@ -1,0 +1,27 @@
+// @flow
+import express from "express";
+
+import { describe, it } from 'flow-typed-test';
+
+describe('express#use', () => {
+  it('should permit routers', () => {
+    const customApp = express();
+
+    customApp.use("/something", express.Router());
+    customApp.use(express.Router(), express.Router());
+
+    // $ExpectError
+    customApp.use("/something", "/something");
+    // $ExpectError
+    customApp.use("/something", "/something", express.Router());
+  });
+});
+
+describe('Router#use', () => {
+  it('should permit solitary middleware functions', () => {
+    const customRouter = express.Router();
+    customRouter.use((req: express$Request, res: express$Response, next: express$NextFunction) => {
+      next();
+    });
+  });
+});


### PR DESCRIPTION
Previously, this would fail to support Router#use function with a single middleware function.

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: [`app.use`](http://expressjs.com/en/4x/api.html#app.use), [`Router#use`](http://expressjs.com/en/4x/api.html#router.use)
- Link to GitHub or npm: https://www.npmjs.com/package/express
- Type of contribution: fix