### PR TITLE
[Lodash] add ReadOnlyArray to lodash/fp and some missed functions

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -206,10 +206,6 @@ declare module "lodash" {
     | string;
   declare type Comparator<T> = (item: T, item2: T) => boolean;
 
-  declare type MapIterator<T, U> =
-    | ((item: T, index: number, array: Array<T>) => U)
-    | propertyIterateeShorthand;
-
   declare type ReadOnlyMapIterator<T, U> =
     | ((item: T, index: number, array: $ReadOnlyArray<T>) => U)
     | propertyIterateeShorthand;
@@ -659,10 +655,9 @@ declare module "lodash" {
       object: T,
       iteratee?: ?ValueOnlyIteratee<A>
     ): { [key: V]: A, ... };
-    map<T, U>(array?: ?Array<T>, iteratee?: ?MapIterator<T, U>): Array<U>;
     map<T, U>(
-      array: ?$ReadOnlyArray<T>,
-      iteratee?: ReadOnlyMapIterator<T, U>
+      array?: ?$ReadOnlyArray<T>,
+      iteratee?: ?ReadOnlyMapIterator<T, U>
     ): Array<U>;
     map<V, T: Object, U>(
       object: ?T,

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -745,12 +745,9 @@ declare module "lodash" {
       object?: ?T,
       predicate?: ?OPredicate<A, T>
     ): Array<V>;
-    sample<T>(array: ?Array<T>): T;
-    sample<V, T: Object>(object: T): V;
-    sampleSize<T>(array?: ?Array<T>, n?: ?number): Array<T>;
-    sampleSize<V, T: Object>(object: T, n?: number): Array<V>;
-    shuffle<T>(array: ?Array<T>): Array<T>;
-    shuffle<V, T: Object>(object: T): Array<V>;
+    sample<T>(collection: ?$ReadOnlyArray<T> | $ReadOnly<{ [id: any]: T, ... }>): T;
+    sampleSize<T>(collection?: ?$ReadOnlyArray<T> | $ReadOnly<{ [id: any]: T, ... }>, n?: ?number): Array<T>;
+    shuffle<T>(array: ?$ReadOnlyArray<T> | $ReadOnly<{ [id: any]: T, ... }>): Array<T>;
     size(collection: $ReadOnlyArray<any> | Object | string): number;
     some<T>(array: void | null, predicate?: ?Predicate<T>): false;
     some<T>(array: ?$ReadOnlyArray<T>, predicate?: Predicate<T>): boolean;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -217,7 +217,7 @@ declare module "lodash" {
   declare class Lodash {
     // Array
     chunk<T>(array?: ?$ReadOnlyArray<T>, size?: ?number): Array<Array<T>>;
-    compact<T, N: ?T>(array?: ?Array<N>): Array<T>;
+    compact<T, N: ?T>(array?: ?$ReadOnlyArray<N>): Array<T>;
     concat<T>(
       base?: ?$ReadOnlyArray<T>,
       ...elements: Array<any>
@@ -236,10 +236,10 @@ declare module "lodash" {
       values?: ?$ReadOnlyArray<U>,
       comparator?: ?(item: T, item2: U) => boolean
     ): Array<T>;
-    drop<T>(array?: ?Array<T>, n?: ?number): Array<T>;
-    dropRight<T>(array?: ?Array<T>, n?: ?number): Array<T>;
-    dropRightWhile<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
-    dropWhile<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
+    drop<T>(array?: ?$ReadOnlyArray<T>, n?: ?number): Array<T>;
+    dropRight<T>(array?: ?$ReadOnlyArray<T>, n?: ?number): Array<T>;
+    dropRightWhile<T>(array?: ?$ReadOnlyArray<T>, predicate?: ?Predicate<T>): Array<T>;
+    dropWhile<T>(array?: ?$ReadOnlyArray<T>, predicate?: ?Predicate<T>): Array<T>;
     fill<T, U>(
       array?: ?Array<T>,
       value?: ?U,
@@ -269,13 +269,13 @@ declare module "lodash" {
     // alias of _.head
     first<T>(array: ?$ReadOnlyArray<T>): T;
     flatten<T, X>(array?: ?$ReadOnlyArray<$ReadOnlyArray<T> | X>): Array<T | X>;
-    flattenDeep<T>(array?: ?(Array<any>)): Array<T>;
-    flattenDepth(array?: ?(Array<any>), depth?: ?number): Array<any>;
+    flattenDeep<T>(array?: ?$ReadOnlyArray<any>): Array<T>;
+    flattenDepth(array?: ?$ReadOnlyArray<any>, depth?: ?number): Array<any>;
     fromPairs<A, B>(pairs?: ?$ReadOnlyArray<[A, B]>): {| [key: A]: B |};
     head<T>(array: ?$ReadOnlyArray<T>): T;
-    indexOf<T>(array: Array<T>, value: T, fromIndex?: number): number;
+    indexOf<T>(array: $ReadOnlyArray<T>, value: T, fromIndex?: number): number;
     indexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
-    initial<T>(array: ?Array<T>): Array<T>;
+    initial<T>(array: ?$ReadOnlyArray<T>): Array<T>;
     intersection<T>(...arrays?: Array<$ReadOnlyArray<T>>): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
     intersectionBy<T>(
@@ -323,12 +323,12 @@ declare module "lodash" {
       a4?: ?$ReadOnlyArray<T>,
       comparator?: ?Comparator<T>
     ): Array<T>;
-    join<T>(array: Array<T>, separator?: ?string): string;
+    join<T>(array: $ReadOnlyArray<T>, separator?: ?string): string;
     join<T>(array: void | null, separator?: ?string): "";
     last<T>(array: ?$ReadOnlyArray<T>): T;
-    lastIndexOf<T>(array: Array<T>, value?: ?T, fromIndex?: ?number): number;
+    lastIndexOf<T>(array: $ReadOnlyArray<T>, value?: ?T, fromIndex?: ?number): number;
     lastIndexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
-    nth<T>(array: Array<T>, n?: ?number): T;
+    nth<T>(array: $ReadOnlyArray<T>, n?: ?number): T;
     nth(array: void | null, n?: ?number): void;
     pull<T>(array: Array<T>, ...values?: $ReadOnlyArray<?T>): Array<T>;
     pull<T: void | null>(array: T, ...values?: $ReadOnlyArray<?any>): T;
@@ -360,10 +360,10 @@ declare module "lodash" {
       start?: ?number,
       end?: ?number
     ): Array<T>;
-    sortedIndex<T>(array: Array<T>, value: T): number;
+    sortedIndex<T>(array: $ReadOnlyArray<T>, value: T): number;
     sortedIndex<T>(array: void | null, value: ?T): 0;
     sortedIndexBy<T>(
-      array: Array<T>,
+      array: $ReadOnlyArray<T>,
       value?: ?T,
       iteratee?: ?ValueOnlyIteratee<T>
     ): number;
@@ -372,12 +372,12 @@ declare module "lodash" {
       value?: ?T,
       iteratee?: ?ValueOnlyIteratee<T>
     ): 0;
-    sortedIndexOf<T>(array: Array<T>, value: T): number;
+    sortedIndexOf<T>(array: $ReadOnlyArray<T>, value: T): number;
     sortedIndexOf<T>(array: void | null, value?: ?T): -1;
-    sortedLastIndex<T>(array: Array<T>, value: T): number;
+    sortedLastIndex<T>(array: $ReadOnlyArray<T>, value: T): number;
     sortedLastIndex<T>(array: void | null, value?: ?T): 0;
     sortedLastIndexBy<T>(
-      array: Array<T>,
+      array: $ReadOnlyArray<T>,
       value: T,
       iteratee?: ValueOnlyIteratee<T>
     ): number;
@@ -386,18 +386,18 @@ declare module "lodash" {
       value?: ?T,
       iteratee?: ?ValueOnlyIteratee<T>
     ): 0;
-    sortedLastIndexOf<T>(array: Array<T>, value: T): number;
+    sortedLastIndexOf<T>(array: $ReadOnlyArray<T>, value: T): number;
     sortedLastIndexOf<T>(array: void | null, value?: ?T): -1;
-    sortedUniq<T>(array?: ?Array<T>): Array<T>;
+    sortedUniq<T>(array?: ?$ReadOnlyArray<T>): Array<T>;
     sortedUniqBy<T>(
-      array?: ?Array<T>,
+      array?: ?$ReadOnlyArray<T>,
       iteratee?: ?ValueOnlyIteratee<T>
     ): Array<T>;
-    tail<T>(array?: ?Array<T>): Array<T>;
+    tail<T>(array?: ?$ReadOnlyArray<T>): Array<T>;
     take<T>(array?: ?$ReadOnlyArray<T>, n?: ?number): Array<T>;
     takeRight<T>(array?: ?$ReadOnlyArray<T>, n?: ?number): Array<T>;
-    takeRightWhile<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
-    takeWhile<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
+    takeRightWhile<T>(array?: ?$ReadOnlyArray<T>, predicate?: ?Predicate<T>): Array<T>;
+    takeWhile<T>(array?: ?$ReadOnlyArray<T>, predicate?: ?Predicate<T>): Array<T>;
     union<T>(...arrays?: Array<$ReadOnlyArray<T>>): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
     unionBy<T>(
@@ -423,7 +423,7 @@ declare module "lodash" {
       iteratee?: ValueOnlyIteratee<T>
     ): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
-    unionWith<T>(a1?: ?Array<T>, comparator?: ?Comparator<T>): Array<T>;
+    unionWith<T>(a1?: ?$ReadOnlyArray<T>, comparator?: ?Comparator<T>): Array<T>;
     unionWith<T>(
       a1: $ReadOnlyArray<T>,
       a2: $ReadOnlyArray<T>,
@@ -445,10 +445,10 @@ declare module "lodash" {
     uniq<T>(array?: ?$ReadOnlyArray<T>): Array<T>;
     uniqBy<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?ValueOnlyIteratee<T>): Array<T>;
     uniqWith<T>(array?: ?$ReadOnlyArray<T>, comparator?: ?Comparator<T>): Array<T>;
-    unzip<T>(array?: ?Array<T>): Array<T>;
-    unzipWith<T>(array: ?Array<T>, iteratee?: ?Iteratee<T>): Array<T>;
+    unzip<T>(array?: ?$ReadOnlyArray<T>): Array<T>;
+    unzipWith<T>(array: ?$ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
     without<T>(array?: ?$ReadOnlyArray<T>, ...values?: Array<?T>): Array<T>;
-    xor<T>(...array: Array<Array<T>>): Array<T>;
+    xor<T>(...array: $ReadOnlyArray<$ReadOnlyArray<T>>): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
     xorBy<T>(a1?: ?$ReadOnlyArray<T>, iteratee?: ?ValueOnlyIteratee<T>): Array<T>;
     xorBy<T>(
@@ -470,23 +470,23 @@ declare module "lodash" {
       iteratee?: ValueOnlyIteratee<T>
     ): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
-    xorWith<T>(a1?: ?Array<T>, comparator?: ?Comparator<T>): Array<T>;
+    xorWith<T>(a1?: ?$ReadOnlyArray<T>, comparator?: ?Comparator<T>): Array<T>;
     xorWith<T>(
-      a1: Array<T>,
-      a2: Array<T>,
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>,
       comparator?: Comparator<T>
     ): Array<T>;
     xorWith<T>(
-      a1: Array<T>,
-      a2: Array<T>,
-      a3: Array<T>,
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>,
+      a3: $ReadOnlyArray<T>,
       comparator?: Comparator<T>
     ): Array<T>;
     xorWith<T>(
-      a1: Array<T>,
-      a2: Array<T>,
-      a3: Array<T>,
-      a4: Array<T>,
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>,
+      a3: $ReadOnlyArray<T>,
+      a4: $ReadOnlyArray<T>,
       comparator?: Comparator<T>
     ): Array<T>;
     zip<A, B>(a1?: ?($ReadOnlyArray<A>), a2?: ?($ReadOnlyArray<B>)): Array<[A, B]>;
@@ -500,49 +500,49 @@ declare module "lodash" {
       a5: $ReadOnlyArray<E>
     ): Array<[A, B, C, D, E]>;
 
-    zipObject<K, V>(props: Array<K>, values?: ?Array<V>): { [key: K]: V, ... };
-    zipObject<K, V>(props: void | null, values?: ?Array<V>): {...};
-    zipObjectDeep(props: Array<any>, values?: ?any): Object;
+    zipObject<K, V>(props: $ReadOnlyArray<K>, values?: ?$ReadOnlyArray<V>): { [key: K]: V, ... };
+    zipObject<K, V>(props: void | null, values?: ?$ReadOnlyArray<V>): {...};
+    zipObjectDeep(props: $ReadOnlyArray<any>, values?: ?any): Object;
     zipObjectDeep(props: void | null, values?: ?any): {...};
 
-    zipWith<A>(a1?: ?Array<A>): Array<[A]>;
-    zipWith<T, A>(a1: Array<A>, iteratee: (A) => T): Array<T>;
+    zipWith<A>(a1?: ?$ReadOnlyArray<A>): Array<[A]>;
+    zipWith<T, A>(a1: $ReadOnlyArray<A>, iteratee: (A) => T): Array<T>;
 
-    zipWith<A, B>(a1: Array<A>, a2: Array<B>): Array<[A, B]>;
+    zipWith<A, B>(a1: $ReadOnlyArray<A>, a2: $ReadOnlyArray<B>): Array<[A, B]>;
     zipWith<T, A, B>(
-      a1: Array<A>,
-      a2: Array<B>,
+      a1: $ReadOnlyArray<A>,
+      a2: $ReadOnlyArray<B>,
       iteratee: (A, B) => T
     ): Array<T>;
 
     zipWith<A, B, C>(
-      a1: Array<A>,
-      a2: Array<B>,
-      a3: Array<C>
+      a1: $ReadOnlyArray<A>,
+      a2: $ReadOnlyArray<B>,
+      a3: $ReadOnlyArray<C>
     ): Array<[A, B, C]>;
     zipWith<T, A, B, C>(
-      a1: Array<A>,
-      a2: Array<B>,
-      a3: Array<C>,
+      a1: $ReadOnlyArray<A>,
+      a2: $ReadOnlyArray<B>,
+      a3: $ReadOnlyArray<C>,
       iteratee: (A, B, C) => T
     ): Array<T>;
 
     zipWith<A, B, C, D>(
-      a1: Array<A>,
-      a2: Array<B>,
-      a3: Array<C>,
-      a4: Array<D>
+      a1: $ReadOnlyArray<A>,
+      a2: $ReadOnlyArray<B>,
+      a3: $ReadOnlyArray<C>,
+      a4: $ReadOnlyArray<D>
     ): Array<[A, B, C, D]>;
     zipWith<T, A, B, C, D>(
-      a1: Array<A>,
-      a2: Array<B>,
-      a3: Array<C>,
-      a4: Array<D>,
+      a1: $ReadOnlyArray<A>,
+      a2: $ReadOnlyArray<B>,
+      a3: $ReadOnlyArray<C>,
+      a4: $ReadOnlyArray<D>,
       iteratee: (A, B, C, D) => T
     ): Array<T>;
 
     // Collection
-    countBy<T>(array: Array<T>, iteratee?: ?ValueOnlyIteratee<T>): { [string]: number, ... };
+    countBy<T>(array: $ReadOnlyArray<T>, iteratee?: ?ValueOnlyIteratee<T>): { [string]: number, ... };
     countBy<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>): {...};
     countBy<T: Object>(object: T, iteratee?: ?ValueOnlyIteratee<T>): { [string]: number, ... };
     // alias of _.forEach
@@ -601,7 +601,7 @@ declare module "lodash" {
       iteratee?: ?OFlatMapIteratee<T, U>
     ): Array<U>;
     flatMapDepth<T, U>(
-      array?: ?Array<T>,
+      array?: ?$ReadOnlyArray<T>,
       iteratee?: ?FlatMapIteratee<T, U>,
       depth?: ?number
     ): Array<U>;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -344,7 +344,7 @@ declare module "lodash" {
       values?: ?$ReadOnlyArray<any>,
       iteratee?: ?ValueOnlyIteratee<any>
     ): T;
-   pullAllWith<T: void | null>(
+    pullAllWith<T: void | null>(
       array: T,
       values?: ?$ReadOnlyArray<any>,
       comparator?: ?Function
@@ -796,12 +796,12 @@ declare module "lodash" {
     negate<A, R>(predicate: (...A) => R): (...A) => boolean;
     once<F: (...Array<any>) => any>(func: F): F;
     overArgs(func?: ?Function, ...transforms?: Array<Function>): Function;
-    overArgs(func?: ?Function, transforms?: ?Array<Function>): Function;
+    overArgs(func?: ?Function, transforms?: ?$ReadOnlyArray<Function>): Function;
     partial<R>(func: (...Array<any>) => R, ...partials: Array<any>): (...Array<any>) => R;
     partialRight<R>(func: (...Array<any>) => R, ...partials: Array<any>): (...Array<any>) => R;
-    partialRight<R>(func: (...Array<any>) => R, partials: Array<any>): (...Array<any>) => R;
+    partialRight<R>(func: (...Array<any>) => R, partials: $ReadOnlyArray<any>): (...Array<any>) => R;
     rearg(func: Function, ...indexes: Array<number>): Function;
-    rearg(func: Function, indexes: Array<number>): Function;
+    rearg(func: Function, indexes: $ReadOnlyArray<number>): Function;
     rest(func: Function, start?: number): Function;
     spread(func: Function): Function;
     throttle<F: (...Array<any>) => any>(
@@ -833,13 +833,13 @@ declare module "lodash" {
     gte(value: any, other: any): boolean;
     isArguments(value: void | null): false;
     isArguments(value: any): boolean;
-    isArray(value: Array<any>): true;
+    isArray(value: $ReadOnlyArray<any>): true;
     isArray(value: any): false;
     isArrayBuffer(value: ArrayBuffer): true;
     isArrayBuffer(value: any): false;
-    isArrayLike(value: Array<any> | string | { length: number, ... }): true;
+    isArrayLike(value: $ReadOnlyArray<any> | string | { length: number, ... }): true;
     isArrayLike(value: any): false;
-    isArrayLikeObject(value: { length: number, ... } | Array<any>): true;
+    isArrayLikeObject(value: { length: number, ... } | $ReadOnlyArray<any>): true;
     isArrayLikeObject(value: any): false;
     isBoolean(value: boolean): true;
     isBoolean(value: any): false;
@@ -944,14 +944,14 @@ declare module "lodash" {
     floor(number: number, precision?: number): number;
     max<T>(array: ?$ReadOnlyArray<T>): T;
     maxBy<T>(array: ?$ReadOnlyArray<T>, iteratee?: Iteratee<T>): T;
-    mean(array: Array<*>): number;
-    meanBy<T>(array: Array<T>, iteratee?: Iteratee<T>): number;
+    mean(array: $ReadOnlyArray<*>): number;
+    meanBy<T>(array: $ReadOnlyArray<T>, iteratee?: Iteratee<T>): number;
     min<T>(array: ?$ReadOnlyArray<T>): T;
     minBy<T>(array: ?$ReadOnlyArray<T>, iteratee?: Iteratee<T>): T;
     multiply(multiplier: number, multiplicand: number): number;
     round(number: number, precision?: number): number;
     subtract(minuend: number, subtrahend: number): number;
-    sum(array: Array<*>): number;
+    sum(array: $ReadOnlyArray<*>): number;
     sumBy<T>(array: $ReadOnlyArray<T>, iteratee?: Iteratee<T>): number;
 
     // number
@@ -1070,7 +1070,7 @@ declare module "lodash" {
       ) => any | void
     ): Object;
     at(object?: ?Object, ...paths: Array<string>): Array<any>;
-    at(object?: ?Object, paths: Array<string>): Array<any>;
+    at(object?: ?Object, paths: $ReadOnlyArray<string>): Array<any>;
     create(prototype: void | null, properties: void | null): {...};
     create<T>(prototype: T, properties: Object): T;
     create(prototype: any, properties: void | null): {...};
@@ -1277,7 +1277,7 @@ declare module "lodash" {
       value?: ?any,
       customizer?: ?(nsValue: any, key: string, nsObject: T) => any
     ): T;
-    toPairs(object?: ?Object | Array<*>): Array<[string, any]>;
+    toPairs(object?: ?Object | $ReadOnlyArray<*>): Array<[string, any]>;
     toPairsIn(object?: ?Object): Array<[string, any]>;
     transform(
       collection: Object | $ReadOnlyArray<any>,
@@ -1393,8 +1393,8 @@ declare module "lodash" {
 
     // Util
     attempt(func: Function, ...args: Array<any>): any;
-    bindAll(object: Object, methodNames?: ?Array<string>): Object;
-    bindAll<T: void | null>(object: T, methodNames?: ?Array<string>): T;
+    bindAll(object: Object, methodNames?: ?$ReadOnlyArray<string>): Object;
+    bindAll<T: void | null>(object: T, methodNames?: ?$ReadOnlyArray<string>): T;
     bindAll(object: Object, ...methodNames: Array<string>): Object;
     cond(pairs?: ?NestedArray<Function>): Function;
     conforms(source?: ?Object): Function;
@@ -1406,8 +1406,8 @@ declare module "lodash" {
     ): T1;
     // NaN is a number instead of its own type, otherwise it would behave like null/void
     defaultTo<T1: number, T2>(value: T1, defaultValue: T2): T1 | T2;
-    flow: $ComposeReverse & ((funcs: Array<Function>) => Function);
-    flowRight: $Compose & ((funcs: Array<Function>) => Function);
+    flow: $ComposeReverse & ((funcs: $ReadOnlyArray<Function>) => Function);
+    flowRight: $Compose & ((funcs: $ReadOnlyArray<Function>) => Function);
     identity<T>(value: T): T;
     iteratee(func?: any): Function;
     matches(source?: ?Object): Function;
@@ -1423,11 +1423,11 @@ declare module "lodash" {
     noop(...args: Array<mixed>): void;
     nthArg(n?: ?number): Function;
     over(...iteratees: Array<Function>): Function;
-    over(iteratees: Array<Function>): Function;
+    over(iteratees: $ReadOnlyArray<Function>): Function;
     overEvery(...predicates: Array<Function>): Function;
-    overEvery(predicates: Array<Function>): Function;
+    overEvery(predicates: $ReadOnlyArray<Function>): Function;
     overSome(...predicates: Array<Function>): Function;
-    overSome(predicates: Array<Function>): Function;
+    overSome(predicates: $ReadOnlyArray<Function>): Function;
     property(path?: ?Path): Function;
     propertyOf(object?: ?Object): Function;
     range(start: number, end: number, step?: number): Array<number>;
@@ -1657,8 +1657,8 @@ declare module "lodash/fp" {
 
   declare class Lodash {
     // Array
-    chunk<T>(size: number): (array: Array<T>) => Array<Array<T>>;
-    chunk<T>(size: number, array: Array<T>): Array<Array<T>>;
+    chunk<T>(size: number): (array: $ReadOnlyArray<T>) => Array<Array<T>>;
+    chunk<T>(size: number, array: $ReadOnlyArray<T>): Array<Array<T>>;
     compact<T, N: ?T>(array?: ?$ReadOnlyArray<N>): Array<T>;
     concat<T, U, A: Array<T> | T, B: Array<U> | U>(
       base: A
@@ -1695,18 +1695,18 @@ declare module "lodash/fp" {
       first: $ReadOnly<T>,
       second: $ReadOnly<T>
     ): Array<T>;
-    drop<T>(n: number): (array: Array<T>) => Array<T>;
-    drop<T>(n: number, array: Array<T>): Array<T>;
-    dropLast<T>(n: number): (array: Array<T>) => Array<T>;
-    dropLast<T>(n: number, array: Array<T>): Array<T>;
-    dropRight<T>(n: number): (array: Array<T>) => Array<T>;
-    dropRight<T>(n: number, array: Array<T>): Array<T>;
-    dropRightWhile<T>(predicate: Predicate<T>): (array: Array<T>) => Array<T>;
-    dropRightWhile<T>(predicate: Predicate<T>, array: Array<T>): Array<T>;
-    dropWhile<T>(predicate: Predicate<T>): (array: Array<T>) => Array<T>;
-    dropWhile<T>(predicate: Predicate<T>, array: Array<T>): Array<T>;
-    dropLastWhile<T>(predicate: Predicate<T>): (array: Array<T>) => Array<T>;
-    dropLastWhile<T>(predicate: Predicate<T>, array: Array<T>): Array<T>;
+    drop<T>(n: number): (array: $ReadOnlyArray<T>) => Array<T>;
+    drop<T>(n: number, array: $ReadOnlyArray<T>): Array<T>;
+    dropLast<T>(n: number): (array: $ReadOnlyArray<T>) => Array<T>;
+    dropLast<T>(n: number, array: $ReadOnlyArray<T>): Array<T>;
+    dropRight<T>(n: number): (array: $ReadOnlyArray<T>) => Array<T>;
+    dropRight<T>(n: number, array: $ReadOnlyArray<T>): Array<T>;
+    dropRightWhile<T>(predicate: Predicate<T>): (array: $ReadOnlyArray<T>) => Array<T>;
+    dropRightWhile<T>(predicate: Predicate<T>, array: $ReadOnlyArray<T>): Array<T>;
+    dropWhile<T>(predicate: Predicate<T>): (array: $ReadOnlyArray<T>) => Array<T>;
+    dropWhile<T>(predicate: Predicate<T>, array: $ReadOnlyArray<T>): Array<T>;
+    dropLastWhile<T>(predicate: Predicate<T>): (array: $ReadOnlyArray<T>) => Array<T>;
+    dropLastWhile<T>(predicate: Predicate<T>, array: $ReadOnlyArray<T>): Array<T>;
     fill<T, U>(
       start: number
     ): ((
@@ -1765,67 +1765,67 @@ declare module "lodash/fp" {
     ): number;
     // alias of _.head
     first<T>(array: $ReadOnlyArray<T>): T;
-    flatten<T, X>(array: Array<Array<T> | X>): Array<T | X>;
-    unnest<T, X>(array: Array<Array<T> | X>): Array<T | X>;
-    flattenDeep<T>(array: Array<any>): Array<T>;
-    flattenDepth(depth: number): (array: Array<any>) => Array<any>;
-    flattenDepth(depth: number, array: Array<any>): Array<any>;
+    flatten<T, X>(array: $ReadOnlyArray<$ReadOnlyArray<T> | X>): Array<T | X>;
+    unnest<T, X>(array: $ReadOnlyArray<$ReadOnlyArray<T> | X>): Array<T | X>;
+    flattenDeep<T>(array: $ReadOnlyArray<any>): Array<T>;
+    flattenDepth(depth: number): (array: $ReadOnlyArray<any>) => Array<any>;
+    flattenDepth(depth: number, array: $ReadOnlyArray<any>): Array<any>;
     fromPairs<A, B>(pairs: $ReadOnlyArray<[A, B]>): {| [key: A]: B |};
     head<T>(array: $ReadOnlyArray<T>): T;
-    indexOf<T>(value: T): (array: Array<T>) => number;
-    indexOf<T>(value: T, array: Array<T>): number;
+    indexOf<T>(value: T): (array: $ReadOnlyArray<T>) => number;
+    indexOf<T>(value: T, array: $ReadOnlyArray<T>): number;
     indexOfFrom<T>(
       value: T
-    ): ((fromIndex: number) => (array: Array<T>) => number) &
-      ((fromIndex: number, array: Array<T>) => number);
-    indexOfFrom<T>(value: T, fromIndex: number): (array: Array<T>) => number;
-    indexOfFrom<T>(value: T, fromIndex: number, array: Array<T>): number;
-    initial<T>(array: Array<T>): Array<T>;
-    init<T>(array: Array<T>): Array<T>;
-    intersection<T>(a1: Array<T>): (a2: Array<T>) => Array<T>;
-    intersection<T>(a1: Array<T>, a2: Array<T>): Array<T>;
+    ): ((fromIndex: number) => (array: $ReadOnlyArray<T>) => number) &
+      ((fromIndex: number, array: $ReadOnlyArray<T>) => number);
+    indexOfFrom<T>(value: T, fromIndex: number): (array: $ReadOnlyArray<T>) => number;
+    indexOfFrom<T>(value: T, fromIndex: number, array: $ReadOnlyArray<T>): number;
+    initial<T>(array: $ReadOnlyArray<T>): Array<T>;
+    init<T>(array: $ReadOnlyArray<T>): Array<T>;
+    intersection<T>(a1: $ReadOnlyArray<T>): (a2: $ReadOnlyArray<T>) => Array<T>;
+    intersection<T>(a1: $ReadOnlyArray<T>, a2: $ReadOnlyArray<T>): Array<T>;
     intersectionBy<T>(
       iteratee: ValueOnlyIteratee<T>
-    ): ((a1: Array<T>) => (a2: Array<T>) => Array<T>) &
-      ((a1: Array<T>, a2: Array<T>) => Array<T>);
+    ): ((a1: $ReadOnlyArray<T>) => (a2: $ReadOnlyArray<T>) => Array<T>) &
+      ((a1: $ReadOnlyArray<T>, a2: $ReadOnlyArray<T>) => Array<T>);
     intersectionBy<T>(
       iteratee: ValueOnlyIteratee<T>,
-      a1: Array<T>
-    ): (a2: Array<T>) => Array<T>;
+      a1: $ReadOnlyArray<T>
+    ): (a2: $ReadOnlyArray<T>) => Array<T>;
     intersectionBy<T>(
       iteratee: ValueOnlyIteratee<T>,
-      a1: Array<T>,
-      a2: Array<T>
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>
     ): Array<T>;
     intersectionWith<T>(
       comparator: Comparator<T>
-    ): ((a1: Array<T>) => (a2: Array<T>) => Array<T>) &
-      ((a1: Array<T>, a2: Array<T>) => Array<T>);
+    ): ((a1: $ReadOnlyArray<T>) => (a2: $ReadOnlyArray<T>) => Array<T>) &
+      ((a1: $ReadOnlyArray<T>, a2: $ReadOnlyArray<T>) => Array<T>);
     intersectionWith<T>(
       comparator: Comparator<T>,
-      a1: Array<T>
-    ): (a2: Array<T>) => Array<T>;
+      a1: $ReadOnlyArray<T>
+    ): (a2: $ReadOnlyArray<T>) => Array<T>;
     intersectionWith<T>(
       comparator: Comparator<T>,
-      a1: Array<T>,
-      a2: Array<T>
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>
     ): Array<T>;
-    join<T>(separator: string): (array: Array<T>) => string;
-    join<T>(separator: string, array: Array<T>): string;
-    last<T>(array: Array<T>): T;
-    lastIndexOf<T>(value: T): (array: Array<T>) => number;
-    lastIndexOf<T>(value: T, array: Array<T>): number;
+    join<T>(separator: string): (array: $ReadOnlyArray<T>) => string;
+    join<T>(separator: string, array: $ReadOnlyArray<T>): string;
+    last<T>(array: $ReadOnlyArray<T>): T;
+    lastIndexOf<T>(value: T): (array: $ReadOnlyArray<T>) => number;
+    lastIndexOf<T>(value: T, array: $ReadOnlyArray<T>): number;
     lastIndexOfFrom<T>(
       value: T
-    ): ((fromIndex: number) => (array: Array<T>) => number) &
-      ((fromIndex: number, array: Array<T>) => number);
+    ): ((fromIndex: number) => (array: $ReadOnlyArray<T>) => number) &
+      ((fromIndex: number, array: $ReadOnlyArray<T>) => number);
     lastIndexOfFrom<T>(
       value: T,
       fromIndex: number
-    ): (array: Array<T>) => number;
-    lastIndexOfFrom<T>(value: T, fromIndex: number, array: Array<T>): number;
-    nth<T>(n: number): (array: Array<T>) => T;
-    nth<T>(n: number, array: Array<T>): T;
+    ): (array: $ReadOnlyArray<T>) => number;
+    lastIndexOfFrom<T>(value: T, fromIndex: number, array: $ReadOnlyArray<T>): number;
+    nth<T>(n: number): (array: $ReadOnlyArray<T>) => T;
+    nth<T>(n: number, array: $ReadOnlyArray<T>): T;
     pull<T>(value: T): (array: Array<T>) => Array<T>;
     pull<T>(value: T, array: Array<T>): Array<T>;
     pullAll<T>(values: $ReadOnlyArray<T>): (array: Array<T>) => Array<T>;
@@ -1856,158 +1856,158 @@ declare module "lodash/fp" {
     reverse<T>(array: Array<T>): Array<T>;
     slice<T>(
       start: number
-    ): ((end: number) => (array: Array<T>) => Array<T>) &
-      ((end: number, array: Array<T>) => Array<T>);
-    slice<T>(start: number, end: number): (array: Array<T>) => Array<T>;
-    slice<T>(start: number, end: number, array: Array<T>): Array<T>;
-    sortedIndex<T>(value: T): (array: Array<T>) => number;
-    sortedIndex<T>(value: T, array: Array<T>): number;
+    ): ((end: number) => (array: $ReadOnlyArray<T>) => Array<T>) &
+      ((end: number, array: $ReadOnlyArray<T>) => Array<T>);
+    slice<T>(start: number, end: number): (array: $ReadOnlyArray<T>) => Array<T>;
+    slice<T>(start: number, end: number, array: $ReadOnlyArray<T>): Array<T>;
+    sortedIndex<T>(value: T): (array: $ReadOnlyArray<T>) => number;
+    sortedIndex<T>(value: T, array: $ReadOnlyArray<T>): number;
     sortedIndexBy<T>(
       iteratee: ValueOnlyIteratee<T>
-    ): ((value: T) => (array: Array<T>) => number) &
-      ((value: T, array: Array<T>) => number);
+    ): ((value: T) => (array: $ReadOnlyArray<T>) => number) &
+      ((value: T, array: $ReadOnlyArray<T>) => number);
     sortedIndexBy<T>(
       iteratee: ValueOnlyIteratee<T>,
       value: T
-    ): (array: Array<T>) => number;
+    ): (array: $ReadOnlyArray<T>) => number;
     sortedIndexBy<T>(
       iteratee: ValueOnlyIteratee<T>,
       value: T,
-      array: Array<T>
+      array: $ReadOnlyArray<T>
     ): number;
-    sortedIndexOf<T>(value: T): (array: Array<T>) => number;
-    sortedIndexOf<T>(value: T, array: Array<T>): number;
-    sortedLastIndex<T>(value: T): (array: Array<T>) => number;
-    sortedLastIndex<T>(value: T, array: Array<T>): number;
+    sortedIndexOf<T>(value: T): (array: $ReadOnlyArray<T>) => number;
+    sortedIndexOf<T>(value: T, array: $ReadOnlyArray<T>): number;
+    sortedLastIndex<T>(value: T): (array: $ReadOnlyArray<T>) => number;
+    sortedLastIndex<T>(value: T, array: $ReadOnlyArray<T>): number;
     sortedLastIndexBy<T>(
       iteratee: ValueOnlyIteratee<T>
-    ): ((value: T) => (array: Array<T>) => number) &
-      ((value: T, array: Array<T>) => number);
+    ): ((value: T) => (array: $ReadOnlyArray<T>) => number) &
+      ((value: T, array: $ReadOnlyArray<T>) => number);
     sortedLastIndexBy<T>(
       iteratee: ValueOnlyIteratee<T>,
       value: T
-    ): (array: Array<T>) => number;
+    ): (array: $ReadOnlyArray<T>) => number;
     sortedLastIndexBy<T>(
       iteratee: ValueOnlyIteratee<T>,
       value: T,
-      array: Array<T>
+      array: $ReadOnlyArray<T>
     ): number;
-    sortedLastIndexOf<T>(value: T): (array: Array<T>) => number;
-    sortedLastIndexOf<T>(value: T, array: Array<T>): number;
-    sortedUniq<T>(array: Array<T>): Array<T>;
-    sortedUniqBy<T>(iteratee: ValueOnlyIteratee<T>, array: Array<T>): Array<T>;
-    tail<T>(array: Array<T>): Array<T>;
+    sortedLastIndexOf<T>(value: T): (array: $ReadOnlyArray<T>) => number;
+    sortedLastIndexOf<T>(value: T, array: $ReadOnlyArray<T>): number;
+    sortedUniq<T>(array: $ReadOnlyArray<T>): Array<T>;
+    sortedUniqBy<T>(iteratee: ValueOnlyIteratee<T>, array: $ReadOnlyArray<T>): Array<T>;
+    tail<T>(array: $ReadOnlyArray<T>): Array<T>;
     take<T>(n: number): (array: $ReadOnlyArray<T>) => Array<T>;
     take<T>(n: number, array: $ReadOnlyArray<T>): Array<T>;
     takeRight<T>(n: number): (array: $ReadOnlyArray<T>) => Array<T>;
     takeRight<T>(n: number, array: $ReadOnlyArray<T>): Array<T>;
-    takeLast<T>(n: number): (array: Array<T>) => Array<T>;
-    takeLast<T>(n: number, array: Array<T>): Array<T>;
-    takeRightWhile<T>(predicate: Predicate<T>): (array: Array<T>) => Array<T>;
-    takeRightWhile<T>(predicate: Predicate<T>, array: Array<T>): Array<T>;
-    takeLastWhile<T>(predicate: Predicate<T>): (array: Array<T>) => Array<T>;
-    takeLastWhile<T>(predicate: Predicate<T>, array: Array<T>): Array<T>;
-    takeWhile<T>(predicate: Predicate<T>): (array: Array<T>) => Array<T>;
-    takeWhile<T>(predicate: Predicate<T>, array: Array<T>): Array<T>;
-    union<T>(a1: Array<T>): (a2: Array<T>) => Array<T>;
-    union<T>(a1: Array<T>, a2: Array<T>): Array<T>;
+    takeLast<T>(n: number): (array: $ReadOnlyArray<T>) => Array<T>;
+    takeLast<T>(n: number, array: $ReadOnlyArray<T>): Array<T>;
+    takeRightWhile<T>(predicate: Predicate<T>): (array: $ReadOnlyArray<T>) => Array<T>;
+    takeRightWhile<T>(predicate: Predicate<T>, array: $ReadOnlyArray<T>): Array<T>;
+    takeLastWhile<T>(predicate: Predicate<T>): (array: $ReadOnlyArray<T>) => Array<T>;
+    takeLastWhile<T>(predicate: Predicate<T>, array: $ReadOnlyArray<T>): Array<T>;
+    takeWhile<T>(predicate: Predicate<T>): (array: $ReadOnlyArray<T>) => Array<T>;
+    takeWhile<T>(predicate: Predicate<T>, array: $ReadOnlyArray<T>): Array<T>;
+    union<T>(a1: $ReadOnlyArray<T>): (a2: $ReadOnlyArray<T>) => Array<T>;
+    union<T>(a1: $ReadOnlyArray<T>, a2: $ReadOnlyArray<T>): Array<T>;
     unionBy<T>(
       iteratee: ValueOnlyIteratee<T>
-    ): ((a1: Array<T>) => (a2: Array<T>) => Array<T>) &
-      ((a1: Array<T>, a2: Array<T>) => Array<T>);
+    ): ((a1: $ReadOnlyArray<T>) => (a2: $ReadOnlyArray<T>) => Array<T>) &
+      ((a1: $ReadOnlyArray<T>, a2: $ReadOnlyArray<T>) => Array<T>);
     unionBy<T>(
       iteratee: ValueOnlyIteratee<T>,
-      a1: Array<T>
-    ): (a2: Array<T>) => Array<T>;
+      a1: $ReadOnlyArray<T>
+    ): (a2: $ReadOnlyArray<T>) => Array<T>;
     unionBy<T>(
       iteratee: ValueOnlyIteratee<T>,
-      a1: Array<T>,
-      a2: Array<T>
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>
     ): Array<T>;
     unionWith<T>(
       comparator: Comparator<T>
-    ): ((a1: Array<T>) => (a2: Array<T>) => Array<T>) &
-      ((a1: Array<T>, a2: Array<T>) => Array<T>);
+    ): ((a1: $ReadOnlyArray<T>) => (a2: $ReadOnlyArray<T>) => Array<T>) &
+      ((a1: $ReadOnlyArray<T>, a2: $ReadOnlyArray<T>) => Array<T>);
     unionWith<T>(
       comparator: Comparator<T>,
-      a1: Array<T>
-    ): (a2: Array<T>) => Array<T>;
+      a1: $ReadOnlyArray<T>
+    ): (a2: $ReadOnlyArray<T>) => Array<T>;
     unionWith<T>(
       comparator: Comparator<T>,
-      a1: Array<T>,
-      a2: Array<T>
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>
     ): Array<T>;
-    uniq<T>(array: Array<T>): Array<T>;
-    uniqBy<T>(iteratee: ValueOnlyIteratee<T>): (array: Array<T>) => Array<T>;
-    uniqBy<T>(iteratee: ValueOnlyIteratee<T>, array: Array<T>): Array<T>;
-    uniqWith<T>(comparator: Comparator<T>): (array: Array<T>) => Array<T>;
-    uniqWith<T>(comparator: Comparator<T>, array: Array<T>): Array<T>;
-    unzip<T>(array: Array<T>): Array<T>;
-    unzipWith<T>(iteratee: Iteratee<T>): (array: Array<T>) => Array<T>;
-    unzipWith<T>(iteratee: Iteratee<T>, array: Array<T>): Array<T>;
-    without<T>(values: Array<T>): (array: Array<T>) => Array<T>;
-    without<T>(values: Array<T>, array: Array<T>): Array<T>;
-    xor<T>(a1: Array<T>): (a2: Array<T>) => Array<T>;
-    xor<T>(a1: Array<T>, a2: Array<T>): Array<T>;
-    symmetricDifference<T>(a1: Array<T>): (a2: Array<T>) => Array<T>;
-    symmetricDifference<T>(a1: Array<T>, a2: Array<T>): Array<T>;
+    uniq<T>(array: $ReadOnlyArray<T>): Array<T>;
+    uniqBy<T>(iteratee: ValueOnlyIteratee<T>): (array: $ReadOnlyArray<T>) => Array<T>;
+    uniqBy<T>(iteratee: ValueOnlyIteratee<T>, array: $ReadOnlyArray<T>): Array<T>;
+    uniqWith<T>(comparator: Comparator<T>): (array: $ReadOnlyArray<T>) => Array<T>;
+    uniqWith<T>(comparator: Comparator<T>, array: $ReadOnlyArray<T>): Array<T>;
+    unzip<T>(array: $ReadOnlyArray<T>): Array<T>;
+    unzipWith<T>(iteratee: Iteratee<T>): (array: $ReadOnlyArray<T>) => Array<T>;
+    unzipWith<T>(iteratee: Iteratee<T>, array: $ReadOnlyArray<T>): Array<T>;
+    without<T>(values: $ReadOnlyArray<T>): (array: $ReadOnlyArray<T>) => Array<T>;
+    without<T>(values: $ReadOnlyArray<T>, array: $ReadOnlyArray<T>): Array<T>;
+    xor<T>(a1: $ReadOnlyArray<T>): (a2: $ReadOnlyArray<T>) => Array<T>;
+    xor<T>(a1: $ReadOnlyArray<T>, a2: $ReadOnlyArray<T>): Array<T>;
+    symmetricDifference<T>(a1: $ReadOnlyArray<T>): (a2: $ReadOnlyArray<T>) => Array<T>;
+    symmetricDifference<T>(a1: $ReadOnlyArray<T>, a2: $ReadOnlyArray<T>): Array<T>;
     xorBy<T>(
       iteratee: ValueOnlyIteratee<T>
-    ): ((a1: Array<T>) => (a2: Array<T>) => Array<T>) &
-      ((a1: Array<T>, a2: Array<T>) => Array<T>);
+    ): ((a1: $ReadOnlyArray<T>) => (a2: $ReadOnlyArray<T>) => Array<T>) &
+      ((a1: $ReadOnlyArray<T>, a2: $ReadOnlyArray<T>) => Array<T>);
     xorBy<T>(
       iteratee: ValueOnlyIteratee<T>,
-      a1: Array<T>
-    ): (a2: Array<T>) => Array<T>;
+      a1: $ReadOnlyArray<T>
+    ): (a2: $ReadOnlyArray<T>) => Array<T>;
     xorBy<T>(
       iteratee: ValueOnlyIteratee<T>,
-      a1: Array<T>,
-      a2: Array<T>
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>
     ): Array<T>;
     symmetricDifferenceBy<T>(
       iteratee: ValueOnlyIteratee<T>
-    ): ((a1: Array<T>) => (a2: Array<T>) => Array<T>) &
-      ((a1: Array<T>, a2: Array<T>) => Array<T>);
+    ): ((a1: $ReadOnlyArray<T>) => (a2: $ReadOnlyArray<T>) => Array<T>) &
+      ((a1: $ReadOnlyArray<T>, a2: $ReadOnlyArray<T>) => Array<T>);
     symmetricDifferenceBy<T>(
       iteratee: ValueOnlyIteratee<T>,
-      a1: Array<T>
-    ): (a2: Array<T>) => Array<T>;
+      a1: $ReadOnlyArray<T>
+    ): (a2: $ReadOnlyArray<T>) => Array<T>;
     symmetricDifferenceBy<T>(
       iteratee: ValueOnlyIteratee<T>,
-      a1: Array<T>,
-      a2: Array<T>
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>
     ): Array<T>;
     xorWith<T>(
       comparator: Comparator<T>
-    ): ((a1: Array<T>) => (a2: Array<T>) => Array<T>) &
-      ((a1: Array<T>, a2: Array<T>) => Array<T>);
+    ): ((a1: $ReadOnlyArray<T>) => (a2: $ReadOnlyArray<T>) => Array<T>) &
+      ((a1: $ReadOnlyArray<T>, a2: $ReadOnlyArray<T>) => Array<T>);
     xorWith<T>(
       comparator: Comparator<T>,
-      a1: Array<T>
-    ): (a2: Array<T>) => Array<T>;
-    xorWith<T>(comparator: Comparator<T>, a1: Array<T>, a2: Array<T>): Array<T>;
+      a1: $ReadOnlyArray<T>
+    ): (a2: $ReadOnlyArray<T>) => Array<T>;
+    xorWith<T>(comparator: Comparator<T>, a1: $ReadOnlyArray<T>, a2: $ReadOnlyArray<T>): Array<T>;
     symmetricDifferenceWith<T>(
       comparator: Comparator<T>
-    ): ((a1: Array<T>) => (a2: Array<T>) => Array<T>) &
-      ((a1: Array<T>, a2: Array<T>) => Array<T>);
+    ): ((a1: $ReadOnlyArray<T>) => (a2: $ReadOnlyArray<T>) => Array<T>) &
+      ((a1: $ReadOnlyArray<T>, a2: $ReadOnlyArray<T>) => Array<T>);
     symmetricDifferenceWith<T>(
       comparator: Comparator<T>,
-      a1: Array<T>
-    ): (a2: Array<T>) => Array<T>;
+      a1: $ReadOnlyArray<T>
+    ): (a2: $ReadOnlyArray<T>) => Array<T>;
     symmetricDifferenceWith<T>(
       comparator: Comparator<T>,
-      a1: Array<T>,
-      a2: Array<T>
+      a1: $ReadOnlyArray<T>,
+      a2: $ReadOnlyArray<T>
     ): Array<T>;
-    zip<A, B>(a1: Array<A>): (a2: Array<B>) => Array<[A, B]>;
-    zip<A, B>(a1: Array<A>, a2: Array<B>): Array<[A, B]>;
-    zipAll(arrays: Array<Array<any>>): Array<any>;
-    zipObject<K, V>(props?: Array<K>): (values?: Array<V>) => { [key: K]: V, ... };
-    zipObject<K, V>(props?: Array<K>, values?: Array<V>): { [key: K]: V, ... };
-    zipObj(props: Array<any>): (values: Array<any>) => Object;
-    zipObj(props: Array<any>, values: Array<any>): Object;
-    zipObjectDeep(props: Array<any>): (values: any) => Object;
-    zipObjectDeep(props: Array<any>, values: any): Object;
+    zip<A, B>(a1: $ReadOnlyArray<A>): (a2: $ReadOnlyArray<B>) => Array<[A, B]>;
+    zip<A, B>(a1: $ReadOnlyArray<A>, a2: $ReadOnlyArray<B>): Array<[A, B]>;
+    zipAll(arrays: $ReadOnlyArray<$ReadOnlyArray<any>>): Array<any>;
+    zipObject<K, V>(props?: $ReadOnlyArray<K>): (values?: $ReadOnlyArray<V>) => { [key: K]: V, ... };
+    zipObject<K, V>(props?: $ReadOnlyArray<K>, values?: $ReadOnlyArray<V>): { [key: K]: V, ... };
+    zipObj(props: $ReadOnlyArray<any>): (values: $ReadOnlyArray<any>) => Object;
+    zipObj(props: $ReadOnlyArray<any>, values: $ReadOnlyArray<any>): Object;
+    zipObjectDeep(props: $ReadOnlyArray<any>): (values: any) => Object;
+    zipObjectDeep(props: $ReadOnlyArray<any>, values: any): Object;
     zipWith<T>(
       iteratee: Iteratee<T>
     ): ((a1: NestedArray<T>) => (a2: NestedArray<T>) => Array<T>) &
@@ -2024,10 +2024,10 @@ declare module "lodash/fp" {
     // Collection
     countBy<T>(
       iteratee: ValueOnlyIteratee<T>
-    ): (collection: Array<T> | { [id: any]: T, ... }) => { [string]: number, ... };
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => { [string]: number, ... };
     countBy<T>(
       iteratee: ValueOnlyIteratee<T>,
-      collection: Array<T> | { [id: any]: T, ... }
+      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
     ): { [string]: number, ... };
     // alias of _.forEach
     each<T>(
@@ -2054,10 +2054,10 @@ declare module "lodash/fp" {
     ): boolean;
     all<T>(
       iteratee: Iteratee<T> | OIteratee<T>
-    ): (collection: Array<T> | { [id: any]: T, ... }) => boolean;
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => boolean;
     all<T>(
       iteratee: Iteratee<T> | OIteratee<T>,
-      collection: Array<T> | { [id: any]: T, ... }
+      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
     ): boolean;
     filter<T>(
       predicate: Predicate<T> | OPredicate<T>
@@ -2085,7 +2085,7 @@ declare module "lodash/fp" {
     findFrom<T>(
       predicate: Predicate<T> | OPredicate<T>,
       fromIndex: number
-    ): (collection: Array<T> | { [id: any]: T, ... }) => T | void;
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => T | void;
     findFrom<T>(
       predicate: Predicate<T> | OPredicate<T>,
       fromIndex: number,
@@ -2118,32 +2118,32 @@ declare module "lodash/fp" {
     ): T | void;
     flatMap<T, U>(
       iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>
-    ): (collection: Array<T> | { [id: any]: T, ... }) => Array<U>;
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<U>;
     flatMap<T, U>(
       iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>,
-      collection: Array<T> | { [id: any]: T, ... }
+      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
     ): Array<U>;
     flatMapDeep<T, U>(
       iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>
-    ): (collection: Array<T> | { [id: any]: T, ... }) => Array<U>;
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<U>;
     flatMapDeep<T, U>(
       iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>,
-      collection: Array<T> | { [id: any]: T, ... }
+      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
     ): Array<U>;
     flatMapDepth<T, U>(
       iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>
     ): ((
       depth: number
-    ) => (collection: Array<T> | { [id: any]: T, ... }) => Array<U>) &
-      ((depth: number, collection: Array<T> | { [id: any]: T, ... }) => Array<U>);
+    ) => (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<U>) &
+      ((depth: number, collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<U>);
     flatMapDepth<T, U>(
       iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>,
       depth: number
-    ): (collection: Array<T> | { [id: any]: T, ... }) => Array<U>;
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<U>;
     flatMapDepth<T, U>(
       iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>,
       depth: number,
-      collection: Array<T> | { [id: any]: T, ... }
+      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
     ): Array<U>;
     forEach<T>(
       iteratee: Iteratee<T> | OIteratee<T>
@@ -2168,14 +2168,14 @@ declare module "lodash/fp" {
       iteratee: ValueOnlyIteratee<T>,
       collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
     ): { [key: V]: Array<T>, ... };
-    includes<T>(value: T): (collection: Array<T> | { [id: any]: T, ... }) => boolean;
-    includes<T>(value: T, collection: Array<T> | { [id: any]: T, ... }): boolean;
+    includes<T>(value: T): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => boolean;
+    includes<T>(value: T, collection: $ReadOnlyArray<T> | { [id: any]: T, ... }): boolean;
     includes(value: string): (str: string) => boolean;
     includes(value: string, str: string): boolean;
     contains(value: string): (str: string) => boolean;
     contains(value: string, str: string): boolean;
-    contains<T>(value: T): (collection: Array<T> | { [id: any]: T, ... }) => boolean;
-    contains<T>(value: T, collection: Array<T> | { [id: any]: T, ... }): boolean;
+    contains<T>(value: T): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => boolean;
+    contains<T>(value: T, collection: $ReadOnlyArray<T> | { [id: any]: T, ... }): boolean;
     includesFrom(
       value: string
     ): ((fromIndex: number) => (str: string) => boolean) &
@@ -2184,37 +2184,37 @@ declare module "lodash/fp" {
     includesFrom(value: string, fromIndex: number, str: string): boolean;
     includesFrom<T>(
       value: T
-    ): ((fromIndex: number) => (collection: Array<T>) => boolean) &
-      ((fromIndex: number, collection: Array<T>) => boolean);
+    ): ((fromIndex: number) => (collection: $ReadOnlyArray<T>) => boolean) &
+      ((fromIndex: number, collection: $ReadOnlyArray<T>) => boolean);
     includesFrom<T>(
       value: T,
       fromIndex: number
-    ): (collection: Array<T>) => boolean;
-    includesFrom<T>(value: T, fromIndex: number, collection: Array<T>): boolean;
+    ): (collection: $ReadOnlyArray<T>) => boolean;
+    includesFrom<T>(value: T, fromIndex: number, collection: $ReadOnlyArray<T>): boolean;
     invokeMap<T>(
       path: ((value: T) => Path) | Path
-    ): (collection: Array<T> | { [id: any]: T, ... }) => Array<any>;
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<any>;
     invokeMap<T>(
       path: ((value: T) => Path) | Path,
-      collection: Array<T> | { [id: any]: T, ... }
+      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
     ): Array<any>;
     invokeArgsMap<T>(
       path: ((value: T) => Path) | Path
     ): ((
-      collection: Array<T> | { [id: any]: T, ... }
-    ) => (args: Array<any>) => Array<any>) &
+      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+    ) => (args: $ReadOnlyArray<any>) => Array<any>) &
       ((
-        collection: Array<T> | { [id: any]: T, ... },
-        args: Array<any>
+        collection: $ReadOnlyArray<T> | { [id: any]: T, ... },
+        args: $ReadOnlyArray<any>
       ) => Array<any>);
     invokeArgsMap<T>(
       path: ((value: T) => Path) | Path,
-      collection: Array<T> | { [id: any]: T, ... }
-    ): (args: Array<any>) => Array<any>;
+      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+    ): (args: $ReadOnlyArray<any>) => Array<any>;
     invokeArgsMap<T>(
       path: ((value: T) => Path) | Path,
-      collection: Array<T> | { [id: any]: T, ... },
-      args: Array<any>
+      collection: $ReadOnlyArray<T> | { [id: any]: T, ... },
+      args: $ReadOnlyArray<any>
     ): Array<any>;
     keyBy<T, V>(
       iteratee: ValueOnlyIteratee<T>
@@ -2241,10 +2241,10 @@ declare module "lodash/fp" {
     map(iteratee: (char: string) => any, str: string): string;
     pluck<T, U>(
       iteratee: MapIterator<T, U> | OMapIterator<T, U>
-    ): (collection: Array<T> | { [id: any]: T, ... }) => Array<U>;
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<U>;
     pluck<T, U>(
       iteratee: MapIterator<T, U> | OMapIterator<T, U>,
-      collection: Array<T> | { [id: any]: T, ... }
+      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
     ): Array<U>;
     pluck(iteratee: (char: string) => any): (str: string) => string;
     pluck(iteratee: (char: string) => any, str: string): string;
@@ -2268,50 +2268,50 @@ declare module "lodash/fp" {
     ): Array<T>;
     partition<T>(
       predicate: Predicate<T> | OPredicate<T>
-    ): (collection: Array<T> | { [id: any]: T, ... }) => [Array<T>, Array<T>];
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => [Array<T>, Array<T>];
     partition<T>(
       predicate: Predicate<T> | OPredicate<T>,
-      collection: Array<T> | { [id: any]: T, ... }
+      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
     ): [Array<T>, Array<T>];
     reduce<T, U>(
       iteratee: (accumulator: U, value: T) => U
-    ): ((accumulator: U) => (collection: Array<T> | { [id: any]: T, ... }) => U) &
-      ((accumulator: U, collection: Array<T> | { [id: any]: T, ... }) => U);
+    ): ((accumulator: U) => (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => U) &
+      ((accumulator: U, collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => U);
     reduce<T, U>(
       iteratee: (accumulator: U, value: T) => U,
       accumulator: U
-    ): (collection: Array<T> | { [id: any]: T, ... }) => U;
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => U;
     reduce<T, U>(
       iteratee: (accumulator: U, value: T) => U,
       accumulator: U,
-      collection: Array<T> | { [id: any]: T, ... }
+      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
     ): U;
     reduceRight<T, U>(
       iteratee: (value: T, accumulator: U) => U
-    ): ((accumulator: U) => (collection: Array<T> | { [id: any]: T, ... }) => U) &
-      ((accumulator: U, collection: Array<T> | { [id: any]: T, ... }) => U);
+    ): ((accumulator: U) => (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => U) &
+      ((accumulator: U, collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => U);
     reduceRight<T, U>(
       iteratee: (value: T, accumulator: U) => U,
       accumulator: U
-    ): (collection: Array<T> | { [id: any]: T, ... }) => U;
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => U;
     reduceRight<T, U>(
       iteratee: (value: T, accumulator: U) => U,
       accumulator: U,
-      collection: Array<T> | { [id: any]: T, ... }
+      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
     ): U;
     reject<T>(
       predicate: Predicate<T> | OPredicate<T>
-    ): (collection: Array<T> | { [id: any]: T, ... }) => Array<T>;
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<T>;
     reject<T>(
       predicate: Predicate<T> | OPredicate<T>,
-      collection: Array<T> | { [id: any]: T, ... }
+      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
     ): Array<T>;
-    sample<T>(collection: Array<T> | { [id: any]: T, ... }): T;
+    sample<T>(collection: $ReadOnlyArray<T> | { [id: any]: T, ... }): T;
     sampleSize<T>(
       n: number
-    ): (collection: Array<T> | { [id: any]: T, ... }) => Array<T>;
-    sampleSize<T>(n: number, collection: Array<T> | { [id: any]: T, ... }): Array<T>;
-    shuffle<T>(collection: Array<T> | { [id: any]: T, ... }): Array<T>;
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<T>;
+    sampleSize<T>(n: number, collection: $ReadOnlyArray<T> | { [id: any]: T, ... }): Array<T>;
+    shuffle<T>(collection: $ReadOnlyArray<T> | { [id: any]: T, ... }): Array<T>;
     size(collection: $ReadOnlyArray<any> | Object | string): number;
     some<T>(
       predicate: Predicate<T> | OPredicate<T>
@@ -2372,16 +2372,16 @@ declare module "lodash/fp" {
     negate<A, R>(predicate: (...A) => R): (...A) => boolean;
     complement(predicate: Function): Function;
     once(func: Function): Function;
-    overArgs(func: Function): (transforms: Array<Function>) => Function;
-    overArgs(func: Function, transforms: Array<Function>): Function;
-    useWith(func: Function): (transforms: Array<Function>) => Function;
-    useWith(func: Function, transforms: Array<Function>): Function;
-    partial(func: Function): (partials: Array<any>) => Function;
-    partial(func: Function, partials: Array<any>): Function;
-    partialRight(func: Function): (partials: Array<any>) => Function;
-    partialRight(func: Function, partials: Array<any>): Function;
-    rearg(indexes: Array<number>): (func: Function) => Function;
-    rearg(indexes: Array<number>, func: Function): Function;
+    overArgs(func: Function): (transforms: $ReadOnlyArray<Function>) => Function;
+    overArgs(func: Function, transforms: $ReadOnlyArray<Function>): Function;
+    useWith(func: Function): (transforms: $ReadOnlyArray<Function>) => Function;
+    useWith(func: Function, transforms: $ReadOnlyArray<Function>): Function;
+    partial(func: Function): (partials: $ReadOnlyArray<any>) => Function;
+    partial(func: Function, partials: $ReadOnlyArray<any>): Function;
+    partialRight(func: Function): (partials: $ReadOnlyArray<any>) => Function;
+    partialRight(func: Function, partials: $ReadOnlyArray<any>): Function;
+    rearg(indexes: $ReadOnlyArray<number>): (func: Function) => Function;
+    rearg(indexes: $ReadOnlyArray<number>, func: Function): Function;
     rest(func: Function): Function;
     unapply(func: Function): Function;
     restFrom(start: number): (func: Function) => Function;
@@ -2570,23 +2570,23 @@ declare module "lodash/fp" {
     divide(dividend: number): (divisor: number) => number;
     divide(dividend: number, divisor: number): number;
     floor(number: number): number;
-    max<T>(array: Array<T>): T;
-    maxBy<T>(iteratee: Iteratee<T>): (array: Array<T>) => T;
-    maxBy<T>(iteratee: Iteratee<T>, array: Array<T>): T;
-    mean(array: Array<*>): number;
-    meanBy<T>(iteratee: Iteratee<T>): (array: Array<T>) => number;
-    meanBy<T>(iteratee: Iteratee<T>, array: Array<T>): number;
-    min<T>(array: Array<T>): T;
-    minBy<T>(iteratee: Iteratee<T>): (array: Array<T>) => T;
-    minBy<T>(iteratee: Iteratee<T>, array: Array<T>): T;
+    max<T>(array: $ReadOnlyArray<T>): T;
+    maxBy<T>(iteratee: Iteratee<T>): (array: $ReadOnlyArray<T>) => T;
+    maxBy<T>(iteratee: Iteratee<T>, array: $ReadOnlyArray<T>): T;
+    mean(array: $ReadOnlyArray<*>): number;
+    meanBy<T>(iteratee: Iteratee<T>): (array: $ReadOnlyArray<T>) => number;
+    meanBy<T>(iteratee: Iteratee<T>, array: $ReadOnlyArray<T>): number;
+    min<T>(array: $ReadOnlyArray<T>): T;
+    minBy<T>(iteratee: Iteratee<T>): (array: $ReadOnlyArray<T>) => T;
+    minBy<T>(iteratee: Iteratee<T>, array: $ReadOnlyArray<T>): T;
     multiply(multiplier: number): (multiplicand: number) => number;
     multiply(multiplier: number, multiplicand: number): number;
     round(number: number): number;
     subtract(minuend: number): (subtrahend: number) => number;
     subtract(minuend: number, subtrahend: number): number;
-    sum(array: Array<*>): number;
-    sumBy<T>(iteratee: Iteratee<T>): (array: Array<T>) => number;
-    sumBy<T>(iteratee: Iteratee<T>, array: Array<T>): number;
+    sum(array: $ReadOnlyArray<*>): number;
+    sumBy<T>(iteratee: Iteratee<T>): (array: $ReadOnlyArray<T>) => number;
+    sumBy<T>(iteratee: Iteratee<T>, array: $ReadOnlyArray<T>): number;
 
     // number
     clamp(
@@ -2729,12 +2729,12 @@ declare module "lodash/fp" {
       ) => any | void,
       objects: Array<Object>
     ): Object;
-    at(paths: Array<string>): (object: Object) => Array<any>;
-    at(paths: Array<string>, object: Object): Array<any>;
-    props(paths: Array<string>): (object: Object) => Array<any>;
-    props(paths: Array<string>, object: Object): Array<any>;
-    paths(paths: Array<string>): (object: Object) => Array<any>;
-    paths(paths: Array<string>, object: Object): Array<any>;
+    at(paths: $ReadOnlyArray<string>): (object: Object) => Array<any>;
+    at(paths: $ReadOnlyArray<string>, object: Object): Array<any>;
+    props(paths: $ReadOnlyArray<string>): (object: Object) => Array<any>;
+    props(paths: $ReadOnlyArray<string>, object: Object): Array<any>;
+    paths(paths: $ReadOnlyArray<string>): (object: Object) => Array<any>;
+    paths(paths: $ReadOnlyArray<string>, object: Object): Array<any>;
     create<T>(prototype: T): T;
     defaults(source: Object): (object: Object) => Object;
     defaults(source: Object, object: Object): Object;
@@ -2811,15 +2811,15 @@ declare module "lodash/fp" {
       path: Path,
       object: Object | $ReadOnlyArray<any> | void | null
     ): any;
-    prop(path: Path): (object: Object | Array<any>) => any;
-    prop(path: Path, object: Object | Array<any>): any;
-    path(path: Path): (object: Object | Array<any>) => any;
-    path(path: Path, object: Object | Array<any>): any;
+    prop(path: Path): (object: Object | $ReadOnlyArray<any>) => any;
+    prop(path: Path, object: Object | $ReadOnlyArray<any>): any;
+    path(path: Path): (object: Object | $ReadOnlyArray<any>) => any;
+    path(path: Path, object: Object | $ReadOnlyArray<any>): any;
     getOr(
       defaultValue: any
     ): ((
       path: Path
-    ) => (object: Object | Array<any>) => any) &
+    ) => (object: Object | $ReadOnlyArray<any>) => any) &
       ((
         path: Path,
         object: Object | $ReadOnlyArray<any> | void | null
@@ -2837,31 +2837,31 @@ declare module "lodash/fp" {
       defaultValue: any
     ): ((
       path: Path
-    ) => (object: Object | Array<any>) => any) &
-      ((path: Path, object: Object | Array<any>) => any);
+    ) => (object: Object | $ReadOnlyArray<any>) => any) &
+      ((path: Path, object: Object | $ReadOnlyArray<any>) => any);
     propOr(
       defaultValue: any,
       path: Path
-    ): (object: Object | Array<any>) => any;
+    ): (object: Object | $ReadOnlyArray<any>) => any;
     propOr(
       defaultValue: any,
       path: Path,
-      object: Object | Array<any>
+      object: Object | $ReadOnlyArray<any>
     ): any;
     pathOr(
       defaultValue: any
     ): ((
       path: Path
-    ) => (object: Object | Array<any>) => any) &
-      ((path: Path, object: Object | Array<any>) => any);
+    ) => (object: Object | $ReadOnlyArray<any>) => any) &
+      ((path: Path, object: Object | $ReadOnlyArray<any>) => any);
     pathOr(
       defaultValue: any,
       path: Path
-    ): (object: Object | Array<any>) => any;
+    ): (object: Object | $ReadOnlyArray<any>) => any;
     pathOr(
       defaultValue: any,
       path: Path,
-      object: Object | Array<any>
+      object: Object | $ReadOnlyArray<any>
     ): any;
     has(path: Path): (object: Object) => boolean;
     has(path: Path, object: Object): boolean;
@@ -2895,7 +2895,7 @@ declare module "lodash/fp" {
     mapValues(iteratee: OIteratee<*>, object: Object): Object;
     merge(object: Object): (source: Object) => Object;
     merge(object: Object, source: Object): Object;
-    mergeAll(objects: Array<Object>): Object;
+    mergeAll(objects: $ReadOnlyArray<Object>): Object;
     mergeWith<T: Object, A: Object, B: Object>(
       customizer: (
         objValue: any,
@@ -2934,7 +2934,7 @@ declare module "lodash/fp" {
         object: Object,
         source: Object
       ) => any | void
-    ): (objects: Array<Object>) => Object;
+    ): (objects: $ReadOnlyArray<Object>) => Object;
     mergeAllWith(
       customizer: (
         objValue: any,
@@ -2943,12 +2943,12 @@ declare module "lodash/fp" {
         object: Object,
         source: Object
       ) => any | void,
-      objects: Array<Object>
+      objects: $ReadOnlyArray<Object>
     ): Object;
-    omit(props: Array<string>): (object: Object) => Object;
-    omit(props: Array<string>, object: Object): Object;
-    omitAll(props: Array<string>): (object: Object) => Object;
-    omitAll(props: Array<string>, object: Object): Object;
+    omit(props: $ReadOnlyArray<string>): (object: Object) => Object;
+    omit(props: $ReadOnlyArray<string>, object: Object): Object;
+    omitAll(props: $ReadOnlyArray<string>): (object: Object) => Object;
+    omitAll(props: $ReadOnlyArray<string>, object: Object): Object;
     omitBy<A, T: $ReadOnly<{ [id: any]: A, ... }>>(
       predicate: OPredicate<A>
     ): (object: T) => Object;
@@ -2957,8 +2957,8 @@ declare module "lodash/fp" {
     pick(props: $ReadOnlyArray<string>, object: Object): Object;
     pick(...props: Array<string>): (object: Object) => Object;
     pick(props: $ReadOnlyArray<string>): (object: Object) => Object;
-    pickAll(props: Array<string>): (object: Object) => Object;
-    pickAll(props: Array<string>, object: Object): Object;
+    pickAll(props: $ReadOnlyArray<string>): (object: Object) => Object;
+    pickAll(props: $ReadOnlyArray<string>, object: Object): Object;
     pickBy<A, T: $ReadOnly<{ [id: any]: A, ... }>>(
       predicate: OPredicate<A>
     ): (object: T) => Object;
@@ -3010,7 +3010,7 @@ declare module "lodash/fp" {
       value: any,
       object: T
     ): Object;
-    toPairs(object: Object | Array<*>): Array<[string, any]>;
+    toPairs(object: Object | $ReadOnlyArray<*>): Array<[string, any]>;
     toPairsIn(object: Object): Array<[string, any]>;
     transform(
       iteratee: OIteratee<*>
@@ -3161,8 +3161,8 @@ declare module "lodash/fp" {
 
     // Util
     attempt(func: Function): any;
-    bindAll(methodNames: Array<string>): (object: Object) => Object;
-    bindAll(methodNames: Array<string>, object: Object): Object;
+    bindAll(methodNames: $ReadOnlyArray<string>): (object: Object) => Object;
+    bindAll(methodNames: $ReadOnlyArray<string>, object: Object): Object;
     cond(pairs: NestedArray<Function>): Function;
     constant<T>(value: T): () => T;
     always<T>(value: T): () => T;
@@ -3178,11 +3178,11 @@ declare module "lodash/fp" {
     // NaN is a number instead of its own type, otherwise it would behave like null/void
     defaultTo<T1: number, T2>(defaultValue: T2): (value: T1) => T1 | T2;
     defaultTo<T1: number, T2>(defaultValue: T2, value: T1): T1 | T2;
-    flow: $ComposeReverse & ((funcs: Array<Function>) => Function);
-    pipe: $ComposeReverse & ((funcs: Array<Function>) => Function);
-    flowRight: $Compose & ((funcs: Array<Function>) => Function);
-    compose: $Compose & ((funcs: Array<Function>) => Function);
-    compose(funcs: Array<Function>): Function;
+    flow: $ComposeReverse & ((funcs: $ReadOnlyArray<Function>) => Function);
+    pipe: $ComposeReverse & ((funcs: $ReadOnlyArray<Function>) => Function);
+    flowRight: $Compose & ((funcs: $ReadOnlyArray<Function>) => Function);
+    compose: $Compose & ((funcs: $ReadOnlyArray<Function>) => Function);
+    compose(funcs: $ReadOnlyArray<Function>): Function;
     identity<T>(value: T): T;
     iteratee(func: any): Function;
     matches(source: Object): (object: Object) => boolean;
@@ -3211,16 +3211,16 @@ declare module "lodash/fp" {
     noConflict(): Lodash;
     noop(...args: Array<mixed>): void;
     nthArg(n: number): Function;
-    over(iteratees: Array<Function>): Function;
-    juxt(iteratees: Array<Function>): Function;
-    overEvery(predicates: Array<Function>): Function;
-    allPass(predicates: Array<Function>): Function;
-    overSome(predicates: Array<Function>): Function;
-    anyPass(predicates: Array<Function>): Function;
+    over(iteratees: $ReadOnlyArray<Function>): Function;
+    juxt(iteratees: $ReadOnlyArray<Function>): Function;
+    overEvery(predicates: $ReadOnlyArray<Function>): Function;
+    allPass(predicates: $ReadOnlyArray<Function>): Function;
+    overSome(predicates: $ReadOnlyArray<Function>): Function;
+    anyPass(predicates: $ReadOnlyArray<Function>): Function;
     property(
       path: Path
-    ): (object: Object | Array<any>) => any;
-    property(path: Path, object: Object | Array<any>): any;
+    ): (object: Object | $ReadOnlyArray<any>) => any;
+    property(path: Path, object: Object | $ReadOnlyArray<any>): any;
     propertyOf(object: Object): (path: Path) => Function;
     propertyOf(object: Object, path: Path): Function;
     range(start: number): (end: number) => Array<number>;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -220,11 +220,11 @@ declare module "lodash" {
     compact<T, N: ?T>(array?: ?$ReadOnlyArray<N>): Array<T>;
     concat<T>(
       base?: ?$ReadOnlyArray<T>,
-      ...elements: Array<any>
+      ...elements: $ReadOnlyArray<any>
     ): Array<T | any>;
     difference<T>(
       array?: ?$ReadOnlyArray<T>,
-      ...values: Array<?$ReadOnlyArray<T>>
+      ...values: $ReadOnlyArray<?$ReadOnlyArray<T>>
     ): Array<T>;
     differenceBy<T, U>(
       array?: ?$ReadOnlyArray<T>,
@@ -349,9 +349,9 @@ declare module "lodash" {
       values?: ?$ReadOnlyArray<any>,
       comparator?: ?Function
     ): T;
-    pullAllWith<T>(array: Array<T>, values?: ?(Array<T>), comparator?: ?Function): Array<T>;
-    pullAt<T>(array?: ?Array<T>, ...indexed?: Array<?number>): Array<T>;
-    pullAt<T>(array?: ?Array<T>, indexed?: ?Array<number>): Array<T>;
+    pullAllWith<T>(array: Array<T>, values?: ?($ReadOnlyArray<T>), comparator?: ?Function): Array<T>;
+    pullAt<T>(array?: ?Array<T>, ...indexed?: $ReadOnlyArray<?number>): Array<T>;
+    pullAt<T>(array?: ?Array<T>, indexed?: ?$ReadOnlyArray<number>): Array<T>;
     remove<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
     reverse<T>(array: Array<T>): Array<T>;
     reverse<T: void | null>(array: T): T;
@@ -639,12 +639,12 @@ declare module "lodash" {
     invokeMap<T>(
       array?: ?$ReadOnlyArray<T>,
       path?: ?((value: T) => Path) | Path,
-      ...args?: Array<any>
+      ...args?: $ReadOnlyArray<any>
     ): Array<any>;
     invokeMap<T: Object>(
       object: T,
       path: ((value: any) => Path) | Path,
-      ...args?: Array<any>
+      ...args?: $ReadOnlyArray<any>
     ): Array<any>;
     keyBy<T, V>(
       array: $ReadOnlyArray<T>,
@@ -765,7 +765,7 @@ declare module "lodash" {
     ): Array<T>;
     sortBy<V, T: Object>(
       object: T,
-      ...iteratees?: Array<OIteratee<T>>
+      ...iteratees?: $ReadOnlyArray<OIteratee<T>>
     ): Array<V>;
     sortBy<V, T: Object>(
       object: T,
@@ -779,37 +779,37 @@ declare module "lodash" {
     after(n: number, fn: Function): Function;
     ary(func: Function, n?: number): Function;
     before(n: number, fn: Function): Function;
-    bind<F:(...Array<any>) => any>(func: F, thisArg: any, ...partials: Array<any>): F;
-    bindKey(obj?: ?Object, key?: ?string, ...partials?: Array<?any>): Function;
+    bind<F:(...$ReadOnlyArray<any>) => any>(func: F, thisArg: any, ...partials: $ReadOnlyArray<any>): F;
+    bindKey(obj?: ?Object, key?: ?string, ...partials?: $ReadOnlyArray<?any>): Function;
     curry: Curry;
     curry(func: Function, arity?: number): Function;
     curryRight(func: Function, arity?: number): Function;
-    debounce<F: (...Array<any>) => any>(
+    debounce<F: (...$ReadOnlyArray<any>) => any>(
       func: F,
       wait?: number,
       options?: DebounceOptions
     ): F & Cancelable;
-    defer(func: (...Array<any>) => any, ...args?: Array<any>): TimeoutID;
-    delay(func: Function, wait: number, ...args?: Array<any>): TimeoutID;
-    flip<R>(func: (...Array<any>) => R): (...Array<any>) => R;
+    defer(func: (...$ReadOnlyArray<any>) => any, ...args?: $ReadOnlyArray<any>): TimeoutID;
+    delay(func: Function, wait: number, ...args?: $ReadOnlyArray<any>): TimeoutID;
+    flip<R>(func: (...$ReadOnlyArray<any>) => R): (...Array<any>) => R;
     memoize<A, R>(func: (...A) => R, resolver?: (...A) => any): (...A) => R;
     negate<A, R>(predicate: (...A) => R): (...A) => boolean;
-    once<F: (...Array<any>) => any>(func: F): F;
-    overArgs(func?: ?Function, ...transforms?: Array<Function>): Function;
+    once<F: (...$ReadOnlyArray<any>) => any>(func: F): F;
+    overArgs(func?: ?Function, ...transforms?: $ReadOnlyArray<Function>): Function;
     overArgs(func?: ?Function, transforms?: ?$ReadOnlyArray<Function>): Function;
-    partial<R>(func: (...Array<any>) => R, ...partials: Array<any>): (...Array<any>) => R;
-    partialRight<R>(func: (...Array<any>) => R, ...partials: Array<any>): (...Array<any>) => R;
-    partialRight<R>(func: (...Array<any>) => R, partials: $ReadOnlyArray<any>): (...Array<any>) => R;
-    rearg(func: Function, ...indexes: Array<number>): Function;
+    partial<R>(func: (...$ReadOnlyArray<any>) => R, ...partials: $ReadOnlyArray<any>): (...Array<any>) => R;
+    partialRight<R>(func: (...$ReadOnlyArray<any>) => R, ...partials: $ReadOnlyArray<any>): (...Array<any>) => R;
+    partialRight<R>(func: (...$ReadOnlyArray<any>) => R, partials: $ReadOnlyArray<any>): (...Array<any>) => R;
+    rearg(func: Function, ...indexes: $ReadOnlyArray<number>): Function;
     rearg(func: Function, indexes: $ReadOnlyArray<number>): Function;
     rest(func: Function, start?: number): Function;
     spread(func: Function): Function;
-    throttle<F: (...Array<any>) => any>(
+    throttle<F: (...$ReadOnlyArray<any>) => any>(
       func: F,
       wait?: number,
       options?: ThrottleOptions
     ): F & Cancelable;
-    unary<F: (...Array<any>) => any>(func: F): F;
+    unary<F: (...$ReadOnlyArray<any>) => any>(func: F): F;
     wrap(value?: any, wrapper?: ?Function): Function;
 
     // Lang
@@ -961,7 +961,7 @@ declare module "lodash" {
     random(lower?: number, upper?: number, floating?: boolean): number;
 
     // Object
-    assign(object?: ?Object, ...sources?: Array<?Object>): Object;
+    assign(object?: ?Object, ...sources?: $ReadOnlyArray<?Object>): Object;
     assignIn(): {...};
     assignIn<A, B>(a: A, b: B): A & B;
     assignIn<A, B, C>(a: A, b: B, c: C): A & B & C;
@@ -1069,13 +1069,13 @@ declare module "lodash" {
         source: A | B | C | D
       ) => any | void
     ): Object;
-    at(object?: ?Object, ...paths: Array<string>): Array<any>;
+    at(object?: ?Object, ...paths: $ReadOnlyArray<string>): Array<any>;
     at(object?: ?Object, paths: $ReadOnlyArray<string>): Array<any>;
     create(prototype: void | null, properties: void | null): {...};
     create<T>(prototype: T, properties: Object): T;
     create(prototype: any, properties: void | null): {...};
-    defaults(object?: ?Object, ...sources?: Array<?Object>): Object;
-    defaultsDeep(object?: ?Object, ...sources?: Array<?Object>): Object;
+    defaults(object?: ?Object, ...sources?: $ReadOnlyArray<?Object>): Object;
+    defaultsDeep(object?: ?Object, ...sources?: $ReadOnlyArray<?Object>): Object;
     // alias for _.toPairs
     entries(object?: ?Object): Array<[string, any]>;
     // alias for _.toPairsIn
@@ -1180,7 +1180,7 @@ declare module "lodash" {
     invoke(
       object?: ?Object,
       path?: ?Path,
-      ...args?: Array<any>
+      ...args?: $ReadOnlyArray<any>
     ): any;
     keys<K>(object?: ?{ [key: K]: any, ... }): Array<K>;
     keys(object?: ?Object): Array<string>;
@@ -1189,7 +1189,7 @@ declare module "lodash" {
     mapKeys(object: void | null, iteratee?: ?OIteratee<*>): {...};
     mapValues(object: Object, iteratee?: ?OIteratee<*>): Object;
     mapValues(object: void | null, iteratee?: ?OIteratee<*>): {...};
-    merge(object?: ?Object, ...sources?: Array<?Object>): Object;
+    merge(object?: ?Object, ...sources?: $ReadOnlyArray<?Object>): Object;
     mergeWith(): {...};
     mergeWith<T: Object, A: Object>(
       object: T,
@@ -1392,10 +1392,10 @@ declare module "lodash" {
     words(string?: ?string, pattern?: ?RegExp | ?string): Array<string>;
 
     // Util
-    attempt(func: Function, ...args: Array<any>): any;
+    attempt(func: Function, ...args: $ReadOnlyArray<any>): any;
     bindAll(object: Object, methodNames?: ?$ReadOnlyArray<string>): Object;
     bindAll<T: void | null>(object: T, methodNames?: ?$ReadOnlyArray<string>): T;
-    bindAll(object: Object, ...methodNames: Array<string>): Object;
+    bindAll(object: Object, ...methodNames: $ReadOnlyArray<string>): Object;
     cond(pairs?: ?NestedArray<Function>): Function;
     conforms(source?: ?Object): Function;
     constant<T>(value: T): () => T;
@@ -1412,21 +1412,21 @@ declare module "lodash" {
     iteratee(func?: any): Function;
     matches(source?: ?Object): Function;
     matchesProperty(path?: ?Path, srcValue: any): Function;
-    method(path?: ?Path, ...args?: Array<any>): Function;
-    methodOf(object?: ?Object, ...args?: Array<any>): Function;
+    method(path?: ?Path, ...args?: $ReadOnlyArray<any>): Function;
+    methodOf(object?: ?Object, ...args?: $ReadOnlyArray<any>): Function;
     mixin<T: Function | Object>(
       object?: T,
       source: Object,
       options?: { chain: boolean, ... }
     ): T;
     noConflict(): Lodash;
-    noop(...args: Array<mixed>): void;
+    noop(...args: $ReadOnlyArray<mixed>): void;
     nthArg(n?: ?number): Function;
-    over(...iteratees: Array<Function>): Function;
+    over(...iteratees: $ReadOnlyArray<Function>): Function;
     over(iteratees: $ReadOnlyArray<Function>): Function;
-    overEvery(...predicates: Array<Function>): Function;
+    overEvery(...predicates: $ReadOnlyArray<Function>): Function;
     overEvery(predicates: $ReadOnlyArray<Function>): Function;
-    overSome(...predicates: Array<Function>): Function;
+    overSome(...predicates: $ReadOnlyArray<Function>): Function;
     overSome(predicates: $ReadOnlyArray<Function>): Function;
     property(path?: ?Path): Function;
     propertyOf(object?: ?Object): Function;
@@ -1441,7 +1441,7 @@ declare module "lodash" {
     stubObject(): {...};
     stubString(): "";
     stubTrue(): true;
-    times(n?: ?number, ...rest?: Array<void | null>): Array<number>;
+    times(n?: ?number, ...rest?: $ReadOnlyArray<void | null>): Array<number>;
     times<T>(n: number, iteratee: (i: number) => T): Array<T>;
     toPath(value: any): Array<string>;
     uniqueId(prefix?: ?string): string;
@@ -2364,7 +2364,7 @@ declare module "lodash/fp" {
     curryRightN(arity: number, func: Function): Function;
     debounce(wait: number): <A, R>(func: (...A) => R) => (...A) => R;
     debounce<A, R>(wait: number, func: (...A) => R): (...A) => R;
-    defer(func: (...Array<any>) => any): TimeoutID;
+    defer(func: (...$ReadOnlyArray<any>) => any): TimeoutID;
     delay(wait: number): (func: Function) => TimeoutID;
     delay(wait: number, func: Function): TimeoutID;
     flip(func: Function): Function;
@@ -2392,7 +2392,7 @@ declare module "lodash/fp" {
     spreadFrom(start: number, func: Function): Function;
     throttle<A, R>(wait: number): (func: (...A) => R) => (...A) => R;
     throttle<A, R>(wait: number, func: (...A) => R): (...A) => R;
-    unary<T, R>(func: (T, ...Array<any>) => R): (T) => R;
+    unary<T, R>(func: (T, ...$ReadOnlyArray<any>) => R): (T) => R;
     wrap(wrapper: Function): (value: any) => Function;
     wrap(wrapper: Function, value: any): Function;
 
@@ -2953,9 +2953,9 @@ declare module "lodash/fp" {
       predicate: OPredicate<A>
     ): (object: T) => Object;
     omitBy<A, T: $ReadOnly<{ [id: any]: A, ... }>>(predicate: OPredicate<A>, object: T): Object;
-    pick(...props: Array<string | {...}>): Object;
+    pick(...props: $ReadOnlyArray<string | {...}>): Object;
     pick(props: $ReadOnlyArray<string>, object: Object): Object;
-    pick(...props: Array<string>): (object: Object) => Object;
+    pick(...props: $ReadOnlyArray<string>): (object: Object) => Object;
     pick(props: $ReadOnlyArray<string>): (object: Object) => Object;
     pickAll(props: $ReadOnlyArray<string>): (object: Object) => Object;
     pickAll(props: $ReadOnlyArray<string>, object: Object): Object;
@@ -3209,7 +3209,7 @@ declare module "lodash/fp" {
       options: { chain: boolean, ... }
     ): T;
     noConflict(): Lodash;
-    noop(...args: Array<mixed>): void;
+    noop(...args: $ReadOnlyArray<mixed>): void;
     nthArg(n: number): Function;
     over(iteratees: $ReadOnlyArray<Function>): Function;
     juxt(iteratees: $ReadOnlyArray<Function>): Function;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -542,9 +542,9 @@ declare module "lodash" {
     ): Array<T>;
 
     // Collection
-    countBy<T>(array: Array<T>, iteratee?: ?ValueOnlyIteratee<T>): Object;
+    countBy<T>(array: Array<T>, iteratee?: ?ValueOnlyIteratee<T>): { [string]: number, ... };
     countBy<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>): {...};
-    countBy<T: Object>(object: T, iteratee?: ?ValueOnlyIteratee<T>): Object;
+    countBy<T: Object>(object: T, iteratee?: ?ValueOnlyIteratee<T>): { [string]: number, ... };
     // alias of _.forEach
     each<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
     each<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -234,12 +234,12 @@ declare module "lodash" {
       array?: ?$ReadOnlyArray<T>,
       values?: ?$ReadOnlyArray<U>,
       iteratee?: ?ValueOnlyIteratee<T | U>
-    ): T[];
+    ): Array<T>;
     differenceWith<T, U>(
       array?: ?$ReadOnlyArray<T>,
       values?: ?$ReadOnlyArray<U>,
       comparator?: ?(item: T, item2: U) => boolean
-    ): T[];
+    ): Array<T>;
     drop<T>(array?: ?Array<T>, n?: ?number): Array<T>;
     dropRight<T>(array?: ?Array<T>, n?: ?number): Array<T>;
     dropRightWhile<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
@@ -273,8 +273,8 @@ declare module "lodash" {
     // alias of _.head
     first<T>(array: ?$ReadOnlyArray<T>): T;
     flatten<T, X>(array?: ?$ReadOnlyArray<$ReadOnlyArray<T> | X>): Array<T | X>;
-    flattenDeep<T>(array?: ?(any[])): Array<T>;
-    flattenDepth(array?: ?(any[]), depth?: ?number): any[];
+    flattenDeep<T>(array?: ?(Array<any>)): Array<T>;
+    flattenDepth(array?: ?(Array<any>), depth?: ?number): Array<any>;
     fromPairs<A, B>(pairs?: ?$ReadOnlyArray<[A, B]>): {| [key: A]: B |};
     head<T>(array: ?$ReadOnlyArray<T>): T;
     indexOf<T>(array: Array<T>, value: T, fromIndex?: number): number;
@@ -332,7 +332,7 @@ declare module "lodash" {
     last<T>(array: ?$ReadOnlyArray<T>): T;
     lastIndexOf<T>(array: Array<T>, value?: ?T, fromIndex?: ?number): number;
     lastIndexOf<T>(array: void | null, value?: ?T, fromIndex?: ?number): -1;
-    nth<T>(array: T[], n?: ?number): T;
+    nth<T>(array: Array<T>, n?: ?number): T;
     nth(array: void | null, n?: ?number): void;
     pull<T>(array: Array<T>, ...values?: $ReadOnlyArray<?T>): Array<T>;
     pull<T: void | null>(array: T, ...values?: $ReadOnlyArray<?any>): T;
@@ -353,7 +353,7 @@ declare module "lodash" {
       values?: ?$ReadOnlyArray<any>,
       comparator?: ?Function
     ): T;
-    pullAllWith<T>(array: T[], values?: ?(T[]), comparator?: ?Function): T[];
+    pullAllWith<T>(array: Array<T>, values?: ?(Array<T>), comparator?: ?Function): Array<T>;
     pullAt<T>(array?: ?Array<T>, ...indexed?: Array<?number>): Array<T>;
     pullAt<T>(array?: ?Array<T>, indexed?: ?Array<number>): Array<T>;
     remove<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;
@@ -506,7 +506,7 @@ declare module "lodash" {
 
     zipObject<K, V>(props: Array<K>, values?: ?Array<V>): { [key: K]: V, ... };
     zipObject<K, V>(props: void | null, values?: ?Array<V>): {...};
-    zipObjectDeep(props: any[], values?: ?any): Object;
+    zipObjectDeep(props: Array<any>, values?: ?any): Object;
     zipObjectDeep(props: void | null, values?: ?any): {...};
 
     zipWith<A>(a1?: ?Array<A>): Array<[A]>;
@@ -787,41 +787,41 @@ declare module "lodash" {
     after(n: number, fn: Function): Function;
     ary(func: Function, n?: number): Function;
     before(n: number, fn: Function): Function;
-    bind<F:(...any[]) => any>(func: F, thisArg: any, ...partials: Array<any>): F;
+    bind<F:(...Array<any>) => any>(func: F, thisArg: any, ...partials: Array<any>): F;
     bindKey(obj?: ?Object, key?: ?string, ...partials?: Array<?any>): Function;
     curry: Curry;
     curry(func: Function, arity?: number): Function;
     curryRight(func: Function, arity?: number): Function;
-    debounce<F: (...any[]) => any>(
+    debounce<F: (...Array<any>) => any>(
       func: F,
       wait?: number,
       options?: DebounceOptions
     ): F & Cancelable;
-    defer(func: (...any[]) => any, ...args?: Array<any>): TimeoutID;
+    defer(func: (...Array<any>) => any, ...args?: Array<any>): TimeoutID;
     delay(func: Function, wait: number, ...args?: Array<any>): TimeoutID;
-    flip<R>(func: (...any[]) => R): (...any[]) => R;
+    flip<R>(func: (...Array<any>) => R): (...Array<any>) => R;
     memoize<A, R>(func: (...A) => R, resolver?: (...A) => any): (...A) => R;
     negate<A, R>(predicate: (...A) => R): (...A) => boolean;
-    once<F: (...any[]) => any>(func: F): F;
+    once<F: (...Array<any>) => any>(func: F): F;
     overArgs(func?: ?Function, ...transforms?: Array<Function>): Function;
     overArgs(func?: ?Function, transforms?: ?Array<Function>): Function;
-    partial<R>(func: (...any[]) => R, ...partials: any[]): (...any[]) => R;
-    partialRight<R>(func: (...any[]) => R, ...partials: Array<any>): (...any[]) => R;
-    partialRight<R>(func: (...any[]) => R, partials: Array<any>): (...any[]) => R;
+    partial<R>(func: (...Array<any>) => R, ...partials: Array<any>): (...Array<any>) => R;
+    partialRight<R>(func: (...Array<any>) => R, ...partials: Array<any>): (...Array<any>) => R;
+    partialRight<R>(func: (...Array<any>) => R, partials: Array<any>): (...Array<any>) => R;
     rearg(func: Function, ...indexes: Array<number>): Function;
     rearg(func: Function, indexes: Array<number>): Function;
     rest(func: Function, start?: number): Function;
     spread(func: Function): Function;
-    throttle<F: (...any[]) => any>(
+    throttle<F: (...Array<any>) => any>(
       func: F,
       wait?: number,
       options?: ThrottleOptions
     ): F & Cancelable;
-    unary<F: (...any[]) => any>(func: F): F;
+    unary<F: (...Array<any>) => any>(func: F): F;
     wrap(value?: any, wrapper?: ?Function): Function;
 
     // Lang
-    castArray(value: *): any[];
+    castArray(value: *): Array<any>;
     clone<T>(value: T): T;
     cloneDeep<T>(value: T): T;
     cloneDeepWith<T, U>(
@@ -1675,34 +1675,34 @@ declare module "lodash/fp" {
       base: A,
       elements: B
     ): Array<T | U>;
-    difference<T>(values: $ReadOnlyArray<T>): (array: $ReadOnlyArray<T>) => T[];
-    difference<T>(values: $ReadOnlyArray<T>, array: $ReadOnlyArray<T>): T[];
+    difference<T>(values: $ReadOnlyArray<T>): (array: $ReadOnlyArray<T>) => Array<T>;
+    difference<T>(values: $ReadOnlyArray<T>, array: $ReadOnlyArray<T>): Array<T>;
     differenceBy<T>(
       iteratee: ValueOnlyIteratee<T>
-    ): ((values: $ReadOnlyArray<T>) => (array: $ReadOnlyArray<T>) => T[]) &
-      ((values: $ReadOnlyArray<T>, array: $ReadOnlyArray<T>) => T[]);
+    ): ((values: $ReadOnlyArray<T>) => (array: $ReadOnlyArray<T>) => Array<T>) &
+      ((values: $ReadOnlyArray<T>, array: $ReadOnlyArray<T>) => Array<T>);
     differenceBy<T>(
       iteratee: ValueOnlyIteratee<T>,
       values: $ReadOnlyArray<T>
-    ): (array: $ReadOnlyArray<T>) => T[];
+    ): (array: $ReadOnlyArray<T>) => Array<T>;
     differenceBy<T>(
       iteratee: ValueOnlyIteratee<T>,
       values: $ReadOnlyArray<T>,
       array: $ReadOnlyArray<T>
-    ): T[];
+    ): Array<T>;
     differenceWith<T>(
       comparator: Comparator<T>
-    ): ((first: $ReadOnly<T>) => (second: $ReadOnly<T>) => T[]) &
-      ((first: $ReadOnly<T>, second: $ReadOnly<T>) => T[]);
+    ): ((first: $ReadOnly<T>) => (second: $ReadOnly<T>) => Array<T>) &
+      ((first: $ReadOnly<T>, second: $ReadOnly<T>) => Array<T>);
     differenceWith<T>(
       comparator: Comparator<T>,
       first: $ReadOnly<T>
-    ): (second: $ReadOnly<T>) => T[];
+    ): (second: $ReadOnly<T>) => Array<T>;
     differenceWith<T>(
       comparator: Comparator<T>,
       first: $ReadOnly<T>,
       second: $ReadOnly<T>
-    ): T[];
+    ): Array<T>;
     drop<T>(n: number): (array: Array<T>) => Array<T>;
     drop<T>(n: number, array: Array<T>): Array<T>;
     dropLast<T>(n: number): (array: Array<T>) => Array<T>;
@@ -1775,9 +1775,9 @@ declare module "lodash/fp" {
     first<T>(array: $ReadOnlyArray<T>): T;
     flatten<T, X>(array: Array<Array<T> | X>): Array<T | X>;
     unnest<T, X>(array: Array<Array<T> | X>): Array<T | X>;
-    flattenDeep<T>(array: any[]): Array<T>;
-    flattenDepth(depth: number): (array: any[]) => any[];
-    flattenDepth(depth: number, array: any[]): any[];
+    flattenDeep<T>(array: Array<any>): Array<T>;
+    flattenDepth(depth: number): (array: Array<any>) => Array<any>;
+    flattenDepth(depth: number, array: Array<any>): Array<any>;
     fromPairs<A, B>(pairs: $ReadOnlyArray<[A, B]>): {| [key: A]: B |};
     head<T>(array: $ReadOnlyArray<T>): T;
     indexOf<T>(value: T): (array: Array<T>) => number;
@@ -1832,8 +1832,8 @@ declare module "lodash/fp" {
       fromIndex: number
     ): (array: Array<T>) => number;
     lastIndexOfFrom<T>(value: T, fromIndex: number, array: Array<T>): number;
-    nth<T>(n: number): (array: T[]) => T;
-    nth<T>(n: number, array: T[]): T;
+    nth<T>(n: number): (array: Array<T>) => T;
+    nth<T>(n: number, array: Array<T>): T;
     pull<T>(value: T): (array: Array<T>) => Array<T>;
     pull<T>(value: T, array: Array<T>): Array<T>;
     pullAll<T>(values: $ReadOnlyArray<T>): (array: Array<T>) => Array<T>;
@@ -1853,10 +1853,10 @@ declare module "lodash/fp" {
     ): Array<T>;
     pullAllWith<T>(
       comparator: Function
-    ): ((values: T[]) => (array: T[]) => T[]) &
-      ((values: T[], array: T[]) => T[]);
-    pullAllWith<T>(comparator: Function, values: T[]): (array: T[]) => T[];
-    pullAllWith<T>(comparator: Function, values: T[], array: T[]): T[];
+    ): ((values: Array<T>) => (array: Array<T>) => Array<T>) &
+      ((values: Array<T>, array: Array<T>) => Array<T>);
+    pullAllWith<T>(comparator: Function, values: Array<T>): (array: Array<T>) => Array<T>;
+    pullAllWith<T>(comparator: Function, values: Array<T>, array: Array<T>): Array<T>;
     pullAt<T>(indexed: Array<number>): (array: Array<T>) => Array<T>;
     pullAt<T>(indexed: Array<number>, array: Array<T>): Array<T>;
     remove<T>(predicate: Predicate<T>): (array: Array<T>) => Array<T>;
@@ -2007,15 +2007,15 @@ declare module "lodash/fp" {
       a1: Array<T>,
       a2: Array<T>
     ): Array<T>;
-    zip<A, B>(a1: A[]): (a2: B[]) => Array<[A, B]>;
-    zip<A, B>(a1: A[], a2: B[]): Array<[A, B]>;
+    zip<A, B>(a1: Array<A>): (a2: Array<B>) => Array<[A, B]>;
+    zip<A, B>(a1: Array<A>, a2: Array<B>): Array<[A, B]>;
     zipAll(arrays: Array<Array<any>>): Array<any>;
     zipObject<K, V>(props?: Array<K>): (values?: Array<V>) => { [key: K]: V, ... };
     zipObject<K, V>(props?: Array<K>, values?: Array<V>): { [key: K]: V, ... };
     zipObj(props: Array<any>): (values: Array<any>) => Object;
     zipObj(props: Array<any>, values: Array<any>): Object;
-    zipObjectDeep(props: any[]): (values: any) => Object;
-    zipObjectDeep(props: any[], values: any): Object;
+    zipObjectDeep(props: Array<any>): (values: any) => Object;
+    zipObjectDeep(props: Array<any>, values: any): Object;
     zipWith<T>(
       iteratee: Iteratee<T>
     ): ((a1: NestedArray<T>) => (a2: NestedArray<T>) => Array<T>) &
@@ -2372,7 +2372,7 @@ declare module "lodash/fp" {
     curryRightN(arity: number, func: Function): Function;
     debounce(wait: number): <A, R>(func: (...A) => R) => (...A) => R;
     debounce<A, R>(wait: number, func: (...A) => R): (...A) => R;
-    defer(func: (...any[]) => any): TimeoutID;
+    defer(func: (...Array<any>) => any): TimeoutID;
     delay(wait: number): (func: Function) => TimeoutID;
     delay(wait: number, func: Function): TimeoutID;
     flip(func: Function): Function;
@@ -2384,8 +2384,8 @@ declare module "lodash/fp" {
     overArgs(func: Function, transforms: Array<Function>): Function;
     useWith(func: Function): (transforms: Array<Function>) => Function;
     useWith(func: Function, transforms: Array<Function>): Function;
-    partial(func: Function): (partials: any[]) => Function;
-    partial(func: Function, partials: any[]): Function;
+    partial(func: Function): (partials: Array<any>) => Function;
+    partial(func: Function, partials: Array<any>): Function;
     partialRight(func: Function): (partials: Array<any>) => Function;
     partialRight(func: Function, partials: Array<any>): Function;
     rearg(indexes: Array<number>): (func: Function) => Function;
@@ -2400,12 +2400,12 @@ declare module "lodash/fp" {
     spreadFrom(start: number, func: Function): Function;
     throttle<A, R>(wait: number): (func: (...A) => R) => (...A) => R;
     throttle<A, R>(wait: number, func: (...A) => R): (...A) => R;
-    unary<T, R>(func: (T, ...any[]) => R): (T) => R;
+    unary<T, R>(func: (T, ...Array<any>) => R): (T) => R;
     wrap(wrapper: Function): (value: any) => Function;
     wrap(wrapper: Function, value: any): Function;
 
     // Lang
-    castArray(value: *): any[];
+    castArray(value: *): Array<any>;
     clone<T>(value: T): T;
     cloneDeep<T>(value: T): T;
     cloneDeepWith<T, U>(

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-fp-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-fp-v4.x.x.js
@@ -41,6 +41,9 @@ import compose from "lodash/fp/compose";
 import includes from "lodash/fp/includes";
 import pick from "lodash/fp/pick";
 
+/**
+ * filter
+ */
 filter("x", [{ x: 1 }, { x: 2 }]);
 filter("x")([{ x: 1 }, { x: 2 }]);
 filter("x", { a: { x: 1 }, b: { x: 2 } });

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -39,6 +39,9 @@ import pick from 'lodash/pick';
 import pickBy from "lodash/pickBy";
 import pullAllBy from "lodash/pullAllBy";
 import range from "lodash/range";
+import sample from "lodash/sample";
+import sampleSize from "lodash/sampleSize";
+import shuffle from "lodash/shuffle";
 import sortedIndexBy from "lodash/sortedIndexBy";
 import sortedLastIndexBy from "lodash/sortedLastIndexBy";
 import sortedUniq from "lodash/sortedUniq";
@@ -60,7 +63,7 @@ type ReadOnlyArray = $ReadOnlyArray<number>
 const readOnlyArray : ReadOnlyArray = [1, 2, 3, 4];
 
 type ReadOnlyObject = $ReadOnly<{ [string]: number, ... }>
-const readOnlyObject : ReadOnlyObject = { [1]: 1, [2]: 2 };
+const readOnlyObject : ReadOnlyObject = { a: 1, b: 2, c: 3 };
 
 describe('Array', () => {
   it('chunk', () => {
@@ -305,7 +308,8 @@ describe('Collection', () => {
     (keyBy(keyByTest_map, "id"): KeyByTest$ByNumberMaybe<KeyByTest$Record>);
   });
 
-  it('map examples from the official doc', () => {
+  it('map', () => {
+    // examples from the official doc
     function square(n) {
       return n * n;
     }
@@ -331,6 +335,30 @@ describe('Collection', () => {
     // return type of iterator is reflected in result and chain
     (nums.map(num => JSON.stringify(num)): string[]);
     (map(nums, num => JSON.stringify(num)): string[]);
+  });
+
+  it('sample', () => {
+    (sample(readOnlyArray): number);
+    (sample(readOnlyObject): number);
+    (sample({ a: 1, b: 'abc' }): number| string);
+    // $ExpectError
+    (sample({ a: 1, b: 'abc' }): number);
+  });
+
+  it('sampleSize', () => {
+    (sampleSize(readOnlyArray, 2): number[]);
+    (sampleSize(readOnlyObject, 2): number[]);
+    (sampleSize({ a: 1, b: 'abc' }, 2): (number| string)[]);
+    // $ExpectError
+    (shuffle({ a: 1, b: 'abc' }, 2): number[]);
+  });
+
+  it('shuffle', () => {
+    (shuffle(readOnlyArray): number[]);
+    (shuffle(readOnlyObject): number[]);
+    (shuffle(readOnlyObject): (number | string)[]);
+    // $ExpectError
+    (shuffle({ a: 1, b: 'abc' }): number[]);
   });
 
   it('orderBy', () => {

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -1,4 +1,9 @@
 // @flow
+
+/**
+ * Please add tests for new functions in the same order as they are in the main file and lodash documentation.
+ */
+
 import assignIn from "lodash/assignIn";
 import attempt from "lodash/attempt";
 import chunk from "lodash/chunk";
@@ -49,24 +54,29 @@ import xorBy from "lodash/xorBy";
 import zip from "lodash/zip";
 import zipWith from "lodash/zipWith";
 
-/**
- * _.attempt
- */
-attempt(() => void 0);
-attempt(x => x);
-attempt(x => x, "first arg");
-attempt((x, y, z) => {}, null, {}, []);
+type ReadOnlyArray = $ReadOnlyArray<number>
+const readOnlyArray : ReadOnlyArray = [1, 2, 3, 4];
+
+type ReadOnlyObject = $ReadOnly<{ [string]: number, ... }>
+const readOnlyObject : ReadOnlyObject = { [1]: 1, [2]: 2 };
+
+// =====   Array   =====
 
 /**
  * _.chunk
  */
-chunk(([1, 2, 3, 4]: $ReadOnlyArray<number>), 2);
+chunk(readOnlyArray, 2);
 
 /**
- * _.countBy
+ * _.concat
  */
-countBy([6.1, 4.2, 6.3], Math.floor);
-countBy(["one", "two", "three"], "length");
+concat(readOnlyArray, readOnlyArray, readOnlyArray);
+// Copy pasted tests from iflow-lodash
+const nums: number[] = [1, 2, 3, 4, 5, 6];
+(concat(nums, "123", "456"): Array<number | string>);
+(concat(nums, ["123", "456"]): Array<number | string>);
+(concat(nums, [[1, 2, 3], "456"]): Array<number | string>);
+(concat(nums, [[1, 2, 3], "456"]): Array<mixed>);
 
 /**
  * _.difference
@@ -84,98 +94,21 @@ difference(
 /**
  * _.differenceBy
  */
-differenceBy(([2.1, 1.2]: $ReadOnlyArray<*>), [2.3, 3.4], Math.floor);
+differenceBy(([2.1, 1.2]: $ReadOnlyArray<number>), [2.3, 3.4], Math.floor);
 differenceBy([{ x: 2 }, { x: 1 }], [{ x: 1 }], "x");
-
+differenceBy(([2.1, 1.2]: $ReadOnlyArray<number>), [2.3, 3.4], Math.floor);
 type A = {| a: 1 |};
 type B = {| b: 1 |};
-function diffTest(a: $ReadOnlyArray<A>, b: $ReadOnlyArray<B>) {
-  differenceBy(a, b, (x: A | B) => {
-    return x.a || x.b;
-  });
-  differenceWith(a, b, (x: A, y: B) => {
-    return x.a === y.b;
-  });
-}
-
-/**
- * _.differenceBy
- */
-differenceBy(([2.1, 1.2]: $ReadOnlyArray<*>), [2.3, 3.4], Math.floor);
-
-/**
- * _.each
- */
-each(([1, 2]: $ReadOnlyArray<number>), (item: number) => false);
-
-/**
- * _.find
- */
-find([1, 2, 3], x => x * 1 == 3);
-find([1, 2, 3], x => x == 2, 1);
-// $ExpectError number cannot be compared to string
-find([1, 2, 3], x => x == "a");
-// $ExpectError number. This type is incompatible with function type.
-find([1, 2, 3], 1);
-// $ExpectError property `y`. Property not found in object literal
-find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.y == 3);
-find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.x == 3);
-find({ x: 1, y: 2 }, (a: number, b: string) => a);
-find({ x: 1, y: 2 }, { x: 3 });
-find((["a", "b"]: $ReadOnlyArray<string>), "c");
-// opaque types are allowed as keys of objects
-opaque type O = string;
-const v: { [O]: number, ... } = { x: 1, y: 2 };
-find(v, { x: 3 });
-
-/**
- * _.find examples from the official doc
- */
-var users = [
-  { user: "barney", age: 36, active: true },
-  { user: "fred", age: 40, active: false },
-  { user: "pebbles", age: 1, active: true }
-];
-
-find(users, function(o) {
-  return o.age < 40;
+differenceBy(([{ a: 1 }, { a: 1 }]: $ReadOnlyArray<A>), ([{ b: 1 }, { b: 1 }]: $ReadOnlyArray<B>), (x: A | B) => {
+  return x.a || x.b;
 });
 
-// The `_.matches` iteratee shorthand.
-find(users, { age: 1, active: true });
-
-// The `_.matchesProperty` iteratee shorthand.
-find(users, ["active", false]);
-
-// The `_.property` iteratee shorthand.
-find(users, "active");
-
 /**
- * _.forEach
+ * _.differenceWith
  */
-forEach(([1, 2]: $ReadOnlyArray<number>), (item: number) => false);
-
-/**
- * _.groupBy
- */
-var numbersGroupedByMathFloor = groupBy([6.1, 4.2, 6.3], Math.floor);
-if (numbersGroupedByMathFloor[6]) {
-  numbersGroupedByMathFloor[6][0] / numbersGroupedByMathFloor[6][1];
-}
-var stringsGroupedByLength = groupBy(["one", "two", "three"], "length");
-if (stringsGroupedByLength[3]) {
-  stringsGroupedByLength[3][0].toLowerCase();
-}
-var numbersObj: { [key: string]: number, ... } = { a: 6.1, b: 4.2, c: 6.3 };
-var numbersGroupedByMathFloor2 = groupBy(numbersObj, Math.floor);
-if (numbersGroupedByMathFloor2[6]) {
-  numbersGroupedByMathFloor2[6][0] / numbersGroupedByMathFloor2[6][1];
-}
-var stringObj: { [key: string]: string, ... } = { a: "one", b: "two", c: "three" };
-var stringsGroupedByLength2 = groupBy(stringObj, "length");
-if (stringsGroupedByLength2[3]) {
-  stringsGroupedByLength2[3][0].toLowerCase();
-}
+differenceWith(([{ a: 1 }, { a: 1 }]: $ReadOnlyArray<A>), ([{ b: 1 }, { b: 1 }]: $ReadOnlyArray<B>), (x: A, y: B) => {
+  return x.a === y.b;
+});
 
 /**
  * _.intersectionBy
@@ -184,126 +117,9 @@ intersectionBy([2.1, 1.2], [2.3, 3.4], Math.floor);
 intersectionBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], "x");
 
 /**
- * _.get
- */
-
-// Object — examples from lodash docs
-var exampleObjectForGetTest = { a: [{ b: { c: 3 } }] };
-get(exampleObjectForGetTest, "a[0].b.c");
-get(exampleObjectForGetTest, ["a", "0", "b", "c"]);
-get(exampleObjectForGetTest, "a.b.c", "default");
-
-// Array — not documented, but _.get does support arrays
-get([1, 2, 3], "0");
-get([1, 2, 3], 0);
-get([1, 2, 3], [0]);
-get(["foo", "bar", "baz"], "[1]");
-get([{ a: "foo" }, { b: "bar" }, { c: "baz" }], "2");
-get([[1, 2], [3, 4], [5, 6], [7, 8]], "3");
-
-// Nil - it is safe to perform on nil root values, just like nil values along the "get" path
-get(null, "thing");
-get(undefined, "data");
-
-/**
- * _.keyBy
- */
-keyBy([{ dir: "left", code: 97 }, { dir: "right", code: 100 }], function(o) {
-  return String.fromCharCode(o.code);
-});
-keyBy([{ dir: "left", code: 97 }, { dir: "right", code: 100 }], "dir");
-
-// Example of keying a map of objects by a number type
-type KeyByTest$ByNumber<T: Object> = { [number]: T, ... };
-type KeyByTest$ByNumberMaybe<T: ?Object> = { [number]: T, ... };
-type KeyByTest$Record = { id: number, ... };
-var keyByTest_array: Array<KeyByTest$Record> = [
-  { id: 4 },
-  { id: 4 },
-  { id: 7 }
-];
-var keyByTest_map: KeyByTest$ByNumber<KeyByTest$Record> = {
-  [keyByTest_array[0].id]: keyByTest_array[0],
-  [keyByTest_array[1].id]: keyByTest_array[1],
-  [keyByTest_array[2].id]: keyByTest_array[2]
-};
-
-var keyByTest_map2: KeyByTest$ByNumberMaybe<KeyByTest$Record> = keyBy(
-  keyByTest_map,
-  "id"
-);
-
-/**
- * _.map examples from the official doc
- */
-function square(n) {
-  return n * n;
-}
-
-map([4, 8], square);
-map({ a: 4, b: 8 }, square);
-
-//accepts tuple types
-
-const tuple: [number, number] = [1, 2];
-map(tuple, val => val + 2);
-//$ExpectError cannot push to tuple
-map(tuple, (val, nothing, tupleArray) => tupleArray.push(123));
-
-var users = [{ user: "barney" }, { user: "fred" }];
-
-// The `_.property` iteratee shorthand.
-map(users, "user");
-
-/**
  * _.pullAllBy
  */
 pullAllBy([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 1 }], [{ x: 1 }, { x: 3 }], "x");
-
-/**
- * _.unionBy
- */
-unionBy([2.1], [1.2, 2.3], Math.floor);
-unionBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], "x");
-
-/**
- * _.uniqBy
- */
-uniqBy([2.1, 1.2, 2.3], Math.floor);
-uniqBy([{ x: 1 }, { x: 2 }, { x: 1 }], "x");
-
-/**
- * _.clone
- */
-clone({ a: 1 }).a == 1;
-// $ExpectError property `b`. Property not found in object literal
-clone({ a: 1 }).b == 1;
-// $ExpectError number. This type is incompatible with function type.
-clone({ a: 1 }).a == "c";
-
-/**
- * _.isEqual
- */
-isEqual("a", "b");
-isEqual({ x: 1 }, { y: 2 });
-
-// Flow considers this compatible with isEqual(a: any, b: any).
-// Reasonable people disagree about whether this should be considered a legal call.
-// See https://github.com/splodingsocks/FlowTyped/pull/1#issuecomment-149345275
-// and https://github.com/facebook/flow/issues/956
-isEqual(1);
-
-// $ExpectError function type expects no more than 2 arguments
-isEqual(1, 2, 3);
-
-/**
- * _.range
- */
-range(0, 10)[4] == 4;
-// $ExpectError string. This type is incompatible with number
-range(0, "a");
-// $ExpectError string cannot be compared to number
-range(0, 10)[4] == "a";
 
 /**
  * _.sortedIndexBy
@@ -334,14 +150,23 @@ sortedUniqBy([1.2, 2.1, 2.3], Math.floor);
 sortedUniqBy([{ x: 1 }, { x: 1 }, { x: 2 }], "x");
 
 /**
- * _.extend
+ * _.take / _.takeRight
  */
-extend({ a: 1 }, { b: 2 }).a;
-extend({ a: 1 }, { b: 2 }).b;
-// $ExpectError property `c`. Property not found in object literal
-extend({ a: 1 }, { b: 2 }).c;
-// $ExpectError property `c`. Poperty not found in object literal
-assignIn({ a: 1 }, { b: 2 }).c;
+var taken: string[];
+taken = take((["abc", "123"]: $ReadOnlyArray<string>), 3);
+taken = takeRight((["abc", "123"]: $ReadOnlyArray<string>));
+
+/**
+ * _.unionBy
+ */
+unionBy([2.1], [1.2, 2.3], Math.floor);
+unionBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], "x");
+
+/**
+ * _.uniqBy
+ */
+uniqBy([2.1, 1.2, 2.3], Math.floor);
+uniqBy([{ x: 1 }, { x: 2 }, { x: 1 }], "x");
 
 /**
  * _.xorBy
@@ -371,13 +196,230 @@ zipWith(["a", "b", "c"], [1, 2, 3], (str: string, num) => ({ [str]: num }));
 // $ExpectError `x` should be a `string`, `y` a `number`
 zipWith(["a", "b", "c"], [1, 2, 3]).map(([x, y]) => x * y);
 
+
+
+// =====   Collection   =====
+
+/**
+ * _.countBy
+ */
+countBy([6.1, 4.2, 6.3], Math.floor);
+countBy(["one", "two", "three"], "length");
+
+/**
+ * _.each
+ */
+each(([1, 2]: $ReadOnlyArray<number>), (item: number) => false);
+each(readOnlyObject, (item: number) => false);
+
+/**
+ * _.find
+ */
+find([1, 2, 3], x => x * 1 == 3);
+find([1, 2, 3], x => x == 2, 1);
+// $ExpectError number cannot be compared to string
+find([1, 2, 3], x => x == "a");
+// $ExpectError number. This type is incompatible with function type.
+find([1, 2, 3], 1);
+// $ExpectError property `y`. Property not found in object literal
+find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.y == 3);
+find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.x == 3);
+find({ x: 1, y: 2 }, (a: number, b: string) => a);
+find({ x: 1, y: 2 }, { x: 3 });
+find((["a", "b"]: $ReadOnlyArray<string>), "c");
+// opaque types are allowed as keys of objects
+opaque type O = string;
+const v: { [O]: number, ... } = { x: 1, y: 2 };
+find(v, { x: 3 });
+
+(find([1, 2, 3], x => x == 1): void | number);
+// $ExpectError number. This type is incompatible with function type.
+(find([1, 2, 3], 1): void | number);
+
+// _.find examples from the official doc
+const users = [
+  { user: "barney", age: 36, active: true },
+  { user: "fred", age: 40, active: false },
+  { user: "pebbles", age: 1, active: true }
+];
+
+find(users, function(o) {
+  return o.age < 40;
+});
+
+// The `_.matches` iteratee shorthand.
+find(users, { age: 1, active: true });
+
+// The `_.matchesProperty` iteratee shorthand.
+find(users, ["active", false]);
+
+// The `_.property` iteratee shorthand.
+find(users, "active");
+
+/**
+ * _.flatMap
+ */
+// this arrow function needs a type annotation due to a bug in flow: https://github.com/facebook/flow/issues/1948
+flatMap([1, 2, 3], (n): number[] => [n, n]);
+flatMap({ a: 1, b: 2 }, n => [n, n]);
+
+/**
+ * _.forEach
+ */
+forEach(([1, 2]: $ReadOnlyArray<number>), (item: number) => false);
+
+/**
+ * _.groupBy
+ */
+const numbersGroupedByMathFloor = groupBy([6.1, 4.2, 6.3], Math.floor);
+if (numbersGroupedByMathFloor[6]) {
+  numbersGroupedByMathFloor[6][0] / numbersGroupedByMathFloor[6][1];
+}
+const stringsGroupedByLength = groupBy(["one", "two", "three"], "length");
+if (stringsGroupedByLength[3]) {
+  stringsGroupedByLength[3][0].toLowerCase();
+}
+const numbersObj: { [key: string]: number, ... } = { a: 6.1, b: 4.2, c: 6.3 };
+const numbersGroupedByMathFloor2 = groupBy(numbersObj, Math.floor);
+if (numbersGroupedByMathFloor2[6]) {
+  numbersGroupedByMathFloor2[6][0] / numbersGroupedByMathFloor2[6][1];
+}
+const stringObj: { [key: string]: string, ... } = { a: "one", b: "two", c: "three" };
+const stringsGroupedByLength2 = groupBy(stringObj, "length");
+if (stringsGroupedByLength2[3]) {
+  stringsGroupedByLength2[3][0].toLowerCase();
+}
+
+/**
+ * _.keyBy
+ */
+keyBy([{ dir: "left", code: 97 }, { dir: "right", code: 100 }], function(o) {
+  return String.fromCharCode(o.code);
+});
+keyBy([{ dir: "left", code: 97 }, { dir: "right", code: 100 }], "dir");
+
+// Example of keying a map of objects by a number type
+type KeyByTest$ByNumber<T: Object> = { [number]: T, ... };
+type KeyByTest$ByNumberMaybe<T: ?Object> = { [number]: T, ... };
+type KeyByTest$Record = { id: number, ... };
+const keyByTest_array: Array<KeyByTest$Record> = [
+  { id: 4 },
+  { id: 4 },
+  { id: 7 }
+];
+const keyByTest_map: KeyByTest$ByNumber<KeyByTest$Record> = {
+  [keyByTest_array[0].id]: keyByTest_array[0],
+  [keyByTest_array[1].id]: keyByTest_array[1],
+  [keyByTest_array[2].id]: keyByTest_array[2]
+};
+(keyBy(keyByTest_map, "id"): KeyByTest$ByNumberMaybe<KeyByTest$Record>);
+
+/**
+ * _.map examples from the official doc
+ */
+function square(n) {
+  return n * n;
+}
+
+map([4, 8], square);
+map({ a: 4, b: 8 }, square);
+
+//accepts tuple types
+
+const tuple: [number, number] = [1, 2];
+map(tuple, val => val + 2);
+//$ExpectError cannot push to tuple
+map(tuple, (val, nothing, tupleArray) => tupleArray.push(123));
+
+// The `_.property` iteratee shorthand.
+map([{ user: "barney" }, { user: "fred" }], "user");
+
+// Array#map, lodash.map, lodash#map
+(nums.map(num => num * num): number[]);
+(map(nums, num => num * num): number[]);
+
+// return type of iterator is reflected in result and chain
+(nums.map(num => JSON.stringify(num)): string[]);
+(map(nums, num => JSON.stringify(num)): string[]);
+
+/**
+ * _.orderBy
+ */
+(orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], ['a']): Array<{
+  a: number,
+  b: number,
+  ...
+}>);
+(orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], [x => x.a]): Array<{
+  a: number,
+  b: number,
+  ...
+}>);
+(orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, ['a']): Array<{
+  a: number,
+  b: number,
+  ...
+}>);
+(orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, [x => x.a]): Array<{
+  a: number,
+  b: number,
+  ...
+}>);
+
+// =====   Date   =====
+
+
+
+// =====   Function   =====
+
+/**
+ * _.debounce
+ */
+var debounced = debounce((a: number) => "foo");
+debounced(1);
+debounced.cancel();
+debounced.flush();
+// $ExpectError string is incompatible with number
+debounced("a");
+
+/**
+ * _.memoize
+ */
+var memoized: (a: number) => string = memoize((a: number) => "foo");
+// $ExpectError memoize retains type information
+memoized = memoize(() => {});
+
+// =====   Lang   =====
+
+/**
+ * _.clone
+ */
+clone({ a: 1 }).a == 1;
+// $ExpectError property `b`. Property not found in object literal
+clone({ a: 1 }).b == 1;
+// $ExpectError number. This type is incompatible with function type.
+clone({ a: 1 }).a == "c";
+
+/**
+ * _.isEqual
+ */
+isEqual("a", "b");
+isEqual({ x: 1 }, { y: 2 });
+
+// Flow considers this compatible with isEqual(a: any, b: any).
+// Reasonable people disagree about whether this should be considered a legal call.
+// See https://github.com/splodingsocks/FlowTyped/pull/1#issuecomment-149345275
+// and https://github.com/facebook/flow/issues/956
+isEqual(1);
+
+// $ExpectError function type expects no more than 2 arguments
+isEqual(1, 2, 3);
+
 /**
  * _.isString
  */
-
 var boolTrue: true;
 var boolFalse: false;
-
 boolTrue = isString("foo");
 boolFalse = isString([""]);
 boolFalse = isString({});
@@ -394,130 +436,65 @@ boolFalse = isString("");
 boolTrue = isString(undefined);
 
 /**
- * _.find
+ * _.conformsTo
  */
-(find([1, 2, 3], x => x == 1): void | number);
-// $ExpectError number. This type is incompatible with function type.
-(find([1, 2, 3], 1): void | number);
-
-// Copy pasted tests from iflow-lodash
-var nums: number[] = [1, 2, 3, 4, 5, 6];
-var num: number;
-var string: string;
-var bool: boolean;
-
-var nativeSquares: number[];
-var directSquares: number[];
-
-var nativeStrings: string[];
-var directStrings: string[];
-
-var allNums: number[];
-var numsAndStrList: Array<number | string>;
-var mixedList: Array<mixed>;
-allNums = concat(nums, nums, nums);
-numsAndStrList = concat(nums, "123", "456");
-numsAndStrList = concat(nums, ["123", "456"]);
-numsAndStrList = concat(nums, [[1, 2, 3], "456"]);
-mixedList = concat(nums, [[1, 2, 3], "456"]);
-
-// Array#map, lodash.map, lodash#map
-nativeSquares = nums.map(function(num) {
-  return num * num;
-});
-directSquares = map(nums, function(num) {
-  return num * num;
-});
-
-num = first(nums);
-
-// return type of iterator is reflected in result and chain
-nativeStrings = nums.map(function(num) {
-  return JSON.stringify(num);
-});
-directStrings = map(nums, function(num) {
-  return JSON.stringify(num);
-});
-
-var obj = { a: 1, b: 2 };
-bool = conformsTo(obj, {
+(conformsTo({ a: 1, b: 2 }, {
   a: function(x: number) {
     return true;
   }
-});
+}): boolean);
 
-num = defaultTo(undefined, 2);
-string = defaultTo(undefined, "str");
-bool = defaultTo(true, "str");
-string = defaultTo("str", true);
 
-num = tap(1, function(n) {
-  return false;
-});
-bool = thru(1, function(n) {
-  return false;
-});
 
-var timesNums: number[];
 
-timesNums = times(5);
-// $ExpectError string. This type is incompatible with number
-var strings: string[] = times(5);
-timesNums = times(5, function(i: number) {
-  return i + 1;
-});
-// $ExpectError string. This type is incompatible with number
-timesNums = times(5, function(i: number) {
-  return JSON.stringify(i);
-});
+// =====   Math   =====
 
-// lodash.flatMap for collections and objects
-// this arrow function needs a type annotation due to a bug in flow
-// https://github.com/facebook/flow/issues/1948
-flatMap([1, 2, 3], (n): number[] => [n, n]);
-flatMap({ a: 1, b: 2 }, n => [n, n]);
+
+
+// =====   Number   =====
+
+
+
+// =====   Object   =====
 
 /**
- * _.noop
+ * _.extend
  */
-noop();
-noop(1);
-noop("a", 2, [], null);
-(noop: string => void);
-(noop: (number, string) => void);
-// $ExpectError functions are contravariant in return types
-(noop: string => string);
+extend({ a: 1 }, { b: 2 }).a;
+extend({ a: 1 }, { b: 2 }).b;
+// $ExpectError property `c`. Property not found in object literal
+extend({ a: 1 }, { b: 2 }).c;
+// $ExpectError property `c`. Poperty not found in object literal
+assignIn({ a: 1 }, { b: 2 }).c;
 
 /**
- * _.memoize
+ * _.get
  */
-var memoized: (a: number) => string = memoize((a: number) => "foo");
-// $ExpectError memoize retains type information
-memoized = memoize(() => {});
+// Object — examples from lodash docs
+var exampleObjectForGetTest = { a: [{ b: { c: 3 } }] };
+get(exampleObjectForGetTest, "a[0].b.c");
+get(exampleObjectForGetTest, ["a", "0", "b", "c"]);
+get(exampleObjectForGetTest, "a.b.c", "default");
+
+// Array — not documented, but _.get does support arrays
+get([1, 2, 3], "0");
+get([1, 2, 3], 0);
+get([1, 2, 3], [0]);
+get(["foo", "bar", "baz"], "[1]");
+get([{ a: "foo" }, { b: "bar" }, { c: "baz" }], "2");
+get([[1, 2], [3, 4], [5, 6], [7, 8]], "3");
+
+// Nil - it is safe to perform on nil root values, just like nil values along the "get" path
+get(null, "thing");
+get(undefined, "data");
 
 /**
- * _.debounce
+ * _.omitBy
  */
-var debounced = debounce((a: number) => "foo");
-debounced(1);
-debounced.cancel();
-debounced.flush();
-// $ExpectError string is incompatible with number
-debounced("a");
-
-/**
- * _.toPairs / _.toPairsIn
- */
-var pairs: [string, number][];
-pairs = toPairs({ a: 12, b: 100 });
-pairs = toPairsIn({ a: 12, b: 100 });
-
-/**
- * _.take / _.takeRight
- */
-var taken: string[];
-taken = take((["abc", "123"]: $ReadOnlyArray<string>), 3);
-taken = takeRight((["abc", "123"]: $ReadOnlyArray<string>));
+(omitBy({ a: 2, b: 3, c: 4 }, num => num % 2): { [prop: string]: number, ... });
+(omitBy(null, num => num % 2): {...});
+(omitBy(undefined, num => num % 2): {...});
+(omitBy({ [1]: 1, [2]: 2 }, num => num === 2): { [prop: number]: number, ... });
 
 /**
  * _.pick
@@ -537,36 +514,82 @@ pick({ a: 2 }, 1);
 (pickBy(null, num => num % 2): {...});
 (pickBy(undefined, num => num % 2): {...});
 (pickBy({ [1]: 1, [2]: 2 }, num => num === 2): { [prop: number]: number, ... });
+(pickBy(readOnlyObject, num => num === 2): { [prop: number]: number, ... });
 
 /**
- * _.omitBy
+ * _.toPairs / _.toPairsIn
  */
-(omitBy({ a: 2, b: 3, c: 4 }, num => num % 2): { [prop: string]: number, ... });
-(omitBy(null, num => num % 2): {...});
-(omitBy(undefined, num => num % 2): {...});
-(omitBy({ [1]: 1, [2]: 2 }, num => num === 2): { [prop: number]: number, ... });
+var pairs: [string, number][];
+pairs = toPairs({ a: 12, b: 100 });
+pairs = toPairsIn({ a: 12, b: 100 });
+
+
+// =====   Seq   =====
 
 /**
- * _.orderBy
+ * _.tap
  */
-(orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], ['a']): Array<{
- a: number,
- b: number,
- ...
-}>);
-(orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], [x => x.a]): Array<{
- a: number,
- b: number,
- ...
-}>);
-(orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, ['a']): Array<{
- a: number,
- b: number,
- ...
-}>);
-(orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, [x => x.a]): Array<{
- a: number,
- b: number,
- ...
-}>);
+(tap(1, n => false): number);
+
+/**
+ * _.thru
+ */
+(thru(1, n => false): boolean);
+
+// =====   String   =====
+
+
+
+// =====   Util   =====
+
+/**
+   * _.attempt
+ */
+attempt(() => void 0);
+attempt(x => x);
+attempt(x => x, "first arg");
+attempt((x, y, z) => {}, null, {}, []);
+
+/**
+ * _.defaultTo
+ */
+(defaultTo(undefined, 2): number);
+(defaultTo(undefined, "str"): string);
+(defaultTo(true, "str"): boolean);
+(defaultTo("str", true): string);
+
+/**
+ * _.noop
+ */
+noop();
+noop(1);
+noop("a", 2, [], null);
+(noop: string => void);
+(noop: (number, string) => void);
+// $ExpectError functions are contravariant in return types
+(noop: string => string);
+
+/**
+ * _.range
+ */
+range(0, 10)[4] == 4;
+// $ExpectError string. This type is incompatible with number
+range(0, "a");
+// $ExpectError string cannot be compared to number
+range(0, 10)[4] == "a";
+
+/**
+ * _.times
+ */
+var timesNums: number[];
+timesNums = times(5);
+// $ExpectError string. This type is incompatible with number
+(times(5): string[]);
+timesNums = times(5, function(i: number) {
+  return i + 1;
+});
+// $ExpectError string. This type is incompatible with number
+timesNums = times(5, function(i: number) {
+  return JSON.stringify(i);
+});
 

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -68,6 +68,11 @@ const readOnlyObject : ReadOnlyObject = { [1]: 1, [2]: 2 };
 chunk(readOnlyArray, 2);
 
 /**
+ * _.compact
+ */
+compact(readOnlyArray);
+
+/**
  * _.concat
  */
 concat(readOnlyArray, readOnlyArray, readOnlyArray);
@@ -193,8 +198,14 @@ zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][2];
  * _.zipWith
  */
 zipWith(["a", "b", "c"], [1, 2, 3], (str: string, num) => ({ [str]: num }));
+zipWith((["a", "b", "c"]: $ReadOnlyArray<string>), ([1, 2, 3]: $ReadOnlyArray<number>), (str: string, num) => ({ [str]: num }));
+zipWith(readOnlyArray, readOnlyArray, readOnlyArray);
+zipWith(readOnlyArray, readOnlyArray, readOnlyArray, (a: number, b: number, c: number) => [a, b, c]);
+zipWith(readOnlyArray, readOnlyArray, readOnlyArray, readOnlyArray);
+zipWith(readOnlyArray, readOnlyArray, readOnlyArray, readOnlyArray, (a: number, b: number, c: number, d: number) => [a, b, c, d]);
 // $ExpectError `x` should be a `string`, `y` a `number`
 zipWith(["a", "b", "c"], [1, 2, 3]).map(([x, y]) => x * y);
+
 
 
 

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -4,6 +4,7 @@
  * Please add tests for new functions in the same order as they are in the main file and lodash documentation.
  */
 
+import { describe, it } from "flow-typed-test";
 import assignIn from "lodash/assignIn";
 import attempt from "lodash/attempt";
 import chunk from "lodash/chunk";
@@ -61,549 +62,548 @@ const readOnlyArray : ReadOnlyArray = [1, 2, 3, 4];
 type ReadOnlyObject = $ReadOnly<{ [string]: number, ... }>
 const readOnlyObject : ReadOnlyObject = { [1]: 1, [2]: 2 };
 
-// =====   Array   =====
+describe('Array', () => {
+  /**
+   * _.chunk
+   */
+  chunk(readOnlyArray, 2);
 
-/**
- * _.chunk
- */
-chunk(readOnlyArray, 2);
+  /**
+   * _.compact
+   */
+  compact(readOnlyArray);
 
-/**
- * _.compact
- */
-compact(readOnlyArray);
-
-/**
- * _.concat
- */
-concat(readOnlyArray, readOnlyArray, readOnlyArray);
+  /**
+   * _.concat
+   */
+  concat(readOnlyArray, readOnlyArray, readOnlyArray);
 // Copy pasted tests from iflow-lodash
-const nums: number[] = [1, 2, 3, 4, 5, 6];
-(concat(nums, "123", "456"): Array<number | string>);
-(concat(nums, ["123", "456"]): Array<number | string>);
-(concat(nums, [[1, 2, 3], "456"]): Array<number | string>);
-(concat(nums, [[1, 2, 3], "456"]): Array<mixed>);
+  const nums: number[] = [1, 2, 3, 4, 5, 6];
+  (concat(nums, "123", "456"): Array<number | string>);
+  (concat(nums, ["123", "456"]): Array<number | string>);
+  (concat(nums, [[1, 2, 3], "456"]): Array<number | string>);
+  (concat(nums, [[1, 2, 3], "456"]): Array<mixed>);
 
-/**
- * _.difference
- */
-difference(
-  (["a", "b"]: $ReadOnlyArray<string>),
-  (["b"]: $ReadOnlyArray<string>)
-);
-difference(
-  (["a", "b"]: $ReadOnlyArray<string>),
-  (["b"]: $ReadOnlyArray<string>),
-  (["a"]: $ReadOnlyArray<string>)
-);
+  /**
+   * _.difference
+   */
+  difference(
+    (["a", "b"]: $ReadOnlyArray<string>),
+    (["b"]: $ReadOnlyArray<string>)
+  );
+  difference(
+    (["a", "b"]: $ReadOnlyArray<string>),
+    (["b"]: $ReadOnlyArray<string>),
+    (["a"]: $ReadOnlyArray<string>)
+  );
 
-/**
- * _.differenceBy
- */
-differenceBy(([2.1, 1.2]: $ReadOnlyArray<number>), [2.3, 3.4], Math.floor);
-differenceBy([{ x: 2 }, { x: 1 }], [{ x: 1 }], "x");
-differenceBy(([2.1, 1.2]: $ReadOnlyArray<number>), [2.3, 3.4], Math.floor);
-type A = {| a: 1 |};
-type B = {| b: 1 |};
-differenceBy(([{ a: 1 }, { a: 1 }]: $ReadOnlyArray<A>), ([{ b: 1 }, { b: 1 }]: $ReadOnlyArray<B>), (x: A | B) => {
-  return x.a || x.b;
-});
+  /**
+   * _.differenceBy
+   */
+  differenceBy(([2.1, 1.2]: $ReadOnlyArray<number>), [2.3, 3.4], Math.floor);
+  differenceBy([{ x: 2 }, { x: 1 }], [{ x: 1 }], "x");
+  differenceBy(([2.1, 1.2]: $ReadOnlyArray<number>), [2.3, 3.4], Math.floor);
+  type A = {| a: 1 |};
+  type B = {| b: 1 |};
+  differenceBy(([{ a: 1 }, { a: 1 }]: $ReadOnlyArray<A>), ([{ b: 1 }, { b: 1 }]: $ReadOnlyArray<B>), (x: A | B) => {
+    return x.a || x.b;
+  });
 
-/**
- * _.differenceWith
- */
-differenceWith(([{ a: 1 }, { a: 1 }]: $ReadOnlyArray<A>), ([{ b: 1 }, { b: 1 }]: $ReadOnlyArray<B>), (x: A, y: B) => {
-  return x.a === y.b;
-});
+  /**
+   * _.differenceWith
+   */
+  differenceWith(([{ a: 1 }, { a: 1 }]: $ReadOnlyArray<A>), ([{ b: 1 }, { b: 1 }]: $ReadOnlyArray<B>), (x: A, y: B) => {
+    return x.a === y.b;
+  });
 
-/**
- * _.intersectionBy
- */
-intersectionBy([2.1, 1.2], [2.3, 3.4], Math.floor);
-intersectionBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], "x");
+  /**
+   * _.intersectionBy
+   */
+  intersectionBy([2.1, 1.2], [2.3, 3.4], Math.floor);
+  intersectionBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], "x");
 
-/**
- * _.pullAllBy
- */
-pullAllBy([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 1 }], [{ x: 1 }, { x: 3 }], "x");
+  /**
+   * _.pullAllBy
+   */
+  pullAllBy([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 1 }], [{ x: 1 }, { x: 3 }], "x");
 
-/**
- * _.sortedIndexBy
- */
-sortedIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, function(o) {
-  return o.x;
-});
-sortedIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, "x");
+  /**
+   * _.sortedIndexBy
+   */
+  sortedIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, function(o) {
+    return o.x;
+  });
+  sortedIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, "x");
 
-/**
- * _.sortedLastIndexBy
- */
-sortedLastIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, function(o) {
-  return o.x;
-});
-sortedLastIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, "x");
+  /**
+   * _.sortedLastIndexBy
+   */
+  sortedLastIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, function(o) {
+    return o.x;
+  });
+  sortedLastIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, "x");
 
-/**
- * _.sortedUniq
- */
-sortedUniq([1, 2, 2]);
-sortedUniq(["a", "b", "b"]);
+  /**
+   * _.sortedUniq
+   */
+  sortedUniq([1, 2, 2]);
+  sortedUniq(["a", "b", "b"]);
 
-/**
- * _.sortedUniqBy
- */
-sortedUniqBy([1.2, 2.1, 2.3], Math.floor);
-sortedUniqBy([{ x: 1 }, { x: 1 }, { x: 2 }], "x");
+  /**
+   * _.sortedUniqBy
+   */
+  sortedUniqBy([1.2, 2.1, 2.3], Math.floor);
+  sortedUniqBy([{ x: 1 }, { x: 1 }, { x: 2 }], "x");
 
-/**
- * _.take / _.takeRight
- */
-var taken: string[];
-taken = take((["abc", "123"]: $ReadOnlyArray<string>), 3);
-taken = takeRight((["abc", "123"]: $ReadOnlyArray<string>));
+  /**
+   * _.take / _.takeRight
+   */
+  var taken: string[];
+  taken = take((["abc", "123"]: $ReadOnlyArray<string>), 3);
+  taken = takeRight((["abc", "123"]: $ReadOnlyArray<string>));
 
-/**
- * _.unionBy
- */
-unionBy([2.1], [1.2, 2.3], Math.floor);
-unionBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], "x");
+  /**
+   * _.unionBy
+   */
+  unionBy([2.1], [1.2, 2.3], Math.floor);
+  unionBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], "x");
 
-/**
- * _.uniqBy
- */
-uniqBy([2.1, 1.2, 2.3], Math.floor);
-uniqBy([{ x: 1 }, { x: 2 }, { x: 1 }], "x");
+  /**
+   * _.uniqBy
+   */
+  uniqBy([2.1, 1.2, 2.3], Math.floor);
+  uniqBy([{ x: 1 }, { x: 2 }, { x: 1 }], "x");
 
-/**
- * _.xorBy
- */
-xorBy([2.1, 1.2], [2.3, 3.4], Math.floor);
-xorBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], "x");
+  /**
+   * _.xorBy
+   */
+  xorBy([2.1, 1.2], [2.3, 3.4], Math.floor);
+  xorBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], "x");
 
