### PR TITLE
Add state and key back to the Location type of react-router

### DIFF
--- a/definitions/npm/react-router-dom_v5.x.x/flow_v0.104.x-/react-router-dom_v5.x.x.js
+++ b/definitions/npm/react-router-dom_v5.x.x/flow_v0.104.x-/react-router-dom_v5.x.x.js
@@ -37,17 +37,20 @@ declare module "react-router-dom" {
 
   // NOTE: Below are duplicated from react-router. If updating these, please
   // update the react-router and react-router-native types as well.
-  declare export type Location = {
+  declare export type Location = $ReadOnly<{
     pathname: string,
     search: string,
     hash: string,
+    state?: any,
+    key?: string,
     ...
-  };
+  }>;
 
   declare export type LocationShape = {
     pathname?: string,
     search?: string,
     hash?: string,
+    state?: any,
     ...
   };
 

--- a/definitions/npm/react-router-native_v4.x.x/flow_v0.104.x-/react-router-native_v4.x.x.js
+++ b/definitions/npm/react-router-native_v4.x.x/flow_v0.104.x-/react-router-native_v4.x.x.js
@@ -21,17 +21,20 @@ declare module "react-router-native" {
 
   // NOTE: Below are duplicated from react-router. If updating these, please
   // update the react-router and react-router-dom types as well.
-  declare export type Location = {
+  declare export type Location = $ReadOnly<{
     pathname: string,
     search: string,
     hash: string,
+    state?: any,
+    key?: string,
     ...
-  };
+  }>;
 
   declare export type LocationShape = {
     pathname?: string,
     search?: string,
     hash?: string,
+    state?: any,
     ...
   };
 

--- a/definitions/npm/react-router_v5.x.x/flow_v0.104.x-/react-router_v5.x.x.js
+++ b/definitions/npm/react-router_v5.x.x/flow_v0.104.x-/react-router_v5.x.x.js
@@ -2,17 +2,20 @@ declare module "react-router" {
   // NOTE: many of these are re-exported by react-router-dom and
   // react-router-native, so when making changes, please be sure to update those
   // as well.
-  declare export type Location = {
+  declare export type Location = $ReadOnly<{
     pathname: string,
     search: string,
     hash: string,
+    state?: any,
+    key?: string,
     ...
-  };
+  }>;
 
   declare export type LocationShape = {
     pathname?: string,
     search?: string,
     hash?: string,
+    state?: any,
     ...
   };
 


### PR DESCRIPTION
- Links to documentation: https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/location.md
- Type of contribution: fix

I saw that in a previous PR these fields were removed; however, as visible from the documentation, these fields can appear in the react-router location and now whenever I try to access them, Flow shows an error about the missing properties. Would you consider adding them back?

