### PR TITLE
fs-extra: inherit fs library types

### DIFF
--- a/definitions/npm/fs-extra_v7.x.x/flow_v0.104.x-/fs-extra_v7.x.x.js
+++ b/definitions/npm/fs-extra_v7.x.x/flow_v0.104.x-/fs-extra_v7.x.x.js
@@ -1,547 +1,535 @@
 declare module "fs-extra" {
   import type { Stats, ReadStream, WriteStream } from "fs";
+  import typeof fsTypes from "fs";
 
-  declare export type SymlinkType = "dir" | "file";
-  declare export type FsSymlinkType = "dir" | "file" | "junction";
+  declare type SymlinkType = "dir" | "file";
+  declare type FsSymlinkType = "dir" | "file" | "junction";
 
-  declare export type CopyFilterSync = (src: string, dest: string) => boolean;
-  declare export type CopyFilterAsync = (
+  declare type CopyFilterSync = (src: string, dest: string) => boolean;
+  declare type CopyFilterAsync = (
     src: string,
     dest: string
   ) => Promise<boolean>;
 
-  declare export type CopyOptions = {
+  declare type CopyOptions = {
     dereference?: boolean,
     overwrite?: boolean,
     preserveTimestamps?: boolean,
     errorOnExist?: boolean,
-    recursive?: boolean,
-    ...
+    recursive?: boolean
   };
 
-  declare export type CopyOptionsAync = CopyOptions & { filter?: CopyFilterSync | CopyFilterAsync, ... };
+  declare type CopyOptionsAync = CopyOptions & {
+    filter?: CopyFilterSync | CopyFilterAsync
+  };
 
-  declare export type CopyOptionsSync = CopyOptions & { filter?: CopyFilterSync, ... };
+  declare type CopyOptionsSync = CopyOptions & {
+    filter?: CopyFilterSync
+  };
 
-  declare export type MoveOptions = {
+  declare type MoveOptions = {
     overwrite?: boolean,
-    limit?: number,
-    ...
+    limit?: number
   };
 
-  declare export type ReadOptions = {
+  declare type ReadOptions = {
     throws?: boolean,
     fs?: Object,
     reviver?: any,
     encoding?: string,
-    flag?: string,
-    ...
+    flag?: string
   };
 
-  declare export type WriteFileOptions = {
+  declare type WriteFileOptions = {
     encoding?: string,
     flag?: string,
-    mode?: number,
-    ...
+    mode?: number
   };
 
-  declare export type WriteOptions = WriteFileOptions & {
+  declare type WriteOptions = WriteFileOptions & {
     fs?: Object,
     replacer?: any,
     spaces?: number | string,
-    EOL?: string,
-    ...
+    EOL?: string
   };
 
-  declare export type ReadResult = {
+  declare type ReadResult = {
     bytesRead: number,
-    buffer: Buffer,
-    ...
+    buffer: Buffer
   };
 
-  declare export type WriteResult = {
+  declare type WriteResult = {
     bytesWritten: number,
-    buffer: Buffer,
-    ...
+    buffer: Buffer
   };
 
-  declare export function copy(
+  declare function copy(
     src: string,
     dest: string,
     options?: CopyOptionsAync
   ): Promise<void>;
-  declare export function copy(
+  declare function copy(
     src: string,
     dest: string,
     callback: (err: Error) => void
   ): void;
-  declare export function copy(
+  declare function copy(
     src: string,
     dest: string,
     options: CopyOptionsAync,
     callback: (err: Error) => void
   ): void;
-  declare export function copySync(
+  declare function copySync(
     src: string,
     dest: string,
     options?: CopyOptionsSync
   ): void;
 
-  declare export function move(
+  declare function move(
     src: string,
     dest: string,
     options?: MoveOptions
   ): Promise<void>;
-  declare export function move(
+  declare function move(
     src: string,
     dest: string,
     callback: (err: Error) => void
   ): void;
-  declare export function move(
+  declare function move(
     src: string,
     dest: string,
     options: MoveOptions,
     callback: (err: Error) => void
   ): void;
-  declare export function moveSync(
+  declare function moveSync(
     src: string,
     dest: string,
     options?: MoveOptions
   ): void;
 
-  declare export function createFile(file: string): Promise<void>;
-  declare export function createFile(
+  declare function createFile(file: string): Promise<void>;
+  declare function createFile(
     file: string,
     callback: (err: Error) => void
   ): void;
-  declare export function createFileSync(file: string): void;
-  declare export function createReadStream(path: string, options?: Object): ReadStream;
-  declare export function createWriteStream(path: string, options?: Object): WriteStream;
+  declare function createFileSync(file: string): void;
+  declare function createReadStream(path: string, options?: Object): ReadStream;
+  declare function createWriteStream(path: string, options?: Object): WriteStream;
 
-  declare export function ensureDir(path: string): Promise<void>;
-  declare export function ensureDir(
+  declare function ensureDir(path: string): Promise<void>;
+  declare function ensureDir(
     path: string,
     callback: (err: Error) => void
   ): void;
-  declare export function ensureDirSync(path: string): void;
+  declare function ensureDirSync(path: string): void;
 
-  declare export function exists(path: string): Promise<boolean>;
-  declare export function exists(path: string, callback?: (exists: boolean) => void): void;
+  declare function exists(path: string): Promise<boolean>;
+  declare function exists(path: string, callback?: (exists: boolean) => void): void;
 
-  declare export function mkdirs(dir: string): Promise<void>;
-  declare export function mkdirs(
+  declare function mkdirs(dir: string): Promise<void>;
+  declare function mkdirs(
     dir: string,
     callback: (err: Error) => void
   ): void;
-  declare export function mkdirsSync(dir: string): void;
+  declare function mkdirsSync(dir: string): void;
 
-  declare export function mkdirp(dir: string): Promise<void>;
-  declare export function mkdirp(
+  declare function mkdirp(dir: string): Promise<void>;
+  declare function mkdirp(
     dir: string,
     callback: (err: Error) => void
   ): void;
-  declare export function mkdirpSync(dir: string): void;
+  declare function mkdirpSync(dir: string): void;
 
-  declare export function outputFile(
+  declare function outputFile(
     file: string,
     data: any,
     options?: WriteFileOptions | string
   ): Promise<void>;
-  declare export function outputFile(
+  declare function outputFile(
     file: string,
     data: any,
     callback: (err: Error) => void
   ): void;
-  declare export function outputFile(
+  declare function outputFile(
     file: string,
     data: any,
     options: WriteFileOptions | string,
     callback: (err: Error) => void
   ): void;
-  declare export function outputFileSync(
+  declare function outputFileSync(
     file: string,
     data: any,
     options?: WriteFileOptions | string
   ): void;
 
-  declare export function readJson(
+  declare function readJson(
     file: string,
     options?: ReadOptions
   ): Promise<any>;
-  declare export function readJson(
+  declare function readJson(
     file: string,
     callback: (err: Error, jsonObject: any) => void
   ): void;
-  declare export function readJson(
+  declare function readJson(
     file: string,
     options: ReadOptions,
     callback: (err: Error, jsonObject: any) => void
   ): void;
-  declare export function readJSON(
+  declare function readJSON(
     file: string,
     options?: ReadOptions
   ): Promise<any>;
-  declare export function readJSON(
+  declare function readJSON(
     file: string,
     callback: (err: Error, jsonObject: any) => void
   ): void;
-  declare export function readJSON(
+  declare function readJSON(
     file: string,
     options: ReadOptions,
     callback: (err: Error, jsonObject: any) => void
   ): void;
 
-  declare export function readJsonSync(
+  declare function readJsonSync(
     file: string,
     options?: ReadOptions
   ): any;
-  declare export function readJSONSync(
+  declare function readJSONSync(
     file: string,
     options?: ReadOptions
   ): any;
 
-  declare export function remove(dir: string): Promise<void>;
-  declare export function remove(
+  declare function remove(dir: string): Promise<void>;
+  declare function remove(
     dir: string,
     callback: (err: Error) => void
   ): void;
-  declare export function removeSync(dir: string): void;
+  declare function removeSync(dir: string): void;
 
-  declare export function outputJson(
+  declare function outputJson(
     file: string,
     data: any,
     options?: WriteOptions
   ): Promise<void>;
-  declare export function outputJSON(
+  declare function outputJSON(
     file: string,
     data: any,
     options?: WriteOptions
   ): Promise<void>;
-  declare export function outputJson(
+  declare function outputJson(
     file: string,
     data: any,
     options: WriteOptions,
     callback: (err: Error) => void
   ): void;
-  declare export function outputJSON(
+  declare function outputJSON(
     file: string,
     data: any,
     options: WriteOptions,
     callback: (err: Error) => void
   ): void;
-  declare export function outputJson(
+  declare function outputJson(
     file: string,
     data: any,
     callback: (err: Error) => void
   ): void;
-  declare export function outputJSON(
+  declare function outputJSON(
     file: string,
     data: any,
     callback: (err: Error) => void
   ): void;
-  declare export function outputJsonSync(
+  declare function outputJsonSync(
     file: string,
     data: any,
     options?: WriteOptions
   ): void;
-  declare export function outputJSONSync(
+  declare function outputJSONSync(
     file: string,
     data: any,
     options?: WriteOptions
   ): void;
 
-  declare export function writeJSON(
+  declare function writeJSON(
     file: string,
     object: any,
     options?: WriteOptions
   ): Promise<void>;
-  declare export function writeJSON(
+  declare function writeJSON(
     file: string,
     object: any,
     callback: (err: Error) => void
   ): void;
-  declare export function writeJSON(
+  declare function writeJSON(
     file: string,
     object: any,
     options: WriteOptions,
     callback: (err: Error) => void
   ): void;
-  declare export function writeJson(
+  declare function writeJson(
     file: string,
     object: any,
     options?: WriteOptions
   ): Promise<void>;
-  declare export function writeJson(
+  declare function writeJson(
     file: string,
     object: any,
     callback: (err: Error) => void
   ): void;
-  declare export function writeJson(
+  declare function writeJson(
     file: string,
     object: any,
     options: WriteOptions,
     callback: (err: Error) => void
   ): void;
 
-  declare export function writeJsonSync(
+  declare function writeJsonSync(
     file: string,
     object: any,
     options?: WriteOptions
   ): void;
-  declare export function writeJSONSync(
+  declare function writeJSONSync(
     file: string,
     object: any,
     options?: WriteOptions
   ): void;
 
-  declare export function ensureFile(path: string): Promise<void>;
-  declare export function ensureFile(
+  declare function ensureFile(path: string): Promise<void>;
+  declare function ensureFile(
     path: string,
     callback: (err: Error) => void
   ): void;
-  declare export function ensureFileSync(path: string): void;
+  declare function ensureFileSync(path: string): void;
 
-  declare export function ensureLink(src: string, dest: string): Promise<void>;
-  declare export function ensureLink(
+  declare function ensureLink(src: string, dest: string): Promise<void>;
+  declare function ensureLink(
     src: string,
     dest: string,
     callback: (err: Error) => void
   ): void;
-  declare export function ensureLinkSync(src: string, dest: string): void;
+  declare function ensureLinkSync(src: string, dest: string): void;
 
-  declare export function ensureSymlink(
+  declare function ensureSymlink(
     src: string,
     dest: string,
     type?: SymlinkType
   ): Promise<void>;
-  declare export function ensureSymlink(
+  declare function ensureSymlink(
     src: string,
     dest: string,
     type: SymlinkType,
     callback: (err: Error) => void
   ): void;
-  declare export function ensureSymlink(
+  declare function ensureSymlink(
     src: string,
     dest: string,
     callback: (err: Error) => void
   ): void;
-  declare export function ensureSymlinkSync(
+  declare function ensureSymlinkSync(
     src: string,
     dest: string,
     type?: SymlinkType
   ): void;
 
-  declare export function emptyDir(path: string): Promise<void>;
-  declare export function emptyDir(
+  declare function emptyDir(path: string): Promise<void>;
+  declare function emptyDir(
     path: string,
     callback: (err: Error) => void
   ): void;
-  declare export function emptyDirSync(path: string): void;
+  declare function emptyDirSync(path: string): void;
 
-  declare export function pathExists(path: string): Promise<boolean>;
-  declare export function pathExists(
+  declare function pathExists(path: string): Promise<boolean>;
+  declare function pathExists(
     path: string,
     callback: (err: Error, exists: boolean) => void
   ): void;
-  declare export function pathExistsSync(path: string): boolean;
+  declare function pathExistsSync(path: string): boolean;
 
-  declare export function access(
+  declare function access(
     path: string | Buffer,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function access(
+  declare function access(
     path: string | Buffer,
     mode: number,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function access(
+  declare function access(
     path: string | Buffer,
     mode?: number
   ): Promise<void>;
 
-  declare export function appendFile(
+  declare function appendFile(
     file: string | Buffer | number,
     data: any,
-    options: {
-      encoding?: string,
-      mode?: number | string,
-      flag?: string,
-      ...
-    },
+    options: { encoding?: string, mode?: number | string, flag?: string },
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function appendFile(
+  declare function appendFile(
     file: string | Buffer | number,
     data: any,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function appendFile(
+  declare function appendFile(
     file: string | Buffer | number,
     data: any,
-    options?: {
-      encoding?: string,
-      mode?: number | string,
-      flag?: string,
-      ...
-    }
+    options?: { encoding?: string, mode?: number | string, flag?: string }
   ): Promise<void>;
 
-  declare export function chmod(
+  declare function chmod(
     path: string | Buffer,
     mode: string | number,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function chmod(
+  declare function chmod(
     path: string | Buffer,
     mode: string | number
   ): Promise<void>;
 
-  declare export function chown(
+  declare function chown(
     path: string | Buffer,
     uid: number,
     gid: number
   ): Promise<void>;
-  declare export function chown(
+  declare function chown(
     path: string | Buffer,
     uid: number,
     gid: number,
     callback: (err: ErrnoError) => void
   ): void;
 
-  declare export function close(
+  declare function close(
     fd: number,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function close(fd: number): Promise<void>;
+  declare function close(fd: number): Promise<void>;
 
-  declare export function fchmod(
+  declare function fchmod(
     fd: number,
     mode: string | number,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function fchmod(
+  declare function fchmod(
     fd: number,
     mode: string | number
   ): Promise<void>;
 
-  declare export function fchown(
+  declare function fchown(
     fd: number,
     uid: number,
     gid: number,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function fchown(
+  declare function fchown(
     fd: number,
     uid: number,
     gid: number
   ): Promise<void>;
 
-  declare export function fdatasync(fd: number, callback: () => void): void;
-  declare export function fdatasync(fd: number): Promise<void>;
+  declare function fdatasync(fd: number, callback: () => void): void;
+  declare function fdatasync(fd: number): Promise<void>;
 
-  declare export function fstat(
+  declare function fstat(
     fd: number,
     callback: (err: ErrnoError, stats: Stats) => any
   ): void;
-  declare export function fstat(fd: number): Promise<Stats>;
+  declare function fstat(fd: number): Promise<Stats>;
 
-  declare export function fsync(
+  declare function fsync(
     fd: number,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function fsync(fd: number): Promise<void>;
+  declare function fsync(fd: number): Promise<void>;
 
-  declare export function ftruncate(
+  declare function ftruncate(
     fd: number,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function ftruncate(
+  declare function ftruncate(
     fd: number,
     len: number,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function ftruncate(fd: number, len?: number): Promise<void>;
+  declare function ftruncate(fd: number, len?: number): Promise<void>;
 
-  declare export function futimes(
+  declare function futimes(
     fd: number,
     atime: number,
     mtime: number,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function futimes(
+  declare function futimes(
     fd: number,
     atime: Date,
     mtime: Date,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function futimes(
+  declare function futimes(
     fd: number,
     atime: number,
     mtime: number
   ): Promise<void>;
-  declare export function futimes(
+  declare function futimes(
     fd: number,
     atime: Date,
     mtime: Date
   ): Promise<void>;
 
-  declare export function lchown(
+  declare function lchown(
     path: string | Buffer,
     uid: number,
     gid: number,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function lchown(
+  declare function lchown(
     path: string | Buffer,
     uid: number,
     gid: number
   ): Promise<void>;
 
-  declare export function link(
+  declare function link(
     srcpath: string | Buffer,
     dstpath: string | Buffer,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function link(
+  declare function link(
     srcpath: string | Buffer,
     dstpath: string | Buffer
   ): Promise<void>;
 
-  declare export function lstat(
+  declare function lstat(
     path: string | Buffer,
     callback: (err: ErrnoError, stats: Stats) => any
   ): void;
-  declare export function lstat(path: string | Buffer): Promise<Stats>;
+  declare function lstat(path: string | Buffer): Promise<Stats>;
 
-  declare export function mkdir(
+  declare function mkdir(
     path: string | Buffer,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function mkdir(
+  declare function mkdir(
     path: string | Buffer,
     mode: number | string,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function mkdir(path: string | Buffer): Promise<void>;
+  declare function mkdir(path: string | Buffer): Promise<void>;
 
-  declare export function open(
+  declare function open(
     path: string | Buffer,
     flags: string | number,
     callback: (err: ErrnoError, fd: number) => void
   ): void;
-  declare export function open(
+  declare function open(
     path: string | Buffer,
     flags: string | number,
     mode: number,
     callback: (err: ErrnoError, fd: number) => void
   ): void;
-  declare export function open(
+  declare function open(
     path: string | Buffer,
     flags: string | number,
     mode?: number
   ): Promise<number>;
 
-  declare export function read(
+  declare function read(
     fd: number,
     buffer: Buffer,
     offset: number,
@@ -549,7 +537,7 @@ declare module "fs-extra" {
     position: number | null,
     callback: (err: ErrnoError, bytesRead: number, buffer: Buffer) => void
   ): void;
-  declare export function read(
+  declare function read(
     fd: number,
     buffer: Buffer,
     offset: number,
@@ -557,151 +545,143 @@ declare module "fs-extra" {
     position: number | null
   ): Promise<ReadResult>;
 
-  declare export function readFile(
+  declare function readFile(
     file: string | Buffer | number,
     callback: (err: ErrnoError, data: Buffer) => void
   ): void;
-  declare export function readFile(
+  declare function readFile(
     file: string | Buffer | number,
     encoding: string,
     callback: (err: ErrnoError, data: string) => void
   ): void;
-  declare export function readFile(
+  declare function readFile(
     file: string | Buffer | number,
-    options: { flag?: string, ... } | {
-      encoding: string,
-      flag?: string,
-      ...
-    },
+    options: { flag?: string } | { encoding: string, flag?: string },
     callback: (err: ErrnoError, data: Buffer) => void
   ): void;
-  declare export function readFile(
+  declare function readFile(
     file: string | Buffer | number,
-    options: { flag?: string, ... } | {
-      encoding: string,
-      flag?: string,
-      ...
-    }
+    options: { flag?: string } | { encoding: string, flag?: string }
   ): Promise<string>;
-  declare export function readFile(
+  declare function readFile(
     file: string | Buffer | number,
     encoding: string
   ): Promise<string>;
-  declare export function readFile(
+  declare function readFile(
     file: string | Buffer | number
   ): Promise<Buffer>;
 
-  declare export function readdir(
+  declare function readdir(
     path: string | Buffer,
     callback: (err: ErrnoError, files: string[]) => void
   ): void;
-  declare export function readdir(path: string | Buffer): Promise<string[]>;
+  declare function readdir(path: string | Buffer): Promise<string[]>;
 
-  declare export function readlink(
+  declare function readlink(
     path: string | Buffer,
     callback: (err: ErrnoError, linkString: string) => any
   ): void;
-  declare export function readlink(path: string | Buffer): Promise<string>;
+  declare function readlink(path: string | Buffer): Promise<string>;
 
-  declare export function realpath(
+  declare function realpath(
     path: string | Buffer,
     callback: (err: ErrnoError, resolvedPath: string) => any
   ): void;
-  declare export function realpath(
+  declare function realpath(
     path: string | Buffer,
-    cache: { [path: string]: string, ... },
+    cache: { [path: string]: string },
     callback: (err: ErrnoError, resolvedPath: string) => any
   ): void;
-  declare export function realpath(
+  declare function realpath(
     path: string | Buffer,
-    cache?: { [path: string]: string, ... }
+    cache?: { [path: string]: string }
   ): Promise<string>;
 
-  declare export function rename(
+  declare function rename(
     oldPath: string,
     newPath: string,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function rename(
+  declare function rename(
     oldPath: string,
     newPath: string
   ): Promise<void>;
 
-  declare export function rmdir(
+  declare function rmdir(
     path: string | Buffer,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function rmdir(path: string | Buffer): Promise<void>;
+  declare function rmdir(path: string | Buffer): Promise<void>;
 
-  declare export function stat(
+  declare function stat(
     path: string | Buffer,
     callback: (err: ErrnoError, stats: Stats) => any
   ): void;
-  declare export function stat(path: string | Buffer): Promise<Stats>;
+  declare function stat(path: string | Buffer): Promise<Stats>;
 
-  declare export function statSync(path: string): Stats;
+  declare function statSync(path: string): Stats;
 
-  declare export function symlink(
+  declare function symlink(
     srcpath: string | Buffer,
     dstpath: string | Buffer,
     type: FsSymlinkType | void,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function symlink(
+  declare function symlink(
     srcpath: string | Buffer,
     dstpath: string | Buffer,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function symlink(
+  declare function symlink(
     srcpath: string | Buffer,
     dstpath: string | Buffer,
     type?: FsSymlinkType
   ): Promise<void>;
 
-  declare export function truncate(
+  declare function truncate(
     path: string | Buffer,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function truncate(
+  declare function truncate(
     path: string | Buffer,
     len: number,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function truncate(
+  declare function truncate(
     path: string | Buffer,
     len?: number
   ): Promise<void>;
 
-  declare export function unlink(
+  declare function unlink(
     path: string | Buffer,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function unlink(path: string | Buffer): Promise<void>;
+  declare function unlink(path: string | Buffer): Promise<void>;
 
-  declare export function utimes(
+  declare function utimes(
     path: string | Buffer,
     atime: number,
     mtime: number,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function utimes(
+  declare function utimes(
     path: string | Buffer,
     atime: Date,
     mtime: Date,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function utimes(
+  declare function utimes(
     path: string | Buffer,
     atime: number,
     mtime: number
   ): Promise<void>;
-  declare export function utimes(
+  declare function utimes(
     path: string | Buffer,
     atime: Date,
     mtime: Date
   ): Promise<void>;
 
-  declare export function write(
+  declare function write(
     fd: number,
     buffer: Buffer,
     offset: number,
@@ -709,65 +689,144 @@ declare module "fs-extra" {
     position: number | null,
     callback: (err: ErrnoError, written: number, buffer: Buffer) => void
   ): void;
-  declare export function write(
+  declare function write(
     fd: number,
     buffer: Buffer,
     offset: number,
     length: number,
     callback: (err: ErrnoError, written: number, buffer: Buffer) => void
   ): void;
-  declare export function write(
+  declare function write(
     fd: number,
     data: any,
     callback: (err: ErrnoError, written: number, str: string) => void
   ): void;
-  declare export function write(
+  declare function write(
     fd: number,
     data: any,
     offset: number,
     callback: (err: ErrnoError, written: number, str: string) => void
   ): void;
-  declare export function write(
+  declare function write(
     fd: number,
     data: any,
     offset: number,
     encoding: string,
     callback: (err: ErrnoError, written: number, str: string) => void
   ): void;
-  declare export function write(
+  declare function write(
     fd: number,
     buffer: Buffer,
     offset: number,
     length: number,
     position?: number | null
   ): Promise<WriteResult>;
-  declare export function write(
+  declare function write(
     fd: number,
     data: any,
     offset: number,
     encoding?: string
   ): Promise<WriteResult>;
 
-  declare export function writeFile(
+  declare function writeFile(
     file: string | Buffer | number,
     data: any,
     callback: (err: ErrnoError) => void
   ): void;
-  declare export function writeFile(
+  declare function writeFile(
     file: string | Buffer | number,
     data: any,
     options?: WriteFileOptions | string
   ): Promise<void>;
-  declare export function writeFile(
+  declare function writeFile(
     file: string | Buffer | number,
     data: any,
     options: WriteFileOptions | string,
     callback: (err: ErrnoError) => void
   ): void;
 
-  declare export function mkdtemp(prefix: string): Promise<string>;
-  declare export function mkdtemp(
+  declare function mkdtemp(prefix: string): Promise<string>;
+  declare function mkdtemp(
     prefix: string,
     callback: (err: ErrnoError, folder: string) => void
   ): void;
+
+  declare module.exports: {
+    ...fsTypes;
+    access: typeof access;
+    appendFile: typeof appendFile;
+    chmod: typeof chmod;
+    chown: typeof chown;
+    close: typeof close;
+    copy: typeof copy;
+    copySync: typeof copySync;
+    createFile: typeof createFile;
+    createFileSync: typeof createFileSync;
+    createReadStream: typeof createReadStream;
+    createWriteStream: typeof createWriteStream;
+    emptyDir: typeof emptyDir;
+    emptyDirSync: typeof emptyDirSync;
+    ensureDir: typeof ensureDir;
+    ensureDirSync: typeof ensureDirSync;
+    ensureFile: typeof ensureFile;
+    ensureFileSync: typeof ensureFileSync;
+    ensureLink: typeof ensureLink;
+    ensureLinkSync: typeof ensureLinkSync;
+    ensureSymlink: typeof ensureSymlink;
+    ensureSymlinkSync: typeof ensureSymlinkSync;
+    exists: typeof exists;
+    fchmod: typeof fchmod;
+    fchown: typeof fchown;
+    fdatasync: typeof fdatasync;
+    fstat: typeof fstat;
+    fsync: typeof fsync;
+    ftruncate: typeof ftruncate;
+    futimes: typeof futimes;
+    lchown: typeof lchown;
+    link: typeof link;
+    lstat: typeof lstat;
+    mkdir: typeof mkdir;
+    mkdirp: typeof mkdirp;
+    mkdirpSync: typeof mkdirpSync;
+    mkdirs: typeof mkdirs;
+    mkdirsSync: typeof mkdirsSync;
+    mkdtemp: typeof mkdtemp;
+    move: typeof move;
+    moveSync: typeof moveSync;
+    open: typeof open;
+    outputFile: typeof outputFile;
+    outputFileSync: typeof outputFileSync;
+    outputJson: typeof outputJson;
+    outputJSON: typeof outputJSON;
+    outputJsonSync: typeof outputJsonSync;
+    outputJSONSync: typeof outputJSONSync;
+    pathExists: typeof pathExists;
+    pathExistsSync: typeof pathExistsSync;
+    read: typeof read;
+    readdir: typeof readdir;
+    readFile: typeof readFile;
+    readJson: typeof readJson;
+    readJSON: typeof readJSON;
+    readJsonSync: typeof readJsonSync;
+    readJSONSync: typeof readJSONSync;
+    readlink: typeof readlink;
+    realpath: typeof realpath;
+    remove: typeof remove;
+    removeSync: typeof removeSync;
+    rename: typeof rename;
+    rmdir: typeof rmdir;
+    stat: typeof stat;
+    statSync: typeof statSync;
+    symlink: typeof symlink;
+    truncate: typeof truncate;
+    unlink: typeof unlink;
+    utimes: typeof utimes;
+    write: typeof write;
+    writeFile: typeof writeFile;
+    writeJSON: typeof writeJSON;
+    writeJson: typeof writeJson;
+    writeJsonSync: typeof writeJsonSync;
+    writeJSONSync: typeof writeJSONSync ;
+  };
+
 }

--- a/definitions/npm/fs-extra_v7.x.x/flow_v0.104.x-/fs-extra_v7.x.x.js
+++ b/definitions/npm/fs-extra_v7.x.x/flow_v0.104.x-/fs-extra_v7.x.x.js
@@ -66,6 +66,20 @@ declare module "fs-extra" {
     ...
   };
 
+  declare type ReadStreamOptions = {|
+    bufferSize?: number,
+    encoding?: string,
+    fd?: number,
+    flags?: string,
+    mode?: number
+  |}
+
+  declare type WriteStreamOptions = {|
+    encoding?: string,
+    flags?: string,
+    string?: string
+  |}
+
   declare function copy(
     src: string,
     dest: string,
@@ -116,8 +130,8 @@ declare module "fs-extra" {
     callback: (err: Error) => void
   ): void;
   declare function createFileSync(file: string): void;
-  declare function createReadStream(path: string, options?: Object): ReadStream;
-  declare function createWriteStream(path: string, options?: Object): WriteStream;
+  declare function createReadStream(path: string, options?: ReadStreamOptions): ReadStream;
+  declare function createWriteStream(path: string, options?: WriteStreamOptions): WriteStream;
 
   declare function ensureDir(path: string): Promise<void>;
   declare function ensureDir(
@@ -849,5 +863,4 @@ declare module "fs-extra" {
     writeJsonSync: typeof writeJsonSync;
     writeJSONSync: typeof writeJSONSync;
   |};
-
 }

--- a/definitions/npm/fs-extra_v7.x.x/flow_v0.104.x-/fs-extra_v7.x.x.js
+++ b/definitions/npm/fs-extra_v7.x.x/flow_v0.104.x-/fs-extra_v7.x.x.js
@@ -772,7 +772,7 @@ declare module "fs-extra" {
     callback: (err: ErrnoError, folder: string) => void
   ): void;
 
-  declare module.exports: {
+  declare module.exports: {|
     ...fsTypes;
     access: typeof access;
     appendFile: typeof appendFile;
@@ -847,7 +847,7 @@ declare module "fs-extra" {
     writeJSON: typeof writeJSON;
     writeJson: typeof writeJson;
     writeJsonSync: typeof writeJsonSync;
-    writeJSONSync: typeof writeJSONSync ;
-  };
+    writeJSONSync: typeof writeJSONSync;
+  |};
 
 }

--- a/definitions/npm/fs-extra_v7.x.x/flow_v0.104.x-/fs-extra_v7.x.x.js
+++ b/definitions/npm/fs-extra_v7.x.x/flow_v0.104.x-/fs-extra_v7.x.x.js
@@ -16,20 +16,18 @@ declare module "fs-extra" {
     overwrite?: boolean,
     preserveTimestamps?: boolean,
     errorOnExist?: boolean,
-    recursive?: boolean
+    recursive?: boolean,
+    ...
   };
 
-  declare type CopyOptionsAync = CopyOptions & {
-    filter?: CopyFilterSync | CopyFilterAsync
-  };
+  declare type CopyOptionsAync = CopyOptions & { filter?: CopyFilterSync | CopyFilterAsync, ... };
 
-  declare type CopyOptionsSync = CopyOptions & {
-    filter?: CopyFilterSync
-  };
+  declare type CopyOptionsSync = CopyOptions & { filter?: CopyFilterSync, ... };
 
   declare type MoveOptions = {
     overwrite?: boolean,
-    limit?: number
+    limit?: number,
+    ...
   };
 
   declare type ReadOptions = {
@@ -37,30 +35,35 @@ declare module "fs-extra" {
     fs?: Object,
     reviver?: any,
     encoding?: string,
-    flag?: string
+    flag?: string,
+    ...
   };
 
   declare type WriteFileOptions = {
     encoding?: string,
     flag?: string,
-    mode?: number
+    mode?: number,
+    ...
   };
 
   declare type WriteOptions = WriteFileOptions & {
     fs?: Object,
     replacer?: any,
     spaces?: number | string,
-    EOL?: string
+    EOL?: string,
+    ...
   };
 
   declare type ReadResult = {
     bytesRead: number,
-    buffer: Buffer
+    buffer: Buffer,
+    ...
   };
 
   declare type WriteResult = {
     bytesWritten: number,
-    buffer: Buffer
+    buffer: Buffer,
+    ...
   };
 
   declare function copy(
@@ -360,7 +363,12 @@ declare module "fs-extra" {
   declare function appendFile(
     file: string | Buffer | number,
     data: any,
-    options: { encoding?: string, mode?: number | string, flag?: string },
+    options: {
+        encoding?: string,
+        mode?: number | string,
+        flag?: string,
+        ...
+    },
     callback: (err: ErrnoError) => void
   ): void;
   declare function appendFile(
@@ -371,7 +379,12 @@ declare module "fs-extra" {
   declare function appendFile(
     file: string | Buffer | number,
     data: any,
-    options?: { encoding?: string, mode?: number | string, flag?: string }
+    options?: {
+        encoding?: string,
+        mode?: number | string,
+        flag?: string,
+        ...
+    }
   ): Promise<void>;
 
   declare function chmod(
@@ -556,12 +569,20 @@ declare module "fs-extra" {
   ): void;
   declare function readFile(
     file: string | Buffer | number,
-    options: { flag?: string } | { encoding: string, flag?: string },
+    options: { flag?: string, ... } | {
+        encoding: string,
+        flag?: string,
+        ...
+    },
     callback: (err: ErrnoError, data: Buffer) => void
   ): void;
   declare function readFile(
     file: string | Buffer | number,
-    options: { flag?: string } | { encoding: string, flag?: string }
+    options: { flag?: string, ... } | {
+        encoding: string,
+        flag?: string,
+        ...
+    },
   ): Promise<string>;
   declare function readFile(
     file: string | Buffer | number,
@@ -589,12 +610,12 @@ declare module "fs-extra" {
   ): void;
   declare function realpath(
     path: string | Buffer,
-    cache: { [path: string]: string },
+    cache: { [path: string]: string, ... },
     callback: (err: ErrnoError, resolvedPath: string) => any
   ): void;
   declare function realpath(
     path: string | Buffer,
-    cache?: { [path: string]: string }
+    cache?: { [path: string]: string, ... }
   ): Promise<string>;
 
   declare function rename(

--- a/definitions/npm/fs-extra_v7.x.x/flow_v0.104.x-/fs-extra_v7.x.x.js
+++ b/definitions/npm/fs-extra_v7.x.x/flow_v0.104.x-/fs-extra_v7.x.x.js
@@ -66,19 +66,21 @@ declare module "fs-extra" {
     ...
   };
 
-  declare type ReadStreamOptions = {|
+  declare type ReadStreamOptions = {
     bufferSize?: number,
     encoding?: string,
     fd?: number,
     flags?: string,
-    mode?: number
-  |}
+    mode?: number,
+    ...
+  }
 
-  declare type WriteStreamOptions = {|
+  declare type WriteStreamOptions = {
     encoding?: string,
     flags?: string,
-    string?: string
-  |}
+    string?: string,
+    ...
+  }
 
   declare function copy(
     src: string,

--- a/definitions/npm/fs-extra_v7.x.x/flow_v0.104.x-/fs-extra_v7.x.x.js
+++ b/definitions/npm/fs-extra_v7.x.x/flow_v0.104.x-/fs-extra_v7.x.x.js
@@ -380,10 +380,10 @@ declare module "fs-extra" {
     file: string | Buffer | number,
     data: any,
     options: {
-        encoding?: string,
-        mode?: number | string,
-        flag?: string,
-        ...
+      encoding?: string,
+      mode?: number | string,
+      flag?: string,
+      ...
     },
     callback: (err: ErrnoError) => void
   ): void;
@@ -396,10 +396,10 @@ declare module "fs-extra" {
     file: string | Buffer | number,
     data: any,
     options?: {
-        encoding?: string,
-        mode?: number | string,
-        flag?: string,
-        ...
+      encoding?: string,
+      mode?: number | string,
+      flag?: string,
+      ...
     }
   ): Promise<void>;
 
@@ -586,18 +586,18 @@ declare module "fs-extra" {
   declare function readFile(
     file: string | Buffer | number,
     options: { flag?: string, ... } | {
-        encoding: string,
-        flag?: string,
-        ...
+      encoding: string,
+      flag?: string,
+      ...
     },
     callback: (err: ErrnoError, data: Buffer) => void
   ): void;
   declare function readFile(
     file: string | Buffer | number,
     options: { flag?: string, ... } | {
-        encoding: string,
-        flag?: string,
-        ...
+      encoding: string,
+      flag?: string,
+      ...
     },
   ): Promise<string>;
   declare function readFile(

--- a/definitions/npm/fs-extra_v7.x.x/test_fs-extra_v7.x.x.js
+++ b/definitions/npm/fs-extra_v7.x.x/test_fs-extra_v7.x.x.js
@@ -14,10 +14,10 @@ let data = '';
 let object = {};
 let errorCallback = (err: Error) => {};
 let readOptions: ReadOptions = {
-    reviver: {}
+  reviver: {}
 };
 let writeOptions: WriteOptions = {
-    replacer: {}
+  replacer: {}
 };
 
 describe("The `copy` function", () => {

--- a/definitions/npm/fs-extra_v7.x.x/test_fs-extra_v7.x.x.js
+++ b/definitions/npm/fs-extra_v7.x.x/test_fs-extra_v7.x.x.js
@@ -1,28 +1,23 @@
-// @flow
+// @flow strict
 
 import { describe, it } from "flow-typed-test";
-import * as fs from "fs-extra";
-import * as Path from "path";
+import fs from "fs-extra";
 
-let len = 2;
-let src = "";
-let dest = "";
-let file = "";
-let dir = "";
-let path = "";
-let data = "";
-let uid = 0;
-let gid = 0;
-let fd = 0;
-let modeNum = 0;
-let modeStr = "";
+import type { ReadOptions, WriteOptions } from "fs-extra";
+
+let src = '';
+let dest = '';
+let file = '';
+let dir = '';
+let path = '';
+let data = '';
 let object = {};
 let errorCallback = (err: Error) => {};
-let readOptions: fs.ReadOptions = {
-  reviver: {}
+let readOptions: ReadOptions = {
+    reviver: {}
 };
-let writeOptions: fs.WriteOptions = {
-  replacer: {}
+let writeOptions: WriteOptions = {
+    replacer: {}
 };
 
 describe("The `copy` function", () => {
@@ -54,11 +49,11 @@ describe("The `copy` function", () => {
     fs.copy(src).then(() => {});
     // $ExpectError
     fs.copy(src);
+    // $ExpectError
     fs.copy(
       src,
       dest,
       {
-        // $ExpectError
         filter: () => []
       },
       errorCallback
@@ -445,20 +440,20 @@ describe("The `outputJson` function", () => {
     fs.outputJson().then(() => {});
     // $ExpectError
     fs.outputJSON().then(() => {});
+    // $ExpectError
     fs.outputJson(
       file,
       data,
       {
-        // $ExpectError
         spaces: true
       },
       errorCallback
     );
+    // $ExpectError
     fs.outputJSON(
       file,
       data,
       {
-        // $ExpectError
         spaces: true
       },
       errorCallback


### PR DESCRIPTION
Right now fs-extra types cover only the new methods that were added to fs-extra. I have added fs library types to cover fs methods that are also available in fs-extra.