### PR TITLE
Add nanoevents v4.x.x definition

### DIFF
--- a/definitions/npm/nanoevents_v4.x.x/flow_v0.104.x-/nanoevents_v4.x.x.js
+++ b/definitions/npm/nanoevents_v4.x.x/flow_v0.104.x-/nanoevents_v4.x.x.js
@@ -1,0 +1,24 @@
+declare module 'nanoevents' {
+  declare type EventsMap = {
+    [event: string]: any,
+    ...,
+  };
+
+  declare export type DefaultEvents = {
+    [event: string]: $ReadOnlyArray<any>,
+    ...,
+  };
+
+  declare export type Emitter<Events: EventsMap> = {|
+    events: $ObjMap<Events, <V>(V) => Array<(...V) => void> | void>,
+    on: <K: $Keys<Events>>(
+      event: K,
+      cb: (...$ElementType<Events, K>) => void,
+    ) => () => void,
+    emit: <K: $Keys<Events>>(event: K, ...$ElementType<Events, K>) => void,
+  |};
+
+  declare export default function createNanoEvents<
+    Events: EventsMap = DefaultEvents,
+  >(): Emitter<Events>;
+}

--- a/definitions/npm/nanoevents_v4.x.x/flow_v0.104.x-/test_nanoevents_v4.x.x.js
+++ b/definitions/npm/nanoevents_v4.x.x/flow_v0.104.x-/test_nanoevents_v4.x.x.js
@@ -1,0 +1,45 @@
+import createNanoEvents from 'nanoevents';
+
+const defaultEmitter = createNanoEvents();
+
+defaultEmitter.emit('any');
+// $ExpectError event name is missing.
+defaultEmitter.emit();
+defaultEmitter.on('any', arg => {
+  (arg: number);
+});
+// $ExpectError event handler is missing
+defaultEmitter.on('any');
+
+const emitter = createNanoEvents<{|
+  event1: [number],
+  event2: [],
+|}>();
+
+emitter.emit('event1', 0);
+// $ExpectError should be number
+emitter.emit('event1', 'string');
+emitter.emit('event2');
+// $ExpectError no parameters expected
+emitter.emit('event2', 'string');
+
+emitter.on('event1', (arg: number) => {});
+// $ExpectError should be number
+emitter.on('event1', (arg: string) => {});
+
+emitter.on('event2', () => {});
+// $ExpectError no parameters expected
+emitter.on('event2', (arg: number) => {});
+
+const unbind = emitter.on('event1', () => {});
+unbind();
+
+// $ExpectError no parameters expected
+unbind(0);
+
+emitter.events.event1;
+// $ExpectError not defined event
+emitter.events.event3;
+// $ExpectError can be undefined
+(emitter.events.event1: Array<(number) => void>);
+(emitter.events.event1: Array<(number) => void> | void);


### PR DESCRIPTION
Api is not class based anymore.

- Link to GitHub or NPM: https://github.com/ai/nanoevents
- Type of contribution: new definition
