### PR TITLE
Lodash - use $ReadOnly object for arguments

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -168,10 +168,10 @@ declare module "lodash" {
   };
 
   declare type Key = string | number;
-  declare type IndexerObject<T, K = Key> = { [key: K]: T, ... };
-  declare type ReadOnlyIndexerObject<T, K = Key> = $ReadOnly<IndexerObject<T, K>>;
-  declare type NestedArray<T> = Array<Array<T>>;
-  declare type Collection<T> = $ReadOnlyArray<T> | ReadOnlyIndexerObject<T>;
+  declare type IndexerObject<V, K = Key> = { [key: K]: V, ... };
+  declare type ReadOnlyIndexerObject<V, K = Key> = $ReadOnly<IndexerObject<V, K>>;
+  declare type NestedArray<V> = Array<Array<V>>;
+  declare type Collection<V> = $ReadOnlyArray<V> | ReadOnlyIndexerObject<V>;
 
   declare type matchesIterateeShorthand = { [key: any]: any, ... };
   declare type matchesPropertyIterateeShorthand = [string, any];
@@ -553,9 +553,9 @@ declare module "lodash" {
     countBy<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>): {...};
     countBy<T>(object: ReadOnlyIndexerObject<T>, iteratee?: ?ValueOnlyIteratee<T>): { [string]: number, ... };
     // alias of _.forEach
-    each<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
+    each<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<A> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     // alias of _.forEachRight
-    eachRight<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
+    eachRight<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<A> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     every<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): boolean;
     every<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: OIterateeWithResult<A, string, T, any>): boolean;
     filter<T>(array?: ?$ReadOnlyArray<T>, predicate?: ?Predicate<T>): Array<T>;
@@ -593,34 +593,34 @@ declare module "lodash" {
       predicate?: ?OPredicate<A, T>,
       fromIndex?: ?number
     ): V;
