### PR TITLE
Fixed signature for `firebase.firestore.Query.onSnapshot` & `firebase.firestore.DocumentReference.onSnapshot`

### DIFF
--- a/definitions/npm/firebase_v5.x.x/flow_v0.104.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.104.x-/firebase_v5.x.x.js
@@ -513,10 +513,12 @@ declare class $npm$firebase$firestore$Query {
   isEqual(other: $npm$firebase$firestore$Query): boolean;
   limit(limit: number): $npm$firebase$firestore$Query;
   onSnapshot(
-    optionsOrObserverOrOnNext: $npm$firebase$firestore$QueryListenOptions | $npm$firebase$firestore$queryObserver,
-    observerOrOnNextOrOnError?: | $npm$firebase$firestore$QueryListenOptions
-    | $npm$firebase$firestore$queryObserver
-    | $npm$firebase$firestore$observerError,
+    optionsOrObserverOrOnNext: 
+      | $npm$firebase$firestore$QueryListenOptions
+      | $npm$firebase$firestore$queryObserver,
+    observerOrOnNextOrOnError?:
+      | $npm$firebase$firestore$queryObserver
+      | $npm$firebase$firestore$observerError,
     onError?: $npm$firebase$firestore$observerError
   ): () => void;
   orderBy(
@@ -553,11 +555,12 @@ declare class $npm$firebase$firestore$DocumentReference {
   get(): Promise<$npm$firebase$firestore$DocumentSnapshot>;
   isEqual(other: $npm$firebase$firestore$DocumentReference): boolean;
   onSnapshot(
-    optionsOrObserverOrOnNext: $npm$firebase$firestore$QueryListenOptions
-    | $npm$firebase$firestore$documentObserver,
-    observerOrOnNextOrOnError?: | $npm$firebase$firestore$QueryListenOptions
-    | $npm$firebase$firestore$documentObserver
-    | $npm$firebase$firestore$observerError,
+    optionsOrObserverOrOnNext:
+      | $npm$firebase$firestore$QueryListenOptions
+      | $npm$firebase$firestore$documentObserver,
+    observerOrOnNextOrOnError?:
+      | $npm$firebase$firestore$documentObserver
+      | $npm$firebase$firestore$observerError,
     onError?: $npm$firebase$firestore$observerError
   ): () => void;
   set(data: { +[string]: mixed, ... }, options?: {| merge?: boolean, mergeFields?: string[] |} | null): Promise<void>;

--- a/definitions/npm/firebase_v5.x.x/flow_v0.104.x-/firebase_v5.x.x.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.104.x-/firebase_v5.x.x.js
@@ -498,7 +498,6 @@ declare interface $npm$firebase$firestore$Blob {
 
 declare interface $npm$firebase$firestore$QueryListenOptions {
   includeMetadataChanges: boolean;
-  includeQueryMetadataChanges: boolean;
 }
 
 declare type $npm$firebase$firestore$documentObserver = (snapshot: $npm$firebase$firestore$DocumentSnapshot) => void | Promise<void>;

--- a/definitions/npm/firebase_v5.x.x/flow_v0.104.x-/test_firebase.js
+++ b/definitions/npm/firebase_v5.x.x/flow_v0.104.x-/test_firebase.js
@@ -252,10 +252,7 @@ firebase
 
 // #26
 // $ExpectError
-firebase
-  .firestore()
-  .doc('/foo/bar')
-  .limit(4)
+firebase.firestore().doc('/foo/bar').limit(4)
 
 // #27
 firebase
@@ -415,3 +412,59 @@ firebase
       (c.newIndex: number);
     });
   });
+
+// #46
+
+firebase
+  .firestore()
+  .collection('listened-collection')
+  .onSnapshot(
+    // Test with options object present
+    { includeMetadataChanges: true },
+    (snapshot: firebase.firestore.QuerySnapshot) => {
+      snapshot.docChanges().forEach(c => {
+        (c.type: string);
+        (c.doc.id: string);
+        (c.oldIndex: number);
+        (c.newIndex: number);
+      });
+    });
+
+// #47
+
+firebase
+  .firestore()
+  .collection('listened-collection')
+  .onSnapshot(
+    // Test typedef with deprecated options object field
+    // $ExpectError
+    { includeQueryMetadataChanges: true },
+    (snapshot: firebase.firestore.QuerySnapshot) => {
+      snapshot.docChanges().forEach(c => {
+        (c.type: string);
+        (c.doc.id: string);
+        (c.oldIndex: number);
+        (c.newIndex: number);
+      });
+    });
+
+// #48
+
+firebase
+  .firestore()
+  .collection('listened-collection')
+  .onSnapshot(
+    { includeMetadataChanges: true },
+    (snapshot: firebase.firestore.QuerySnapshot) => {
+      snapshot.docChanges().forEach(c => {
+        (c.type: string);
+        (c.doc.id: string);
+        (c.oldIndex: number);
+        (c.newIndex: number);
+      });
+    },
+    // Test with error handler present
+    (error) => {
+      (error: typeof firebase.FirebaseError);
+    }
+  );


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
From Firebase v5.0.0 changelog: "Merged the includeQueryMetadataChanges and includeDocumentMetadataChanges options passed to Query.onSnapshot() into a single includeMetadataChanges option."

Changes:

- Removed deprecated `includeQueryMetadataChanges` option from the `$npm$firebase$firestore$QueryListenOptions` interface. (Curiously, the other deprecated option, `includeDocumentMetadataChanges` didn't seem to have ever been in the interface.)
- Removed `$npm$firebase$firestore$QueryListenOptions` variant from `observerOrOnNextOrOnError` in the `firebase.firestore.Query.onSnapshot` `firebase.firestore.DocumentReference.onSnapshot`. 

Not sure why the options variant was provided as an option in the second position. Maybe I'm wrong here—does the options variant need to stay?

- Links to documentation:
https://firebase.google.com/support/release-notes/js#cloud-firestore_55

- Type of contribution: fix

Other notes:


