### PR TITLE
Allow function within styled(..)

### DIFF
--- a/definitions/npm/styled-components_v4.x.x/flow_v0.104.x-/styled-components_v4.x.x.js
+++ b/definitions/npm/styled-components_v4.x.x/flow_v0.104.x-/styled-components_v4.x.x.js
@@ -26,6 +26,7 @@ declare module 'styled-components' {
   declare export type TaggedTemplateLiteral<I, R> = {
     [[call]]: (strings: string[], ...interpolations: Interpolation<I>[]) => R,
     [[call]]: ((props: I) => Interpolation<any>) => R,
+    ...
   };
 
   // Should this be `mixed` perhaps?

--- a/definitions/npm/styled-components_v4.x.x/flow_v0.104.x-/styled-components_v4.x.x.js
+++ b/definitions/npm/styled-components_v4.x.x/flow_v0.104.x-/styled-components_v4.x.x.js
@@ -23,7 +23,10 @@ declare module 'styled-components' {
     | void
     | {[ruleOrSelector: string]: string | number, ...} // CSS-in-JS object returned by polished are also supported, partially
 
-  declare export type TaggedTemplateLiteral<I, R> = (strings: string[], ...interpolations: Interpolation<I>[]) => R
+  declare export type TaggedTemplateLiteral<I, R> = {
+    [[call]]: (strings: string[], ...interpolations: Interpolation<I>[]) => R,
+    [[call]]: ((props: I) => Interpolation<any>) => R,
+  };
 
   // Should this be `mixed` perhaps?
   declare export type CSSRules = Interpolation<any>[] // eslint-disable-line flowtype/no-weak-types


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

Fixes #3778 

Allows functions to be used and does proper type checking within.

_Thanks go to @dennisoelkers for helping troubleshoot and find a solution for this._