-/**
- * _.zip
- */
-zip(["a", "b", "c"], ["d", "e", "f"])[0].length;
-zip(["a", "b", "c"], [1, 2, 3])[0].length;
-zip(["a", "b", "c"], [1, 2, 3])[0][0] + "a";
-zip(["a", "b", "c"], [1, 2, 3])[0][1] * 10;
+  /**
+   * _.zip
+   */
+  zip(["a", "b", "c"], ["d", "e", "f"])[0].length;
+  zip(["a", "b", "c"], [1, 2, 3])[0].length;
+  zip(["a", "b", "c"], [1, 2, 3])[0][0] + "a";
+  zip(["a", "b", "c"], [1, 2, 3])[0][1] * 10;
 // $ExpectError `x` property not found in Array
-zip([{ x: 1 }], [{ x: 2, y: 1 }])[0].x;
+  zip([{ x: 1 }], [{ x: 2, y: 1 }])[0].x;
 // $ExpectError `y` property not found in object literal
-zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][0].y;
-zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][1].y;
+  zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][0].y;
+  zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][1].y;
 // $ExpectError Flow could potentially catch this -- the tuple only has two elements.
-zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][2];
+  zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][2];
 
-/**
- * _.zipWith
- */
-zipWith(["a", "b", "c"], [1, 2, 3], (str: string, num) => ({ [str]: num }));
-zipWith((["a", "b", "c"]: $ReadOnlyArray<string>), ([1, 2, 3]: $ReadOnlyArray<number>), (str: string, num) => ({ [str]: num }));
-zipWith(readOnlyArray, readOnlyArray, readOnlyArray);
-zipWith(readOnlyArray, readOnlyArray, readOnlyArray, (a: number, b: number, c: number) => [a, b, c]);
-zipWith(readOnlyArray, readOnlyArray, readOnlyArray, readOnlyArray);
-zipWith(readOnlyArray, readOnlyArray, readOnlyArray, readOnlyArray, (a: number, b: number, c: number, d: number) => [a, b, c, d]);
-// $ExpectError `x` should be a `string`, `y` a `number`
-zipWith(["a", "b", "c"], [1, 2, 3]).map(([x, y]) => x * y);
-
-
+  /**
+   * _.zipWith
+   */
+  zipWith(["a", "b", "c"], [1, 2, 3], (str: string, num) => ({ [str]: num }));
+  zipWith((["a", "b", "c"]: $ReadOnlyArray<string>), ([1, 2, 3]: $ReadOnlyArray<number>), (str: string, num) => ({ [str]: num }));
+  zipWith(readOnlyArray, readOnlyArray, readOnlyArray);
+  zipWith(readOnlyArray, readOnlyArray, readOnlyArray, (a: number, b: number, c: number) => [a, b, c]);
+  zipWith(readOnlyArray, readOnlyArray, readOnlyArray, readOnlyArray);
+  zipWith(readOnlyArray, readOnlyArray, readOnlyArray, readOnlyArray, (a: number, b: number, c: number, d: number) => [a, b, c, d]);
+  // $ExpectError `x` should be a `string`, `y` a `number`
+  zipWith(["a", "b", "c"], [1, 2, 3]).map(([x, y]) => x * y);
 
 
-// =====   Collection   =====
 
