### PR TITLE
StyledComponent infer type from shorthand

### DIFF
--- a/definitions/npm/styled-components_v5.x.x/flow_v0.104.x-/styled-components_v5.x.x.js
+++ b/definitions/npm/styled-components_v5.x.x/flow_v0.104.x-/styled-components_v5.x.x.js
@@ -248,7 +248,10 @@ declare module 'styled-components' {
   |};
 
   declare export type StyledShorthandFactory<V> = {|
-    [[call]]: <StyleProps, Theme>(
+    [[call]]: (
+      string[]
+    ) => StyledComponent<{ ... }, { ... }, V>,
+    [[call]]: <StyleProps = { ... }, Theme = { ... }>(
       string[],
       ...Interpolation<PropsWithTheme<StyleProps, Theme>>[]
     ) => StyledComponent<StyleProps, Theme, V>,


### PR DESCRIPTION
Fixes #3766

When a shorthand is called as:

```js
import styled from 'styled-components';

export const Red = styled.div`
  border: 1px solid red;
`;
```

We can infer its type as `StyledComponent<{}, {}, HTMLDivElement>`.

This is currently a WIP. I'm fairly new to flow so some direction would be appreciated cc @omninonsense @jbrown215 @goodmind @AndrewSouthpaw 

- maybe a more extensive solution is possible?

e.g. this doesn't currently infer a type for:

```js
const RED = 'red';

export const Red = styled.div`
  border: 1px solid ${RED};
`;
```

or
```js
export const Red = styled(MyComponent)`
  border: 1px solid 'red';
`;
```

But both could be inferred AFAIK

- I'm not sure how to test for this, as I can't write a failing test without using `export` which isn't possible inside a test.