-    flatMap<A, K, U, T: $ReadOnlyArray<T>>(
+    flatMap<A, K, U, T: $ReadOnlyArray<A> = Array<A>>(
       array: T,
       iteratee?: ?AFlatMapIteratee<A, T, U>
     ): Array<U>;
-    flatMap<A, K, U, T: ?ReadOnlyIndexerObject<A> | string = IndexerObject<T>>(
+    flatMap<A, K, U, T: ?ReadOnlyIndexerObject<A> | string = IndexerObject<A>>(
       object: T,
       iteratee?: ?OFlatMapIteratee<A, K, T, U>
     ): Array<U>;
-    flatMapDeep<A, U, T: $ReadOnlyArray<T> = Array<T>>(
+    flatMapDeep<A, U, T: $ReadOnlyArray<A> = Array<A>>(
       array: T,
       iteratee?: ?AFlatMapIteratee<A, T, any>
     ): Array<U>;
-    flatMapDeep<A, K, U, T: ?ReadOnlyIndexerObject<A> | string = IndexerObject<T>>(
+    flatMapDeep<A, K, U, T: ?ReadOnlyIndexerObject<A> | string = IndexerObject<A>>(
       object: T,
       iteratee?: ?OFlatMapIteratee<A, K, T, any>
     ): Array<U>;
-    flatMapDepth<A, U, T: $ReadOnlyArray<T> = Array<T>>(
+    flatMapDepth<A, U, T: $ReadOnlyArray<A> = Array<A>>(
       array: T,
       iteratee?: ?AFlatMapIteratee<A, T, any>,
       depth?: ?number
     ): Array<U>;
-    flatMapDepth<A, K, U, T: ?ReadOnlyIndexerObject<A> | string = IndexerObject<T>>(
+    flatMapDepth<A, K, U, T: ?ReadOnlyIndexerObject<A> | string = IndexerObject<A>>(
       object: T,
       iteratee?: ?OFlatMapIteratee<A, K, T, any>,
       depth?: ?number
     ): Array<U>;
-    forEach<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
-    forEachRight<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
+    forEach<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<A> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
+    forEachRight<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<A> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     groupBy<V, T>(
       array: $ReadOnlyArray<T>,
       iteratee?: ?ValueOnlyIteratee<T>

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -168,7 +168,8 @@ declare module "lodash" {
   };
 
   declare type Key = string | number;
-  declare type ReadOnlyIndexerObject<T, I = Key> = $ReadOnly<{ [id: I]: T, ... }>
+  declare type IndexerObject<T, I = Key> = { [id: I]: T, ... };
+  declare type ReadOnlyIndexerObject<T, I = Key> = $ReadOnly<IndexerObject<T, I>>;
   declare type NestedArray<T> = Array<Array<T>>;
   declare type Collection<T> = $ReadOnlyArray<T> | ReadOnlyIndexerObject<T>;
 
@@ -192,9 +193,9 @@ declare module "lodash" {
   declare type OIteratee<O> = OIterateeWithResult<any, string, O, any>;
 
   declare type AFlatMapIteratee<T, O, U> =
-    | ((item: T, index: number, array: O) => Array<U>)
-    | string;
-  declare type OFlatMapIteratee<V, T, U, K = string> = IterateeWithResult<V, K, T, Array<U>>;
+    | ((item: T, index: number, array: O) => Array<U> | U)
+    | string
+  declare type OFlatMapIteratee<V, K, T, U> = IterateeWithResult<V, K, T, Array<U> | U>;
 
   declare type Predicate<T> =
     | ((value: T, index: number, array: Array<T>) => any)
@@ -592,30 +593,30 @@ declare module "lodash" {
       predicate?: ?OPredicate<A, T>,
       fromIndex?: ?number
     ): V;
-    flatMap<A, U, T: ?$ReadOnlyArray<T> = Array<T>>(
+    flatMap<A, K, U, T: $ReadOnlyArray<T>>(
       array: T,
       iteratee?: ?AFlatMapIteratee<A, T, U>
     ): Array<U>;
-    flatMap<A, U, T: ?ReadOnlyIndexerObject<A> = ReadOnlyIndexerObject<T>>(
+    flatMap<A, K, U, T: ?ReadOnlyIndexerObject<A> | string = IndexerObject<T>>(
       object: T,
-      iteratee?: ?OFlatMapIteratee<A, T, U>
+      iteratee?: ?OFlatMapIteratee<A, K, T, U>
     ): Array<U>;
-    flatMapDeep<A, U, T: ?$ReadOnlyArray<T> = Array<T>>(
+    flatMapDeep<A, U, T: $ReadOnlyArray<T> = Array<T>>(
       array: T,
       iteratee?: ?AFlatMapIteratee<A, T, any>
     ): Array<U>;
-    flatMapDeep<A, U, T: ?ReadOnlyIndexerObject<A> = ReadOnlyIndexerObject<T>>(
+    flatMapDeep<A, K, U, T: ?ReadOnlyIndexerObject<A> | string = IndexerObject<T>>(
       object: T,
-      iteratee?: ?OFlatMapIteratee<A, T, any>
+      iteratee?: ?OFlatMapIteratee<A, K, T, any>
     ): Array<U>;
-    flatMapDepth<A, U, T: ?$ReadOnlyArray<T> = Array<T>>(
+    flatMapDepth<A, U, T: $ReadOnlyArray<T> = Array<T>>(
       array: T,
       iteratee?: ?AFlatMapIteratee<A, T, any>,
       depth?: ?number
     ): Array<U>;
-    flatMapDepth<A, U, T: ?ReadOnlyIndexerObject<A> = ReadOnlyIndexerObject<T>>(
+    flatMapDepth<A, K, U, T: ?ReadOnlyIndexerObject<A> | string = IndexerObject<T>>(
       object: T,
-      iteratee?: ?OFlatMapIteratee<A, T, any>,
+      iteratee?: ?OFlatMapIteratee<A, K, T, any>,
       depth?: ?number
     ): Array<U>;
     forEach<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -758,8 +758,8 @@ declare module "lodash" {
     ): Array<A>;
     sample<T>(collection: ?Collection<T>): T;
     sampleSize<T>(collection?: ?Collection<T>, n?: ?number): Array<T>;
-    shuffle<T>(array: ?Collection<T>): Array<T>;
-    size(collection: Collection<any> | string): number;
+    shuffle<T>(array?: ?Collection<T>): Array<T>;
+    size(collection?: ?Collection<any> | string): number;
     some<T>(array: void | null, predicate?: ?Predicate<T>): false;
     some<T>(array: ?$ReadOnlyArray<T>, predicate?: Predicate<T>): boolean;
     some<A, T: ReadOnlyIndexerObject<A>>(

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -552,15 +552,9 @@ declare module "lodash" {
     countBy<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>): {...};
     countBy<T>(object: ReadOnlyIndexerObject<T>, iteratee?: ?ValueOnlyIteratee<T>): { [string]: number, ... };
     // alias of _.forEach
-    each<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
-    each<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
-    each<T: string>(str: string, iteratee?: ?Iteratee<string>): T;
-    each<A, K, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
+    each<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     // alias of _.forEachRight
-    eachRight<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
-    eachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
-    eachRight<T: string>(str: string, iteratee?: ?Iteratee<string>): T;
-    eachRight<A, K, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
+    eachRight<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     every<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): boolean;
     every<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: OIterateeWithResult<A, string, T, any>): boolean;
     filter<T>(array?: ?$ReadOnlyArray<T>, predicate?: ?Predicate<T>): Array<T>;
@@ -624,17 +618,8 @@ declare module "lodash" {
       iteratee?: ?OFlatMapIteratee<A, T, any>,
       depth?: ?number
     ): Array<U>;
-    forEach<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
-    forEach<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
-    forEach<T: string>(str: string, iteratee?: ?Iteratee<string>): T;
-    forEach<A, K, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
-    forEachRight<T>(
-      array: $ReadOnlyArray<T>,
-      iteratee?: ?Iteratee<T>
-    ): Array<T>;
-    forEachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
-    forEachRight<T: string>(str: string, iteratee?: ?Iteratee<string>): T;
-    forEachRight<A, K, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
+    forEach<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
+    forEachRight<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     groupBy<V, T>(
       array: $ReadOnlyArray<T>,
       iteratee?: ?ValueOnlyIteratee<T>

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -172,7 +172,7 @@ declare module "lodash" {
   declare type NestedArray<T> = Array<Array<T>>;
   declare type Collection<T> = $ReadOnlyArray<T> | ReadOnlyIndexerObject<T>;
 
-  declare type matchesIterateeShorthand = { [key: Key]: any, ... };
+  declare type matchesIterateeShorthand = { [key: any]: any, ... };
   declare type matchesPropertyIterateeShorthand = [string, any];
   declare type propertyIterateeShorthand = string;
 
@@ -554,10 +554,12 @@ declare module "lodash" {
     // alias of _.forEach
     each<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
     each<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    each<T: string>(str: string, iteratee?: ?Iteratee<string>): T;
     each<A, K, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     // alias of _.forEachRight
     eachRight<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
     eachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    eachRight<T: string>(str: string, iteratee?: ?Iteratee<string>): T;
     eachRight<A, K, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     every<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): boolean;
     every<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: OIterateeWithResult<A, string, T, any>): boolean;
@@ -624,12 +626,14 @@ declare module "lodash" {
     ): Array<U>;
     forEach<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
     forEach<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    forEach<T: string>(str: string, iteratee?: ?Iteratee<string>): T;
     forEach<A, K, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     forEachRight<T>(
       array: $ReadOnlyArray<T>,
       iteratee?: ?Iteratee<T>
     ): Array<T>;
     forEachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
+    forEachRight<T: string>(str: string, iteratee?: ?Iteratee<string>): T;
     forEachRight<A, K, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     groupBy<V, T>(
       array: $ReadOnlyArray<T>,
@@ -1634,7 +1638,7 @@ declare module "lodash/fp" {
   declare type NestedArray<T> = Array<Array<T>>;
   declare type Collection<T> = $ReadOnlyArray<T> | ReadOnlyIndexerObject<T>;
 
-  declare type matchesIterateeShorthand = { [key: Key]: any, ... };
+  declare type matchesIterateeShorthand = { [key: any]: any, ... };
   declare type matchesPropertyIterateeShorthand = [string, any];
   declare type propertyIterateeShorthand = string;
 

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -182,19 +182,19 @@ declare module "lodash" {
     | matchesPropertyIterateeShorthand
     | propertyIterateeShorthand;
 
-  declare type IterateeWithResult<V, O, R, K = string> =
+  declare type IterateeWithResult<V, K, O, R> =
     | ((value: V, key: K, object: O) => R)
     | string;
 
-  declare type OIterateeWithResult<V, O, R> =
+  declare type OIterateeWithResult<V, K, O, R> =
     | ReadOnlyIndexerObject<V>
-    | IterateeWithResult<V, O, R>;
-  declare type OIteratee<O> = OIterateeWithResult<any, O, any>;
+    | IterateeWithResult<V, K, O, R>;
+  declare type OIteratee<O> = OIterateeWithResult<any, string, O, any>;
 
   declare type AFlatMapIteratee<T, O, U> =
     | ((item: T, index: number, array: O) => Array<U>)
     | string;
-  declare type OFlatMapIteratee<V, T, U, K = string> = IterateeWithResult<V, T, Array<U>, K>;
+  declare type OFlatMapIteratee<V, T, U, K = string> = IterateeWithResult<V, K, T, Array<U>>;
 
   declare type Predicate<T> =
     | ((value: T, index: number, array: Array<T>) => any)
@@ -554,13 +554,13 @@ declare module "lodash" {
     // alias of _.forEach
     each<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
     each<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
-    each<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, T, boolean | void>): T;
+    each<A, K, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     // alias of _.forEachRight
     eachRight<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
     eachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
-    eachRight<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, T, boolean | void>): T;
+    eachRight<A, K, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     every<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): boolean;
-    every<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: OIterateeWithResult<A, T, any>): boolean;
+    every<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: OIterateeWithResult<A, string, T, any>): boolean;
     filter<T>(array?: ?$ReadOnlyArray<T>, predicate?: ?Predicate<T>): Array<T>;
     filter<A, T: ReadOnlyIndexerObject<A>>(
       object: T,
@@ -624,13 +624,13 @@ declare module "lodash" {
     ): Array<U>;
     forEach<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
     forEach<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
-    forEach<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, T, boolean | void>): T;
+    forEach<A, K, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     forEachRight<T>(
       array: $ReadOnlyArray<T>,
       iteratee?: ?Iteratee<T>
     ): Array<T>;
     forEachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
-    forEachRight<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, T, boolean | void>): T;
+    forEachRight<A, K, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     groupBy<V, T>(
       array: $ReadOnlyArray<T>,
       iteratee?: ?ValueOnlyIteratee<T>

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -552,12 +552,14 @@ declare module "lodash" {
     // Collection
     countBy<T>(array: $ReadOnlyArray<T>, iteratee?: ?ValueOnlyIteratee<T>): { [string]: number, ... };
     countBy<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>): {...};
+    countBy(string: string, iteratee?: ?ValueOnlyIteratee<string>): { [string]: number, ... };
     countBy<T>(object: ReadOnlyIndexerObject<T>, iteratee?: ?ValueOnlyIteratee<T>): { [string]: number, ... };
     // alias of _.forEach
     each<A, K, T: ReadOnlyIndexerObject<A, K> | $ReadOnlyArray<A> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     // alias of _.forEachRight
     eachRight<A, K, T: ReadOnlyIndexerObject<A, K> | $ReadOnlyArray<A> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     every<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): boolean;
+    every(str: string, iteratee?: ?Iteratee<string>): boolean;
     every<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: OIterateeWithResult<A, string, T, any>): boolean;
     filter<T>(array?: ?$ReadOnlyArray<T>, predicate?: ?Predicate<T>): Array<T>;
     filter<A, T: ReadOnlyIndexerObject<A>>(
@@ -708,12 +710,12 @@ declare module "lodash" {
       iteratee?: ?(
         accumulator: U,
         value: T,
-        index: number,
+        index: any,
         array: ?Array<T>
       ) => U,
-      accumulator?: ?U
-    ): void | null;
-    reduce<T: Object, U>(
+      accumulator?: U
+    ): U;
+    reduce<A, T: ReadOnlyIndexerObject<A>, U>(
       object: T,
       iteratee?: (accumulator: U, value: any, key: string, object: T) => U,
       accumulator?: U
@@ -723,11 +725,11 @@ declare module "lodash" {
       iteratee?: ?(
         accumulator: U,
         value: T,
-        index: number,
+        index: any,
         array: ?Array<T>
       ) => U,
-      accumulator?: ?U
-    ): void | null;
+      accumulator?: U
+    ): U;
     reduceRight<T, U>(
       array: $ReadOnlyArray<T>,
       iteratee?: ?(
@@ -738,7 +740,7 @@ declare module "lodash" {
       ) => U,
       accumulator?: ?U
     ): U;
-    reduceRight<T: Object, U>(
+    reduceRight<A, T: ReadOnlyIndexerObject<A>, U>(
       object: T,
       iteratee?: ?(accumulator: U, value: any, key: string, object: T) => U,
       accumulator?: ?U

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -182,8 +182,8 @@ declare module "lodash" {
     | matchesPropertyIterateeShorthand
     | propertyIterateeShorthand;
 
-  declare type IterateeWithResult<V, O, R> =
-    | ((value: V, key: string, object: O) => R)
+  declare type IterateeWithResult<V, O, R, K = string> =
+    | ((value: V, key: K, object: O) => R)
     | string;
 
   declare type OIterateeWithResult<V, O, R> =
@@ -191,9 +191,10 @@ declare module "lodash" {
     | IterateeWithResult<V, O, R>;
   declare type OIteratee<O> = OIterateeWithResult<any, O, any>;
 
-  declare type AFlatMapIteratee<T, U> =
-    | ((item: T, index: number, array: ?$ReadOnlyArray<T>) => Array<U>)
-  declare type OFlatMapIteratee<V, T, U> = IterateeWithResult<V, T, Array<U>>;
+  declare type AFlatMapIteratee<T, O, U> =
+    | ((item: T, index: number, array: O) => Array<U>)
+    | string;
+  declare type OFlatMapIteratee<V, T, U, K = string> = IterateeWithResult<V, T, Array<U>, K>;
 
   declare type Predicate<T> =
     | ((value: T, index: number, array: Array<T>) => any)
@@ -595,31 +596,31 @@ declare module "lodash" {
       predicate?: ?OPredicate<A, T>,
       fromIndex?: ?number
     ): V;
-    flatMap<T, U>(
-      array?: ?$ReadOnlyArray<T>,
-      iteratee?: ?AFlatMapIteratee<T, U>
+    flatMap<A, U, T: ?$ReadOnlyArray<T> = Array<T>>(
+      array: T,
+      iteratee?: ?AFlatMapIteratee<A, T, U>
     ): Array<U>;
-    flatMap<A, T: ReadOnlyIndexerObject<A>, U>(
-      object: T,
-      iteratee?: OFlatMapIteratee<A, T, U>
-    ): Array<U>;
-    flatMapDeep<T, U>(
-      array?: ?$ReadOnlyArray<T>,
-      iteratee?: ?AFlatMapIteratee<T, U>
-    ): Array<U>;
-    flatMapDeep<A, T: ReadOnlyIndexerObject<A>, U>(
+    flatMap<A, U, T: ?ReadOnlyIndexerObject<A> = ReadOnlyIndexerObject<T>>(
       object: T,
       iteratee?: ?OFlatMapIteratee<A, T, U>
     ): Array<U>;
-    flatMapDepth<T, U>(
-      array?: ?$ReadOnlyArray<T>,
-      iteratee?: ?AFlatMapIteratee<T, U>,
+    flatMapDeep<A, U, T: ?$ReadOnlyArray<T> = Array<T>>(
+      array: T,
+      iteratee?: ?AFlatMapIteratee<A, T, any>
+    ): Array<U>;
+    flatMapDeep<A, U, T: ?ReadOnlyIndexerObject<A> = ReadOnlyIndexerObject<T>>(
+      object: T,
+      iteratee?: ?OFlatMapIteratee<A, T, any>
+    ): Array<U>;
+    flatMapDepth<A, U, T: ?$ReadOnlyArray<T> = Array<T>>(
+      array: T,
+      iteratee?: ?AFlatMapIteratee<A, T, any>,
       depth?: ?number
     ): Array<U>;
-    flatMapDepth<A, T: ReadOnlyIndexerObject<A>, U>(
+    flatMapDepth<A, U, T: ?ReadOnlyIndexerObject<A> = ReadOnlyIndexerObject<T>>(
       object: T,
-      iteratee?: OFlatMapIteratee<A, T, U>,
-      depth?: number
+      iteratee?: ?OFlatMapIteratee<A, T, any>,
+      depth?: ?number
     ): Array<U>;
     forEach<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
     forEach<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -167,11 +167,12 @@ declare module "lodash" {
     ...
   };
 
+  // using opaque type for object key is not supported by Flow atm: https://github.com/facebook/flow/issues/5407
   declare type Key = string | number;
   declare type IndexerObject<V, K = Key> = { [key: K]: V, ... };
   declare type ReadOnlyIndexerObject<V, K = Key> = $ReadOnly<IndexerObject<V, K>>;
   declare type NestedArray<V> = Array<Array<V>>;
-  declare type Collection<V> = $ReadOnlyArray<V> | ReadOnlyIndexerObject<V>;
+  declare type Collection<V, K = Key> = $ReadOnlyArray<V> | ReadOnlyIndexerObject<V, K>;
 
   declare type matchesIterateeShorthand = { [key: any]: any, ... };
   declare type matchesPropertyIterateeShorthand = [string, any];
@@ -553,9 +554,9 @@ declare module "lodash" {
     countBy<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>): {...};
     countBy<T>(object: ReadOnlyIndexerObject<T>, iteratee?: ?ValueOnlyIteratee<T>): { [string]: number, ... };
     // alias of _.forEach
-    each<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<A> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
+    each<A, K, T: ReadOnlyIndexerObject<A, K> | $ReadOnlyArray<A> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     // alias of _.forEachRight
-    eachRight<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<A> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
+    eachRight<A, K, T: ReadOnlyIndexerObject<A, K> | $ReadOnlyArray<A> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     every<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): boolean;
     every<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: OIterateeWithResult<A, string, T, any>): boolean;
     filter<T>(array?: ?$ReadOnlyArray<T>, predicate?: ?Predicate<T>): Array<T>;
@@ -573,11 +574,11 @@ declare module "lodash" {
       predicate?: ?Predicate<T>,
       fromIndex?: ?number
     ): void;
-    find<V, A, T: ReadOnlyIndexerObject<A>>(
+    find<R, A, T: ReadOnlyIndexerObject<A>>(
       object: T,
       predicate?: ?OPredicate<A, T>,
       fromIndex?: ?number
-    ): V;
+    ): R;
     findLast<T>(
       array: $ReadOnlyArray<T>,
       predicate?: ?Predicate<T>,
@@ -588,16 +589,16 @@ declare module "lodash" {
       predicate?: ?Predicate<T>,
       fromIndex?: ?number
     ): void;
-    findLast<V, A, T: ReadOnlyIndexerObject<A>>(
+    findLast<R, A, T: ReadOnlyIndexerObject<A>>(
       object: T,
       predicate?: ?OPredicate<A, T>,
       fromIndex?: ?number
-    ): V;
+    ): R;
     flatMap<A, K, U, T: $ReadOnlyArray<A> = Array<A>>(
       array: T,
       iteratee?: ?AFlatMapIteratee<A, T, U>
     ): Array<U>;
-    flatMap<A, K, U, T: ?ReadOnlyIndexerObject<A> | string = IndexerObject<A>>(
+    flatMap<A, K, U, T: ?ReadOnlyIndexerObject<A, K> | string = IndexerObject<A, K>>(
       object: T,
       iteratee?: ?OFlatMapIteratee<A, K, T, U>
     ): Array<U>;
@@ -605,7 +606,7 @@ declare module "lodash" {
       array: T,
       iteratee?: ?AFlatMapIteratee<A, T, any>
     ): Array<U>;
-    flatMapDeep<A, K, U, T: ?ReadOnlyIndexerObject<A> | string = IndexerObject<A>>(
+    flatMapDeep<A, K, U, T: ?ReadOnlyIndexerObject<A, K> | string = IndexerObject<A, K>>(
       object: T,
       iteratee?: ?OFlatMapIteratee<A, K, T, any>
     ): Array<U>;
@@ -614,13 +615,13 @@ declare module "lodash" {
       iteratee?: ?AFlatMapIteratee<A, T, any>,
       depth?: ?number
     ): Array<U>;
-    flatMapDepth<A, K, U, T: ?ReadOnlyIndexerObject<A> | string = IndexerObject<A>>(
+    flatMapDepth<A, K, U, T: ?ReadOnlyIndexerObject<A, K> | string = IndexerObject<A, K>>(
       object: T,
       iteratee?: ?OFlatMapIteratee<A, K, T, any>,
       depth?: ?number
     ): Array<U>;
-    forEach<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<A> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
-    forEachRight<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<A> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
+    forEach<A, K, T: ReadOnlyIndexerObject<A, K> | $ReadOnlyArray<A> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
+    forEachRight<A, K, T: ReadOnlyIndexerObject<A, K> | $ReadOnlyArray<A> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     groupBy<V, T>(
       array: $ReadOnlyArray<T>,
       iteratee?: ?ValueOnlyIteratee<T>
@@ -653,7 +654,7 @@ declare module "lodash" {
       iteratee?: ?ValueOnlyIteratee<T>
     ): { [key: V]: T, ... };
     keyBy(array: void | null, iteratee?: ?ValueOnlyIteratee<*>): {...};
-    keyBy<V, A, I, T: ReadOnlyIndexerObject<A, I>>(
+    keyBy<V, A, K, T: ReadOnlyIndexerObject<A, K>>(
       object: T,
       iteratee?: ?ValueOnlyIteratee<A>
     ): { [key: V]: A, ... };

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -174,7 +174,7 @@ declare module "lodash" {
   declare type NestedArray<V> = Array<Array<V>>;
   declare type Collection<V, K = Key> = $ReadOnlyArray<V> | ReadOnlyIndexerObject<V, K>;
 
-  declare type matchesIterateeShorthand = { [key: any]: any, ... };
+  declare type matchesIterateeShorthand = { [Key]: any, ... };
   declare type matchesPropertyIterateeShorthand = [string, any];
   declare type propertyIterateeShorthand = string;
 
@@ -1621,11 +1621,11 @@ declare module "lodash/fp" {
   };
 
   declare type Key = string | number;
-  declare type ReadOnlyIndexerObject<T, I = Key> = $ReadOnly<{ [id: I]: T, ... }>
-  declare type NestedArray<T> = Array<Array<T>>;
-  declare type Collection<T> = $ReadOnlyArray<T> | ReadOnlyIndexerObject<T>;
+  declare type ReadOnlyIndexerObject<V, K = Key> = $ReadOnly<{ [id: K]: V, ... }>
+  declare type NestedArray<V> = Array<Array<V>>;
+  declare type Collection<V, K = Key> = $ReadOnlyArray<V> | ReadOnlyIndexerObject<V, K>;
 
-  declare type matchesIterateeShorthand = { [key: any]: any, ... };
+  declare type matchesIterateeShorthand = { [Key]: any, ... };
   declare type matchesPropertyIterateeShorthand = [string, any];
   declare type propertyIterateeShorthand = string;
 

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -1617,6 +1617,8 @@ declare module "lodash/fp" {
     ...
   };
 
+  declare type Key = string | number;
+  declare type ReadOnlyIndexerObject<T, I = Key> = $ReadOnly<{ [id: I]: T, ... }>
   declare type NestedArray<T> = Array<Array<T>>;
 
   declare type matchesIterateeShorthand = { [string | number]: any, ... };
@@ -2414,25 +2416,25 @@ declare module "lodash/fp" {
       customizer: (value: T, key: number | string, object: T, stack: any) => U,
       value: T
     ): U;
-    conformsTo<T: { [key: string]: mixed, ... }>(
-      predicates: T & { [key: string]: (x: any) => boolean, ... }
+    conformsTo<T: ReadOnlyIndexerObject<mixed>>(
+      predicates: T & $ReadOnly<{ [key: string]: (x: any) => boolean, ... }>
     ): (source: T) => boolean;
-    conformsTo<T: { [key: string]: mixed, ... }>(
-      predicates: T & { [key: string]: (x: any) => boolean, ... },
+    conformsTo<T: ReadOnlyIndexerObject<mixed>>(
+      predicates: T & $ReadOnly<{ [key: string]: (x: any) => boolean, ... }>,
       source: T
     ): boolean;
-    where<T: { [key: string]: mixed, ... }>(
-      predicates: T & { [key: string]: (x: any) => boolean, ... }
+    where<T: ReadOnlyIndexerObject<mixed>>(
+      predicates: T & $ReadOnly<{ [key: string]: (x: any) => boolean, ... }>
     ): (source: T) => boolean;
-    where<T: { [key: string]: mixed, ... }>(
-      predicates: T & { [key: string]: (x: any) => boolean, ... },
+    where<T: ReadOnlyIndexerObject<mixed>>(
+      predicates: T & $ReadOnly<{ [key: string]: (x: any) => boolean, ... }>,
       source: T
     ): boolean;
-    conforms<T: { [key: string]: mixed, ... }>(
-      predicates: T & { [key: string]: (x: any) => boolean, ... }
+    conforms<T: ReadOnlyIndexerObject<mixed>>(
+      predicates: T & $ReadOnly<{ [key: string]: (x: any) => boolean, ... }>
     ): (source: T) => boolean;
-    conforms<T: { [key: string]: mixed, ... }>(
-      predicates: T & { [key: string]: (x: any) => boolean, ... },
+    conforms<T: ReadOnlyIndexerObject<mixed>>(
+      predicates: T & $ReadOnly<{ [key: string]: (x: any) => boolean, ... }>,
       source: T
     ): boolean;
     eq(value: any): (other: any) => boolean;
@@ -2780,17 +2782,17 @@ declare module "lodash/fp" {
       object: T,
       s1: A
     ): Object;
-    findKey<A, T: { [id: any]: A, ... }>(
+    findKey<A, T: ReadOnlyIndexerObject<A>>(
       predicate: OPredicate<A>
     ): (object: T) => string | void;
-    findKey<A, T: { [id: any]: A, ... }>(
+    findKey<A, T: ReadOnlyIndexerObject<A>>(
       predicate: OPredicate<A>,
       object: T
     ): string | void;
-    findLastKey<A, T: { [id: any]: A, ... }>(
+    findLastKey<A, T: ReadOnlyIndexerObject<A>>(
       predicate: OPredicate<A>
     ): (object: T) => string | void;
-    findLastKey<A, T: { [id: any]: A, ... }>(
+    findLastKey<A, T: ReadOnlyIndexerObject<A>>(
       predicate: OPredicate<A>,
       object: T
     ): string | void;
@@ -2886,7 +2888,7 @@ declare module "lodash/fp" {
       object: Object,
       args: Array<any>
     ): any;
-    keys<K>(object: { [key: K]: any, ... }): Array<K>;
+    keys<K>(object: ReadOnlyIndexerObject<any, K>): Array<K>;
     keys(object: Object): Array<string>;
     keysIn(object: Object): Array<string>;
     mapKeys(iteratee: OIteratee<*>): (object: Object) => Object;
@@ -2949,20 +2951,20 @@ declare module "lodash/fp" {
     omit(props: $ReadOnlyArray<string>, object: Object): Object;
     omitAll(props: $ReadOnlyArray<string>): (object: Object) => Object;
     omitAll(props: $ReadOnlyArray<string>, object: Object): Object;
-    omitBy<A, T: $ReadOnly<{ [id: any]: A, ... }>>(
+    omitBy<A, T: ReadOnlyIndexerObject<A>>(
       predicate: OPredicate<A>
     ): (object: T) => Object;
-    omitBy<A, T: $ReadOnly<{ [id: any]: A, ... }>>(predicate: OPredicate<A>, object: T): Object;
+    omitBy<A, T: ReadOnlyIndexerObject<A>>(predicate: OPredicate<A>, object: T): Object;
     pick(...props: $ReadOnlyArray<string | {...}>): Object;
     pick(props: $ReadOnlyArray<string>, object: Object): Object;
     pick(...props: $ReadOnlyArray<string>): (object: Object) => Object;
     pick(props: $ReadOnlyArray<string>): (object: Object) => Object;
     pickAll(props: $ReadOnlyArray<string>): (object: Object) => Object;
     pickAll(props: $ReadOnlyArray<string>, object: Object): Object;
-    pickBy<A, T: $ReadOnly<{ [id: any]: A, ... }>>(
+    pickBy<A, T: ReadOnlyIndexerObject<A>>(
       predicate: OPredicate<A>
     ): (object: T) => Object;
-    pickBy<A, T: $ReadOnly<{ [id: any]: A, ... }>>(predicate: OPredicate<A>, object: T): Object;
+    pickBy<A, T: ReadOnlyIndexerObject<A>>(predicate: OPredicate<A>, object: T): Object;
     result(path: Path): (object: Object) => any;
     result(path: Path, object: Object): any;
     set(

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -168,8 +168,8 @@ declare module "lodash" {
   };
 
   declare type Key = string | number;
-  declare type IndexerObject<T, I = Key> = { [id: I]: T, ... };
-  declare type ReadOnlyIndexerObject<T, I = Key> = $ReadOnly<IndexerObject<T, I>>;
+  declare type IndexerObject<T, K = Key> = { [key: K]: T, ... };
+  declare type ReadOnlyIndexerObject<T, K = Key> = $ReadOnly<IndexerObject<T, K>>;
   declare type NestedArray<T> = Array<Array<T>>;
   declare type Collection<T> = $ReadOnlyArray<T> | ReadOnlyIndexerObject<T>;
 
@@ -188,14 +188,14 @@ declare module "lodash" {
     | string;
 
   declare type OIterateeWithResult<V, K, O, R> =
-    | ReadOnlyIndexerObject<V>
+    | ReadOnlyIndexerObject<V, K>
     | IterateeWithResult<V, K, O, R>;
-  declare type OIteratee<O> = OIterateeWithResult<any, string, O, any>;
+  declare type OIteratee<O> = OIterateeWithResult<any, any, O, any>;
 
-  declare type AFlatMapIteratee<T, O, U> =
-    | ((item: T, index: number, array: O) => Array<U> | U)
+  declare type AFlatMapIteratee<V, O, R> =
+    | ((item: V, index: number, array: O) => Array<R> | R)
     | string
-  declare type OFlatMapIteratee<V, K, T, U> = IterateeWithResult<V, K, T, Array<U> | U>;
+  declare type OFlatMapIteratee<V, K, O, R> = IterateeWithResult<V, K, O, Array<R> | R>;
 
   declare type Predicate<T> =
     | ((value: T, index: number, array: Array<T>) => any)
@@ -553,9 +553,9 @@ declare module "lodash" {
     countBy<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>): {...};
     countBy<T>(object: ReadOnlyIndexerObject<T>, iteratee?: ?ValueOnlyIteratee<T>): { [string]: number, ... };
     // alias of _.forEach
-    each<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
+    each<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     // alias of _.forEachRight
-    eachRight<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
+    eachRight<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     every<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): boolean;
     every<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: OIterateeWithResult<A, string, T, any>): boolean;
     filter<T>(array?: ?$ReadOnlyArray<T>, predicate?: ?Predicate<T>): Array<T>;
@@ -619,8 +619,8 @@ declare module "lodash" {
       iteratee?: ?OFlatMapIteratee<A, K, T, any>,
       depth?: ?number
     ): Array<U>;
-    forEach<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
-    forEachRight<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(object: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
+    forEach<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
+    forEachRight<A, K, T: ReadOnlyIndexerObject<A> | $ReadOnlyArray<T> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     groupBy<V, T>(
       array: $ReadOnlyArray<T>,
       iteratee?: ?ValueOnlyIteratee<T>

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -172,7 +172,7 @@ declare module "lodash" {
   declare type NestedArray<T> = Array<Array<T>>;
   declare type Collection<T> = $ReadOnlyArray<T> | ReadOnlyIndexerObject<T>;
 
-  declare type matchesIterateeShorthand = { [key: any]: any, ... };
+  declare type matchesIterateeShorthand = { [key: Key]: any, ... };
   declare type matchesPropertyIterateeShorthand = [string, any];
   declare type propertyIterateeShorthand = string;
 
@@ -182,12 +182,18 @@ declare module "lodash" {
     | matchesPropertyIterateeShorthand
     | propertyIterateeShorthand;
 
+  declare type IterateeWithResult<V, O, R> =
+    | ((value: V, key: string, object: O) => R)
+    | string;
+
   declare type OIterateeWithResult<V, O, R> =
-    | Object
-    | string
-    | ((value: V, key: string, object: O) => R);
+    | ReadOnlyIndexerObject<V>
+    | IterateeWithResult<V, O, R>;
   declare type OIteratee<O> = OIterateeWithResult<any, O, any>;
-  declare type OFlatMapIteratee<T, U> = OIterateeWithResult<any, T, Array<U>>;
+
+  declare type AFlatMapIteratee<T, U> =
+    | ((item: T, index: number, array: ?$ReadOnlyArray<T>) => Array<U>)
+  declare type OFlatMapIteratee<V, T, U> = IterateeWithResult<V, T, Array<U>>;
 
   declare type Predicate<T> =
     | ((value: T, index: number, array: Array<T>) => any)
@@ -203,10 +209,6 @@ declare module "lodash" {
     array: ?Array<T>
   ) => mixed;
   declare type Iteratee<T> = _Iteratee<T> | Object | string;
-  declare type FlatMapIteratee<T, U> =
-    | ((item: T, index: number, array: ?$ReadOnlyArray<T>) => Array<U>)
-    | Object
-    | string;
   declare type Comparator<T> = (item: T, item2: T) => boolean;
 
   declare type ReadOnlyMapIterator<T, U> =
@@ -589,28 +591,28 @@ declare module "lodash" {
     ): V;
     flatMap<T, U>(
       array?: ?$ReadOnlyArray<T>,
-      iteratee?: ?FlatMapIteratee<T, U>
+      iteratee?: ?AFlatMapIteratee<T, U>
     ): Array<U>;
-    flatMap<T: Object, U>(
+    flatMap<A, T: ReadOnlyIndexerObject<A>, U>(
       object: T,
-      iteratee?: OFlatMapIteratee<T, U>
+      iteratee?: OFlatMapIteratee<A, T, U>
     ): Array<U>;
     flatMapDeep<T, U>(
       array?: ?$ReadOnlyArray<T>,
-      iteratee?: ?FlatMapIteratee<T, U>
+      iteratee?: ?AFlatMapIteratee<T, U>
     ): Array<U>;
-    flatMapDeep<T: Object, U>(
+    flatMapDeep<A, T: ReadOnlyIndexerObject<A>, U>(
       object: T,
-      iteratee?: ?OFlatMapIteratee<T, U>
+      iteratee?: ?OFlatMapIteratee<A, T, U>
     ): Array<U>;
     flatMapDepth<T, U>(
       array?: ?$ReadOnlyArray<T>,
-      iteratee?: ?FlatMapIteratee<T, U>,
+      iteratee?: ?AFlatMapIteratee<T, U>,
       depth?: ?number
     ): Array<U>;
-    flatMapDepth<T: Object, U>(
+    flatMapDepth<A, T: ReadOnlyIndexerObject<A>, U>(
       object: T,
-      iteratee?: OFlatMapIteratee<T, U>,
+      iteratee?: OFlatMapIteratee<A, T, U>,
       depth?: number
     ): Array<U>;
     forEach<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
@@ -1625,7 +1627,7 @@ declare module "lodash/fp" {
   declare type NestedArray<T> = Array<Array<T>>;
   declare type Collection<T> = $ReadOnlyArray<T> | ReadOnlyIndexerObject<T>;
 
-  declare type matchesIterateeShorthand = { [string | number]: any, ... };
+  declare type matchesIterateeShorthand = { [key: Key]: any, ... };
   declare type matchesPropertyIterateeShorthand = [string, any];
   declare type propertyIterateeShorthand = string;
 
@@ -1635,9 +1637,14 @@ declare module "lodash/fp" {
     | matchesPropertyIterateeShorthand
     | propertyIterateeShorthand;
 
-  declare type OIterateeWithResult<V, R> = Object | string | ((value: V) => R);
+  declare type IterateeWithResult<V, R> =
+    | ((value: V) => R)
+    | string;
+
+  declare type OIterateeWithResult<V, R> =
+     | ReadOnlyIndexerObject<V>
+     | IterateeWithResult<V, R>;
   declare type OIteratee<O> = OIterateeWithResult<any, any>;
-  declare type OFlatMapIteratee<T, U> = OIterateeWithResult<any, Array<U>>;
 
   declare type Predicate<T> =
     | ((value: T) => any)
@@ -1649,10 +1656,10 @@ declare module "lodash/fp" {
   declare type ValueOnlyIteratee<T> = _ValueOnlyIteratee<T> | string;
   declare type _Iteratee<T> = (item: T) => mixed;
   declare type Iteratee<T> = _Iteratee<T> | Object | string;
-  declare type FlatMapIteratee<T, U> =
+  declare type AFlatMapIteratee<T, U> =
     | ((item: T) => Array<U>)
-    | Object
     | string;
+  declare type OFlatMapIteratee<T, U> = IterateeWithResult<T, Array<U>>;
   declare type Comparator<T> = (item: T, item2: T) => boolean;
 
   declare type MapIterator<T, U> = ((item: T) => U) | propertyIterateeShorthand;
@@ -2123,33 +2130,33 @@ declare module "lodash/fp" {
       collection: Collection<T>
     ): T | void;
     flatMap<T, U>(
-      iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<U>;
+      iteratee: AFlatMapIteratee<T, U> | OFlatMapIteratee<T, U>
+    ): (collection: Collection<T>) => Array<U>;
     flatMap<T, U>(
-      iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      iteratee: AFlatMapIteratee<T, U> | OFlatMapIteratee<T, U>,
+      collection: Collection<T>
     ): Array<U>;
     flatMapDeep<T, U>(
-      iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<U>;
+      iteratee: AFlatMapIteratee<T, U> | OFlatMapIteratee<T, U>
+    ): (collection: Collection<T>) => Array<U>;
     flatMapDeep<T, U>(
-      iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      iteratee: AFlatMapIteratee<T, U> | OFlatMapIteratee<T, U>,
+      collection: Collection<T>
     ): Array<U>;
     flatMapDepth<T, U>(
-      iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>
+      iteratee: AFlatMapIteratee<T, U> | OFlatMapIteratee<T, U>
     ): ((
       depth: number
-    ) => (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<U>) &
-      ((depth: number, collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<U>);
+    ) => (collection: Collection<T>) => Array<U>) &
+      ((depth: number, collection: Collection<T>) => Array<U>);
     flatMapDepth<T, U>(
-      iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>,
+      iteratee: AFlatMapIteratee<T, U> | OFlatMapIteratee<T, U>,
       depth: number
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<U>;
+    ): (collection: Collection<T>) => Array<U>;
     flatMapDepth<T, U>(
-      iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>,
+      iteratee: AFlatMapIteratee<T, U> | OFlatMapIteratee<T, U>,
       depth: number,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): Array<U>;
     forEach<T>(
       iteratee: Iteratee<T> | OIteratee<T>

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -1620,6 +1620,7 @@ declare module "lodash/fp" {
   declare type Key = string | number;
   declare type ReadOnlyIndexerObject<T, I = Key> = $ReadOnly<{ [id: I]: T, ... }>
   declare type NestedArray<T> = Array<Array<T>>;
+  declare type Collection<T> = $ReadOnlyArray<T> | ReadOnlyIndexerObject<T>;
 
   declare type matchesIterateeShorthand = { [string | number]: any, ... };
   declare type matchesPropertyIterateeShorthand = [string, any];
@@ -2026,97 +2027,97 @@ declare module "lodash/fp" {
     // Collection
     countBy<T>(
       iteratee: ValueOnlyIteratee<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => { [string]: number, ... };
+    ): (collection: Collection<T>) => { [string]: number, ... };
     countBy<T>(
       iteratee: ValueOnlyIteratee<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): { [string]: number, ... };
     // alias of _.forEach
     each<T>(
       iteratee: Iteratee<T> | OIteratee<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<T>;
+    ): (collection: Collection<T>) => Array<T>;
     each<T>(
       iteratee: Iteratee<T> | OIteratee<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): Array<T>;
     // alias of _.forEachRight
     eachRight<T>(
       iteratee: Iteratee<T> | OIteratee<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<T>;
+    ): (collection: Collection<T>) => Array<T>;
     eachRight<T>(
       iteratee: Iteratee<T> | OIteratee<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): Array<T>;
     every<T>(
       iteratee: Iteratee<T> | OIteratee<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => boolean;
+    ): (collection: Collection<T>) => boolean;
     every<T>(
       iteratee: Iteratee<T> | OIteratee<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): boolean;
     all<T>(
       iteratee: Iteratee<T> | OIteratee<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => boolean;
+    ): (collection: Collection<T>) => boolean;
     all<T>(
       iteratee: Iteratee<T> | OIteratee<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): boolean;
     filter<T>(
       predicate: Predicate<T> | OPredicate<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<T>;
+    ): (collection: Collection<T>) => Array<T>;
     filter<T>(
       predicate: Predicate<T> | OPredicate<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): Array<T>;
     find<T>(
       predicate: Predicate<T> | OPredicate<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => T | void;
+    ): (collection: Collection<T>) => T | void;
     find<T>(
       predicate: Predicate<T> | OPredicate<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): T | void;
     findFrom<T>(
       predicate: Predicate<T> | OPredicate<T>
     ): ((
       fromIndex: number
-    ) => (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => T | void) &
+    ) => (collection: Collection<T>) => T | void) &
       ((
         fromIndex: number,
-        collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+        collection: Collection<T>
       ) => T | void);
     findFrom<T>(
       predicate: Predicate<T> | OPredicate<T>,
       fromIndex: number
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => T | void;
+    ): (collection: Collection<T>) => T | void;
     findFrom<T>(
       predicate: Predicate<T> | OPredicate<T>,
       fromIndex: number,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): T | void;
     findLast<T>(
       predicate: Predicate<T> | OPredicate<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => T | void;
+    ): (collection: Collection<T>) => T | void;
     findLast<T>(
       predicate: Predicate<T> | OPredicate<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): T | void;
     findLastFrom<T>(
       predicate: Predicate<T> | OPredicate<T>
     ): ((
       fromIndex: number
-    ) => (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => T | void) &
+    ) => (collection: Collection<T>) => T | void) &
       ((
         fromIndex: number,
-        collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+        collection: Collection<T>
       ) => T | void);
     findLastFrom<T>(
       predicate: Predicate<T> | OPredicate<T>,
       fromIndex: number
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => T | void;
+    ): (collection: Collection<T>) => T | void;
     findLastFrom<T>(
       predicate: Predicate<T> | OPredicate<T>,
       fromIndex: number,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): T | void;
     flatMap<T, U>(
       iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>
@@ -2149,35 +2150,35 @@ declare module "lodash/fp" {
     ): Array<U>;
     forEach<T>(
       iteratee: Iteratee<T> | OIteratee<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<T>;
+    ): (collection: Collection<T>) => Array<T>;
     forEach<T>(
       iteratee: Iteratee<T> | OIteratee<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): Array<T>;
     forEachRight<T>(
       iteratee: Iteratee<T> | OIteratee<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<T>;
+    ): (collection: Collection<T>) => Array<T>;
     forEachRight<T>(
       iteratee: Iteratee<T> | OIteratee<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): Array<T>;
     groupBy<V, T>(
       iteratee: ValueOnlyIteratee<T>
     ): (
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ) => { [key: V]: Array<T>, ... };
     groupBy<V, T>(
       iteratee: ValueOnlyIteratee<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): { [key: V]: Array<T>, ... };
-    includes<T>(value: T): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => boolean;
-    includes<T>(value: T, collection: $ReadOnlyArray<T> | { [id: any]: T, ... }): boolean;
+    includes<T>(value: T): (collection: Collection<T>) => boolean;
+    includes<T>(value: T, collection: Collection<T>): boolean;
     includes(value: string): (str: string) => boolean;
     includes(value: string, str: string): boolean;
     contains(value: string): (str: string) => boolean;
     contains(value: string, str: string): boolean;
-    contains<T>(value: T): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => boolean;
-    contains<T>(value: T, collection: $ReadOnlyArray<T> | { [id: any]: T, ... }): boolean;
+    contains<T>(value: T): (collection: Collection<T>) => boolean;
+    contains<T>(value: T, collection: Collection<T>): boolean;
     includesFrom(
       value: string
     ): ((fromIndex: number) => (str: string) => boolean) &
@@ -2195,58 +2196,58 @@ declare module "lodash/fp" {
     includesFrom<T>(value: T, fromIndex: number, collection: $ReadOnlyArray<T>): boolean;
     invokeMap<T>(
       path: ((value: T) => Path) | Path
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<any>;
+    ): (collection: Collection<T>) => Array<any>;
     invokeMap<T>(
       path: ((value: T) => Path) | Path,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): Array<any>;
     invokeArgsMap<T>(
       path: ((value: T) => Path) | Path
     ): ((
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ) => (args: $ReadOnlyArray<any>) => Array<any>) &
       ((
-        collection: $ReadOnlyArray<T> | { [id: any]: T, ... },
+        collection: Collection<T>,
         args: $ReadOnlyArray<any>
       ) => Array<any>);
     invokeArgsMap<T>(
       path: ((value: T) => Path) | Path,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): (args: $ReadOnlyArray<any>) => Array<any>;
     invokeArgsMap<T>(
       path: ((value: T) => Path) | Path,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... },
+      collection: Collection<T>,
       args: $ReadOnlyArray<any>
     ): Array<any>;
     keyBy<T, V>(
       iteratee: ValueOnlyIteratee<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => { [key: V]: T, ... };
+    ): (collection: Collection<T>) => { [key: V]: T, ... };
     keyBy<T, V>(
       iteratee: ValueOnlyIteratee<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): { [key: V]: T, ... };
     indexBy<T, V>(
       iteratee: ValueOnlyIteratee<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => { [key: V]: T, ... };
+    ): (collection: Collection<T>) => { [key: V]: T, ... };
     indexBy<T, V>(
       iteratee: ValueOnlyIteratee<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): { [key: V]: T, ... };
     map<T, U>(
       iteratee: MapIterator<T, U> | OMapIterator<T, U>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<U>;
+    ): (collection: Collection<T>) => Array<U>;
     map<T, U>(
       iteratee: MapIterator<T, U> | OMapIterator<T, U>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): Array<U>;
     map(iteratee: (char: string) => any): (str: string) => string;
     map(iteratee: (char: string) => any, str: string): string;
     pluck<T, U>(
       iteratee: MapIterator<T, U> | OMapIterator<T, U>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<U>;
+    ): (collection: Collection<T>) => Array<U>;
     pluck<T, U>(
       iteratee: MapIterator<T, U> | OMapIterator<T, U>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): Array<U>;
     pluck(iteratee: (char: string) => any): (str: string) => string;
     pluck(iteratee: (char: string) => any, str: string): string;
@@ -2254,93 +2255,93 @@ declare module "lodash/fp" {
       iteratees: $ReadOnlyArray<Iteratee<T> | OIteratee<*>> | string
     ): ((
       orders: $ReadOnlyArray<"asc" | "desc"> | string
-    ) => (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<T>) &
+    ) => (collection: Collection<T>) => Array<T>) &
       ((
         orders: $ReadOnlyArray<"asc" | "desc"> | string,
-        collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+        collection: Collection<T>
       ) => Array<T>);
     orderBy<T>(
       iteratees: $ReadOnlyArray<Iteratee<T> | OIteratee<*>> | string,
       orders: $ReadOnlyArray<"asc" | "desc"> | string
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<T>;
+    ): (collection: Collection<T>) => Array<T>;
     orderBy<T>(
       iteratees: $ReadOnlyArray<Iteratee<T> | OIteratee<*>> | string,
       orders: $ReadOnlyArray<"asc" | "desc"> | string,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): Array<T>;
     partition<T>(
       predicate: Predicate<T> | OPredicate<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => [Array<T>, Array<T>];
+    ): (collection: Collection<T>) => [Array<T>, Array<T>];
     partition<T>(
       predicate: Predicate<T> | OPredicate<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): [Array<T>, Array<T>];
     reduce<T, U>(
       iteratee: (accumulator: U, value: T) => U
-    ): ((accumulator: U) => (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => U) &
-      ((accumulator: U, collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => U);
+    ): ((accumulator: U) => (collection: Collection<T>) => U) &
+      ((accumulator: U, collection: Collection<T>) => U);
     reduce<T, U>(
       iteratee: (accumulator: U, value: T) => U,
       accumulator: U
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => U;
+    ): (collection: Collection<T>) => U;
     reduce<T, U>(
       iteratee: (accumulator: U, value: T) => U,
       accumulator: U,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): U;
     reduceRight<T, U>(
       iteratee: (value: T, accumulator: U) => U
-    ): ((accumulator: U) => (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => U) &
-      ((accumulator: U, collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => U);
+    ): ((accumulator: U) => (collection: Collection<T>) => U) &
+      ((accumulator: U, collection: Collection<T>) => U);
     reduceRight<T, U>(
       iteratee: (value: T, accumulator: U) => U,
       accumulator: U
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => U;
+    ): (collection: Collection<T>) => U;
     reduceRight<T, U>(
       iteratee: (value: T, accumulator: U) => U,
       accumulator: U,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): U;
     reject<T>(
       predicate: Predicate<T> | OPredicate<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<T>;
+    ): (collection: Collection<T>) => Array<T>;
     reject<T>(
       predicate: Predicate<T> | OPredicate<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): Array<T>;
-    sample<T>(collection: $ReadOnlyArray<T> | { [id: any]: T, ... }): T;
+    sample<T>(collection: Collection<T>): T;
     sampleSize<T>(
       n: number
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<T>;
-    sampleSize<T>(n: number, collection: $ReadOnlyArray<T> | { [id: any]: T, ... }): Array<T>;
-    shuffle<T>(collection: $ReadOnlyArray<T> | { [id: any]: T, ... }): Array<T>;
+    ): (collection: Collection<T>) => Array<T>;
+    sampleSize<T>(n: number, collection: Collection<T>): Array<T>;
+    shuffle<T>(collection: Collection<T>): Array<T>;
     size(collection: $ReadOnlyArray<any> | Object | string): number;
     some<T>(
       predicate: Predicate<T> | OPredicate<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => boolean;
+    ): (collection: Collection<T>) => boolean;
     some<T>(
       predicate: Predicate<T> | OPredicate<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): boolean;
     any<T>(
       predicate: Predicate<T> | OPredicate<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => boolean;
+    ): (collection: Collection<T>) => boolean;
     any<T>(
       predicate: Predicate<T> | OPredicate<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): boolean;
     sortBy<T>(
       iteratees:
         | $ReadOnlyArray<Iteratee<T> | OIteratee<T>>
         | Iteratee<T>
         | OIteratee<T>
-    ): (collection: $ReadOnlyArray<T> | { [id: any]: T, ... }) => Array<T>;
+    ): (collection: Collection<T>) => Array<T>;
     sortBy<T>(
       iteratees:
         | $ReadOnlyArray<Iteratee<T> | OIteratee<T>>
         | Iteratee<T>
         | OIteratee<T>,
-      collection: $ReadOnlyArray<T> | { [id: any]: T, ... }
+      collection: Collection<T>
     ): Array<T>;
 
     // Date

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -167,7 +167,10 @@ declare module "lodash" {
     ...
   };
 
+  declare type Key = string | number;
+  declare type ReadOnlyIndexerObject<T, I = Key> = $ReadOnly<{ [id: I]: T, ... }>
   declare type NestedArray<T> = Array<Array<T>>;
+  declare type Collection<T> = $ReadOnlyArray<T> | ReadOnlyIndexerObject<T>;
 
   declare type matchesIterateeShorthand = { [key: any]: any, ... };
   declare type matchesPropertyIterateeShorthand = [string, any];
@@ -556,7 +559,7 @@ declare module "lodash" {
     every<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): boolean;
     every<T: Object>(object: T, iteratee?: OIteratee<T>): boolean;
     filter<T>(array?: ?$ReadOnlyArray<T>, predicate?: ?Predicate<T>): Array<T>;
-    filter<A, T: { [id: any]: A, ... }>(
+    filter<A, T: ReadOnlyIndexerObject<A>>(
       object: T,
       predicate?: OPredicate<A, T>
     ): Array<A>;
@@ -570,7 +573,7 @@ declare module "lodash" {
       predicate?: ?Predicate<T>,
       fromIndex?: ?number
     ): void;
-    find<V, A, T: { [id: any]: A, ... }>(
+    find<V, A, T: ReadOnlyIndexerObject<A>>(
       object: T,
       predicate?: OPredicate<A, T>,
       fromIndex?: number
@@ -580,7 +583,7 @@ declare module "lodash" {
       predicate?: ?Predicate<T>,
       fromIndex?: ?number
     ): T | void;
-    findLast<V, A, T: { [id: any]: A, ... }>(
+    findLast<V, A, T: ReadOnlyIndexerObject<A>>(
       object: T,
       predicate?: ?OPredicate<A, T>
     ): V;
@@ -624,7 +627,7 @@ declare module "lodash" {
       iteratee?: ?ValueOnlyIteratee<T>
     ): { [key: V]: Array<T>, ... };
     groupBy(array: void | null, iteratee?: ?ValueOnlyIteratee<any>): {...};
-    groupBy<V, A, T: { [id: any]: A, ... }>(
+    groupBy<V, A, T: ReadOnlyIndexerObject<A>>(
       object: T,
       iteratee?: ValueOnlyIteratee<A>
     ): { [key: V]: Array<A>, ... };
@@ -651,7 +654,7 @@ declare module "lodash" {
       iteratee?: ?ValueOnlyIteratee<T>
     ): { [key: V]: T, ... };
     keyBy(array: void | null, iteratee?: ?ValueOnlyIteratee<*>): {...};
-    keyBy<V, A, I, T: { [id: I]: A, ... }>(
+    keyBy<V, A, I, T: ReadOnlyIndexerObject<A, I>>(
       object: T,
       iteratee?: ?ValueOnlyIteratee<A>
     ): { [key: V]: A, ... };
@@ -686,7 +689,7 @@ declare module "lodash" {
       array?: ?$ReadOnlyArray<T>,
       predicate?: ?Predicate<T>
     ): [Array<T>, Array<T>];
-    partition<V, A, T: { [id: any]: A, ... }>(
+    partition<V, A, T: ReadOnlyIndexerObject<A>>(
       object: T,
       predicate?: OPredicate<A, T>
     ): [Array<V>, Array<V>];
@@ -741,17 +744,17 @@ declare module "lodash" {
       accumulator?: ?U
     ): U;
     reject<T>(array: ?$ReadOnlyArray<T>, predicate?: Predicate<T>): Array<T>;
-    reject<V: Object, A, T: { [id: any]: A, ... }>(
+    reject<V: Object, A, T: ReadOnlyIndexerObject<A>>(
       object?: ?T,
       predicate?: ?OPredicate<A, T>
     ): Array<V>;
-    sample<T>(collection: ?$ReadOnlyArray<T> | $ReadOnly<{ [id: any]: T, ... }>): T;
-    sampleSize<T>(collection?: ?$ReadOnlyArray<T> | $ReadOnly<{ [id: any]: T, ... }>, n?: ?number): Array<T>;
-    shuffle<T>(array: ?$ReadOnlyArray<T> | $ReadOnly<{ [id: any]: T, ... }>): Array<T>;
-    size(collection: $ReadOnlyArray<any> | Object | string): number;
+    sample<T>(collection: ?Collection<T>): T;
+    sampleSize<T>(collection?: ?Collection<T>, n?: ?number): Array<T>;
+    shuffle<T>(array: ?Collection<T>): Array<T>;
+    size(collection: Collection<any> | string): number;
     some<T>(array: void | null, predicate?: ?Predicate<T>): false;
     some<T>(array: ?$ReadOnlyArray<T>, predicate?: Predicate<T>): boolean;
-    some<A, T: { [id: any]: A, ... }>(
+    some<A, T: ReadOnlyIndexerObject<A>>(
       object?: ?T,
       predicate?: OPredicate<A, T>
     ): boolean;
@@ -824,9 +827,9 @@ declare module "lodash" {
       value: T,
       customizer?: ?(value: T, key: number | string, object: T, stack: any) => U
     ): U;
-    conformsTo<T: { [key: string]: mixed, ... }>(
+    conformsTo<T: ReadOnlyIndexerObject<mixed>>(
       source: T,
-      predicates: T & { [key: string]: (x: any) => boolean, ... }
+      predicates: T & $ReadOnly<{ [key: string]: (x: any) => boolean, ... }>
     ): boolean;
     eq(value: any, other: any): boolean;
     gt(value: any, other: any): boolean;
@@ -1136,19 +1139,19 @@ declare module "lodash" {
         source: A | B | C | D
       ) => any | void
     ): Object;
-    findKey<A, T: { [id: any]: A, ... }>(
+    findKey<A, T: ReadOnlyIndexerObject<A>>(
       object: T,
       predicate?: ?OPredicate<A, T>
     ): string | void;
-    findKey<A, T: { [id: any]: A, ... }>(
+    findKey<A, T: ReadOnlyIndexerObject<A>>(
       object: void | null,
       predicate?: ?OPredicate<A, T>
     ): void;
-    findLastKey<A, T: { [id: any]: A, ... }>(
+    findLastKey<A, T: ReadOnlyIndexerObject<A>>(
       object: T,
       predicate?: ?OPredicate<A, T>
     ): string | void;
-    findLastKey<A, T: { [id: any]: A, ... }>(
+    findLastKey<A, T: ReadOnlyIndexerObject<A>>(
       object: void | null,
       predicate?: ?OPredicate<A, T>
     ): void;
@@ -1182,7 +1185,7 @@ declare module "lodash" {
       path?: ?Path,
       ...args?: $ReadOnlyArray<any>
     ): any;
-    keys<K>(object?: ?{ [key: K]: any, ... }): Array<K>;
+    keys<K>(object?: ?ReadOnlyIndexerObject<any, K>): Array<K>;
     keys(object?: ?Object): Array<string>;
     keysIn(object?: ?Object): Array<string>;
     mapKeys(object: Object, iteratee?: ?OIteratee<*>): Object;
@@ -1242,14 +1245,14 @@ declare module "lodash" {
     ): Object;
     omit(object?: ?Object, ...props: $ReadOnlyArray<string>): Object;
     omit(object?: ?Object, props: $ReadOnlyArray<string>): Object;
-    omitBy<A, T: $ReadOnly<{ [id: any]: A, ... } | { [id: number]: A, ... }>>(
+    omitBy<A, T: ReadOnlyIndexerObject<A>>(
       object: $ReadOnly<T>,
       predicate?: ?OPredicate<A, T>
     ): Object;
     omitBy<A, T>(object: void | null, predicate?: ?OPredicate<A, T>): {...};
     pick(object?: ?Object, ...props: $ReadOnlyArray<string>): Object;
     pick(object?: ?Object, props: $ReadOnlyArray<string>): Object;
-    pickBy<A, T: $ReadOnly<{ [id: any]: A, ... } | { [id: number]: A, ... }>>(
+    pickBy<A, T: ReadOnlyIndexerObject<A>>(
       object: $ReadOnly<T>,
       predicate?: ?OPredicate<A, T>
     ): Object;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -549,17 +549,17 @@ declare module "lodash" {
     // Collection
     countBy<T>(array: $ReadOnlyArray<T>, iteratee?: ?ValueOnlyIteratee<T>): { [string]: number, ... };
     countBy<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>): {...};
-    countBy<T: Object>(object: T, iteratee?: ?ValueOnlyIteratee<T>): { [string]: number, ... };
+    countBy<T>(object: ReadOnlyIndexerObject<T>, iteratee?: ?ValueOnlyIteratee<T>): { [string]: number, ... };
     // alias of _.forEach
     each<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
     each<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
-    each<T: Object>(object: T, iteratee?: ?OIteratee<T>): T;
+    each<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, T, boolean | void>): T;
     // alias of _.forEachRight
     eachRight<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
     eachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
-    eachRight<T: Object>(object: T, iteratee?: OIteratee<T>): T;
+    eachRight<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, T, boolean | void>): T;
     every<T>(array?: ?$ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): boolean;
-    every<T: Object>(object: T, iteratee?: OIteratee<T>): boolean;
+    every<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: OIterateeWithResult<A, T, any>): boolean;
     filter<T>(array?: ?$ReadOnlyArray<T>, predicate?: ?Predicate<T>): Array<T>;
     filter<A, T: ReadOnlyIndexerObject<A>>(
       object: T,
@@ -577,17 +577,23 @@ declare module "lodash" {
     ): void;
     find<V, A, T: ReadOnlyIndexerObject<A>>(
       object: T,
-      predicate?: OPredicate<A, T>,
-      fromIndex?: number
+      predicate?: ?OPredicate<A, T>,
+      fromIndex?: ?number
     ): V;
     findLast<T>(
-      array: ?$ReadOnlyArray<T>,
+      array: $ReadOnlyArray<T>,
       predicate?: ?Predicate<T>,
       fromIndex?: ?number
     ): T | void;
+    findLast<T>(
+      array: void | null,
+      predicate?: ?Predicate<T>,
+      fromIndex?: ?number
+    ): void;
     findLast<V, A, T: ReadOnlyIndexerObject<A>>(
       object: T,
-      predicate?: ?OPredicate<A, T>
+      predicate?: ?OPredicate<A, T>,
+      fromIndex?: ?number
     ): V;
     flatMap<T, U>(
       array?: ?$ReadOnlyArray<T>,
@@ -617,13 +623,13 @@ declare module "lodash" {
     ): Array<U>;
     forEach<T>(array: $ReadOnlyArray<T>, iteratee?: ?Iteratee<T>): Array<T>;
     forEach<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
-    forEach<T: Object>(object: T, iteratee?: ?OIteratee<T>): T;
+    forEach<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, T, boolean | void>): T;
     forEachRight<T>(
       array: $ReadOnlyArray<T>,
       iteratee?: ?Iteratee<T>
     ): Array<T>;
     forEachRight<T: void | null>(array: T, iteratee?: ?Iteratee<any>): T;
-    forEachRight<T: Object>(object: T, iteratee?: ?OIteratee<T>): T;
+    forEachRight<A, T: ReadOnlyIndexerObject<A>>(object: T, iteratee?: ?IterateeWithResult<A, T, boolean | void>): T;
     groupBy<V, T>(
       array: $ReadOnlyArray<T>,
       iteratee?: ?ValueOnlyIteratee<T>
@@ -639,15 +645,15 @@ declare module "lodash" {
       fromIndex?: ?number
     ): boolean;
     includes<T>(array: void | null, value?: ?T, fromIndex?: ?number): false;
-    includes<T: Object>(object: T, value: any, fromIndex?: number): boolean;
+    includes<A>(object: ReadOnlyIndexerObject<A>, value: A, fromIndex?: number): boolean;
     includes(str: string, value: string, fromIndex?: number): boolean;
     invokeMap<T>(
       array?: ?$ReadOnlyArray<T>,
       path?: ?((value: T) => Path) | Path,
       ...args?: $ReadOnlyArray<any>
     ): Array<any>;
-    invokeMap<T: Object>(
-      object: T,
+    invokeMap<A>(
+      object: ReadOnlyIndexerObject<A>,
       path: ((value: any) => Path) | Path,
       ...args?: $ReadOnlyArray<any>
     ): Array<any>;
@@ -664,7 +670,7 @@ declare module "lodash" {
       array?: ?$ReadOnlyArray<T>,
       iteratee?: ?ReadOnlyMapIterator<T, U>
     ): Array<U>;
-    map<V, T: Object, U>(
+    map<V, T: ReadOnlyIndexerObject<V>, U>(
       object: ?T,
       iteratee?: OMapIterator<V, T, U>
     ): Array<U>;
@@ -682,7 +688,7 @@ declare module "lodash" {
       iteratees?: ?$ReadOnlyArray<Iteratee<T>> | ?string,
       orders?: ?$ReadOnlyArray<"asc" | "desc"> | ?string
     ): Array<T>;
-    orderBy<V, T: {...}>(
+    orderBy<V, T: ReadOnlyIndexerObject<V>>(
       object: T,
       iteratees?: $ReadOnlyArray<OIteratee<*>> | string,
       orders?: $ReadOnlyArray<"asc" | "desc"> | string
@@ -745,11 +751,11 @@ declare module "lodash" {
       iteratee?: ?(accumulator: U, value: any, key: string, object: T) => U,
       accumulator?: ?U
     ): U;
-    reject<T>(array: ?$ReadOnlyArray<T>, predicate?: Predicate<T>): Array<T>;
-    reject<V: Object, A, T: ReadOnlyIndexerObject<A>>(
+    reject<T>(array?: ?$ReadOnlyArray<T>, predicate?: ?Predicate<T>): Array<T>;
+    reject<A, T: ReadOnlyIndexerObject<A>>(
       object?: ?T,
       predicate?: ?OPredicate<A, T>
-    ): Array<V>;
+    ): Array<A>;
     sample<T>(collection: ?Collection<T>): T;
     sampleSize<T>(collection?: ?Collection<T>, n?: ?number): Array<T>;
     shuffle<T>(array: ?Collection<T>): Array<T>;
@@ -768,11 +774,11 @@ declare module "lodash" {
       array: ?$ReadOnlyArray<T>,
       iteratees?: $ReadOnlyArray<Iteratee<T>>
     ): Array<T>;
-    sortBy<V, T: Object>(
+    sortBy<V, T: ReadOnlyIndexerObject<V>>(
       object: T,
       ...iteratees?: $ReadOnlyArray<OIteratee<T>>
     ): Array<V>;
-    sortBy<V, T: Object>(
+    sortBy<V, T: ReadOnlyIndexerObject<V>>(
       object: T,
       iteratees?: $ReadOnlyArray<OIteratee<T>>
     ): Array<V>;
@@ -2034,6 +2040,7 @@ declare module "lodash/fp" {
       a1: NestedArray<T>,
       a2: NestedArray<T>
     ): Array<T>;
+
     // Collection
     countBy<T>(
       iteratee: ValueOnlyIteratee<T>

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-fp-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-fp-v4.x.x.js
@@ -444,9 +444,7 @@ timesNums = times(function(i: number) {
   return i + 1;
 }, 5);
 // $ExpectError string. This type is incompatible with number
-timesNums = times(function(i: number) {
-  return JSON.stringify(i);
-}, 5);
+timesNums = times((i: number) => JSON.stringify(i), 5);
 
 // lodash.flatMap for collections and objects
 // this arrow function needs a type annotation due to a bug in flow

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -275,23 +275,25 @@ describe('Collection', () => {
   const testForEachFunction = (f: typeof forEach) => {
     (f(([1, 2]: $ReadOnlyArray<number>), (v: number) => false): number[]);
 
-    (f(arrayOrVoid, (v: number) => !!v): ArrayOrVoid);
+    (f('123', (char: string) => {}): string);
 
+    (f(arrayOrVoid, (v: number) => !!v): ArrayOrVoid);
 
     (f(objectWithOpaqueKey, (v: string, k: OpaqueKey) => {}): ObjectWithOpaqueKey);
     (f(indexerObject, (v: number) => {}): IndexerObject);
     (f(exactObject, (v: number) => !!v): ExactObject);
     (f(exactHeterogeneousObject, (v: number | string | boolean) => !!v): ExactHeterogeneousObject);
+    (f(objectOrVoid, (v: number) => {}): ObjectOrVoid);
 
-    // $ExpectError
+    // $ExpectError wrong iteratee return value
     f(exactObject, (v: number) => ({ a: 1, b: 2}));
-    // $ExpectError
+    // $ExpectError wrong iteratee argument type
     f(exactHeterogeneousObject, (v: number) => false);
-    // $ExpectError
+    // $ExpectError wrong iteratee return type
     f(exactObject, (v: number) => v + 2);
-    // $ExpectError
-    (f(exactObject, (v: number) => false): void); // each() returns collection passed in the first argument
-    // $ExpectError
+    // $ExpectError wrong return type: forEach() returns collection passed in the first argument
+    (f(exactObject, (v: number) => false): void);
+    // $ExpectError wrong iteratee type, should be function
     f(exactObject, {a: 1});
   }
 

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -81,11 +81,8 @@ import zipWith from "lodash/zipWith";
 type ReadOnlyArray = $ReadOnlyArray<number>
 const readOnlyArray : ReadOnlyArray = Object.freeze([1, 2, 3, 4]);
 
-type ArrayOrNull = number[] | null;
-const arrayOrNull: ArrayOrNull = readOnlyArray[0] > 100 ? [1, 2, 3] : null;
-
-type ArrayOrVoid = number[] | void;
-const arrayOrVoid: ArrayOrVoid = readOnlyArray[0] > 100 ? [1, 2, 3] : undefined;
+type ArrayOrNullOrVoid = number[] | null | void;
+const arrayOrNullOrVoid: ArrayOrNullOrVoid = readOnlyArray[0] > 100 ? [1, 2, 3] : readOnlyArray[1] > 100 ? null : undefined;
 
 // Test objects
 type IndexerObject = { [string]: number, ... };
@@ -103,11 +100,8 @@ const readOnlyIndexerObject: ReadOnlyIndexerObject = { ...indexerObject }; // ex
 type ReadOnlyExactObject = $ReadOnly<ExactObject>
 const readOnlyExactObject: ReadOnlyExactObject = { ...exactObject };
 
-type ObjectOrNull = IndexerObject | null;
-const objectOrNull: ObjectOrNull = readOnlyArray[0] > 100 ? indexerObject : null;
-
-type ObjectOrVoid = IndexerObject | void;
-const objectOrVoid: ObjectOrVoid = readOnlyArray[0] > 100 ? indexerObject : undefined;
+type ObjectOrNullOrVoid = IndexerObject | null | void;
+const objectOrNullOrVoid: ObjectOrNullOrVoid = readOnlyArray[0] > 100 ? indexerObject : readOnlyArray[1] > 100 ? null : undefined;
 
 type ArrayOrObjectOrString = number[] | ExactObject | string;
 const arrayOrObjectOrString: ArrayOrObjectOrString = readOnlyArray[0] > 100 ? [1, 2, 3] : (readOnlyArray[1] > 100 ? exactObject : 'abc');
@@ -277,7 +271,7 @@ describe('Collection', () => {
 
     (f('123', (char: string) => {}): string);
 
-    (f(arrayOrVoid, (v: number) => !!v): ArrayOrVoid);
+    (f(arrayOrNullOrVoid, (v: number) => !!v): ArrayOrNullOrVoid);
 
     (f(indexerObject, (v: number) => {}): IndexerObject);
     (f(exactObject, (v: number) => !!v): ExactObject);
@@ -290,7 +284,7 @@ describe('Collection', () => {
     // $ExpectError wrong iteratee argument type
     f(exactHeterogeneousObject, (v: number) => false);
 
-    (f(objectOrVoid, (v: number) => {}): ObjectOrVoid);
+    (f(objectOrNullOrVoid, (v: number) => {}): ObjectOrNullOrVoid);
     (f(arrayOrObjectOrString, (v: number | string, key: string) => !!v): ArrayOrObjectOrString);
     // $ExpectError wrong iteratee argument type,
     (f(arrayOrObjectOrString, (v: string) => !!v): ArrayOrObjectOrString);
@@ -374,10 +368,8 @@ describe('Collection', () => {
     const v: V = { x: 1, y: 2 };
 
     (f([1, 2, 3], x => x == 1): number | void);
-    (find(arrayOrNull, v => !!v, null): number | void);
-    (find(arrayOrVoid, v => !!v, null): number | void);
-    (find(objectOrNull, v => !!v, null): number | void);
-    (find(objectOrVoid, v => !!v, null): number | void);
+    (find(arrayOrNullOrVoid, v => !!v, null): number | void);
+    (find(objectOrNullOrVoid, v => !!v, null): number | void);
 
     // $ExpectError number cannot be compared to string
     f([1, 2, 3], x => x == "a");
@@ -408,13 +400,11 @@ describe('Collection', () => {
 
     (flatMap(['a', 'b', 'c'], (v: string, i: number, collection: string[]) => [{ v, i }]): ({| v: string, i: number |})[]);
     flatMap([{ a: [1, 2] }, { a: [3,4] }], 'a');
-    (flatMap(arrayOrNull, (n: number, i: number, collection: ArrayOrNull) => [n, n]): number[]);
-    (flatMap(arrayOrVoid, (n: number, i: number, collection: ArrayOrVoid): number[] => [n, n]): number[]);
+    (flatMap(arrayOrNullOrVoid, (n: number, i: number, collection: ArrayOrNullOrVoid): number[] => [n, n]): number[]);
     (flatMap(readOnlyArray, (n: number, i: number, collection: ReadOnlyArray) => [n, n]): number[]);
 
     (flatMap({ a: 1, b: 2 }, (n: number, k: string, collection: {| a: number, b: number |}) => [n, k]): (number| string)[]);
-    (flatMap(objectOrNull, (n: number, k: string, collection: ObjectOrNull) => [n, n]): number[]);
-    (flatMap(objectOrVoid, (n: number, k: string, collection: ObjectOrVoid) => [n, n]): number[]);
+    (flatMap(objectOrNullOrVoid, (n: number, k: string, collection: ObjectOrNullOrVoid) => [n, n]): number[]);
     (flatMap(readOnlyExactObject, (n: number, k: string, collection: ReadOnlyExactObject) => [n, n]): number[]);
     (flatMap(readOnlyIndexerObject, (n: number, k: string, collection: ReadOnlyIndexerObject) => [n, n]): number[]);
     (flatMap(arrayOrObjectOrString, (n: number| string, k: number | string, collection: ArrayOrObjectOrString) => [n, n]): (number| string)[]);
@@ -426,24 +416,20 @@ describe('Collection', () => {
     (flatMapDeep([1, 2, 3], (n: number) => [[[n, n]]]): number[]);
 
     (flatMapDeep(['a', 'b', 'c'], (v: string, i: number, collection: string[]) => [[[v, collection[0], i]]]): (number | string)[]);
-    (flatMapDeep(arrayOrNull, (n: number, i: number, collection: ArrayOrNull) => [[[n, n]]]): number[]);
-    (flatMapDeep(arrayOrVoid, (n: number, i: number, collection: ArrayOrVoid) => [[[n, n]]]): number[]);
+    (flatMapDeep(arrayOrNullOrVoid, (n: number, i: number, collection: ArrayOrNullOrVoid) => [[[n, n]]]): number[]);
 
     (flatMapDeep({ a: 1, b: 2 }, (n: number, k: string, collection: {| a: number, b: number |}) => [[[n, k]]]): (number| string)[]);
-    (flatMapDeep(objectOrNull, (n: number, k: string, collection: ObjectOrNull) => [[[n, n]]]): number[]);
-    (flatMapDeep(objectOrVoid, (n: number, k: string, collection: ObjectOrVoid) => [[[n, n]]]): number[]);
+    (flatMapDeep(objectOrNullOrVoid, (n: number, k: string, collection: ObjectOrNullOrVoid) => [[[n, n]]]): number[]);
   });
 
   it('flatMapDepth', () => {
     (flatMapDepth([1, 2, 3], (n) => [[[n, n]]], 2): number[]);
 
     (flatMapDepth(['a', 'b', 'c'], (v: string, i: number, collection: string[]) => [[[v, collection[0], i]]], 2): (number | string)[]);
-    (flatMapDepth(arrayOrNull, (n: number, i: number, collection: ArrayOrNull) => [[[n, n]]], 2): number[]);
-    (flatMapDepth(arrayOrVoid, (n: number, i: number, collection: ArrayOrVoid) => [[[n, n]]], 2): number[]);
+    (flatMapDepth(arrayOrNullOrVoid, (n: number, i: number, collection: ArrayOrNullOrVoid) => [[[n, n]]], 2): number[]);
 
     (flatMapDepth({ a: 1, b: 2 }, (n: number, k: string, collection: {| a: number, b: number |}) => [[[n, k]]], 2): (number| string)[]);
-    (flatMapDepth(objectOrNull, (n: number, k: string, collection: ObjectOrNull) => [[[n, n]]], 2): number[]);
-    (flatMapDepth(objectOrVoid, (n: number, k: string, collection: ObjectOrVoid) => [[[n, n]]], 2): number[]);
+    (flatMapDepth(objectOrNullOrVoid, (n: number, k: string, collection: ObjectOrNullOrVoid) => [[[n, n]]], 2): number[]);
   });
 
   it('forEach', () => {

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -109,13 +109,9 @@ const objectOrNull: ObjectOrNull = readOnlyArray[0] > 100 ? indexerObject : null
 type ObjectOrVoid = IndexerObject | void;
 const objectOrVoid: ObjectOrVoid = readOnlyArray[0] > 100 ? indexerObject : undefined;
 
-opaque type OpaqueKey = number;
-const toOpaqueKey = (v: number): OpaqueKey => v;
-type ObjectWithOpaqueKey = { [OpaqueKey]: string, ... };
-const objectWithOpaqueKey: ObjectWithOpaqueKey  = { [toOpaqueKey(1)]: 'a', [toOpaqueKey(2)]: 'b' };
-
 type ArrayOrObjectOrString = number[] | ExactObject | string;
 const arrayOrObjectOrString: ArrayOrObjectOrString = readOnlyArray[0] > 100 ? [1, 2, 3] : (readOnlyArray[1] > 100 ? exactObject : 'abc');
+
 
 describe('Array', () => {
   it('chunk', () => {
@@ -299,12 +295,6 @@ describe('Collection', () => {
     // $ExpectError wrong iteratee argument type,
     (f(arrayOrObjectOrString, (v: string) => !!v): ArrayOrObjectOrString);
 
-    (f(objectWithOpaqueKey, (v: string, k: OpaqueKey) => {}): ObjectWithOpaqueKey);
-    // $ExpectError wrong return type - must be opaque type
-    (f(objectWithOpaqueKey, (v, k) => {}): { [string]: string, ...});
-    // $ExpectError wrong key type - must be opaque type
-    f(objectWithOpaqueKey, (v, k: sting) => {});
-
     // $ExpectError wrong iteratee return value
     f(exactObject, (v: number) => ({ a: 1, b: 2}));
     // $ExpectError wrong return type: forEach() returns collection passed in the first argument
@@ -336,15 +326,16 @@ describe('Collection', () => {
   });
 
   const testFilterFunction = (f: typeof filter) => {
-    const users = [
+    type User = {| user: string, age: number, active: boolean; |}
+    const users : User[] = [
       { 'user': 'barney', 'age': 36, 'active': true },
       { 'user': 'fred',   'age': 40, 'active': false }
     ];
 
-    (filter(users, function(o) { return !o.active; }): typeof users);
-    (filter(users, { 'age': 36, 'active': true }): typeof users);
-    (filter(users, ['active', false]): typeof users);
-    (filter(users, 'active'): typeof users);
+    (filter(users, (u: User, i: number, collection: User[]) => !u.active ): User[]);
+    (filter(users, { 'age': 36, 'active': true }): User[]);
+    (filter(users, ['active', false]): User[]);
+    (filter(users, 'active'): User[]);
 
     // $ExpectError first arg should be array or object type is wrong
     filter(123, function(o) { return !o.active; });
@@ -427,7 +418,6 @@ describe('Collection', () => {
     (flatMap(readOnlyExactObject, (n: number, k: string, collection: ReadOnlyExactObject) => [n, n]): number[]);
     (flatMap(readOnlyIndexerObject, (n: number, k: string, collection: ReadOnlyIndexerObject) => [n, n]): number[]);
     (flatMap(arrayOrObjectOrString, (n: number| string, k: number | string, collection: ArrayOrObjectOrString) => [n, n]): (number| string)[]);
-    (flatMap(objectWithOpaqueKey, (n: string, k: OpaqueKey, collection: ObjectWithOpaqueKey) => [n, k]): (string| OpaqueKey)[]);
     // $ExpectError key cannot be only string since index is `number` for array
     flatMap(arrayOrObjectOrString, (n, k: string) => [n, n]);
   });

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -410,10 +410,15 @@ describe('Collection', () => {
     // this arrow function needs a type annotation due to a bug in flow: https://github.com/facebook/flow/issues/1948
     (flatMap([1, 2, 3], (n: number) => [n, n]): number[]);
 
+    (flatMap([1, 2, 3], (n: number, i: number, collection: number[]) => n): number[]);
     (flatMap(['a', 'b', 'c'], (v: string, i: number, collection: string[]) => [v, collection[0], i]): (number | string)[]);
+    // $ExpectError array index is a number
+    (flatMap(['a', 'b', 'c'], (v, i: string) => [v, v]));
+
     (flatMap(['a', 'b', 'c'], (v: string, i: number, collection: string[]) => [{ v, i }]): ({| v: string, i: number |})[]);
+    flatMap([{ a: [1, 2] }, { a: [3,4] }], 'a');
     (flatMap(arrayOrNull, (n: number, i: number, collection: ArrayOrNull) => [n, n]): number[]);
-    (flatMap(arrayOrVoid, (n: number, i: number, collection: ArrayOrVoid) => [n, n]): number[]);
+    (flatMap(arrayOrVoid, (n: number, i: number, collection: ArrayOrVoid): number[] => [n, n]): number[]);
     (flatMap(readOnlyArray, (n: number, i: number, collection: ReadOnlyArray) => [n, n]): number[]);
 
     (flatMap({ a: 1, b: 2 }, (n: number, k: string, collection: {| a: number, b: number |}) => [n, k]): (number| string)[]);
@@ -421,6 +426,10 @@ describe('Collection', () => {
     (flatMap(objectOrVoid, (n: number, k: string, collection: ObjectOrVoid) => [n, n]): number[]);
     (flatMap(readOnlyExactObject, (n: number, k: string, collection: ReadOnlyExactObject) => [n, n]): number[]);
     (flatMap(readOnlyIndexerObject, (n: number, k: string, collection: ReadOnlyIndexerObject) => [n, n]): number[]);
+    (flatMap(arrayOrObjectOrString, (n: number| string, k: number | string, collection: ArrayOrObjectOrString) => [n, n]): (number| string)[]);
+    (flatMap(objectWithOpaqueKey, (n: string, k: OpaqueKey, collection: ObjectWithOpaqueKey) => [n, k]): (string| OpaqueKey)[]);
+    // $ExpectError key cannot be only string since index is `number` for array
+    flatMap(arrayOrObjectOrString, (n, k: string) => [n, n]);
   });
 
   it('flatMapDeep', () => {

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -114,6 +114,8 @@ const toOpaqueKey = (v: number): OpaqueKey => v;
 type ObjectWithOpaqueKey = { [OpaqueKey]: string, ... };
 const objectWithOpaqueKey: ObjectWithOpaqueKey  = { [toOpaqueKey(1)]: 'a', [toOpaqueKey(2)]: 'b' };
 
+type ArrayOrObjectOrString = number[] | ExactObject | string;
+const arrayOrObjectOrString: ArrayOrObjectOrString = readOnlyArray[0] > 100 ? [1, 2, 3] : (readOnlyArray[1] > 100 ? exactObject : 'abc');
 
 describe('Array', () => {
   it('chunk', () => {
@@ -273,7 +275,7 @@ describe('Collection', () => {
    * 2) Enforce that type definitions for all related functions (e.g. each, eachRight, forEach, forEachRight) are the same, as they should be by the docs.
    */
   const testForEachFunction = (f: typeof forEach) => {
-    (f(([1, 2]: $ReadOnlyArray<number>), (v: number) => false): number[]);
+    (f(([1, 2]: $ReadOnlyArray<number>), (v: number) => false): $ReadOnlyArray<number>);
 
     (f('123', (char: string) => {}): string);
 
@@ -284,6 +286,7 @@ describe('Collection', () => {
     (f(exactObject, (v: number) => !!v): ExactObject);
     (f(exactHeterogeneousObject, (v: number | string | boolean) => !!v): ExactHeterogeneousObject);
     (f(objectOrVoid, (v: number) => {}): ObjectOrVoid);
+    (f(arrayOrObjectOrString, (v: number | string, key: string) => !!v): ArrayOrObjectOrString);
 
     // $ExpectError wrong iteratee return value
     f(exactObject, (v: number) => ({ a: 1, b: 2}));
@@ -295,6 +298,12 @@ describe('Collection', () => {
     (f(exactObject, (v: number) => false): void);
     // $ExpectError wrong iteratee type, should be function
     f(exactObject, {a: 1});
+    // $ExpectError wrong iteratee argument type,
+    (f(arrayOrObjectOrString, (v: string) => !!v): ArrayOrObjectOrString);
+    // $ExpectError forEach returns its first argument, therefore, if it was readonly, it should remain readonly
+    (f(([1, 2]: $ReadOnlyArray<number>), (v) => {}): number[]);
+    // $ExpectError forEach returns its first argument, therefore, if it was readonly, it should remain readonly
+    (f((readOnlyExactObject), (v) => {}): ExactObject);
   }
 
   it('each', () => {

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -275,35 +275,44 @@ describe('Collection', () => {
    * 2) Enforce that type definitions for all related functions (e.g. each, eachRight, forEach, forEachRight) are the same, as they should be by the docs.
    */
   const testForEachFunction = (f: typeof forEach) => {
-    (f(([1, 2]: $ReadOnlyArray<number>), (v: number) => false): $ReadOnlyArray<number>);
+    (f((readOnlyArray), (v: number) => false): $ReadOnlyArray<number>);
+    // $ExpectError forEach returns its first argument, therefore, if it was readonly, it should remain readonly
+    (f((readOnlyArray), (v) => {}): number[]);
 
     (f('123', (char: string) => {}): string);
 
     (f(arrayOrVoid, (v: number) => !!v): ArrayOrVoid);
 
-    (f(objectWithOpaqueKey, (v: string, k: OpaqueKey) => {}): ObjectWithOpaqueKey);
     (f(indexerObject, (v: number) => {}): IndexerObject);
     (f(exactObject, (v: number) => !!v): ExactObject);
+
+    (f((readOnlyExactObject), (v) => {}): ReadOnlyExactObject);
+    // $ExpectError forEach returns its first argument, therefore, if it was readonly, it should remain readonly
+    (f((readOnlyExactObject), (v) => {}): ExactObject);
+
     (f(exactHeterogeneousObject, (v: number | string | boolean) => !!v): ExactHeterogeneousObject);
+    // $ExpectError wrong iteratee argument type
+    f(exactHeterogeneousObject, (v: number) => false);
+
     (f(objectOrVoid, (v: number) => {}): ObjectOrVoid);
     (f(arrayOrObjectOrString, (v: number | string, key: string) => !!v): ArrayOrObjectOrString);
+    // $ExpectError wrong iteratee argument type,
+    (f(arrayOrObjectOrString, (v: string) => !!v): ArrayOrObjectOrString);
+
+    (f(objectWithOpaqueKey, (v: string, k: OpaqueKey) => {}): ObjectWithOpaqueKey);
+    // $ExpectError wrong return type - must be opaque type
+    (f(objectWithOpaqueKey, (v, k) => {}): { [string]: string, ...});
+    // $ExpectError wrong key type - must be opaque type
+    f(objectWithOpaqueKey, (v, k: sting) => {});
 
     // $ExpectError wrong iteratee return value
     f(exactObject, (v: number) => ({ a: 1, b: 2}));
-    // $ExpectError wrong iteratee argument type
-    f(exactHeterogeneousObject, (v: number) => false);
-    // $ExpectError wrong iteratee return type
-    f(exactObject, (v: number) => v + 2);
     // $ExpectError wrong return type: forEach() returns collection passed in the first argument
     (f(exactObject, (v: number) => false): void);
+    // $ExpectError wrong iteratee return type
+    f(exactObject, (v: number) => v + 2);
     // $ExpectError wrong iteratee type, should be function
     f(exactObject, {a: 1});
-    // $ExpectError wrong iteratee argument type,
-    (f(arrayOrObjectOrString, (v: string) => !!v): ArrayOrObjectOrString);
-    // $ExpectError forEach returns its first argument, therefore, if it was readonly, it should remain readonly
-    (f(([1, 2]: $ReadOnlyArray<number>), (v) => {}): number[]);
-    // $ExpectError forEach returns its first argument, therefore, if it was readonly, it should remain readonly
-    (f((readOnlyExactObject), (v) => {}): ExactObject);
   }
 
   it('each', () => {

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -77,7 +77,7 @@ import zip from "lodash/zip";
 import zipWith from "lodash/zipWith";
 
 // Ideally, there should be a test for each of the variables below. To verify that these use cases do not break on code changes.
-// test arrays
+// Test arrays
 type ReadOnlyArray = $ReadOnlyArray<number>
 const readOnlyArray : ReadOnlyArray = Object.freeze([1, 2, 3, 4]);
 
@@ -87,7 +87,7 @@ const arrayOrNull: ArrayOrNull = readOnlyArray[0] > 100 ? [1, 2, 3] : null;
 type ArrayOrVoid = number[] | void;
 const arrayOrVoid: ArrayOrVoid = readOnlyArray[0] > 100 ? [1, 2, 3] : undefined;
 
-// test objects
+// Test objects
 type IndexerObject = { [string]: number, ... };
 const indexerObject: IndexerObject = { a: 1, b: 2, c: 3 };
 

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -19,29 +19,46 @@ import difference from "lodash/difference";
 import differenceBy from "lodash/differenceBy";
 import differenceWith from "lodash/differenceWith";
 import each from "lodash/each";
+import eachRight from "lodash/eachRight";
+import every from "lodash/every";
 import extend from "lodash/extend";
+import filter from "lodash/filter";
 import find from "lodash/find";
+import findLast from "lodash/findLast";
 import first from "lodash/first";
 import flatMap from "lodash/flatMap";
+import flatMapDeep from "lodash/flatMapDeep";
+import flatMapDepth from "lodash/flatMapDepth";
 import forEach from "lodash/forEach";
+import forEachRight from "lodash/forEachRight";
 import get from "lodash/get";
 import groupBy from "lodash/groupBy";
+import includes from "lodash/includes";
 import intersectionBy from "lodash/intersectionBy";
+import invokeMap from "lodash/invokeMap";
 import isEqual from "lodash/isEqual";
 import isString from "lodash/isString";
 import keyBy from "lodash/keyBy";
+import keys from "lodash/keys";
 import map from "lodash/map";
 import memoize from "lodash/memoize";
 import noop from "lodash/noop";
 import omitBy from "lodash/omitBy";
 import orderBy from 'lodash/orderBy';
+import partition from 'lodash/partition';
 import pick from 'lodash/pick';
 import pickBy from "lodash/pickBy";
 import pullAllBy from "lodash/pullAllBy";
 import range from "lodash/range";
+import reduce from "lodash/reduce";
+import reduceRight from "lodash/reduceRight";
+import reject from "lodash/reject";
 import sample from "lodash/sample";
 import sampleSize from "lodash/sampleSize";
 import shuffle from "lodash/shuffle";
+import size from "lodash/size";
+import some from "lodash/some";
+import sortBy from "lodash/sortBy";
 import sortedIndexBy from "lodash/sortedIndexBy";
 import sortedLastIndexBy from "lodash/sortedLastIndexBy";
 import sortedUniq from "lodash/sortedUniq";
@@ -62,8 +79,20 @@ import zipWith from "lodash/zipWith";
 type ReadOnlyArray = $ReadOnlyArray<number>
 const readOnlyArray : ReadOnlyArray = [1, 2, 3, 4];
 
-type ReadOnlyObject = $ReadOnly<{ [string]: number, ... }>
-const readOnlyObject : ReadOnlyObject = { a: 1, b: 2, c: 3 };
+type IndexerObject = { [string]: number, ... };
+const indexerObject: IndexerObject = { a: 1, b: 2, c: 3 };
+
+type ExactObject = {| a: number, b: number, c: number; |};
+const exactObject: ExactObject = { a: 1, b: 2, c: 3 };
+
+type ExactHeterogeneousObject = {| a: number, b: string, c: boolean; |};
+const exactHeterogeneousObject: ExactHeterogeneousObject = { a: 1, b: 'abc', c: true };
+
+type ReadOnlyIndexerObject = $ReadOnly<IndexerObject>
+const readOnlyIndexerObject: ReadOnlyIndexerObject = { ...indexerObject };
+
+type ReadOnlyExactObject = $ReadOnly<ExactObject>
+const readOnlyExactObject: ReadOnlyExactObject = { ...exactObject };
 
 describe('Array', () => {
   it('chunk', () => {
@@ -202,56 +231,128 @@ describe('Collection', () => {
   it('countBy', () => {
     (countBy([6.1, 4.2, 6.3], Math.floor): { [string]: number, ... });
     (countBy(["one", "two", "three"], "length"): { [string]: number, ... });
+    (countBy(indexerObject, (v: number) => v): { [string]: number, ... });
+    (countBy(exactObject, (v: number) => v): { [string]: number, ... });
+    (countBy(exactHeterogeneousObject, (v: number | string | boolean) => v): { [string]: number, ... });
+    (countBy(readOnlyExactObject, (v: number) => v): { [string]: number, ... });
+
     // $ExpectError
     (countBy(["one", "two", "three"], "length"): { [string]: string, ... });
+    // $ExpectError
+    countBy(123, "length");
+    // $ExpectError
+    countBy(["one", "two", "three"], (v: boolean) => v);
+    // $ExpectError
+    countBy(["one", "two", "three"], (v, arg2: number) => arg2);
   });
+
+  /**
+   * Using such functions allows to:
+   * 1) Ensure all tests are run and up to date for each function
+   * 2) Enforce that type definitions for all related functions (e.g. each, eachRight, forEach, forEachRight) are the same, as they should be by the docs.
+   */
+  const testForEachFunction = (f: typeof forEach) => {
+    (f(([1, 2]: $ReadOnlyArray<number>), (v: number) => false): number[]);
+    (f(indexerObject, (v: number) => {}): IndexerObject);
+    (f(exactObject, (v: number) => !!v): ExactObject);
+    (f(exactHeterogeneousObject, (v: number | string | boolean) => !!v): ExactHeterogeneousObject);
+
+    // $ExpectError
+    f(exactObject, (v: number) => ({ a: 1, b: 2}));
+    // $ExpectError
+    f(exactHeterogeneousObject, (v: number) => false);
+    // $ExpectError
+    f(exactObject, (v: number) => v + 2);
+    // $ExpectError
+    (f(exactObject, (v: number) => false): void); // each() returns collection passed in the first argument
+    // $ExpectError
+    f(exactObject, {a: 1});
+  }
 
   it('each', () => {
-    each(([1, 2]: $ReadOnlyArray<number>), (item: number) => false);
-    each(readOnlyObject, (item: number) => false);
+    testForEachFunction(each);
   });
 
-  it('find', () => {
-    find([1, 2, 3], x => x * 1 == 3);
-    find([1, 2, 3], x => x == 2, 1);
-    // $ExpectError number cannot be compared to string
-    find([1, 2, 3], x => x == "a");
-    // $ExpectError number. This type is incompatible with function type.
-    find([1, 2, 3], 1);
-    // $ExpectError property `y`. Property not found in object literal
-    find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.y == 3);
-    find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.x == 3);
-    find({ x: 1, y: 2 }, (a: number, b: string) => a);
-    find({ x: 1, y: 2 }, { x: 3 });
-    find((["a", "b"]: $ReadOnlyArray<string>), "c");
-    // opaque types are allowed as keys of objects
-    opaque type O = string;
-    const v: { [O]: number, ... } = { x: 1, y: 2 };
-    find(v, { x: 3 });
+  it('eachRight', () => {
+    testForEachFunction(eachRight);
+  });
 
-    (find([1, 2, 3], x => x == 1): void | number);
-    // $ExpectError number. This type is incompatible with function type.
-    (find([1, 2, 3], 1): void | number);
-
-    // _.find examples from the official doc
+  it('every', () => {
     const users = [
+      { 'user': 'barney', 'age': 36, 'active': false },
+      { 'user': 'fred',   'age': 40, 'active': false }
+    ];
+
+    (every([true, 1, null, 'yes'], Boolean): boolean);
+    (every(users, { 'user': 'barney', 'active': false }): boolean);
+    (every(users, ['active', false]): boolean);
+    (every(users, 'active'): boolean);
+  });
+
+  const testFilterFunction = (f: typeof filter) => {
+    const users = [
+      { 'user': 'barney', 'age': 36, 'active': true },
+      { 'user': 'fred',   'age': 40, 'active': false }
+    ];
+
+    (filter(users, function(o) { return !o.active; }): typeof users);
+    (filter(users, { 'age': 36, 'active': true }): typeof users);
+    (filter(users, ['active', false]): typeof users);
+    (filter(users, 'active'): typeof users);
+
+    // $ExpectError first arg should be array or object type is wrong
+    filter(123, function(o) { return !o.active; });
+    // $ExpectError return type is wrong
+    (filter(users, function(o) { return !o.active; }): boolean);
+  };
+
+  it('filter', () => {
+    testFilterFunction(filter);
+  });
+
+  const testFindFunction = (f: typeof find) => {
+    // examples from the official doc
+    type User = {| user: string, age: number, active: boolean |};
+    const users: User[] = [
       { user: "barney", age: 36, active: true },
       { user: "fred", age: 40, active: false },
       { user: "pebbles", age: 1, active: true }
     ];
+    (f(users, function(o) { return o.age < 40; }): User | void);
+    (f(users, { age: 1, active: true }): User | void);
+    (f(users, ["active", false]): User | void);
+    (f(users, "active"): User | void);
 
-    find(users, function(o) {
-      return o.age < 40;
-    });
+    (f([1, 2, 3], x => x * 1 == 3): number | void);
+    (f([1, 2, 3], x => x == 2, 1): number | void);
 
-    // The `_.matches` iteratee shorthand.
-    find(users, { age: 1, active: true });
+    (f([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.x == 3): {| x: number |} | void);
+    (f({ x: 1, y: 2 }, (v: number, key: string) => v): number | void);
 
-    // The `_.matchesProperty` iteratee shorthand.
-    find(users, ["active", false]);
+    (f((["a", "b"]: $ReadOnlyArray<string>), "c"): string | void);
+    // opaque types are allowed as keys of objects
+    opaque type O = string;
+    type V = { [O]: number, ... };
+    const v: V = { x: 1, y: 2 };
 
-    // The `_.property` iteratee shorthand.
-    find(users, "active");
+    (f([1, 2, 3], x => x == 1): void | number);
+
+    // $ExpectError number cannot be compared to string
+    f([1, 2, 3], x => x == "a");
+    // $ExpectError number is incompatible with function type.
+    f([1, 2, 3], 1);
+    // $ExpectError property `y` not found in object literal
+    f([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.y == 3);
+    // $ExpectError function may not find the item, therefore `void` is always a valid result
+    (f(users, function(o) { return o.age < 40; }): User);
+  }
+
+  it('find', () => {
+    testFindFunction(find);
+  });
+
+  it('findLast', () => {
+    testFindFunction(findLast);
   });
 
   it('flatMap', () => {
@@ -260,8 +361,22 @@ describe('Collection', () => {
     flatMap({ a: 1, b: 2 }, n => [n, n]);
   });
 
+  it('flatMapDeep', () => {
+    flatMapDeep([1, 2, 3], (n) => [[[n, n]]]);
+    flatMapDeep({ a: 1, b: 2 }, n => [[[n, n]]]);
+  });
+
+  it('flatMapDepth', () => {
+    flatMapDepth([1, 2, 3], (n) => [[[n, n]]], 2);
+    flatMapDepth({ a: 1, b: 2 }, n => [[[n, n]]], 2);
+  });
+
   it('forEach', () => {
-    forEach(([1, 2]: $ReadOnlyArray<number>), (item: number) => false);
+    testForEachFunction(forEach);
+  });
+
+  it('forEachRight', () => {
+    testForEachFunction(forEachRight);
   });
 
   it('groupBy', () => {
@@ -269,21 +384,39 @@ describe('Collection', () => {
     if (numbersGroupedByMathFloor[6]) {
       numbersGroupedByMathFloor[6][0] / numbersGroupedByMathFloor[6][1];
     }
+
     const stringsGroupedByLength = groupBy(["one", "two", "three"], "length");
     if (stringsGroupedByLength[3]) {
       stringsGroupedByLength[3][0].toLowerCase();
     }
+
     const numbersObj: { [key: string]: number, ... } = { a: 6.1, b: 4.2, c: 6.3 };
     const numbersGroupedByMathFloor2 = groupBy(numbersObj, Math.floor);
     if (numbersGroupedByMathFloor2[6]) {
       numbersGroupedByMathFloor2[6][0] / numbersGroupedByMathFloor2[6][1];
     }
+
     const stringObj: { [key: string]: string, ... } = { a: "one", b: "two", c: "three" };
     const stringsGroupedByLength2 = groupBy(stringObj, "length");
     if (stringsGroupedByLength2[3]) {
       stringsGroupedByLength2[3][0].toLowerCase();
     }
   });
+
+  it('includes', function () {
+    (includes([1, 2, 3], 1): boolean);
+    (includes([1, 2, 3], 1, 2): boolean);
+    (includes({ 'a': 1, 'b': 2 }, 1): boolean);
+    (includes('abcd', 'bc'): boolean);
+  })
+
+  it('invokeMap', function () {
+    (invokeMap([[5, 1, 7], [3, 2, 1]], 'sort'): number[][]);
+    (invokeMap(['123', '456'], String.prototype.split, ''): string[][]);
+
+    // $ExpectError
+    invokeMap([123, 456], String.prototype.split, '');
+  })
 
   it('keyBy', () => {
     keyBy([{ dir: "left", code: 97 }, { dir: "right", code: 100 }], function(o) {
@@ -310,22 +443,21 @@ describe('Collection', () => {
 
   it('map', () => {
     // examples from the official doc
-    function square(n) {
+    function square(n: number): number {
       return n * n;
     }
-
-    map([4, 8], square);
-    map({ a: 4, b: 8 }, square);
+    (map([4, 8], square): number[]);
+    (map({ a: 4, b: 8 }, square): number[]);
+    (map([{ user: "barney" }, { user: "fred" }], "user"): string[]);
+    (map([{ user: "barney", anotherProp: 1 }, { user: "fred", anotherProp: 2 }], "user"): string[]);
 
     //accepts tuple types
-
     const tuple: [number, number] = [1, 2];
-    map(tuple, val => val + 2);
+    (map(tuple, val => val + 2): number[]);
     //$ExpectError cannot push to tuple
     map(tuple, (val, nothing, tupleArray) => tupleArray.push(123));
-
-    // The `_.property` iteratee shorthand.
-    map([{ user: "barney" }, { user: "fred" }], "user");
+    //$ExpectError wrong return type
+    (map(tuple, val => val + 2): [number, number]);
 
     // Array#map, lodash.map, lodash#map
     const nums: number[] = [1, 2, 3, 4, 5, 6];
@@ -337,51 +469,129 @@ describe('Collection', () => {
     (map(nums, num => JSON.stringify(num)): string[]);
   });
 
+  it('orderBy', () => {
+    type User = {| user: string, age: number |};
+    const users: User[] = [
+      { 'user': 'fred',   'age': 48 },
+      { 'user': 'barney', 'age': 34 },
+      { 'user': 'fred',   'age': 40 },
+      { 'user': 'barney', 'age': 36 }
+    ];
+    (orderBy(users, ['user', 'age'], ['asc', 'desc']): User[]);
+
+    type Item = {| a: number, b: number |};
+    (orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], ['a']): Item[]);
+    (orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], [x => x.a]): Item[]);
+    (orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, ['a']): Item[]);
+    (orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, [x => x.a]): Item[]);
+  });
+
+  it('partition', () => {
+    type User = {| user: string, age: number, active: boolean |}
+    const users: User[] = [
+      { 'user': 'barney',  'age': 36, 'active': false },
+      { 'user': 'fred',    'age': 40, 'active': true },
+      { 'user': 'pebbles', 'age': 1,  'active': false }
+    ];
+    (partition(users, function(o) { return o.active; }): [User[], User[]] );
+    (partition(users, { 'age': 1, 'active': false }): [User[], User[]]);
+    (partition(users, ['active', false]): [User[], User[]]);
+    (partition(users, 'active'): [User[], User[]]);
+  });
+
+  const testReduceFunction = (f: typeof reduce) => {
+    (f([1, 2], function(sum: number, n: number) { return sum + n;}, 0): number);
+
+    type Result = {[number]: string[], ...};
+    (f({ 'a': 1, 'b': 2, 'c': 1 }, function(result: Result, value: number, key: string) {
+      (result[value] || (result[value] = [])).push(key);
+      return result;
+    }, {}): Result);
+
+    (f([[0, 1], [2, 3], [4, 5]], function(flattened: number[], other: number[]) {
+      return flattened.concat(other);
+    }, []): number[]);
+
+    // $ExpectError return type
+    (f([1, 2], function(sum, n) { return sum + n;}, 0): string);
+  };
+
+  it('reduce', () => {
+    testReduceFunction(reduce);
+  });
+
+  it('reduceRight', () => {
+    testReduceFunction(reduceRight);
+  });
+
+  it('reject', () => {
+    testFilterFunction(reject);
+  });
+
   it('sample', () => {
+    (sample([1, 2, 3, 4]): number);
     (sample(readOnlyArray): number);
-    (sample(readOnlyObject): number);
+    (sample(readOnlyIndexerObject): number);
     (sample({ a: 1, b: 'abc' }): number| string);
+
     // $ExpectError
     (sample({ a: 1, b: 'abc' }): number);
   });
 
   it('sampleSize', () => {
+    (sampleSize([1, 2, 3], 4): number[]);
     (sampleSize(readOnlyArray, 2): number[]);
-    (sampleSize(readOnlyObject, 2): number[]);
+    (sampleSize(readOnlyIndexerObject, 2): number[]);
     (sampleSize({ a: 1, b: 'abc' }, 2): (number| string)[]);
+
     // $ExpectError
     (shuffle({ a: 1, b: 'abc' }, 2): number[]);
   });
 
   it('shuffle', () => {
+    (shuffle([1, 2, 3, 4]): number[]);
     (shuffle(readOnlyArray): number[]);
-    (shuffle(readOnlyObject): number[]);
-    (shuffle(readOnlyObject): (number | string)[]);
+    (shuffle(readOnlyIndexerObject): number[]);
+    (shuffle(readOnlyIndexerObject): (number | string)[]);
+
     // $ExpectError
     (shuffle({ a: 1, b: 'abc' }): number[]);
   });
 
-  it('orderBy', () => {
-    (orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], ['a']): Array<{
-      a: number,
-      b: number,
-      ...
-    }>);
-    (orderBy([{a: 1, b: 2}, {a: 2, b: 1}, {a: 3, b: 0}], [x => x.a]): Array<{
-      a: number,
-      b: number,
-      ...
-    }>);
-    (orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, ['a']): Array<{
-      a: number,
-      b: number,
-      ...
-    }>);
-    (orderBy({[0]: {a: 1, b: 2}, [2]: {a: 2, b: 1}, [1]: {a: 3, b: 0}}, [x => x.a]): Array<{
-      a: number,
-      b: number,
-      ...
-    }>);
+  it('size', () => {
+    (size([1, 2, 3]): number);
+    (size({ 'a': 1, 'b': 2 }): number);
+    (size('pebbles'): number);
+
+    (size(readOnlyArray): number);
+    (size(readOnlyIndexerObject): number);
+  });
+
+  it('some', () => {
+    const users = [
+      { 'user': 'barney', 'active': true },
+      { 'user': 'fred',   'active': false }
+    ];
+    (some([null, 0, 'yes', false], Boolean): boolean);
+    (some(users, { 'user': 'barney', 'active': false }): boolean);
+    (some(users, ['active', false]): boolean);
+    (some(users, 'active'): boolean);
+
+    (some(readOnlyArray, Boolean): boolean);
+    (some(readOnlyIndexerObject, Boolean): boolean);
+  });
+
+  it('sortBy', () => {
+    const users = [
+      { 'user': 'fred',   'age': 48 },
+      { 'user': 'barney', 'age': 36 },
+      { 'user': 'fred',   'age': 40 },
+      { 'user': 'barney', 'age': 34 }
+    ];
+    (sortBy(users, [function(o) { return o.user; }]): typeof users);
+    (sortBy(users, ['user', 'age']): typeof users);
+
+    (sortBy(readOnlyArray, (v) => v): typeof readOnlyArray);
   });
 });
 
@@ -448,11 +658,7 @@ describe('Lang', () => {
   });
 
   it('conformsTo', () => {
-    (conformsTo({ a: 1, b: 2 }, {
-      a: function(x: number) {
-        return true;
-      }
-    }): boolean);
+    (conformsTo({ a: 1, b: 2 }, { b: function(n: number) { return true; }}): boolean);
   });
 });
 
@@ -492,6 +698,17 @@ describe('Object', () => {
     get(undefined, "data");
   });
 
+  it('keys', () => {
+    function Foo() {
+      this.a = 1;
+      this.b = 2;
+    }
+    Foo.prototype.c = 3;
+
+    (keys(new Foo): string[]);
+    (keys('hi'): string[]);
+  });
+
   it('omitBy', () => {
     (omitBy({ a: 2, b: 3, c: 4 }, num => num % 2): { [prop: string]: number, ... });
     (omitBy(null, num => num % 2): {...});
@@ -514,7 +731,7 @@ describe('Object', () => {
     (pickBy(null, num => num % 2): {...});
     (pickBy(undefined, num => num % 2): {...});
     (pickBy({ [1]: 1, [2]: 2 }, num => num === 2): { [prop: number]: number, ... });
-    (pickBy(readOnlyObject, num => num === 2): { [prop: number]: number, ... });
+    (pickBy(readOnlyIndexerObject, num => num === 2): { [prop: number]: number, ... });
   });
 
   it('toPairs / _.toPairsIn', () => {

--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/test_lodash-v4.x.x.js
@@ -94,6 +94,9 @@ const readOnlyIndexerObject: ReadOnlyIndexerObject = { ...indexerObject };
 type ReadOnlyExactObject = $ReadOnly<ExactObject>
 const readOnlyExactObject: ReadOnlyExactObject = { ...exactObject };
 
+type NullableObject = IndexerObject | null;
+const nullableObject: NullableObject = readOnlyArray[0] > 100 ? indexerObject : null;
+
 describe('Array', () => {
   it('chunk', () => {
     chunk(readOnlyArray, 2);
@@ -322,6 +325,7 @@ describe('Collection', () => {
     (f(users, { age: 1, active: true }): User | void);
     (f(users, ["active", false]): User | void);
     (f(users, "active"): User | void);
+    (f(users, "active"): User | void);
 
     (f([1, 2, 3], x => x * 1 == 3): number | void);
     (f([1, 2, 3], x => x == 2, 1): number | void);
@@ -335,7 +339,8 @@ describe('Collection', () => {
     type V = { [O]: number, ... };
     const v: V = { x: 1, y: 2 };
 
-    (f([1, 2, 3], x => x == 1): void | number);
+    (f([1, 2, 3], x => x == 1): number | void);
+    (find(nullableObject, v => !!v, null): number | void);
 
     // $ExpectError number cannot be compared to string
     f([1, 2, 3], x => x == "a");


### PR DESCRIPTION
* Type of contribution: fix, refactor, tests

1. Lodash functions should accept $ReadOnly objects as arguments for functions which do not mutate them. Right now it does not.
This is also in line with guides in CONTRIBUTING doc - to prefer $ReadOnly objects over just `{}`;
This fix is similar to #3763 but it is for objects instead of arrays.

1.  This PR also adds some unit tests:
* test for code examples from docs for all Collections functions
* Reusing tests for functions which must have exactly same types according to docs (e.g. `each/eachRight/forEach/forEachRight`) . THis has helped to uncover some inconsistencies in them.
* tests for readonly objects - for functions with non-trivial changes. Can add to more.
* add testing of return types for all existing Collection functions. Adding some ExpectError tests - not to allow `any` as a return type.

Much more tests could have been added, but adding them often uncovers existing bugs in types (for example, each(), every(), flatMap() used to hide some errors). This PR includes some of the fixes, but adding more would increase the size of the code changes and risk of merging it.


3. Other (unplanned) fixes include:
* `T: Object` would allow T to be number, string, array, any etc. In functions where these values are not supported (at least there is no meaningful result returned from lodash). Such places were replaced with indexer object.
* `countBy`
    * support string in collection argument
* `each/eachRight/forEach/forEachRight`:
    * aligning to have same types (as they should per docs). Adding tests to enforce this. Is it possible to reuse a variable for their definition?
    * type iteratee arguments and return type
    * return the type of passed collection correctly now, previously e.g. readonly array would be changed to writeable array.
    * add support for opaque types keys (opaque values were already supported)
    * not to accept object as iteratee, 
* `filter/reject`:
    * aligning to have same types, adding tests to enforce this
* `every`
    * support string in collection argument
*`find/findLast`:
    * aligning to have same types, adding tests to enforce this
    * support `null` in collection argument
* `reduce/reduceRight`:
    * aligning to have same types, adding tests to enforce this
    * returns accumulator type instead of void if void or null passed to it as first argument. 
* `find`:
    * support null for iteratee and fromIndex args. This is useful e.g. to allow nullable objects to be passed to the function.
* `flatMap/flatMapDeep/flatMapDepth`:
    * do not accept object as iteratee argument anymore, same as in lodash docs 
    * add support for opaque keys

All changes have been checked in code sandbox that lodash actually does something meaningful for these news supported inputs.