-/**
- * _.countBy
- */
-(countBy([6.1, 4.2, 6.3], Math.floor): { [string]: number, ... });
-(countBy(["one", "two", "three"], "length"): { [string]: number, ... });
-// $ExpectError
-(countBy(["one", "two", "three"], "length"): { [string]: string, ... });
 
-/**
- * _.each
- */
-each(([1, 2]: $ReadOnlyArray<number>), (item: number) => false);
-each(readOnlyObject, (item: number) => false);
-
-/**
- * _.find
- */
-find([1, 2, 3], x => x * 1 == 3);
-find([1, 2, 3], x => x == 2, 1);
-// $ExpectError number cannot be compared to string
-find([1, 2, 3], x => x == "a");
-// $ExpectError number. This type is incompatible with function type.
-find([1, 2, 3], 1);
-// $ExpectError property `y`. Property not found in object literal
-find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.y == 3);
-find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.x == 3);
-find({ x: 1, y: 2 }, (a: number, b: string) => a);
-find({ x: 1, y: 2 }, { x: 3 });
-find((["a", "b"]: $ReadOnlyArray<string>), "c");
-// opaque types are allowed as keys of objects
-opaque type O = string;
-const v: { [O]: number, ... } = { x: 1, y: 2 };
-find(v, { x: 3 });
-
-(find([1, 2, 3], x => x == 1): void | number);
-// $ExpectError number. This type is incompatible with function type.
-(find([1, 2, 3], 1): void | number);
-
-// _.find examples from the official doc
-const users = [
-  { user: "barney", age: 36, active: true },
-  { user: "fred", age: 40, active: false },
-  { user: "pebbles", age: 1, active: true }
-];
-
-find(users, function(o) {
-  return o.age < 40;
 });
 
