### PR TITLE
fix(zen-observable): fix variance, subscriber return type

### DIFF
--- a/definitions/npm/zen-observable_v0.8.x/flow_v0.104.x-/test_zen-observable.js
+++ b/definitions/npm/zen-observable_v0.8.x/flow_v0.104.x-/test_zen-observable.js
@@ -24,6 +24,30 @@ describe('new Observable().subscribe', () => {
     );
     subscription2.unsubscribe();
   });
+  it('subscriber can return function', () => {
+    const observable = new Observable(observer => {
+      observer.next(1);
+      observer.next(2);
+      observer.next(3);
+      if (observer.closed) observer.error(new Error('test'));
+      observer.complete();
+      return () => {};
+    });
+  });
+  it('subscriber can return subscription', () => {
+    const o1 = new Observable(observer => {
+      observer.next(1);
+    });
+    const o2 = new Observable(observer => {
+      return o1.subscribe(observer);
+    });
+  });
+  it(`subscriber can't return other types`, () => {
+    const o1 = new Observable(observer => {
+      // $ExpectError
+      return 2;
+    });
+  });
   it(`doesn't require all subscribe callbacks to be given`, () => {
     const observable = new Observable(observer => {
       observer.next(1);

--- a/definitions/npm/zen-observable_v0.8.x/flow_v0.104.x-/zen-observable_v0.8.x.js
+++ b/definitions/npm/zen-observable_v0.8.x/flow_v0.104.x-/zen-observable_v0.8.x.js
@@ -1,15 +1,15 @@
 declare module 'zen-observable' {
   declare export interface SubscriptionObserver<T> {
-    next(value: T): void;
-    error(err: Error): void;
-    complete(): void;
+    +next: (value: T) => void;
+    +error: (err: Error) => void;
+    +complete: () => void;
     get closed(): boolean;
   }
 
   declare export interface Observer<T> {
-    next?: (value: T) => any;
-    error?: (err: Error) => any;
-    complete?: () => any;
+    +next?: (value: T) => any;
+    +error?: (err: Error) => any;
+    +complete?: () => any;
   }
 
   declare export interface Subscription {
@@ -17,8 +17,12 @@ declare module 'zen-observable' {
     unsubscribe(): void;
   }
 
+  declare export type Subscriber<T> = (
+    observer: SubscriptionObserver<T>
+  ) => void | (() => mixed) | Subscription;
+
   declare export default class Observable<T> {
-    constructor(subscriber: (observer: SubscriptionObserver<T>) => mixed): void;
+    constructor(subscriber: Subscriber<T>): void;
     subscribe(
       next: (value: T) => mixed,
       error?: (err: Error) => mixed,

--- a/definitions/npm/zen-observable_v0.8.x/flow_v0.69.0-v0.103.x/test_zen-observable.js
+++ b/definitions/npm/zen-observable_v0.8.x/flow_v0.69.0-v0.103.x/test_zen-observable.js
@@ -24,6 +24,30 @@ describe('new Observable().subscribe', () => {
     );
     subscription2.unsubscribe();
   });
+  it('subscriber can return function', () => {
+    const observable = new Observable(observer => {
+      observer.next(1);
+      observer.next(2);
+      observer.next(3);
+      if (observer.closed) observer.error(new Error('test'));
+      observer.complete();
+      return () => {};
+    });
+  });
+  it('subscriber can return subscription', () => {
+    const o1 = new Observable(observer => {
+      observer.next(1);
+    });
+    const o2 = new Observable(observer => {
+      return o1.subscribe(observer);
+    });
+  });
+  it(`subscriber can't return other types`, () => {
+    const o1 = new Observable(observer => {
+      // $ExpectError
+      return 2;
+    });
+  });
   it(`doesn't require all subscribe callbacks to be given`, () => {
     const observable = new Observable(observer => {
       observer.next(1);

--- a/definitions/npm/zen-observable_v0.8.x/flow_v0.69.0-v0.103.x/zen-observable_v0.8.x.js
+++ b/definitions/npm/zen-observable_v0.8.x/flow_v0.69.0-v0.103.x/zen-observable_v0.8.x.js
@@ -1,15 +1,15 @@
 declare module 'zen-observable' {
   declare export interface SubscriptionObserver<T> {
-    next(value: T): void;
-    error(err: Error): void;
-    complete(): void;
+    +next: (value: T) => void;
+    +error: (err: Error) => void;
+    +complete: () => void;
     get closed(): boolean;
   }
 
   declare export interface Observer<T> {
-    next?: (value: T) => any;
-    error?: (err: Error) => any;
-    complete?: () => any;
+    +next?: (value: T) => any;
+    +error?: (err: Error) => any;
+    +complete?: () => any;
   }
 
   declare export interface Subscription {
@@ -17,8 +17,12 @@ declare module 'zen-observable' {
     unsubscribe(): void;
   }
 
+  declare export type Subscriber<T> = (
+    observer: SubscriptionObserver<T>
+  ) => void | (() => mixed) | Subscription;
+
   declare export default class Observable<T> {
-    constructor(subscriber: (observer: SubscriptionObserver<T>) => mixed): void;
+    constructor(subscriber: Subscriber<T>): void;
     subscribe(
       next: (value: T) => mixed,
       error?: (err: Error) => mixed,


### PR DESCRIPTION
Other notes: I forgot that the function passed to the Observable constructor can
return a cleanup function or subscription (https://github.com/zenparsing/zen-observable#new-observablesubscribe)

Also `SubscriptionObserver` couldn't be passed as an `Observer`, this is now fixed