### PR TITLE
Fix definitions for @koa/router

### DIFF
--- a/definitions/npm/@koa/router_v8.0.x/flow_v0.84.x-/router_v8.0.x.js
+++ b/definitions/npm/@koa/router_v8.0.x/flow_v0.84.x-/router_v8.0.x.js
@@ -1,4 +1,4 @@
-declare module "koa-router" {
+declare module "@koa/router" {
   declare type Middleware = (
     ctx: any,
     next: () => Promise<void>

--- a/definitions/npm/@koa/router_v8.0.x/test_koa-router.js
+++ b/definitions/npm/@koa/router_v8.0.x/test_koa-router.js
@@ -1,5 +1,5 @@
 import { describe, it } from 'flow-typed-test';
-import Router from "koa-router";
+import Router from "@koa/router";
 
 describe('expectations', () => {
   it('defines a Middleware type', () => {


### PR DESCRIPTION
I realized that I got it wrong when I implemented it some months ago. Locally I was using an older version of the file that didn't have this problem.
Maybe this sort of issue could be found by automatic tests?