-// The `_.matches` iteratee shorthand.
-find(users, { age: 1, active: true });
+describe('Collection', () => {
 
-// The `_.matchesProperty` iteratee shorthand.
-find(users, ["active", false]);
-
-// The `_.property` iteratee shorthand.
-find(users, "active");
-
-/**
- * _.flatMap
- */
-// this arrow function needs a type annotation due to a bug in flow: https://github.com/facebook/flow/issues/1948
-flatMap([1, 2, 3], (n): number[] => [n, n]);
-flatMap({ a: 1, b: 2 }, n => [n, n]);
-
-/**
- * _.forEach
- */
-forEach(([1, 2]: $ReadOnlyArray<number>), (item: number) => false);
-
-/**
- * _.groupBy
- */
-const numbersGroupedByMathFloor = groupBy([6.1, 4.2, 6.3], Math.floor);
-if (numbersGroupedByMathFloor[6]) {
-  numbersGroupedByMathFloor[6][0] / numbersGroupedByMathFloor[6][1];
-}
-const stringsGroupedByLength = groupBy(["one", "two", "three"], "length");
-if (stringsGroupedByLength[3]) {
-  stringsGroupedByLength[3][0].toLowerCase();
-}
-const numbersObj: { [key: string]: number, ... } = { a: 6.1, b: 4.2, c: 6.3 };
-const numbersGroupedByMathFloor2 = groupBy(numbersObj, Math.floor);
-if (numbersGroupedByMathFloor2[6]) {
-  numbersGroupedByMathFloor2[6][0] / numbersGroupedByMathFloor2[6][1];
-}
-const stringObj: { [key: string]: string, ... } = { a: "one", b: "two", c: "three" };
-const stringsGroupedByLength2 = groupBy(stringObj, "length");
-if (stringsGroupedByLength2[3]) {
-  stringsGroupedByLength2[3][0].toLowerCase();
-}
-
-/**
- * _.keyBy
- */
-keyBy([{ dir: "left", code: 97 }, { dir: "right", code: 100 }], function(o) {
-  return String.fromCharCode(o.code);
-});
-keyBy([{ dir: "left", code: 97 }, { dir: "right", code: 100 }], "dir");
-
-// Example of keying a map of objects by a number type
-type KeyByTest$ByNumber<T: Object> = { [number]: T, ... };
-type KeyByTest$ByNumberMaybe<T: ?Object> = { [number]: T, ... };
-type KeyByTest$Record = { id: number, ... };
-const keyByTest_array: Array<KeyByTest$Record> = [
-  { id: 4 },
-  { id: 4 },
-  { id: 7 }
-];
-const keyByTest_map: KeyByTest$ByNumber<KeyByTest$Record> = {
-  [keyByTest_array[0].id]: keyByTest_array[0],
-  [keyByTest_array[1].id]: keyByTest_array[1],
-  [keyByTest_array[2].id]: keyByTest_array[2]
-};
-(keyBy(keyByTest_map, "id"): KeyByTest$ByNumberMaybe<KeyByTest$Record>);
-
-/**
- * _.map examples from the official doc
- */
-function square(n) {
-  return n * n;
-}
-
-map([4, 8], square);
-map({ a: 4, b: 8 }, square);
-
-//accepts tuple types
-
-const tuple: [number, number] = [1, 2];
-map(tuple, val => val + 2);
-//$ExpectError cannot push to tuple
-map(tuple, (val, nothing, tupleArray) => tupleArray.push(123));
-
-// The `_.property` iteratee shorthand.
-map([{ user: "barney" }, { user: "fred" }], "user");
-
-// Array#map, lodash.map, lodash#map
-(nums.map(num => num * num): number[]);
-(map(nums, num => num * num): number[]);
-
-// return type of iterator is reflected in result and chain
-(nums.map(num => JSON.stringify(num)): string[]);
-(map(nums, num => JSON.stringify(num)): string[]);
-
-/**
- * _.orderBy
- */
-(orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], ['a']): Array<{
-  a: number,
-  b: number,
-  ...
-}>);
-(orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], [x => x.a]): Array<{
-  a: number,
-  b: number,
-  ...
-}>);
-(orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, ['a']): Array<{
-  a: number,
-  b: number,
-  ...
-}>);
-(orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, [x => x.a]): Array<{
-  a: number,
-  b: number,
-  ...
-}>);
-
-// =====   Date   =====
-
-
-
-// =====   Function   =====
-
-/**
- * _.debounce
- */
-var debounced = debounce((a: number) => "foo");
-debounced(1);
-debounced.cancel();
-debounced.flush();
-// $ExpectError string is incompatible with number
-debounced("a");
-
-/**
- * _.memoize
- */
-var memoized: (a: number) => string = memoize((a: number) => "foo");
-// $ExpectError memoize retains type information
-memoized = memoize(() => {});
-
-// =====   Lang   =====
-
-/**
- * _.clone
- */
-clone({ a: 1 }).a == 1;
-// $ExpectError property `b`. Property not found in object literal
-clone({ a: 1 }).b == 1;
-// $ExpectError number. This type is incompatible with function type.
-clone({ a: 1 }).a == "c";
-
-/**
- * _.isEqual
- */
-isEqual("a", "b");
-isEqual({ x: 1 }, { y: 2 });
-
-// Flow considers this compatible with isEqual(a: any, b: any).
-// Reasonable people disagree about whether this should be considered a legal call.
-// See https://github.com/splodingsocks/FlowTyped/pull/1#issuecomment-149345275
-// and https://github.com/facebook/flow/issues/956
-isEqual(1);
-
-// $ExpectError function type expects no more than 2 arguments
-isEqual(1, 2, 3);
-
-/**
- * _.isString
- */
-var boolTrue: true;
-var boolFalse: false;
-boolTrue = isString("foo");
-boolFalse = isString([""]);
-boolFalse = isString({});
-boolFalse = isString(5);
-boolFalse = isString(function(f) {
-  return f;
-});
-boolFalse = isString();
-boolFalse = isString(true);
-
+  /**
+   * _.countBy
+   */
+  (countBy([6.1, 4.2, 6.3], Math.floor): { [string]: number, ... });
+  (countBy(["one", "two", "three"], "length"): { [string]: number, ... });
 // $ExpectError
-boolFalse = isString("");
-// $ExpectError
-boolTrue = isString(undefined);
+  (countBy(["one", "two", "three"], "length"): { [string]: string, ... });
 
-/**
- * _.conformsTo
- */
-(conformsTo({ a: 1, b: 2 }, {
-  a: function(x: number) {
-    return true;
+  /**
+   * _.each
+   */
+  each(([1, 2]: $ReadOnlyArray<number>), (item: number) => false);
+  each(readOnlyObject, (item: number) => false);
+
+  /**
+   * _.find
+   */
+  find([1, 2, 3], x => x * 1 == 3);
+  find([1, 2, 3], x => x == 2, 1);
+  // $ExpectError number cannot be compared to string
+  find([1, 2, 3], x => x == "a");
+  // $ExpectError number. This type is incompatible with function type.
+  find([1, 2, 3], 1);
+  // $ExpectError property `y`. Property not found in object literal
+  find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.y == 3);
+  find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.x == 3);
+  find({ x: 1, y: 2 }, (a: number, b: string) => a);
+  find({ x: 1, y: 2 }, { x: 3 });
+  find((["a", "b"]: $ReadOnlyArray<string>), "c");
+  // opaque types are allowed as keys of objects
+  opaque type O = string;
+  const v: { [O]: number, ... } = { x: 1, y: 2 };
+  find(v, { x: 3 });
+
+  (find([1, 2, 3], x => x == 1): void | number);
+  // $ExpectError number. This type is incompatible with function type.
+  (find([1, 2, 3], 1): void | number);
+
+  // _.find examples from the official doc
+  const users = [
+    { user: "barney", age: 36, active: true },
+    { user: "fred", age: 40, active: false },
+    { user: "pebbles", age: 1, active: true }
+  ];
+
+  find(users, function(o) {
+    return o.age < 40;
+  });
+
+  // The `_.matches` iteratee shorthand.
+  find(users, { age: 1, active: true });
+
+  // The `_.matchesProperty` iteratee shorthand.
+  find(users, ["active", false]);
+
+  // The `_.property` iteratee shorthand.
+  find(users, "active");
+
+  /**
+   * _.flatMap
+   */
+  // this arrow function needs a type annotation due to a bug in flow: https://github.com/facebook/flow/issues/1948
+  flatMap([1, 2, 3], (n): number[] => [n, n]);
+  flatMap({ a: 1, b: 2 }, n => [n, n]);
+
+  /**
+   * _.forEach
+   */
+  forEach(([1, 2]: $ReadOnlyArray<number>), (item: number) => false);
+
+  /**
+   * _.groupBy
+   */
+  const numbersGroupedByMathFloor = groupBy([6.1, 4.2, 6.3], Math.floor);
+  if (numbersGroupedByMathFloor[6]) {
+    numbersGroupedByMathFloor[6][0] / numbersGroupedByMathFloor[6][1];
   }
-}): boolean);
+  const stringsGroupedByLength = groupBy(["one", "two", "three"], "length");
+  if (stringsGroupedByLength[3]) {
+    stringsGroupedByLength[3][0].toLowerCase();
+  }
+  const numbersObj: { [key: string]: number, ... } = { a: 6.1, b: 4.2, c: 6.3 };
+  const numbersGroupedByMathFloor2 = groupBy(numbersObj, Math.floor);
+  if (numbersGroupedByMathFloor2[6]) {
+    numbersGroupedByMathFloor2[6][0] / numbersGroupedByMathFloor2[6][1];
+  }
+  const stringObj: { [key: string]: string, ... } = { a: "one", b: "two", c: "three" };
+  const stringsGroupedByLength2 = groupBy(stringObj, "length");
+  if (stringsGroupedByLength2[3]) {
+    stringsGroupedByLength2[3][0].toLowerCase();
+  }
 
+  /**
+   * _.keyBy
+   */
+  keyBy([{ dir: "left", code: 97 }, { dir: "right", code: 100 }], function(o) {
+    return String.fromCharCode(o.code);
+  });
+  keyBy([{ dir: "left", code: 97 }, { dir: "right", code: 100 }], "dir");
 
+  // Example of keying a map of objects by a number type
+  type KeyByTest$ByNumber<T: Object> = { [number]: T, ... };
+  type KeyByTest$ByNumberMaybe<T: ?Object> = { [number]: T, ... };
+  type KeyByTest$Record = { id: number, ... };
+  const keyByTest_array: Array<KeyByTest$Record> = [
+    { id: 4 },
+    { id: 4 },
+    { id: 7 }
+  ];
+  const keyByTest_map: KeyByTest$ByNumber<KeyByTest$Record> = {
+    [keyByTest_array[0].id]: keyByTest_array[0],
+    [keyByTest_array[1].id]: keyByTest_array[1],
+    [keyByTest_array[2].id]: keyByTest_array[2]
+  };
+  (keyBy(keyByTest_map, "id"): KeyByTest$ByNumberMaybe<KeyByTest$Record>);
 
+  /**
+   * _.map examples from the official doc
+   */
+  function square(n) {
+    return n * n;
+  }
 
-// =====   Math   =====
+  map([4, 8], square);
+  map({ a: 4, b: 8 }, square);
 
+  //accepts tuple types
 
+  const tuple: [number, number] = [1, 2];
+  map(tuple, val => val + 2);
+  //$ExpectError cannot push to tuple
+  map(tuple, (val, nothing, tupleArray) => tupleArray.push(123));
 
-// =====   Number   =====
+  // The `_.property` iteratee shorthand.
+  map([{ user: "barney" }, { user: "fred" }], "user");
 
+  // Array#map, lodash.map, lodash#map
+  const nums: number[] = [1, 2, 3, 4, 5, 6];
+  (nums.map(num => num * num): number[]);
+  (map(nums, num => num * num): number[]);
 
+  // return type of iterator is reflected in result and chain
+  (nums.map(num => JSON.stringify(num)): string[]);
+  (map(nums, num => JSON.stringify(num)): string[]);
 
-// =====   Object   =====
-
-/**
- * _.extend
- */
-extend({ a: 1 }, { b: 2 }).a;
-extend({ a: 1 }, { b: 2 }).b;
-// $ExpectError property `c`. Property not found in object literal
-extend({ a: 1 }, { b: 2 }).c;
-// $ExpectError property `c`. Poperty not found in object literal
-assignIn({ a: 1 }, { b: 2 }).c;
-
-/**
- * _.get
- */
-// Object — examples from lodash docs
-var exampleObjectForGetTest = { a: [{ b: { c: 3 } }] };
-get(exampleObjectForGetTest, "a[0].b.c");
-get(exampleObjectForGetTest, ["a", "0", "b", "c"]);
-get(exampleObjectForGetTest, "a.b.c", "default");
-
-// Array — not documented, but _.get does support arrays
-get([1, 2, 3], "0");
-get([1, 2, 3], 0);
-get([1, 2, 3], [0]);
-get(["foo", "bar", "baz"], "[1]");
-get([{ a: "foo" }, { b: "bar" }, { c: "baz" }], "2");
-get([[1, 2], [3, 4], [5, 6], [7, 8]], "3");
-
-// Nil - it is safe to perform on nil root values, just like nil values along the "get" path
-get(null, "thing");
-get(undefined, "data");
-
-/**
- * _.omitBy
- */
-(omitBy({ a: 2, b: 3, c: 4 }, num => num % 2): { [prop: string]: number, ... });
-(omitBy(null, num => num % 2): {...});
-(omitBy(undefined, num => num % 2): {...});
-(omitBy({ [1]: 1, [2]: 2 }, num => num === 2): { [prop: number]: number, ... });
-
-/**
- * _.pick
- */
-(pick({ a: 2, b: 3, c: 4 }, 'a'): { [prop: string]: number, ... });
-(pick(null, 'a'): {...});
-(pick(undefined, 'a'): {...});
-(pick({ [1]: 1, [2]: 2 }, 'a'): { [prop: number]: number, ... });
-
-// $ExpectError
-pick({ a: 2 }, 1);
-
-/**
- * _.pickBy
- */
-(pickBy({ a: 2, b: 3, c: 4 }, num => num % 2): { [prop: string]: number, ... });
-(pickBy(null, num => num % 2): {...});
-(pickBy(undefined, num => num % 2): {...});
-(pickBy({ [1]: 1, [2]: 2 }, num => num === 2): { [prop: number]: number, ... });
-(pickBy(readOnlyObject, num => num === 2): { [prop: number]: number, ... });
-
-/**
- * _.toPairs / _.toPairsIn
- */
-var pairs: [string, number][];
-pairs = toPairs({ a: 12, b: 100 });
-pairs = toPairsIn({ a: 12, b: 100 });
-
-
-// =====   Seq   =====
-
-/**
- * _.tap
- */
-(tap(1, n => false): number);
-
-/**
- * _.thru
- */
-(thru(1, n => false): boolean);
-
-// =====   String   =====
-
-
-
-// =====   Util   =====
-
-/**
-   * _.attempt
- */
-attempt(() => void 0);
-attempt(x => x);
-attempt(x => x, "first arg");
-attempt((x, y, z) => {}, null, {}, []);
-
-/**
- * _.defaultTo
- */
-(defaultTo(undefined, 2): number);
-(defaultTo(undefined, "str"): string);
-(defaultTo(true, "str"): boolean);
-(defaultTo("str", true): string);
-
-/**
- * _.noop
- */
-noop();
-noop(1);
-noop("a", 2, [], null);
-(noop: string => void);
-(noop: (number, string) => void);
-// $ExpectError functions are contravariant in return types
-(noop: string => string);
-
-/**
- * _.range
- */
-range(0, 10)[4] == 4;
-// $ExpectError string. This type is incompatible with number
-range(0, "a");
-// $ExpectError string cannot be compared to number
-range(0, 10)[4] == "a";
-
-/**
- * _.times
- */
-var timesNums: number[];
-timesNums = times(5);
-// $ExpectError string. This type is incompatible with number
-(times(5): string[]);
-timesNums = times(5, function(i: number) {
-  return i + 1;
+  /**
+   * _.orderBy
+   */
+  (orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], ['a']): Array<{
+    a: number,
+    b: number,
+    ...
+  }>);
+  (orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], [x => x.a]): Array<{
+    a: number,
+    b: number,
+    ...
+  }>);
+  (orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, ['a']): Array<{
+    a: number,
+    b: number,
+    ...
+  }>);
+  (orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, [x => x.a]): Array<{
+    a: number,
+    b: number,
+    ...
+  }>);
 });
-// $ExpectError string. This type is incompatible with number
-timesNums = times(5, function(i: number) {
-  return JSON.stringify(i);
+
+describe('Date', () => {
+});
+
+describe('Function', () => {
+
+  /**
+   * _.debounce
+   */
+  var debounced = debounce((a: number) => "foo");
+  debounced(1);
+  debounced.cancel();
+  debounced.flush();
+  // $ExpectError string is incompatible with number
+  debounced("a");
+
+  /**
+   * _.memoize
+   */
+  var memoized: (a: number) => string = memoize((a: number) => "foo");
+  // $ExpectError memoize retains type information
+  memoized = memoize(() => {});
+});
+
+describe('Lang', () => {
+
+  /**
+   * _.clone
+   */
+  clone({ a: 1 }).a == 1;
+  // $ExpectError property `b`. Property not found in object literal
+  clone({ a: 1 }).b == 1;
+  // $ExpectError number. This type is incompatible with function type.
+  clone({ a: 1 }).a == "c";
+
+  /**
+   * _.isEqual
+   */
+  isEqual("a", "b");
+  isEqual({ x: 1 }, { y: 2 });
+
+  // Flow considers this compatible with isEqual(a: any, b: any).
+  // Reasonable people disagree about whether this should be considered a legal call.
+  // See https://github.com/splodingsocks/FlowTyped/pull/1#issuecomment-149345275
+  // and https://github.com/facebook/flow/issues/956
+  isEqual(1);
+
+  // $ExpectError function type expects no more than 2 arguments
+  isEqual(1, 2, 3);
+
+  /**
+   * _.isString
+   */
+  var boolTrue: true;
+  var boolFalse: false;
+  boolTrue = isString("foo");
+  boolFalse = isString([""]);
+  boolFalse = isString({});
+  boolFalse = isString(5);
+  boolFalse = isString(function(f) {
+    return f;
+  });
+  boolFalse = isString();
+  boolFalse = isString(true);
+
+  // $ExpectError
+  boolFalse = isString("");
+  // $ExpectError
+  boolTrue = isString(undefined);
+
+  /**
+   * _.conformsTo
+   */
+  (conformsTo({ a: 1, b: 2 }, {
+    a: function(x: number) {
+      return true;
+    }
+  }): boolean);
+});
+
+describe('Math', () => {
+});
+
+describe('Number', () => {
+});
+
+describe('Object', () => {
+
+  /**
+   * _.extend
+   */
+  extend({ a: 1 }, { b: 2 }).a;
+  extend({ a: 1 }, { b: 2 }).b;
+  // $ExpectError property `c`. Property not found in object literal
+  extend({ a: 1 }, { b: 2 }).c;
+  // $ExpectError property `c`. Poperty not found in object literal
+  assignIn({ a: 1 }, { b: 2 }).c;
+
+  /**
+   * _.get
+   */
+  // Object — examples from lodash docs
+  var exampleObjectForGetTest = { a: [{ b: { c: 3 } }] };
+  get(exampleObjectForGetTest, "a[0].b.c");
+  get(exampleObjectForGetTest, ["a", "0", "b", "c"]);
+  get(exampleObjectForGetTest, "a.b.c", "default");
+
+  // Array — not documented, but _.get does support arrays
+  get([1, 2, 3], "0");
+  get([1, 2, 3], 0);
+  get([1, 2, 3], [0]);
+  get(["foo", "bar", "baz"], "[1]");
+  get([{ a: "foo" }, { b: "bar" }, { c: "baz" }], "2");
+  get([[1, 2], [3, 4], [5, 6], [7, 8]], "3");
+
+  // Nil - it is safe to perform on nil root values, just like nil values along the "get" path
+  get(null, "thing");
+  get(undefined, "data");
+
+  /**
+   * _.omitBy
+   */
+  (omitBy({ a: 2, b: 3, c: 4 }, num => num % 2): { [prop: string]: number, ... });
+  (omitBy(null, num => num % 2): {...});
+  (omitBy(undefined, num => num % 2): {...});
+  (omitBy({ [1]: 1, [2]: 2 }, num => num === 2): { [prop: number]: number, ... });
+
+  /**
+   * _.pick
+   */
+  (pick({ a: 2, b: 3, c: 4 }, 'a'): { [prop: string]: number, ... });
+  (pick(null, 'a'): {...});
+  (pick(undefined, 'a'): {...});
+  (pick({ [1]: 1, [2]: 2 }, 'a'): { [prop: number]: number, ... });
+
+  // $ExpectError
+  pick({ a: 2 }, 1);
+
+  /**
+   * _.pickBy
+   */
+  (pickBy({ a: 2, b: 3, c: 4 }, num => num % 2): { [prop: string]: number, ... });
+  (pickBy(null, num => num % 2): {...});
+  (pickBy(undefined, num => num % 2): {...});
+  (pickBy({ [1]: 1, [2]: 2 }, num => num === 2): { [prop: number]: number, ... });
+  (pickBy(readOnlyObject, num => num === 2): { [prop: number]: number, ... });
+
+  /**
+   * _.toPairs / _.toPairsIn
+   */
+  var pairs: [string, number][];
+  pairs = toPairs({ a: 12, b: 100 });
+  pairs = toPairsIn({ a: 12, b: 100 });
+});
+
+describe('Seq', () => {
+
+  /**
+   * _.tap
+   */
+  (tap(1, n => false): number);
+
+  /**
+   * _.thru
+   */
+  (thru(1, n => false): boolean);
+});
+
+describe('String', () => {
+})
+
+describe('Util', () => {
+  /**
+     * _.attempt
+   */
+  attempt(() => void 0);
+  attempt(x => x);
+  attempt(x => x, "first arg");
+  attempt((x, y, z) => {}, null, {}, []);
+
+  /**
+   * _.defaultTo
+   */
+  (defaultTo(undefined, 2): number);
+  (defaultTo(undefined, "str"): string);
+  (defaultTo(true, "str"): boolean);
+  (defaultTo("str", true): string);
+
+  /**
+   * _.noop
+   */
+  noop();
+  noop(1);
+  noop("a", 2, [], null);
+  (noop: string => void);
+  (noop: (number, string) => void);
+  // $ExpectError functions are contravariant in return types
+  (noop: string => string);
+
+  /**
+   * _.range
+   */
+  range(0, 10)[4] == 4;
+  // $ExpectError string. This type is incompatible with number
+  range(0, "a");
+  // $ExpectError string cannot be compared to number
+  range(0, 10)[4] == "a";
+
+  /**
+   * _.times
+   */
+  var timesNums: number[];
+  timesNums = times(5);
+  // $ExpectError string. This type is incompatible with number
+  (times(5): string[]);
+  timesNums = times(5, function(i: number) {
+    return i + 1;
+  });
+  // $ExpectError string. This type is incompatible with number
+  timesNums = times(5, function(i: number) {
+    return JSON.stringify(i);
+  });
 });
 

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -8,6 +8,7 @@ import assignIn from "lodash/assignIn";
 import attempt from "lodash/attempt";
 import chunk from "lodash/chunk";
 import clone from "lodash/clone";
+import compact from "lodash/compact";
 import concat from "lodash/concat";
 import conformsTo from "lodash/conformsTo";
 import countBy from "lodash/countBy";

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -203,8 +203,10 @@ zipWith(["a", "b", "c"], [1, 2, 3]).map(([x, y]) => x * y);
 /**
  * _.countBy
  */
-countBy([6.1, 4.2, 6.3], Math.floor);
-countBy(["one", "two", "three"], "length");
+(countBy([6.1, 4.2, 6.3], Math.floor): { [string]: number, ... });
+(countBy(["one", "two", "three"], "length"): { [string]: number, ... });
+// $ExpectError
+(countBy(["one", "two", "three"], "length"): { [string]: string, ... });
 
 /**
  * _.each

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -63,404 +63,369 @@ type ReadOnlyObject = $ReadOnly<{ [string]: number, ... }>
 const readOnlyObject : ReadOnlyObject = { [1]: 1, [2]: 2 };
 
 describe('Array', () => {
-  /**
-   * _.chunk
-   */
-  chunk(readOnlyArray, 2);
 
-  /**
-   * _.compact
-   */
-  compact(readOnlyArray);
-
-  /**
-   * _.concat
-   */
-  concat(readOnlyArray, readOnlyArray, readOnlyArray);
-// Copy pasted tests from iflow-lodash
-  const nums: number[] = [1, 2, 3, 4, 5, 6];
-  (concat(nums, "123", "456"): Array<number | string>);
-  (concat(nums, ["123", "456"]): Array<number | string>);
-  (concat(nums, [[1, 2, 3], "456"]): Array<number | string>);
-  (concat(nums, [[1, 2, 3], "456"]): Array<mixed>);
-
-  /**
-   * _.difference
-   */
-  difference(
-    (["a", "b"]: $ReadOnlyArray<string>),
-    (["b"]: $ReadOnlyArray<string>)
-  );
-  difference(
-    (["a", "b"]: $ReadOnlyArray<string>),
-    (["b"]: $ReadOnlyArray<string>),
-    (["a"]: $ReadOnlyArray<string>)
-  );
-
-  /**
-   * _.differenceBy
-   */
-  differenceBy(([2.1, 1.2]: $ReadOnlyArray<number>), [2.3, 3.4], Math.floor);
-  differenceBy([{ x: 2 }, { x: 1 }], [{ x: 1 }], "x");
-  differenceBy(([2.1, 1.2]: $ReadOnlyArray<number>), [2.3, 3.4], Math.floor);
-  type A = {| a: 1 |};
-  type B = {| b: 1 |};
-  differenceBy(([{ a: 1 }, { a: 1 }]: $ReadOnlyArray<A>), ([{ b: 1 }, { b: 1 }]: $ReadOnlyArray<B>), (x: A | B) => {
-    return x.a || x.b;
+  it('chunk', () => {
+    chunk(readOnlyArray, 2);
   });
 
-  /**
-   * _.differenceWith
-   */
-  differenceWith(([{ a: 1 }, { a: 1 }]: $ReadOnlyArray<A>), ([{ b: 1 }, { b: 1 }]: $ReadOnlyArray<B>), (x: A, y: B) => {
-    return x.a === y.b;
+  it('compact', () => {
+    compact(readOnlyArray);
   });
 
-  /**
-   * _.intersectionBy
-   */
-  intersectionBy([2.1, 1.2], [2.3, 3.4], Math.floor);
-  intersectionBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], "x");
-
-  /**
-   * _.pullAllBy
-   */
-  pullAllBy([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 1 }], [{ x: 1 }, { x: 3 }], "x");
-
-  /**
-   * _.sortedIndexBy
-   */
-  sortedIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, function(o) {
-    return o.x;
+  it('concat', () => {
+    concat(readOnlyArray, readOnlyArray, readOnlyArray);
+  // Copy pasted tests from iflow-lodash
+    const nums: number[] = [1, 2, 3, 4, 5, 6];
+    (concat(nums, "123", "456"): Array<number | string>);
+    (concat(nums, ["123", "456"]): Array<number | string>);
+    (concat(nums, [[1, 2, 3], "456"]): Array<number | string>);
+    (concat(nums, [[1, 2, 3], "456"]): Array<mixed>);
   });
-  sortedIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, "x");
 
-  /**
-   * _.sortedLastIndexBy
-   */
-  sortedLastIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, function(o) {
-    return o.x;
+  it('difference', () => {
+    difference(
+      (["a", "b"]: $ReadOnlyArray<string>),
+      (["b"]: $ReadOnlyArray<string>)
+    );
+    difference(
+      (["a", "b"]: $ReadOnlyArray<string>),
+      (["b"]: $ReadOnlyArray<string>),
+      (["a"]: $ReadOnlyArray<string>)
+    );
   });
-  sortedLastIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, "x");
 
-  /**
-   * _.sortedUniq
-   */
-  sortedUniq([1, 2, 2]);
-  sortedUniq(["a", "b", "b"]);
+  it('differenceBy', () => {
+    differenceBy(([2.1, 1.2]: $ReadOnlyArray<number>), [2.3, 3.4], Math.floor);
+    differenceBy([{ x: 2 }, { x: 1 }], [{ x: 1 }], "x");
+    differenceBy(([2.1, 1.2]: $ReadOnlyArray<number>), [2.3, 3.4], Math.floor);
+    type A = {| a: 1 |};
+    type B = {| b: 1 |};
+    differenceBy(([{ a: 1 }, { a: 1 }]: $ReadOnlyArray<A>), ([{ b: 1 }, { b: 1 }]: $ReadOnlyArray<B>), (x: A | B) => {
+      return x.a || x.b;
+    });
+  });
 
-  /**
-   * _.sortedUniqBy
-   */
-  sortedUniqBy([1.2, 2.1, 2.3], Math.floor);
-  sortedUniqBy([{ x: 1 }, { x: 1 }, { x: 2 }], "x");
+  it('differenceWith', () => {
+    type A = {| a: 1 |};
+    type B = {| b: 1 |};
+    differenceWith(([{ a: 1 }, { a: 1 }]: $ReadOnlyArray<A>), ([{ b: 1 }, { b: 1 }]: $ReadOnlyArray<B>), (x: A, y: B) => {
+      return x.a === y.b;
+    });
+  });
 
-  /**
-   * _.take / _.takeRight
-   */
-  var taken: string[];
-  taken = take((["abc", "123"]: $ReadOnlyArray<string>), 3);
-  taken = takeRight((["abc", "123"]: $ReadOnlyArray<string>));
+  it('intersectionBy', () => {
+    intersectionBy([2.1, 1.2], [2.3, 3.4], Math.floor);
+    intersectionBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], "x");
+  });
 
-  /**
-   * _.unionBy
-   */
-  unionBy([2.1], [1.2, 2.3], Math.floor);
-  unionBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], "x");
+  it('pullAllBy', () => {
+    pullAllBy([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 1 }], [{ x: 1 }, { x: 3 }], "x");
+  });
 
-  /**
-   * _.uniqBy
-   */
-  uniqBy([2.1, 1.2, 2.3], Math.floor);
-  uniqBy([{ x: 1 }, { x: 2 }, { x: 1 }], "x");
+  it('sortedIndexBy', () => {
+    sortedIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, function(o) {
+      return o.x;
+    });
+    sortedIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, "x");
+  });
 
-  /**
-   * _.xorBy
-   */
-  xorBy([2.1, 1.2], [2.3, 3.4], Math.floor);
-  xorBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], "x");
+  it('sortedLastIndexBy', () => {
+    sortedLastIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, function(o) {
+      return o.x;
+    });
+    sortedLastIndexBy([{ x: 4 }, { x: 5 }], { x: 4 }, "x");
+  });
 
-  /**
-   * _.zip
-   */
-  zip(["a", "b", "c"], ["d", "e", "f"])[0].length;
-  zip(["a", "b", "c"], [1, 2, 3])[0].length;
-  zip(["a", "b", "c"], [1, 2, 3])[0][0] + "a";
-  zip(["a", "b", "c"], [1, 2, 3])[0][1] * 10;
-// $ExpectError `x` property not found in Array
-  zip([{ x: 1 }], [{ x: 2, y: 1 }])[0].x;
-// $ExpectError `y` property not found in object literal
-  zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][0].y;
-  zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][1].y;
-// $ExpectError Flow could potentially catch this -- the tuple only has two elements.
-  zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][2];
+  it('sortedUniq', () => {
+    sortedUniq([1, 2, 2]);
+    sortedUniq(["a", "b", "b"]);
+  });
 
-  /**
-   * _.zipWith
-   */
-  zipWith(["a", "b", "c"], [1, 2, 3], (str: string, num) => ({ [str]: num }));
-  zipWith((["a", "b", "c"]: $ReadOnlyArray<string>), ([1, 2, 3]: $ReadOnlyArray<number>), (str: string, num) => ({ [str]: num }));
-  zipWith(readOnlyArray, readOnlyArray, readOnlyArray);
-  zipWith(readOnlyArray, readOnlyArray, readOnlyArray, (a: number, b: number, c: number) => [a, b, c]);
-  zipWith(readOnlyArray, readOnlyArray, readOnlyArray, readOnlyArray);
-  zipWith(readOnlyArray, readOnlyArray, readOnlyArray, readOnlyArray, (a: number, b: number, c: number, d: number) => [a, b, c, d]);
-  // $ExpectError `x` should be a `string`, `y` a `number`
-  zipWith(["a", "b", "c"], [1, 2, 3]).map(([x, y]) => x * y);
+  it('sortedUniqBy', () => {
+    sortedUniqBy([1.2, 2.1, 2.3], Math.floor);
+    sortedUniqBy([{ x: 1 }, { x: 1 }, { x: 2 }], "x");
+  });
 
+  it('take / _.takeRight', () => {
+    var taken: string[];
+    taken = take((["abc", "123"]: $ReadOnlyArray<string>), 3);
+    taken = takeRight((["abc", "123"]: $ReadOnlyArray<string>));
+  });
 
+  it('unionBy', () => {
+    unionBy([2.1], [1.2, 2.3], Math.floor);
+    unionBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], "x");
+  });
 
+  it('uniqBy', () => {
+    uniqBy([2.1, 1.2, 2.3], Math.floor);
+    uniqBy([{ x: 1 }, { x: 2 }, { x: 1 }], "x");
+  });
 
+  it('xorBy', () => {
+    xorBy([2.1, 1.2], [2.3, 3.4], Math.floor);
+    xorBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], "x");
+  });
+
+  it('zip', () => {
+    zip(["a", "b", "c"], ["d", "e", "f"])[0].length;
+    zip(["a", "b", "c"], [1, 2, 3])[0].length;
+    zip(["a", "b", "c"], [1, 2, 3])[0][0] + "a";
+    zip(["a", "b", "c"], [1, 2, 3])[0][1] * 10;
+  // $ExpectError `x` property not found in Array
+    zip([{ x: 1 }], [{ x: 2, y: 1 }])[0].x;
+  // $ExpectError `y` property not found in object literal
+    zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][0].y;
+    zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][1].y;
+  // $ExpectError Flow could potentially catch this -- the tuple only has two elements.
+    zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][2];
+  });
+
+  it('zipWith', () => {
+    zipWith(["a", "b", "c"], [1, 2, 3], (str: string, num) => ({ [str]: num }));
+    zipWith((["a", "b", "c"]: $ReadOnlyArray<string>), ([1, 2, 3]: $ReadOnlyArray<number>), (str: string, num) => ({ [str]: num }));
+    zipWith(readOnlyArray, readOnlyArray, readOnlyArray);
+    zipWith(readOnlyArray, readOnlyArray, readOnlyArray, (a: number, b: number, c: number) => [a, b, c]);
+    zipWith(readOnlyArray, readOnlyArray, readOnlyArray, readOnlyArray);
+    zipWith(readOnlyArray, readOnlyArray, readOnlyArray, readOnlyArray, (a: number, b: number, c: number, d: number) => [a, b, c, d]);
+    // $ExpectError `x` should be a `string`, `y` a `number`
+    zipWith(["a", "b", "c"], [1, 2, 3]).map(([x, y]) => x * y);
+  });
 });
 
 describe('Collection', () => {
 
-  /**
-   * _.countBy
-   */
-  (countBy([6.1, 4.2, 6.3], Math.floor): { [string]: number, ... });
-  (countBy(["one", "two", "three"], "length"): { [string]: number, ... });
-// $ExpectError
-  (countBy(["one", "two", "three"], "length"): { [string]: string, ... });
-
-  /**
-   * _.each
-   */
-  each(([1, 2]: $ReadOnlyArray<number>), (item: number) => false);
-  each(readOnlyObject, (item: number) => false);
-
-  /**
-   * _.find
-   */
-  find([1, 2, 3], x => x * 1 == 3);
-  find([1, 2, 3], x => x == 2, 1);
-  // $ExpectError number cannot be compared to string
-  find([1, 2, 3], x => x == "a");
-  // $ExpectError number. This type is incompatible with function type.
-  find([1, 2, 3], 1);
-  // $ExpectError property `y`. Property not found in object literal
-  find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.y == 3);
-  find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.x == 3);
-  find({ x: 1, y: 2 }, (a: number, b: string) => a);
-  find({ x: 1, y: 2 }, { x: 3 });
-  find((["a", "b"]: $ReadOnlyArray<string>), "c");
-  // opaque types are allowed as keys of objects
-  opaque type O = string;
-  const v: { [O]: number, ... } = { x: 1, y: 2 };
-  find(v, { x: 3 });
-
-  (find([1, 2, 3], x => x == 1): void | number);
-  // $ExpectError number. This type is incompatible with function type.
-  (find([1, 2, 3], 1): void | number);
-
-  // _.find examples from the official doc
-  const users = [
-    { user: "barney", age: 36, active: true },
-    { user: "fred", age: 40, active: false },
-    { user: "pebbles", age: 1, active: true }
-  ];
-
-  find(users, function(o) {
-    return o.age < 40;
+  it('countBy', () => {
+    (countBy([6.1, 4.2, 6.3], Math.floor): { [string]: number, ... });
+    (countBy(["one", "two", "three"], "length"): { [string]: number, ... });
+  // $ExpectError
+    (countBy(["one", "two", "three"], "length"): { [string]: string, ... });
   });
 
-  // The `_.matches` iteratee shorthand.
-  find(users, { age: 1, active: true });
-
-  // The `_.matchesProperty` iteratee shorthand.
-  find(users, ["active", false]);
-
-  // The `_.property` iteratee shorthand.
-  find(users, "active");
-
-  /**
-   * _.flatMap
-   */
-  // this arrow function needs a type annotation due to a bug in flow: https://github.com/facebook/flow/issues/1948
-  flatMap([1, 2, 3], (n): number[] => [n, n]);
-  flatMap({ a: 1, b: 2 }, n => [n, n]);
-
-  /**
-   * _.forEach
-   */
-  forEach(([1, 2]: $ReadOnlyArray<number>), (item: number) => false);
-
-  /**
-   * _.groupBy
-   */
-  const numbersGroupedByMathFloor = groupBy([6.1, 4.2, 6.3], Math.floor);
-  if (numbersGroupedByMathFloor[6]) {
-    numbersGroupedByMathFloor[6][0] / numbersGroupedByMathFloor[6][1];
-  }
-  const stringsGroupedByLength = groupBy(["one", "two", "three"], "length");
-  if (stringsGroupedByLength[3]) {
-    stringsGroupedByLength[3][0].toLowerCase();
-  }
-  const numbersObj: { [key: string]: number, ... } = { a: 6.1, b: 4.2, c: 6.3 };
-  const numbersGroupedByMathFloor2 = groupBy(numbersObj, Math.floor);
-  if (numbersGroupedByMathFloor2[6]) {
-    numbersGroupedByMathFloor2[6][0] / numbersGroupedByMathFloor2[6][1];
-  }
-  const stringObj: { [key: string]: string, ... } = { a: "one", b: "two", c: "three" };
-  const stringsGroupedByLength2 = groupBy(stringObj, "length");
-  if (stringsGroupedByLength2[3]) {
-    stringsGroupedByLength2[3][0].toLowerCase();
-  }
-
-  /**
-   * _.keyBy
-   */
-  keyBy([{ dir: "left", code: 97 }, { dir: "right", code: 100 }], function(o) {
-    return String.fromCharCode(o.code);
+  it('each', () => {
+    each(([1, 2]: $ReadOnlyArray<number>), (item: number) => false);
+    each(readOnlyObject, (item: number) => false);
   });
-  keyBy([{ dir: "left", code: 97 }, { dir: "right", code: 100 }], "dir");
 
-  // Example of keying a map of objects by a number type
-  type KeyByTest$ByNumber<T: Object> = { [number]: T, ... };
-  type KeyByTest$ByNumberMaybe<T: ?Object> = { [number]: T, ... };
-  type KeyByTest$Record = { id: number, ... };
-  const keyByTest_array: Array<KeyByTest$Record> = [
-    { id: 4 },
-    { id: 4 },
-    { id: 7 }
-  ];
-  const keyByTest_map: KeyByTest$ByNumber<KeyByTest$Record> = {
-    [keyByTest_array[0].id]: keyByTest_array[0],
-    [keyByTest_array[1].id]: keyByTest_array[1],
-    [keyByTest_array[2].id]: keyByTest_array[2]
-  };
-  (keyBy(keyByTest_map, "id"): KeyByTest$ByNumberMaybe<KeyByTest$Record>);
+  it('find', () => {
+    find([1, 2, 3], x => x * 1 == 3);
+    find([1, 2, 3], x => x == 2, 1);
+    // $ExpectError number cannot be compared to string
+    find([1, 2, 3], x => x == "a");
+    // $ExpectError number. This type is incompatible with function type.
+    find([1, 2, 3], 1);
+    // $ExpectError property `y`. Property not found in object literal
+    find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.y == 3);
+    find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.x == 3);
+    find({ x: 1, y: 2 }, (a: number, b: string) => a);
+    find({ x: 1, y: 2 }, { x: 3 });
+    find((["a", "b"]: $ReadOnlyArray<string>), "c");
+    // opaque types are allowed as keys of objects
+    opaque type O = string;
+    const v: { [O]: number, ... } = { x: 1, y: 2 };
+    find(v, { x: 3 });
 
-  /**
-   * _.map examples from the official doc
-   */
-  function square(n) {
-    return n * n;
-  }
+    (find([1, 2, 3], x => x == 1): void | number);
+    // $ExpectError number. This type is incompatible with function type.
+    (find([1, 2, 3], 1): void | number);
 
-  map([4, 8], square);
-  map({ a: 4, b: 8 }, square);
+    // _.find examples from the official doc
+    const users = [
+      { user: "barney", age: 36, active: true },
+      { user: "fred", age: 40, active: false },
+      { user: "pebbles", age: 1, active: true }
+    ];
 
-  //accepts tuple types
+    find(users, function(o) {
+      return o.age < 40;
+    });
 
-  const tuple: [number, number] = [1, 2];
-  map(tuple, val => val + 2);
-  //$ExpectError cannot push to tuple
-  map(tuple, (val, nothing, tupleArray) => tupleArray.push(123));
+    // The `_.matches` iteratee shorthand.
+    find(users, { age: 1, active: true });
 
-  // The `_.property` iteratee shorthand.
-  map([{ user: "barney" }, { user: "fred" }], "user");
+    // The `_.matchesProperty` iteratee shorthand.
+    find(users, ["active", false]);
 
-  // Array#map, lodash.map, lodash#map
-  const nums: number[] = [1, 2, 3, 4, 5, 6];
-  (nums.map(num => num * num): number[]);
-  (map(nums, num => num * num): number[]);
+    // The `_.property` iteratee shorthand.
+    find(users, "active");
+  });
 
-  // return type of iterator is reflected in result and chain
-  (nums.map(num => JSON.stringify(num)): string[]);
-  (map(nums, num => JSON.stringify(num)): string[]);
+  it('flatMap', () => {
+    // this arrow function needs a type annotation due to a bug in flow: https://github.com/facebook/flow/issues/1948
+    flatMap([1, 2, 3], (n): number[] => [n, n]);
+    flatMap({ a: 1, b: 2 }, n => [n, n]);
+  });
 
-  /**
-   * _.orderBy
-   */
-  (orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], ['a']): Array<{
-    a: number,
-    b: number,
-    ...
-  }>);
-  (orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], [x => x.a]): Array<{
-    a: number,
-    b: number,
-    ...
-  }>);
-  (orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, ['a']): Array<{
-    a: number,
-    b: number,
-    ...
-  }>);
-  (orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, [x => x.a]): Array<{
-    a: number,
-    b: number,
-    ...
-  }>);
-});
+  it('forEach', () => {
+    forEach(([1, 2]: $ReadOnlyArray<number>), (item: number) => false);
+  });
 
-describe('Date', () => {
-});
+  it('groupBy', () => {
+    const numbersGroupedByMathFloor = groupBy([6.1, 4.2, 6.3], Math.floor);
+    if (numbersGroupedByMathFloor[6]) {
+      numbersGroupedByMathFloor[6][0] / numbersGroupedByMathFloor[6][1];
+    }
+    const stringsGroupedByLength = groupBy(["one", "two", "three"], "length");
+    if (stringsGroupedByLength[3]) {
+      stringsGroupedByLength[3][0].toLowerCase();
+    }
+    const numbersObj: { [key: string]: number, ... } = { a: 6.1, b: 4.2, c: 6.3 };
+    const numbersGroupedByMathFloor2 = groupBy(numbersObj, Math.floor);
+    if (numbersGroupedByMathFloor2[6]) {
+      numbersGroupedByMathFloor2[6][0] / numbersGroupedByMathFloor2[6][1];
+    }
+    const stringObj: { [key: string]: string, ... } = { a: "one", b: "two", c: "three" };
+    const stringsGroupedByLength2 = groupBy(stringObj, "length");
+    if (stringsGroupedByLength2[3]) {
+      stringsGroupedByLength2[3][0].toLowerCase();
+    }
+  });
 
-describe('Function', () => {
+  it('keyBy', () => {
+    keyBy([{ dir: "left", code: 97 }, { dir: "right", code: 100 }], function(o) {
+      return String.fromCharCode(o.code);
+    });
+    keyBy([{ dir: "left", code: 97 }, { dir: "right", code: 100 }], "dir");
 
-  /**
-   * _.debounce
-   */
-  var debounced = debounce((a: number) => "foo");
-  debounced(1);
-  debounced.cancel();
-  debounced.flush();
-  // $ExpectError string is incompatible with number
-  debounced("a");
+    // Example of keying a map of objects by a number type
+    type KeyByTest$ByNumber<T: Object> = { [number]: T, ... };
+    type KeyByTest$ByNumberMaybe<T: ?Object> = { [number]: T, ... };
+    type KeyByTest$Record = { id: number, ... };
+    const keyByTest_array: Array<KeyByTest$Record> = [
+      { id: 4 },
+      { id: 4 },
+      { id: 7 }
+    ];
+    const keyByTest_map: KeyByTest$ByNumber<KeyByTest$Record> = {
+      [keyByTest_array[0].id]: keyByTest_array[0],
+      [keyByTest_array[1].id]: keyByTest_array[1],
+      [keyByTest_array[2].id]: keyByTest_array[2]
+    };
+    (keyBy(keyByTest_map, "id"): KeyByTest$ByNumberMaybe<KeyByTest$Record>);
+  });
 
-  /**
-   * _.memoize
-   */
-  var memoized: (a: number) => string = memoize((a: number) => "foo");
-  // $ExpectError memoize retains type information
-  memoized = memoize(() => {});
+  it('map examples from the official doc', () => {
+    function square(n) {
+      return n * n;
+    }
+
+    map([4, 8], square);
+    map({ a: 4, b: 8 }, square);
+
+    //accepts tuple types
+
+    const tuple: [number, number] = [1, 2];
+    map(tuple, val => val + 2);
+    //$ExpectError cannot push to tuple
+    map(tuple, (val, nothing, tupleArray) => tupleArray.push(123));
+
+    // The `_.property` iteratee shorthand.
+    map([{ user: "barney" }, { user: "fred" }], "user");
+
+    // Array#map, lodash.map, lodash#map
+    const nums: number[] = [1, 2, 3, 4, 5, 6];
+    (nums.map(num => num * num): number[]);
+    (map(nums, num => num * num): number[]);
+
+    // return type of iterator is reflected in result and chain
+    (nums.map(num => JSON.stringify(num)): string[]);
+    (map(nums, num => JSON.stringify(num)): string[]);
+  });
+
+  it('orderBy', () => {
+    (orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], ['a']): Array<{
+      a: number,
+      b: number,
+      ...
+    }>);
+    (orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], [x => x.a]): Array<{
+      a: number,
+      b: number,
+      ...
+    }>);
+    (orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, ['a']): Array<{
+      a: number,
+      b: number,
+      ...
+    }>);
+    (orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, [x => x.a]): Array<{
+      a: number,
+      b: number,
+      ...
+    }>);
+  });
+
+  describe('Date', () => {
+  });
+
+  describe('Function', () => {
+  });
+
+  it('debounce', () => {
+    var debounced = debounce((a: number) => "foo");
+    debounced(1);
+    debounced.cancel();
+    debounced.flush();
+    // $ExpectError string is incompatible with number
+    debounced("a");
+  });
+
+  it('memoize', () => {
+    var memoized: (a: number) => string = memoize((a: number) => "foo");
+    // $ExpectError memoize retains type information
+    memoized = memoize(() => {});
+  });
 });
 
 describe('Lang', () => {
-
-  /**
-   * _.clone
-   */
-  clone({ a: 1 }).a == 1;
-  // $ExpectError property `b`. Property not found in object literal
-  clone({ a: 1 }).b == 1;
-  // $ExpectError number. This type is incompatible with function type.
-  clone({ a: 1 }).a == "c";
-
-  /**
-   * _.isEqual
-   */
-  isEqual("a", "b");
-  isEqual({ x: 1 }, { y: 2 });
-
-  // Flow considers this compatible with isEqual(a: any, b: any).
-  // Reasonable people disagree about whether this should be considered a legal call.
-  // See https://github.com/splodingsocks/FlowTyped/pull/1#issuecomment-149345275
-  // and https://github.com/facebook/flow/issues/956
-  isEqual(1);
-
-  // $ExpectError function type expects no more than 2 arguments
-  isEqual(1, 2, 3);
-
-  /**
-   * _.isString
-   */
-  var boolTrue: true;
-  var boolFalse: false;
-  boolTrue = isString("foo");
-  boolFalse = isString([""]);
-  boolFalse = isString({});
-  boolFalse = isString(5);
-  boolFalse = isString(function(f) {
-    return f;
+  it('clone', () => {
+    clone({ a: 1 }).a == 1;
+    // $ExpectError property `b`. Property not found in object literal
+    clone({ a: 1 }).b == 1;
+    // $ExpectError number. This type is incompatible with function type.
+    clone({ a: 1 }).a == "c";
   });
-  boolFalse = isString();
-  boolFalse = isString(true);
 
-  // $ExpectError
-  boolFalse = isString("");
-  // $ExpectError
-  boolTrue = isString(undefined);
+  it('isEqual', () => {
+    isEqual("a", "b");
+    isEqual({ x: 1 }, { y: 2 });
 
-  /**
-   * _.conformsTo
-   */
-  (conformsTo({ a: 1, b: 2 }, {
-    a: function(x: number) {
-      return true;
-    }
-  }): boolean);
+    // Flow considers this compatible with isEqual(a: any, b: any).
+    // Reasonable people disagree about whether this should be considered a legal call.
+    // See https://github.com/splodingsocks/FlowTyped/pull/1#issuecomment-149345275
+    // and https://github.com/facebook/flow/issues/956
+    isEqual(1);
+
+    // $ExpectError function type expects no more than 2 arguments
+    isEqual(1, 2, 3);
+  });
+
+  it('isString', () => {
+    var boolTrue: true;
+    var boolFalse: false;
+    boolTrue = isString("foo");
+    boolFalse = isString([""]);
+    boolFalse = isString({});
+    boolFalse = isString(5);
+    boolFalse = isString(function(f) {
+      return f;
+    });
+    boolFalse = isString();
+    boolFalse = isString(true);
+
+    // $ExpectError
+    boolFalse = isString("");
+    // $ExpectError
+    boolTrue = isString(undefined);
+  });
+
+  it('conformsTo', () => {
+    (conformsTo({ a: 1, b: 2 }, {
+      a: function(x: number) {
+        return true;
+      }
+    }): boolean);
+  });
 });
 
 describe('Math', () => {
@@ -470,140 +435,127 @@ describe('Number', () => {
 });
 
 describe('Object', () => {
+  it('extend', () => {
+    extend({ a: 1 }, { b: 2 }).a;
+    extend({ a: 1 }, { b: 2 }).b;
+    // $ExpectError property `c`. Property not found in object literal
+    extend({ a: 1 }, { b: 2 }).c;
+    // $ExpectError property `c`. Poperty not found in object literal
+    assignIn({ a: 1 }, { b: 2 }).c;
+  });
 
-  /**
-   * _.extend
-   */
-  extend({ a: 1 }, { b: 2 }).a;
-  extend({ a: 1 }, { b: 2 }).b;
-  // $ExpectError property `c`. Property not found in object literal
-  extend({ a: 1 }, { b: 2 }).c;
-  // $ExpectError property `c`. Poperty not found in object literal
-  assignIn({ a: 1 }, { b: 2 }).c;
+  it('get', () => {
+    // Object — examples from lodash docs
+    var exampleObjectForGetTest = { a: [{ b: { c: 3 } }] };
+    get(exampleObjectForGetTest, "a[0].b.c");
+    get(exampleObjectForGetTest, ["a", "0", "b", "c"]);
+    get(exampleObjectForGetTest, "a.b.c", "default");
 
-  /**
-   * _.get
-   */
-  // Object — examples from lodash docs
-  var exampleObjectForGetTest = { a: [{ b: { c: 3 } }] };
-  get(exampleObjectForGetTest, "a[0].b.c");
-  get(exampleObjectForGetTest, ["a", "0", "b", "c"]);
-  get(exampleObjectForGetTest, "a.b.c", "default");
+    // Array — not documented, but _.get does support arrays
+    get([1, 2, 3], "0");
+    get([1, 2, 3], 0);
+    get([1, 2, 3], [0]);
+    get(["foo", "bar", "baz"], "[1]");
+    get([{ a: "foo" }, { b: "bar" }, { c: "baz" }], "2");
+    get([[1, 2], [3, 4], [5, 6], [7, 8]], "3");
 
-  // Array — not documented, but _.get does support arrays
-  get([1, 2, 3], "0");
-  get([1, 2, 3], 0);
-  get([1, 2, 3], [0]);
-  get(["foo", "bar", "baz"], "[1]");
-  get([{ a: "foo" }, { b: "bar" }, { c: "baz" }], "2");
-  get([[1, 2], [3, 4], [5, 6], [7, 8]], "3");
+    // Nil - it is safe to perform on nil root values, just like nil values along the "get" path
+    get(null, "thing");
+    get(undefined, "data");
+  });
 
-  // Nil - it is safe to perform on nil root values, just like nil values along the "get" path
-  get(null, "thing");
-  get(undefined, "data");
+  it('omitBy', () => {
+    (omitBy({ a: 2, b: 3, c: 4 }, num => num % 2): { [prop: string]: number, ... });
+    (omitBy(null, num => num % 2): {...});
+    (omitBy(undefined, num => num % 2): {...});
+    (omitBy({ [1]: 1, [2]: 2 }, num => num === 2): { [prop: number]: number, ... });
+  });
 
-  /**
-   * _.omitBy
-   */
-  (omitBy({ a: 2, b: 3, c: 4 }, num => num % 2): { [prop: string]: number, ... });
-  (omitBy(null, num => num % 2): {...});
-  (omitBy(undefined, num => num % 2): {...});
-  (omitBy({ [1]: 1, [2]: 2 }, num => num === 2): { [prop: number]: number, ... });
+  it('pick', () => {
+    (pick({ a: 2, b: 3, c: 4 }, 'a'): { [prop: string]: number, ... });
+    (pick(null, 'a'): {...});
+    (pick(undefined, 'a'): {...});
+    (pick({ [1]: 1, [2]: 2 }, 'a'): { [prop: number]: number, ... });
 
-  /**
-   * _.pick
-   */
-  (pick({ a: 2, b: 3, c: 4 }, 'a'): { [prop: string]: number, ... });
-  (pick(null, 'a'): {...});
-  (pick(undefined, 'a'): {...});
-  (pick({ [1]: 1, [2]: 2 }, 'a'): { [prop: number]: number, ... });
+    // $ExpectError
+    pick({ a: 2 }, 1);
+  });
 
-  // $ExpectError
-  pick({ a: 2 }, 1);
+  it('pickBy', () => {
+    (pickBy({ a: 2, b: 3, c: 4 }, num => num % 2): { [prop: string]: number, ... });
+    (pickBy(null, num => num % 2): {...});
+    (pickBy(undefined, num => num % 2): {...});
+    (pickBy({ [1]: 1, [2]: 2 }, num => num === 2): { [prop: number]: number, ... });
+    (pickBy(readOnlyObject, num => num === 2): { [prop: number]: number, ... });
+  });
 
-  /**
-   * _.pickBy
-   */
-  (pickBy({ a: 2, b: 3, c: 4 }, num => num % 2): { [prop: string]: number, ... });
-  (pickBy(null, num => num % 2): {...});
-  (pickBy(undefined, num => num % 2): {...});
-  (pickBy({ [1]: 1, [2]: 2 }, num => num === 2): { [prop: number]: number, ... });
-  (pickBy(readOnlyObject, num => num === 2): { [prop: number]: number, ... });
-
-  /**
-   * _.toPairs / _.toPairsIn
-   */
-  var pairs: [string, number][];
-  pairs = toPairs({ a: 12, b: 100 });
-  pairs = toPairsIn({ a: 12, b: 100 });
+  it('toPairs / _.toPairsIn', () => {
+    var pairs: [string, number][];
+    pairs = toPairs({ a: 12, b: 100 });
+    pairs = toPairsIn({ a: 12, b: 100 });
+  });
 });
 
 describe('Seq', () => {
 
-  /**
-   * _.tap
-   */
-  (tap(1, n => false): number);
+  it('tap', () => {
+    (tap(1, n => false): number);
+  });
 
-  /**
-   * _.thru
-   */
-  (thru(1, n => false): boolean);
+  it('thru', () => {
+    (thru(1, n => false): boolean);
+  });
 });
 
 describe('String', () => {
 })
 
 describe('Util', () => {
-  /**
-     * _.attempt
-   */
-  attempt(() => void 0);
-  attempt(x => x);
-  attempt(x => x, "first arg");
-  attempt((x, y, z) => {}, null, {}, []);
 
-  /**
-   * _.defaultTo
-   */
-  (defaultTo(undefined, 2): number);
-  (defaultTo(undefined, "str"): string);
-  (defaultTo(true, "str"): boolean);
-  (defaultTo("str", true): string);
-
-  /**
-   * _.noop
-   */
-  noop();
-  noop(1);
-  noop("a", 2, [], null);
-  (noop: string => void);
-  (noop: (number, string) => void);
-  // $ExpectError functions are contravariant in return types
-  (noop: string => string);
-
-  /**
-   * _.range
-   */
-  range(0, 10)[4] == 4;
-  // $ExpectError string. This type is incompatible with number
-  range(0, "a");
-  // $ExpectError string cannot be compared to number
-  range(0, 10)[4] == "a";
-
-  /**
-   * _.times
-   */
-  var timesNums: number[];
-  timesNums = times(5);
-  // $ExpectError string. This type is incompatible with number
-  (times(5): string[]);
-  timesNums = times(5, function(i: number) {
-    return i + 1;
+  it('attempt', () => {
+    attempt(() => void 0);
+    attempt(x => x);
+    attempt(x => x, "first arg");
+    attempt((x, y, z) => {}, null, {}, []);
   });
-  // $ExpectError string. This type is incompatible with number
-  timesNums = times(5, function(i: number) {
-    return JSON.stringify(i);
+
+  it('defaultTo', () => {
+    (defaultTo(undefined, 2): number);
+    (defaultTo(undefined, "str"): string);
+    (defaultTo(true, "str"): boolean);
+    (defaultTo("str", true): string);
+  });
+
+  it('noop', () => {
+    noop();
+    noop(1);
+    noop("a", 2, [], null);
+    (noop: string => void);
+    (noop: (number, string) => void);
+    // $ExpectError functions are contravariant in return types
+    (noop: string => string);
+  });
+
+  it('range', () => {
+    range(0, 10)[4] == 4;
+    // $ExpectError string. This type is incompatible with number
+    range(0, "a");
+    // $ExpectError string cannot be compared to number
+    range(0, 10)[4] == "a";
+  });
+
+  it('times', () => {
+    var timesNums: number[];
+    timesNums = times(5);
+    // $ExpectError string. This type is incompatible with number
+    (times(5): string[]);
+    timesNums = times(5, function(i: number) {
+      return i + 1;
+    });
+    // $ExpectError string. This type is incompatible with number
+    timesNums = times(5, function(i: number) {
+      return JSON.stringify(i);
+    });
   });
 });
 

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -63,7 +63,6 @@ type ReadOnlyObject = $ReadOnly<{ [string]: number, ... }>
 const readOnlyObject : ReadOnlyObject = { [1]: 1, [2]: 2 };
 
 describe('Array', () => {
-
   it('chunk', () => {
     chunk(readOnlyArray, 2);
   });
@@ -113,6 +112,10 @@ describe('Array', () => {
     });
   });
 
+  it('first', () => {
+    (first([1, 2, 3, 4]): number);
+  });
+
   it('intersectionBy', () => {
     intersectionBy([2.1, 1.2], [2.3, 3.4], Math.floor);
     intersectionBy([{ x: 1 }], [{ x: 2 }, { x: 1 }], "x");
@@ -147,9 +150,8 @@ describe('Array', () => {
   });
 
   it('take / _.takeRight', () => {
-    var taken: string[];
-    taken = take((["abc", "123"]: $ReadOnlyArray<string>), 3);
-    taken = takeRight((["abc", "123"]: $ReadOnlyArray<string>));
+    (take((["abc", "123"]: $ReadOnlyArray<string>), 3): string[]);
+    (takeRight((["abc", "123"]: $ReadOnlyArray<string>)): string[]);
   });
 
   it('unionBy', () => {
@@ -172,12 +174,12 @@ describe('Array', () => {
     zip(["a", "b", "c"], [1, 2, 3])[0].length;
     zip(["a", "b", "c"], [1, 2, 3])[0][0] + "a";
     zip(["a", "b", "c"], [1, 2, 3])[0][1] * 10;
-  // $ExpectError `x` property not found in Array
+    // $ExpectError `x` property not found in Array
     zip([{ x: 1 }], [{ x: 2, y: 1 }])[0].x;
-  // $ExpectError `y` property not found in object literal
+    // $ExpectError `y` property not found in object literal
     zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][0].y;
     zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][1].y;
-  // $ExpectError Flow could potentially catch this -- the tuple only has two elements.
+    // $ExpectError Flow could potentially catch this -- the tuple only has two elements.
     zip([{ x: 1 }], [{ x: 2, y: 1 }])[0][2];
   });
 
@@ -194,11 +196,10 @@ describe('Array', () => {
 });
 
 describe('Collection', () => {
-
   it('countBy', () => {
     (countBy([6.1, 4.2, 6.3], Math.floor): { [string]: number, ... });
     (countBy(["one", "two", "three"], "length"): { [string]: number, ... });
-  // $ExpectError
+    // $ExpectError
     (countBy(["one", "two", "three"], "length"): { [string]: string, ... });
   });
 
@@ -354,13 +355,12 @@ describe('Collection', () => {
       ...
     }>);
   });
+});
 
-  describe('Date', () => {
-  });
+describe('Date', () => {
+});
 
-  describe('Function', () => {
-  });
-
+describe('Function', () => {
   it('debounce', () => {
     var debounced = debounce((a: number) => "foo");
     debounced(1);
@@ -497,7 +497,6 @@ describe('Object', () => {
 });
 
 describe('Seq', () => {
-
   it('tap', () => {
     (tap(1, n => false): number);
   });
@@ -511,7 +510,6 @@ describe('String', () => {
 })
 
 describe('Util', () => {
-
   it('attempt', () => {
     attempt(() => void 0);
     attempt(x => x);
@@ -558,4 +556,3 @@ describe('Util', () => {
     });
   });
 });
-


### PR DESCRIPTION
- Type of contribution: fix

Previous PR #3763 was closed a bit too quickly :) 

This PR is kind of a second part to that one - it adds $ReadOnlyArray<> instead of Array<> to lodash/fp functions arguments (only for functions which do not mutate input arrays according to docs). This PR is also related to closing #1099 .

Also this PR makes types of sample, sampleSize, shuffle more precise (tests added).

