### PR TITLE
[reselect_v3.x.x.js] Redefine OutputSelector type as a callable object 

### DIFF
--- a/definitions/npm/re-reselect_v1.x.x/flow_v0.104.x-/test_re-reselect_1.x.x.js
+++ b/definitions/npm/re-reselect_v1.x.x/flow_v0.104.x-/test_re-reselect_1.x.x.js
@@ -1,13 +1,14 @@
 /* @flow */
+import { it } from 'flow-typed-test';
 import createCachedSelector from "re-reselect";
 
-it('Should pass for 2 selectors given as arguments', () => {
-  type State = {
-    x: number,
-    y: number,
-    ...
-  };
+type State = {
+  x: number,
+  y: number,
+  ...
+};
 
+it('Should pass for 2 selectors given as arguments', () => {
   const test1Selector = createCachedSelector(
     (state: State) => state.x,
     (state: State) => state.y,
@@ -46,6 +47,7 @@ it('Should pass when selectors have additional Props argument', () => {
     (x, y) => {
       return x + y;
     }
+  // $ExpectError property `x` is missing in object in `test3Selector({ x: 100, y: 200 }, { y: 10 })`
   )((state, props) => props.x)
 
   test3Selector(
@@ -91,9 +93,9 @@ it('Should work when using more complex selectors as functions', () => {
 it('Should validate parameters based on the return values of nested', () => {
   // selectors.
   createCachedSelector(
+    // $ExpectError x is a number, not a string.
     (state: State) => state.x,
     (state: State) => state.y,
-    // $ExpectError first argument will be a number, not a string.
     (x: string, y: number) => "foo"
   )
 });

--- a/definitions/npm/re-reselect_v1.x.x/flow_v0.104.x-/test_re-reselect_1.x.x.js
+++ b/definitions/npm/re-reselect_v1.x.x/flow_v0.104.x-/test_re-reselect_1.x.x.js
@@ -1,65 +1,64 @@
 /* @flow */
 import createCachedSelector from "re-reselect";
 
-// TEST: Should pass for 2 selectors given as arguments
-type State = {
-  x: number,
-  y: number,
-  ...
-};
+it('Should pass for 2 selectors given as arguments', () => {
+  type State = {
+    x: number,
+    y: number,
+    ...
+  };
 
-const test1Selector = createCachedSelector(
-  (state: State) => state.x,
-  (state: State) => state.y,
-  (x, y) => {
-    return x + y;
-  }
-)(() => 1)
+  const test1Selector = createCachedSelector(
+    (state: State) => state.x,
+    (state: State) => state.y,
+    (x, y) => {
+      return x + y;
+    }
+  )(() => 1)
 
-test1Selector({ x: 100, y: 200 });
-// $ExpectError invalid state
-test1Selector({ x: 100 });
-// END TEST
+  test1Selector({ x: 100, y: 200 });
+  // $ExpectError invalid state
+  test1Selector({ x: 100 });
+});
 
-// TEST: Should pass for 2 selectors given as array
-const test2Selector = createCachedSelector(
-  [(state: State) => state.x, (state: State) => state.y],
-  (x, y) => {
-    return x + y;
-  }
-)(() => 2)
+it('Should pass for 2 selectors given as array', () => {
+  const test2Selector = createCachedSelector(
+    [(state: State) => state.x, (state: State) => state.y],
+    (x, y) => {
+      return x + y;
+    }
+  )(() => 2)
 
-test2Selector({ x: 100, y: 200 });
-// $ExpectError invalid state
-test2Selector({ x: 100 });
-// END TEST
+  test2Selector({ x: 100, y: 200 });
+  // $ExpectError invalid state
+  test2Selector({ x: 100 });
+});
 
-// TEST: Should pass when selectors have additional Props argument
-type TestProps = {
-  x: number,
-  ...
-};
+it('Should pass when selectors have additional Props argument', () => {
+  type TestProps = {
+    x: number,
+    ...
+  };
 
-const test3Selector = createCachedSelector(
-  (state: State, props: TestProps) => state.x + props.x,
-  (state: State, props: TestProps) => state.y + props.x,
-  (x, y) => {
-    return x + y;
-  }
-)((state, props) => props.x)
+  const test3Selector = createCachedSelector(
+    (state: State, props: TestProps) => state.x + props.x,
+    (state: State, props: TestProps) => state.y + props.x,
+    (x, y) => {
+      return x + y;
+    }
+  )((state, props) => props.x)
 
-test3Selector(
-  { x: 100, y: 200 },
-  { x: 10 }
-);
-// $ExpectError invalid state
-test3Selector({ x: 100 }, { x: 10 });
-// $ExpectError invalid props
-test3Selector({ x: 100, y: 200 }, { y: 10 });
-// END TEST
+  test3Selector(
+    { x: 100, y: 200 },
+    { x: 10 }
+  );
+  // $ExpectError invalid state
+  test3Selector({ x: 100 }, { x: 10 });
+  // $ExpectError invalid props
+  test3Selector({ x: 100, y: 200 }, { y: 10 });
+});
 
-// TEST: Should work when using another selector as functions
-{
+it('Should work when using another selector as functions', () => {
   const simpleSelector = (state: State): string => "foo";
   const resultSelector = (arg: string): string => "foo";
 
@@ -72,11 +71,9 @@ test3Selector({ x: 100, y: 200 }, { y: 10 });
   combinedSelector1({ x: 100, y: 200 })
   // $ExpectError invalid state
   combinedSelector1({ x: 100 })
-}
-// END TEST
+});
 
-// TEST: Should work when using more complex selectors as functions
-{
+it('Should work when using more complex selectors as functions', () => {
   const resultFunc = (param1: string, param2: number): number => 42;
   const simpleSelector = (state: State): string => "foo";
   const compoundSelector = createCachedSelector(simpleSelector, () => 42)(() => 1);
@@ -89,15 +86,14 @@ test3Selector({ x: 100, y: 200 }, { y: 10 });
   const result: number = selector({ x: 42, y: 42 });
   // $ExpectError invalid state
   selector({ x: 42 });
-}
-// END TEST
+});
 
-// TEST: Should validate parameters based on the return values of nested
-// selectors.
-createCachedSelector(
-  (state: State) => state.x,
-  (state: State) => state.y,
-  // $ExpectError first argument will be a number, not a string.
-  (x: string, y: number) => "foo"
-)
-// END TEST
+it('Should validate parameters based on the return values of nested', () => {
+  // selectors.
+  createCachedSelector(
+    (state: State) => state.x,
+    (state: State) => state.y,
+    // $ExpectError first argument will be a number, not a string.
+    (x: string, y: number) => "foo"
+  )
+});

--- a/definitions/npm/re-reselect_v2.x.x/flow_v0.104.x-/test_re-reselect.js
+++ b/definitions/npm/re-reselect_v2.x.x/flow_v0.104.x-/test_re-reselect.js
@@ -3,7 +3,7 @@
 // The API stayed the same, apart from exposing `cache` in ReOutputSelector
 import createCachedSelector from "re-reselect";
 
-// TEST: Should pass for 2 selectors given as arguments
+it('Should pass for 2 selectors given as arguments', () => {
 type State = {
   x: number,
   y: number,
@@ -21,9 +21,9 @@ const test1Selector = createCachedSelector(
 test1Selector({ x: 100, y: 200 });
 // $ExpectError invalid state
 test1Selector({ x: 100 });
-// END TEST
+});
 
-// TEST: Should pass for 2 selectors given as array
+it('Should pass for 2 selectors given as array', () => {
 const test2Selector = createCachedSelector(
   [(state: State) => state.x, (state: State) => state.y],
   (x, y) => {
@@ -34,9 +34,9 @@ const test2Selector = createCachedSelector(
 test2Selector({ x: 100, y: 200 });
 // $ExpectError invalid state
 test2Selector({ x: 100 });
-// END TEST
+});
 
-// TEST: Should pass when selectors have additional Props argument
+it('Should pass when selectors have additional Props argument', () => {
 type TestProps = {
   x: number,
   ...
@@ -58,9 +58,9 @@ test3Selector(
 test3Selector({ x: 100 }, { x: 10 });
 // $ExpectError invalid props
 test3Selector({ x: 100, y: 200 }, { y: 10 });
-// END TEST
+});
 
-// TEST: Should work when using another selector as functions
+it('Should work when using another selector as functions', () => {
 {
   const simpleSelector = (state: State): string => "foo";
   const resultSelector = (arg: string): string => "foo";
@@ -75,9 +75,9 @@ test3Selector({ x: 100, y: 200 }, { y: 10 });
   // $ExpectError invalid state
   combinedSelector1({ x: 100 })
 }
-// END TEST
+});
 
-// TEST: Should work when using more complex selectors as functions
+it('Should work when using more complex selectors as functions', () => {
 {
   const resultFunc = (param1: string, param2: number): number => 42;
   const simpleSelector = (state: State): string => "foo";
@@ -92,9 +92,9 @@ test3Selector({ x: 100, y: 200 }, { y: 10 });
   // $ExpectError invalid state
   selector({ x: 42 });
 }
-// END TEST
+});
 
-// TEST: Should validate parameters based on the return values of nested
+it('Should validate parameters based on the return values of nested', () => {
 // selectors.
 createCachedSelector(
   (state: State) => state.x,
@@ -102,4 +102,4 @@ createCachedSelector(
   // $ExpectError first argument will be a number, not a string.
   (x: string, y: number) => "foo"
 )
-// END TEST
+});

--- a/definitions/npm/re-reselect_v2.x.x/flow_v0.104.x-/test_re-reselect.js
+++ b/definitions/npm/re-reselect_v2.x.x/flow_v0.104.x-/test_re-reselect.js
@@ -2,66 +2,66 @@
 // Test copied from libdef for older version of re-reselect
 // The API stayed the same, apart from exposing `cache` in ReOutputSelector
 import createCachedSelector from "re-reselect";
+import { it } from 'flow-typed-test';
 
-it('Should pass for 2 selectors given as arguments', () => {
 type State = {
   x: number,
   y: number,
   ...
 };
 
-const test1Selector = createCachedSelector(
-  (state: State) => state.x,
-  (state: State) => state.y,
-  (x, y) => {
-    return x + y;
-  }
-)(() => 1)
+it('Should pass for 2 selectors given as arguments', () => {
+  const test1Selector = createCachedSelector(
+    (state: State) => state.x,
+    (state: State) => state.y,
+    (x, y) => {
+      return x + y;
+    }
+  )(() => 1)
 
-test1Selector({ x: 100, y: 200 });
-// $ExpectError invalid state
-test1Selector({ x: 100 });
+  test1Selector({ x: 100, y: 200 });
+  // $ExpectError invalid state
+  test1Selector({ x: 100 });
 });
 
 it('Should pass for 2 selectors given as array', () => {
-const test2Selector = createCachedSelector(
-  [(state: State) => state.x, (state: State) => state.y],
-  (x, y) => {
-    return x + y;
-  }
-)(() => 2)
+  const test2Selector = createCachedSelector(
+    [(state: State) => state.x, (state: State) => state.y],
+    (x, y) => {
+      return x + y;
+    }
+  )(() => 2)
 
-test2Selector({ x: 100, y: 200 });
-// $ExpectError invalid state
-test2Selector({ x: 100 });
+  test2Selector({ x: 100, y: 200 });
+  // $ExpectError invalid state
+  test2Selector({ x: 100 });
 });
 
 it('Should pass when selectors have additional Props argument', () => {
-type TestProps = {
-  x: number,
-  ...
-};
+  type TestProps = {
+    x: number,
+    ...
+  };
 
-const test3Selector = createCachedSelector(
-  (state: State, props: TestProps) => state.x + props.x,
-  (state: State, props: TestProps) => state.y + props.x,
-  (x, y) => {
-    return x + y;
-  }
-)((state, props) => props.x)
+  const test3Selector = createCachedSelector(
+    (state: State, props: TestProps) => state.x + props.x,
+    (state: State, props: TestProps) => state.y + props.x,
+    (x, y) => {
+      return x + y;
+    }
+  )((state, props) => props.x)
 
-test3Selector(
-  { x: 100, y: 200 },
-  { x: 10 }
-);
-// $ExpectError invalid props
-test3Selector({ x: 100 }, { x: 10 });
-// $ExpectError invalid props
-test3Selector({ x: 100, y: 200 }, { y: 10 });
+  test3Selector(
+    { x: 100, y: 200 },
+    { x: 10 }
+  );
+  // $ExpectError invalid props
+  test3Selector({ x: 100 }, { x: 10 });
+  // $ExpectError invalid props
+  test3Selector({ x: 100, y: 200 }, { y: 10 });
 });
 
 it('Should work when using another selector as functions', () => {
-{
   const simpleSelector = (state: State): string => "foo";
   const resultSelector = (arg: string): string => "foo";
 
@@ -74,11 +74,9 @@ it('Should work when using another selector as functions', () => {
   combinedSelector1({ x: 100, y: 200 })
   // $ExpectError invalid state
   combinedSelector1({ x: 100 })
-}
 });
 
 it('Should work when using more complex selectors as functions', () => {
-{
   const resultFunc = (param1: string, param2: number): number => 42;
   const simpleSelector = (state: State): string => "foo";
   const compoundSelector = createCachedSelector(simpleSelector, () => 42)(() => 1);
@@ -91,15 +89,14 @@ it('Should work when using more complex selectors as functions', () => {
   const result: number = selector({ x: 42, y: 42 });
   // $ExpectError invalid state
   selector({ x: 42 });
-}
 });
 
 it('Should validate parameters based on the return values of nested', () => {
-// selectors.
-createCachedSelector(
-  (state: State) => state.x,
-  (state: State) => state.y,
-  // $ExpectError first argument will be a number, not a string.
-  (x: string, y: number) => "foo"
-)
+  // selectors.
+  createCachedSelector(
+    // $ExpectError x is a number, not a string.
+    (state: State) => state.x,
+    (state: State) => state.y,
+    (x: string, y: number) => "foo"
+  )
 });

--- a/definitions/npm/reselect_v2.x.x/flow_v0.104.x-/test_reselect_2.x.x.js
+++ b/definitions/npm/reselect_v2.x.x/flow_v0.104.x-/test_reselect_2.x.x.js
@@ -107,6 +107,7 @@ createSelector(
   (x, y) => {
     return x + y
   }
+// $ExpectError: property `d` is missing state but exists in TestState2
 )({x: 100, y: 200});
 
 createSelector(
@@ -118,7 +119,6 @@ createSelector(
   }
 )({x: 100, y: 200}, { x: 20 });
 
-// $ExpectError: Should not result do not include property
 createSelector(
   (state) => state.x,
   (state) => state.y,
@@ -128,6 +128,7 @@ createSelector(
       y
     }
   }
+// $ExpectError: property `d` is missing createSelector() return object
 )({x: 100, y: 200}, { x: 20 }).d;
 
 // $ExpectError
@@ -173,8 +174,9 @@ createSelector(
     first: (state) => state.x,
     second: (state) => state.y
   }),
-  // $ExpectError: Return types of input selectors propogate
+  // $ExpectError: Return types of input selectors propagate
   ({first, second}: {first: number, second: number}) => first + second
+// $ExpectError: property `second` is missing in object
 )({
   x: 10,
   y: false

--- a/definitions/npm/reselect_v2.x.x/flow_v0.104.x-/test_reselect_2.x.x.js
+++ b/definitions/npm/reselect_v2.x.x/flow_v0.104.x-/test_reselect_2.x.x.js
@@ -1,4 +1,5 @@
 /* @flow */
+import { it } from "flow-typed-test";
 import {
   createSelector,
   defaultMemoize,
@@ -6,80 +7,80 @@ import {
   createStructuredSelector
 } from 'reselect';
 
-// TEST: Should pass for 2 selectors given as arguments
 type State = {
   x: number,
   y: number,
   ...
 };
 
-const test1Selector = createSelector(
-  (state: State) => state.x,
-  (state: State) => state.y,
-  (x, y) => {
-    return x + y
-  }
-)({x: 100, y: 200})
-// END TEST
-
-// TEST: Should pass for 2 selectors given as array
-createSelector(
-  [
-    (state: State) => state.x,
-    (state: State) => state.y
-  ] ,
-  (x, y) => {
-    return x + y
-  }
-)({x: 100, y: 200})
-// END TEST
-
-// TEST: Should pass when selectors have additional Props argument
 type TestProps = {
   x: number,
   ...
 };
 
-createSelector(
-  (state: State, props: TestProps) => state.x + props.x,
-  (state: State, props: TestProps) => state.y + props.x,
-  (x, y) => {
-    return x + y
-  }
-)({x: 100, y: 200}, {
-  x: 10
+it('Should pass for 2 selectors given as arguments', () => {
+  const test1Selector = createSelector(
+    (state: State) => state.x,
+    (state: State) => state.y,
+    (x, y) => {
+      return x + y
+    }
+  )({x: 100, y: 200})
 });
-// END TEST
 
-// TEST: Should pass for additional arguments
-createSelector(
-  (state: State, props: TestProps, test) => state.x + props.x + test,
-  (state: State, props: TestProps, test) => state.y + props.x + test,
-  (x, y) => {
-    return x + y
-  }
-)({x: 100, y: 200}, {
-  x: 10
-}, 10);
-// END TEST
+it('Should pass for 2 selectors given as array', () => {
+  createSelector(
+    [
+      (state: State) => state.x,
+      (state: State) => state.y
+    ] ,
+    (x, y) => {
+      return x + y
+    }
+  )({x: 100, y: 200})
+});
+
+it('Should pass when selectors have additional Props argument', () => {
+  createSelector(
+    (state: State, props: TestProps) => state.x + props.x,
+    (state: State, props: TestProps) => state.y + props.x,
+    (x, y) => {
+      return x + y
+    }
+  )({x: 100, y: 200}, {
+    x: 10
+  });
+});
+
+it('Should pass for additional arguments', () => {
+  createSelector(
+    (state: State, props: TestProps, test) => state.x + props.x + test,
+    (state: State, props: TestProps, test) => state.y + props.x + test,
+    (x, y) => {
+      return x + y
+    }
+  )({x: 100, y: 200}, {
+    x: 10
+  }, 10);
+});
 
 defaultMemoize((a: number) => a + 1)(2);
 defaultMemoize((a: number) => a + 1, (a, b) => a + b)(2);
 
-// TEST 8: Should threat newly created selector as normal one
-let x = createSelectorCreator(defaultMemoize)(
-  (state) => state.x,
-  (state) => state.y,
-  (x, y) => {
-    return x + y;
-  }
-)
+it('Should threat newly created selector as normal one', () => {
+  let x = createSelectorCreator(defaultMemoize)(
+    (state) => state.x,
+    (state) => state.y,
+    (x, y) => {
+      return x + y;
+    }
+  )
 
-x({
-  x: 10,
-  y: 20
-})
-// END TEST
+  x({
+    x: 10,
+    y: 20
+  })
+});
 
 createStructuredSelector({
   first: (state) => state.x,

--- a/definitions/npm/reselect_v3.x.x/flow_v0.104.x-/reselect_v3.x.x.js
+++ b/definitions/npm/reselect_v3.x.x/flow_v0.104.x-/reselect_v3.x.x.js
@@ -4,14 +4,12 @@ declare module "reselect" {
   declare type InputSelector<-TState, TProps, TResult> =
     (state: TState, props: TProps, ...rest: any[]) => TResult
 
-  declare type OutputSelector<-TState, TProps, TResult> =
-    & InputSelector<TState, TProps, TResult>
-    & {
-    recomputations(): number,
-    resetRecomputations(): number,
-    resultFunc(...args: any[]): TResult,
-    ...
-  };
+  declare type OutputSelector<-TState, TProps, TResult> = {|
+      (state: TState, props: TProps, ...rest: any[]): TResult,
+      recomputations(): number,
+      resetRecomputations(): number,
+      resultFunc(...args: any[]): TResult,
+  |};
 
   declare type SelectorCreator = {
     <TState, TProps, TResult, T1>(

--- a/definitions/npm/reselect_v3.x.x/flow_v0.104.x-/reselect_v3.x.x.js
+++ b/definitions/npm/reselect_v3.x.x/flow_v0.104.x-/reselect_v3.x.x.js
@@ -5,10 +5,10 @@ declare module "reselect" {
     (state: TState, props: TProps, ...rest: any[]) => TResult
 
   declare type OutputSelector<-TState, TProps, TResult> = {|
-      (state: TState, props: TProps, ...rest: any[]): TResult,
-      recomputations(): number,
-      resetRecomputations(): number,
-      resultFunc(...args: any[]): TResult,
+    (state: TState, props: TProps, ...rest: any[]): TResult,
+    recomputations(): number,
+    resetRecomputations(): number,
+    resultFunc(...args: any[]): TResult,
   |};
 
   declare type SelectorCreator = {

--- a/definitions/npm/reselect_v3.x.x/flow_v0.104.x-/test_reselect_3.x.x.js
+++ b/definitions/npm/reselect_v3.x.x/flow_v0.104.x-/test_reselect_3.x.x.js
@@ -1,4 +1,5 @@
 /* @flow */
+import { it } from "flow-typed-test";
 import {
   createSelector,
   defaultMemoize,
@@ -6,69 +7,68 @@ import {
   createStructuredSelector
 } from "reselect";
 
-// TEST: Should pass for 2 selectors given as arguments
 type State = {
   x: number,
   y: number,
   ...
 };
 
-const test1Selector = createSelector(
-  (state: State) => state.x,
-  (state: State) => state.y,
-  (x, y) => {
-    return x + y;
-  }
-)({ x: 100, y: 200 });
-// END TEST
-
-// TEST: Should pass for 2 selectors given as array
-createSelector(
-  [(state: State) => state.x, (state: State) => state.y],
-  (x, y) => {
-    return x + y;
-  }
-)({ x: 100, y: 200 });
-// END TEST
-
-// TEST: Should pass when selectors have additional Props argument
 type TestProps = {
   x: number,
   ...
 };
 
-createSelector(
-  (state: State, props: TestProps) => state.x + props.x,
-  (state: State, props: TestProps) => state.y + props.x,
-  (x, y) => {
-    return x + y;
-  }
-)(
-  { x: 100, y: 200 },
-  {
-    x: 10
-  }
-);
-// END TEST
+it('Should pass for 2 selectors given as arguments', () => {
+  const test1Selector = createSelector(
+    (state: State) => state.x,
+    (state: State) => state.y,
+    (x, y) => {
+      return x + y;
+    }
+  )({ x: 100, y: 200 });
+});
 
-// TEST: Should pass for additional arguments
-createSelector(
-  (state: State, props: TestProps, test) => state.x + props.x + test,
-  (state: State, props: TestProps, test) => state.y + props.x + test,
-  (x, y) => {
-    return x + y;
-  }
-)(
-  { x: 100, y: 200 },
-  {
-    x: 10
-  },
-  10
-);
-// END TEST
+it('Should pass for 2 selectors given as array', () => {
+  createSelector(
+    [(state: State) => state.x, (state: State) => state.y],
+    (x, y) => {
+      return x + y;
+    }
+  )({ x: 100, y: 200 });
+});
 
-// TEST: Should work when using another selector as functions
-{
+it('Should pass when selectors have additional Props argument', () => {
+  createSelector(
+    (state: State, props: TestProps) => state.x + props.x,
+    (state: State, props: TestProps) => state.y + props.x,
+    (x, y) => {
+      return x + y;
+    }
+  )(
+    { x: 100, y: 200 },
+    {
+      x: 10
+    }
+  );
+});
+
+it('Should pass for additional arguments', () => {
+  createSelector(
+    (state: State, props: TestProps, test) => state.x + props.x + test,
+    (state: State, props: TestProps, test) => state.y + props.x + test,
+    (x, y) => {
+      return x + y;
+    }
+  )(
+    { x: 100, y: 200 },
+    {
+      x: 10
+    },
+    10
+  );
+});
+
+it('Should work when using another selector as functions', () => {
   const simpleSelector = (state: State): string => "foo";
   const resultSelector = (arg: string): string => "foo";
 
@@ -78,11 +78,9 @@ createSelector(
     combinedSelector1,
     resultSelector
   );
-}
-// END TEST
+});
 
-// TEST: Should work when using more complex selectors as functions
-{
+it('Should work when using more complex selectors as functions', () => {
   const resultFunc = (param1: string, param2: number): number => 42;
   const simpleSelector = (state: State): string => "foo";
   const compoundSelector = createSelector(simpleSelector, () => 42);
@@ -93,26 +91,25 @@ createSelector(
   );
 
   const result: number = func({ x: 42, y: 42 });
-}
-// END TEST
+});
 
 defaultMemoize((a: number) => a + 1)(2);
 defaultMemoize((a: number) => a + 1, (a, b) => a + b)(2);
 
-// TEST 8: Should threat newly created selector as normal one
-let x = createSelectorCreator(defaultMemoize)(
-  state => state.x,
-  state => state.y,
-  (x, y) => {
-    return x + y;
-  }
-);
+it('Should threat newly created selector as normal one', () => {
+  let x = createSelectorCreator(defaultMemoize)(
+    state => state.x,
+    state => state.y,
+    (x, y) => {
+      return x + y;
+    }
+  );
 
-x({
-  x: 10,
-  y: 20
+  x({
+    x: 10,
+    y: 20
+  });
 });
-// END TEST
 
 createStructuredSelector({
   first: state => state.x,
@@ -216,35 +213,35 @@ createSelector(
   y: false
 });
 
-// TEST: Should pass for accessing selector recomputations
-createSelector(
-  (state: State, props: TestProps, test) => state.x + props.x + test,
-  (state: State, props: TestProps, test) => state.y + props.x + test,
-  (x, y) => {
-    return x + y;
-  }
-).recomputations() + 5;
-// END TEST
+it('Should pass for accessing selector recomputations', () => {
+  createSelector(
+    (state: State, props: TestProps, test) => state.x + props.x + test,
+    (state: State, props: TestProps, test) => state.y + props.x + test,
+    (x, y) => {
+      return x + y;
+    }
+  ).recomputations() + 5;
+});
 
-// TEST: Should pass for reseting selector recomputations
-createSelector(
-  (state: State, props: TestProps, test) => state.x + props.x + test,
-  (state: State, props: TestProps, test) => state.y + props.x + test,
-  (x, y) => {
-    return x + y;
-  }
-).resetRecomputations();
-// END TEST
+it('Should pass for reseting selector recomputations', () => {
+  createSelector(
+    (state: State, props: TestProps, test) => state.x + props.x + test,
+    (state: State, props: TestProps, test) => state.y + props.x + test,
+    (x, y) => {
+      return x + y;
+    }
+  ).resetRecomputations();
+});
 
-// TEST: Should pass for accessing selector resultFunc
-createSelector(
-  (state: State, props: TestProps, test) => state.x + props.x + test,
-  (state: State, props: TestProps, test) => state.y + props.x + test,
-  (x, y) => {
-    return x + y;
-  }
-).resultFunc(
-  100,
-  200,
-) + 15;
-// END TEST
+it('Should pass for accessing selector resultFunc', () => {
+  createSelector(
+    (state: State, props: TestProps, test) => state.x + props.x + test,
+    (state: State, props: TestProps, test) => state.y + props.x + test,
+    (x, y) => {
+      return x + y;
+    }
+  ).resultFunc(
+    100,
+    200,
+  ) + 15;
+});

--- a/definitions/npm/reselect_v3.x.x/flow_v0.104.x-/test_reselect_3.x.x.js
+++ b/definitions/npm/reselect_v3.x.x/flow_v0.104.x-/test_reselect_3.x.x.js
@@ -133,6 +133,7 @@ type TestState2 = {
   ...
 };
 
+// $ExpectError: property `d` is missing state but exists in TestState2
 createSelector(
   (state: TestState1) => state.x,
   // $ExpectError: Should not pass when selectors handle different states
@@ -142,8 +143,8 @@ createSelector(
   }
 )({ x: 100, y: 200 });
 
+// $ExpectError: Should not pass when selectors handle different states
 createSelector(
-  // $ExpectError: Should not pass when selectors handle different states
   (state, props) => state.x + props.d,
   state => state.y,
   (x, y) => {
@@ -151,7 +152,6 @@ createSelector(
   }
 )({ x: 100, y: 200 }, { x: 20 });
 
-// $ExpectError: Should not result do not include property
 createSelector(
   state => state.x,
   state => state.y,
@@ -161,6 +161,7 @@ createSelector(
       y
     };
   }
+// $ExpectError: property `d` is missing createSelector() return object
 )({ x: 100, y: 200 }, { x: 20 }).d;
 
 // $ExpectError
@@ -168,9 +169,9 @@ defaultMemoize((a: number) => a + 1)("");
 // $ExpectError
 defaultMemoize((a: number) => a + 1, (a, b) => "")(2);
 
+// $ExpectError: Should fail when state don't have good properties
 createSelectorCreator(defaultMemoize)(
   state => state.x,
-  // $ExpectError: Should fail when state don't have good properties
   state => state.y,
   (x, y) => {
     return x + y;
@@ -180,8 +181,8 @@ createSelectorCreator(defaultMemoize)(
   d: 20
 });
 
+// $ExpectError: Should fail when state don't have good properties
 createStructuredSelector({
-  // $ExpectError: Should fail when state don't have good properties
   first: state => state.d,
   second: state => state.y
 })({
@@ -189,6 +190,7 @@ createStructuredSelector({
   y: 20
 });
 
+// $ExpectError: Cannot call `createSelector` because property `third` is missing in createStructuredSelector() result
 createSelector(
   createStructuredSelector({
     first: (state) => state.x,
@@ -201,12 +203,13 @@ createSelector(
   y: 20
 });
 
+// $ExpectError: Cannot call `createSelector` because `y: boolean` is incompatible with `second: number` in createStructuredSelector() result
 createSelector(
   createStructuredSelector({
     first: (state) => state.x,
     second: (state) => state.y
   }),
-  // $ExpectError: Return types of input selectors propogate
+  // $ExpectError: Return types of input selectors propagate
   ({first, second}: {first: number, second: number}) => first + second
 )({
   x: 10,

--- a/definitions/npm/reselect_v3.x.x/flow_v0.104.x-/test_reselect_3.x.x.js
+++ b/definitions/npm/reselect_v3.x.x/flow_v0.104.x-/test_reselect_3.x.x.js
@@ -130,7 +130,6 @@ type TestState2 = {
   ...
 };
 
-// $ExpectError: property `d` is missing state but exists in TestState2
 createSelector(
   (state: TestState1) => state.x,
   // $ExpectError: Should not pass when selectors handle different states
@@ -138,10 +137,11 @@ createSelector(
   (x, y) => {
     return x + y;
   }
+// $ExpectError: property `d` is missing state but exists in TestState2
 )({ x: 100, y: 200 });
 
-// $ExpectError: Should not pass when selectors handle different states
 createSelector(
+  // $ExpectError: Should not pass when selectors handle different states
   (state, props) => state.x + props.d,
   state => state.y,
   (x, y) => {
@@ -166,9 +166,9 @@ defaultMemoize((a: number) => a + 1)("");
 // $ExpectError
 defaultMemoize((a: number) => a + 1, (a, b) => "")(2);
 
-// $ExpectError: Should fail when state don't have good properties
 createSelectorCreator(defaultMemoize)(
   state => state.x,
+  // $ExpectError: Should fail when state don't have good properties
   state => state.y,
   (x, y) => {
     return x + y;
@@ -178,8 +178,8 @@ createSelectorCreator(defaultMemoize)(
   d: 20
 });
 
-// $ExpectError: Should fail when state don't have good properties
 createStructuredSelector({
+  // $ExpectError: Should fail when state don't have good properties
   first: state => state.d,
   second: state => state.y
 })({
@@ -200,7 +200,6 @@ createSelector(
   y: 20
 });
 
-// $ExpectError: Cannot call `createSelector` because `y: boolean` is incompatible with `second: number` in createStructuredSelector() result
 createSelector(
   createStructuredSelector({
     first: (state) => state.x,

--- a/definitions/npm/reselect_v4.x.x/flow_v0.104.x-/test_reselect_4.x.x.js
+++ b/definitions/npm/reselect_v4.x.x/flow_v0.104.x-/test_reselect_4.x.x.js
@@ -140,6 +140,7 @@ createSelector(
   (x, y) => {
     return x + y;
   }
+// $ExpectError: property .d is required in TestState2 but is missing in passed state
 )({ x: 100, y: 200 });
 
 createSelector(
@@ -151,7 +152,6 @@ createSelector(
   }
 )({ x: 100, y: 200 }, { x: 20 });
 
-// $ExpectError: Should not result do not include property
 createSelector(
   state => state.x,
   state => state.y,
@@ -161,6 +161,7 @@ createSelector(
       y
     };
   }
+// $ExpectError: Should not result do not include property
 )({ x: 100, y: 200 }, { x: 20 }).d;
 
 // $ExpectError
@@ -189,6 +190,7 @@ createStructuredSelector({
   y: 20
 });
 
+// $ExpectError: Cannot call `createSelector` because property `third` is missing in createStructuredSelector() result
 createSelector(
   createStructuredSelector({
     first: (state) => state.x,

--- a/definitions/npm/reselect_v4.x.x/flow_v0.104.x-/test_reselect_4.x.x.js
+++ b/definitions/npm/reselect_v4.x.x/flow_v0.104.x-/test_reselect_4.x.x.js
@@ -1,4 +1,5 @@
 /* @flow */
+import { it } from "flow-typed-test";
 import {
   createSelector,
   defaultMemoize,
@@ -6,69 +7,68 @@ import {
   createStructuredSelector
 } from "reselect";
 
-// TEST: Should pass for 2 selectors given as arguments
 type State = {
   x: number,
   y: number,
   ...
 };
 
-const test1Selector = createSelector(
-  (state: State) => state.x,
-  (state: State) => state.y,
-  (x, y) => {
-    return x + y;
-  }
-)({ x: 100, y: 200 });
-// END TEST
-
-// TEST: Should pass for 2 selectors given as array
-createSelector(
-  [(state: State) => state.x, (state: State) => state.y],
-  (x, y) => {
-    return x + y;
-  }
-)({ x: 100, y: 200 });
-// END TEST
-
-// TEST: Should pass when selectors have additional Props argument
 type TestProps = {
   x: number,
   ...
 };
 
-createSelector(
-  (state: State, props: TestProps) => state.x + props.x,
-  (state: State, props: TestProps) => state.y + props.x,
-  (x, y) => {
-    return x + y;
-  }
-)(
-  { x: 100, y: 200 },
-  {
-    x: 10
-  }
-);
-// END TEST
+it('Should pass for 2 selectors given as arguments', () => {
+  const test1Selector = createSelector(
+    (state: State) => state.x,
+    (state: State) => state.y,
+    (x, y) => {
+      return x + y;
+    }
+  )({ x: 100, y: 200 });
+});
 
-// TEST: Should pass for additional arguments
-createSelector(
-  (state: State, props: TestProps, test) => state.x + props.x + test,
-  (state: State, props: TestProps, test) => state.y + props.x + test,
-  (x, y) => {
-    return x + y;
-  }
-)(
-  { x: 100, y: 200 },
-  {
-    x: 10
-  },
-  10
-);
-// END TEST
+it('Should pass for 2 selectors given as array', () => {
+  createSelector(
+    [(state: State) => state.x, (state: State) => state.y],
+    (x, y) => {
+      return x + y;
+    }
+  )({ x: 100, y: 200 });
+});
 
-// TEST: Should work when using another selector as functions
-{
+it('Should pass when selectors have additional Props argument', () => {
+  createSelector(
+    (state: State, props: TestProps) => state.x + props.x,
+    (state: State, props: TestProps) => state.y + props.x,
+    (x, y) => {
+      return x + y;
+    }
+  )(
+    { x: 100, y: 200 },
+    {
+      x: 10
+    }
+  );
+});
+
+it('Should pass for additional arguments', () => {
+  createSelector(
+    (state: State, props: TestProps, test) => state.x + props.x + test,
+    (state: State, props: TestProps, test) => state.y + props.x + test,
+    (x, y) => {
+      return x + y;
+    }
+  )(
+    { x: 100, y: 200 },
+    {
+      x: 10
+    },
+    10
+  );
+});
+
+it('Should work when using another selector as functions', () => {
   const simpleSelector = (state: State): string => "foo";
   const resultSelector = (arg: string): string => "foo";
 
@@ -78,11 +78,9 @@ createSelector(
     combinedSelector1,
     resultSelector
   );
-}
-// END TEST
+});
 
-// TEST: Should work when using more complex selectors as functions
-{
+it('Should work when using more complex selectors as functions', () => {
   const resultFunc = (param1: string, param2: number): number => 42;
   const simpleSelector = (state: State): string => "foo";
   const compoundSelector = createSelector(simpleSelector, () => 42);
@@ -93,26 +91,25 @@ createSelector(
   );
 
   const result: number = func({ x: 42, y: 42 });
-}
-// END TEST
+});
 
 defaultMemoize((a: number) => a + 1)(2);
 defaultMemoize((a: number) => a + 1, (a, b) => a + b)(2);
 
-// TEST 8: Should threat newly created selector as normal one
-let x = createSelectorCreator(defaultMemoize)(
-  state => state.x,
-  state => state.y,
-  (x, y) => {
-    return x + y;
-  }
-);
+it('Should threat newly created selector as normal one', () => {
+  let x = createSelectorCreator(defaultMemoize)(
+    state => state.x,
+    state => state.y,
+    (x, y) => {
+      return x + y;
+    }
+  );
 
-x({
-  x: 10,
-  y: 20
+  x({
+    x: 10,
+    y: 20
+  });
 });
-// END TEST
 
 createStructuredSelector({
   first: state => state.x,
@@ -215,35 +212,35 @@ createSelector(
   y: false
 });
 
-// TEST: Should pass for accessing selector recomputations
-createSelector(
-  (state: State, props: TestProps, test) => state.x + props.x + test,
-  (state: State, props: TestProps, test) => state.y + props.x + test,
-  (x, y) => {
-    return x + y;
-  }
-).recomputations() + 5;
-// END TEST
+it('Should pass for accessing selector recomputations', () => {
+  createSelector(
+    (state: State, props: TestProps, test) => state.x + props.x + test,
+    (state: State, props: TestProps, test) => state.y + props.x + test,
+    (x, y) => {
+      return x + y;
+    }
+  ).recomputations() + 5;
+});
 
-// TEST: Should pass for reseting selector recomputations
-createSelector(
-  (state: State, props: TestProps, test) => state.x + props.x + test,
-  (state: State, props: TestProps, test) => state.y + props.x + test,
-  (x, y) => {
-    return x + y;
-  }
-).resetRecomputations();
-// END TEST
+it('Should pass for reseting selector recomputations', () => {
+  createSelector(
+    (state: State, props: TestProps, test) => state.x + props.x + test,
+    (state: State, props: TestProps, test) => state.y + props.x + test,
+    (x, y) => {
+      return x + y;
+    }
+  ).resetRecomputations();
+});
 
-// TEST: Should pass for accessing selector resultFunc
-createSelector(
-  (state: State, props: TestProps, test) => state.x + props.x + test,
-  (state: State, props: TestProps, test) => state.y + props.x + test,
-  (x, y) => {
-    return x + y;
-  }
-).resultFunc(
-  100,
-  200,
-) + 15;
-// END TEST
+it('Should pass for accessing selector resultFunc', () => {
+  createSelector(
+    (state: State, props: TestProps, test) => state.x + props.x + test,
+    (state: State, props: TestProps, test) => state.y + props.x + test,
+    (x, y) => {
+      return x + y;
+    }
+  ).resultFunc(
+    100,
+    200,
+  ) + 15;
+});

--- a/definitions/npm/validator_v7.x.x/test_validator_v7.x.x.js
+++ b/definitions/npm/validator_v7.x.x/test_validator_v7.x.x.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import { describe, it } from "flow-typed-test";
 import validator from 'validator';
 
 /** Types as variables */
@@ -9,235 +10,235 @@ let number: number = 5;
 let date: Date = new Date();
 
 /** Validators */
-// TEST: output->boolean input<-(string)
-boolean = validator.isAscii(string);
-// $ExpectError
-boolean = validator.isAscii(boolean);
+it('output->boolean input<-(string)', () => {
+  boolean = validator.isAscii(string);
+  // $ExpectError
+  boolean = validator.isAscii(boolean);
 
-boolean = validator.isBase64(string);
-// $ExpectError
-boolean = validator.isBase64(boolean);
+  boolean = validator.isBase64(string);
+  // $ExpectError
+  boolean = validator.isBase64(boolean);
 
-boolean = validator.isBoolean(string);
-// $ExpectError
-boolean = validator.isBoolean(boolean);
+  boolean = validator.isBoolean(string);
+  // $ExpectError
+  boolean = validator.isBoolean(boolean);
 
-boolean = validator.isCreditCard(string);
-// $ExpectError
-boolean = validator.isCreditCard(boolean);
+  boolean = validator.isCreditCard(string);
+  // $ExpectError
+  boolean = validator.isCreditCard(boolean);
 
-boolean = validator.isDate(string);
-// $ExpectError
-boolean = validator.isDate(boolean);
+  boolean = validator.isDate(string);
+  // $ExpectError
+  boolean = validator.isDate(boolean);
 
-boolean = validator.isDecimal(string);
-// $ExpectError
-boolean = validator.isDecimal(boolean);
+  boolean = validator.isDecimal(string);
+  // $ExpectError
+  boolean = validator.isDecimal(boolean);
 
-boolean = validator.isEmpty(string);
-// $ExpectError
-boolean = validator.isEmpty(boolean);
+  boolean = validator.isEmpty(string);
+  // $ExpectError
+  boolean = validator.isEmpty(boolean);
 
-boolean = validator.isFullWidth(string);
-// $ExpectError
-boolean = validator.isFullWidth(boolean);
+  boolean = validator.isFullWidth(string);
+  // $ExpectError
+  boolean = validator.isFullWidth(boolean);
 
-boolean = validator.isHalfWidth(string);
-// $ExpectError
-boolean = validator.isHalfWidth(boolean);
+  boolean = validator.isHalfWidth(string);
+  // $ExpectError
+  boolean = validator.isHalfWidth(boolean);
 
-boolean = validator.isHexadecimal(string);
-// $ExpectError
-boolean = validator.isHexadecimal(boolean);
+  boolean = validator.isHexadecimal(string);
+  // $ExpectError
+  boolean = validator.isHexadecimal(boolean);
 
-boolean = validator.isHexColor(string);
-// $ExpectError
-boolean = validator.isHexColor(boolean);
+  boolean = validator.isHexColor(string);
+  // $ExpectError
+  boolean = validator.isHexColor(boolean);
 
-boolean = validator.isISIN(string);
-// $ExpectError
-boolean = validator.isISIN(boolean);
+  boolean = validator.isISIN(string);
+  // $ExpectError
+  boolean = validator.isISIN(boolean);
 
-boolean = validator.isISO8601(string);
-// $ExpectError
-boolean = validator.isISO8601(boolean);
+  boolean = validator.isISO8601(string);
+  // $ExpectError
+  boolean = validator.isISO8601(boolean);
 
-boolean = validator.isJSON(string);
-// $ExpectError
-boolean = validator.isJSON(boolean);
+  boolean = validator.isJSON(string);
+  // $ExpectError
+  boolean = validator.isJSON(boolean);
 
-boolean = validator.isLowercase(string);
-// $ExpectError
-boolean = validator.isLowercase(boolean);
+  boolean = validator.isLowercase(string);
+  // $ExpectError
+  boolean = validator.isLowercase(boolean);
 
-boolean = validator.isMACAddress(string);
-// $ExpectError
-boolean = validator.isMACAddress(boolean);
+  boolean = validator.isMACAddress(string);
+  // $ExpectError
+  boolean = validator.isMACAddress(boolean);
 
-boolean = validator.isMD5(string);
-// $ExpectError
-boolean = validator.isMD5(boolean);
+  boolean = validator.isMD5(string);
+  // $ExpectError
+  boolean = validator.isMD5(boolean);
 
-boolean = validator.isMongoId(string);
-// $ExpectError
-boolean = validator.isMongoId(boolean);
+  boolean = validator.isMongoId(string);
+  // $ExpectError
+  boolean = validator.isMongoId(boolean);
 
-boolean = validator.isMultibyte(string);
-// $ExpectError
-boolean = validator.isMultibyte(boolean);
+  boolean = validator.isMultibyte(string);
+  // $ExpectError
+  boolean = validator.isMultibyte(boolean);
 
-boolean = validator.isNumeric(string);
-// $ExpectError
-boolean = validator.isNumeric(boolean);
+  boolean = validator.isNumeric(string);
+  // $ExpectError
+  boolean = validator.isNumeric(boolean);
 
-boolean = validator.isSurrogatePair(string);
-// $ExpectError
-boolean = validator.isSurrogatePair(boolean);
+  boolean = validator.isSurrogatePair(string);
+  // $ExpectError
+  boolean = validator.isSurrogatePair(boolean);
 
-boolean = validator.isUppercase(string);
-// $ExpectError
-boolean = validator.isUppercase(boolean);
+  boolean = validator.isUppercase(string);
+  // $ExpectError
+  boolean = validator.isUppercase(boolean);
 
-boolean = validator.isVariableWidth(string);
-// $ExpectError
-boolean = validator.isVariableWidth(boolean);
+  boolean = validator.isVariableWidth(string);
+  // $ExpectError
+  boolean = validator.isVariableWidth(boolean);
 
-boolean = validator.isDataURI(string);
-// $ExpectError
-boolean = validator.isDataURI(boolean);
-// END TEST
+  boolean = validator.isDataURI(string);
+  // $ExpectError
+  boolean = validator.isDataURI(boolean);
+});
 
-// TEST: output->boolean input<-(string, {min: number, max: number})
-// TEST: input<-(string, {min?: number, max?: number}?)
-boolean = validator.isFloat(string);
-boolean = validator.isFloat(string, { min: number });
-boolean = validator.isFloat(string, { max: number });
-boolean = validator.isFloat(string, { min: number, max: number });
-// $ExpectError
-boolean = validator.isFloat(number);
-// $ExpectError
-boolean = validator.isFloat(string, { min: string, max: number });
-// $ExpectError
-boolean = validator.isFloat(string, { min: boolean, max: number });
+describe('output->boolean input<-(string, {min: number, max: number})', () => {
+  it('input<-(string, {min?: number, max?: number}?)', () => {
+    boolean = validator.isFloat(string);
+    boolean = validator.isFloat(string, { min: number });
+    boolean = validator.isFloat(string, { max: number });
+    boolean = validator.isFloat(string, { min: number, max: number });
+    // $ExpectError
+    boolean = validator.isFloat(number);
+    // $ExpectError
+    boolean = validator.isFloat(string, { min: string, max: number });
+    // $ExpectError
+    boolean = validator.isFloat(string, { min: boolean, max: number });
 
-boolean = validator.isInt(string);
-boolean = validator.isInt(string, { min: number });
-boolean = validator.isInt(string, { max: number });
-boolean = validator.isInt(string, { min: number, max: number });
-// $ExpectError
-boolean = validator.isInt(number);
-// $ExpectError
-boolean = validator.isInt(string, { min: string, max: number });
-// $ExpectError
-boolean = validator.isInt(string, { min: boolean, max: number });
-// END TEST
+    boolean = validator.isInt(string);
+    boolean = validator.isInt(string, { min: number });
+    boolean = validator.isInt(string, { max: number });
+    boolean = validator.isInt(string, { min: number, max: number });
+    // $ExpectError
+    boolean = validator.isInt(number);
+    // $ExpectError
+    boolean = validator.isInt(string, { min: string, max: number });
+    // $ExpectError
+    boolean = validator.isInt(string, { min: boolean, max: number });
+  });
 
-// TEST: input<-(string, {min: number, max?: number})
-boolean = validator.isLength(string, { min: number, max: number });
-boolean = validator.isLength(string, { min: number });
-// $ExpectError
-boolean = validator.isLength(number);
-// $ExpectError
-boolean = validator.isLength(string);
-// $ExpectError
-boolean = validator.isLength(string, {});
-// $ExpectError
-boolean = validator.isLength(string, { max: number });
-// $ExpectError
-boolean = validator.isLength(string, { min: string, max: number });
-// $ExpectError
-boolean = validator.isLength(string, { min: number, max: boolean });
+  it('input<-(string, {min: number, max?: number})', () => {
+    boolean = validator.isLength(string, { min: number, max: number });
+    boolean = validator.isLength(string, { min: number });
+    // $ExpectError
+    boolean = validator.isLength(number);
+    // $ExpectError
+    boolean = validator.isLength(string);
+    // $ExpectError
+    boolean = validator.isLength(string, {});
+    // $ExpectError
+    boolean = validator.isLength(string, { max: number });
+    // $ExpectError
+    boolean = validator.isLength(string, { min: string, max: number });
+    // $ExpectError
+    boolean = validator.isLength(string, { min: number, max: boolean });
 
-boolean = validator.isByteLength(string, { min: number, max: number });
-boolean = validator.isByteLength(string, { min: number });
-// $ExpectError
-boolean = validator.isByteLength(number);
-// $ExpectError
-boolean = validator.isByteLength(string);
-// $ExpectError
-boolean = validator.isByteLength(string, {});
-// $ExpectError
-boolean = validator.isByteLength(string, { max: number });
-// $ExpectError
-boolean = validator.isByteLength(string, { min: string, max: number });
-// $ExpectError
-boolean = validator.isByteLength(string, { min: number, max: boolean });
-// END TEST
-// END TEST
+    boolean = validator.isByteLength(string, { min: number, max: number });
+    boolean = validator.isByteLength(string, { min: number });
+    // $ExpectError
+    boolean = validator.isByteLength(number);
+    // $ExpectError
+    boolean = validator.isByteLength(string);
+    // $ExpectError
+    boolean = validator.isByteLength(string, {});
+    // $ExpectError
+    boolean = validator.isByteLength(string, { max: number });
+    // $ExpectError
+    boolean = validator.isByteLength(string, { min: string, max: number });
+    // $ExpectError
+    boolean = validator.isByteLength(string, { min: number, max: boolean });
+  });
+});
 
-// TEST: output->boolean input<-(string, mixed?)
-boolean = validator.contains(string, string);
-boolean = validator.contains(string, number);
-boolean = validator.contains(string);
-// END TEST
+it('output->boolean input<-(string, mixed?)', () => {
+  boolean = validator.contains(string, string);
+  boolean = validator.contains(string, number);
+  boolean = validator.contains(string);
+});
 
-// TEST: output->boolean input<-(string, string)
-boolean = validator.equals(string, string);
-// $ExpectError
-boolean = validator.equals(string, number);
-// $ExpectError
-boolean = validator.equals(number, string);
-// $ExpectError
-boolean = validator.equals(string);
+it('output->boolean input<-(string, string)', () => {
+  boolean = validator.equals(string, string);
+  // $ExpectError
+  boolean = validator.equals(string, number);
+  // $ExpectError
+  boolean = validator.equals(number, string);
+  // $ExpectError
+  boolean = validator.equals(string);
 
-boolean = validator.isWhitelisted(string, string);
-// $ExpectError
-boolean = validator.isWhitelisted(string, number);
-// $ExpectError
-boolean = validator.isWhitelisted(number, string);
-// $ExpectError
-boolean = validator.isWhitelisted(string);
+  boolean = validator.isWhitelisted(string, string);
+  // $ExpectError
+  boolean = validator.isWhitelisted(string, number);
+  // $ExpectError
+  boolean = validator.isWhitelisted(number, string);
+  // $ExpectError
+  boolean = validator.isWhitelisted(string);
 
-boolean = validator.isAfter(string, string);
-boolean = validator.isAfter(string);
-// $ExpectError
-boolean = validator.isAfter(string, number);
-// $ExpectError
-boolean = validator.isAfter(number, string);
+  boolean = validator.isAfter(string, string);
+  boolean = validator.isAfter(string);
+  // $ExpectError
+  boolean = validator.isAfter(string, number);
+  // $ExpectError
+  boolean = validator.isAfter(number, string);
 
-boolean = validator.isBefore(string, string);
-boolean = validator.isBefore(string);
-// $ExpectError
-boolean = validator.isBefore(string, number);
-// $ExpectError
-boolean = validator.isBefore(number, string);
-// END TEST
+  boolean = validator.isBefore(string, string);
+  boolean = validator.isBefore(string);
+  // $ExpectError
+  boolean = validator.isBefore(string, number);
+  // $ExpectError
+  boolean = validator.isBefore(number, string);
+});
 
-// TEST: output->boolean input<-(string, string|number)
-boolean = validator.isDivisibleBy(string, number);
-boolean = validator.isDivisibleBy(string, string);
-// $ExpectError
-boolean = validator.isDivisibleBy(number, string);
-// $ExpectError
-boolean = validator.isDivisibleBy(string);
-// $ExpectError
-boolean = validator.isDivisibleBy(boolean, string);
-// $ExpectError
-boolean = validator.isDivisibleBy(string, boolean);
-// END TEST
+it('output->boolean input<-(string, string|number)', () => {
+  boolean = validator.isDivisibleBy(string, number);
+  boolean = validator.isDivisibleBy(string, string);
+  // $ExpectError
+  boolean = validator.isDivisibleBy(number, string);
+  // $ExpectError
+  boolean = validator.isDivisibleBy(string);
+  // $ExpectError
+  boolean = validator.isDivisibleBy(boolean, string);
+  // $ExpectError
+  boolean = validator.isDivisibleBy(string, boolean);
+});
 
-// TEST: output->boolean input<-(string, Array<string>|string)
-boolean = validator.isIn(string, string);
-boolean = validator.isIn(string, [string]);
-// $ExpectError
-boolean = validator.isIn(string, boolean);
-// $ExpectError
-boolean = validator.isIn(string, [boolean]);
-// $ExpectError
-boolean = validator.isIn(boolean, string);
-// END TEST
+it('output->boolean input<-(string, Array<string>|string)', () => {
+  boolean = validator.isIn(string, string);
+  boolean = validator.isIn(string, [string]);
+  // $ExpectError
+  boolean = validator.isIn(string, boolean);
+  // $ExpectError
+  boolean = validator.isIn(string, [boolean]);
+  // $ExpectError
+  boolean = validator.isIn(boolean, string);
+});
 
-// TEST: output->boolean input<-(string, enum)
-boolean = validator.isIP(string);
-boolean = validator.isIP(string, 4);
-boolean = validator.isIP(string, 6);
-// $ExpectError
-boolean = validator.isIP(boolean);
-// $ExpectError
-boolean = validator.isIP(boolean, 6);
-// $ExpectError
-boolean = validator.isIP(string, 10);
-// END TEST
+it('output->boolean input<-(string, enum)', () => {
+  boolean = validator.isIP(string);
+  boolean = validator.isIP(string, 4);
+  boolean = validator.isIP(string, 6);
+  // $ExpectError
+  boolean = validator.isIP(boolean);
+  // $ExpectError
+  boolean = validator.isIP(boolean, 6);
+  // $ExpectError
+  boolean = validator.isIP(string, 10);
+});
 
 boolean = validator.isISBN(string);
 boolean = validator.isISBN(string, 10);
@@ -284,281 +285,279 @@ boolean = validator.isUUID(boolean);
 boolean = validator.isUUID(boolean, 3);
 // $ExpectError
 boolean = validator.isUUID(string, 10);
-// END TEST
 
-// TEST: output->boolean input<-(string, options?)
-boolean = validator.isISSN(string);
-boolean = validator.isISSN(string, {});
-boolean = validator.isISSN(string, { case_sensitive: boolean });
-boolean = validator.isISSN(string, { require_hyphen: boolean });
-boolean = validator.isISSN(string, { case_sensitive: boolean, require_hyphen: boolean });
-// $ExpectError
-boolean = validator.isISSN(boolean);
-// $ExpectError
-boolean = validator.isISSN(string, { case_sensitive: string});
-// $ExpectError
-boolean = validator.isISSN(string, { require_hyphen: string});
+it('output->boolean input<-(string, options?)', () => {
+  boolean = validator.isISSN(string);
+  boolean = validator.isISSN(string, {});
+  boolean = validator.isISSN(string, { case_sensitive: boolean });
+  boolean = validator.isISSN(string, { require_hyphen: boolean });
+  boolean = validator.isISSN(string, { case_sensitive: boolean, require_hyphen: boolean });
+  // $ExpectError
+  boolean = validator.isISSN(boolean);
+  // $ExpectError
+  boolean = validator.isISSN(string, { case_sensitive: string});
+  // $ExpectError
+  boolean = validator.isISSN(string, { require_hyphen: string});
 
-boolean = validator.isCurrency(string);
-boolean = validator.isCurrency(string ,{
-  symbol: string,
-  require_symbol: boolean,
-  allow_space_after_symbol: boolean,
-  symbol_after_digits: boolean,
-  allow_negatives: boolean,
-  parens_for_negatives: boolean,
-  negative_sign_before_digits: boolean,
-  negative_sign_after_digits: boolean,
-  allow_negative_sign_placeholder: boolean,
-  thousands_separator: string,
-  decimal_separator: string,
-  allow_space_after_digits: boolean,
-});
-// $ExpectError
-boolean = validator.isCurrency(boolean);
-// $ExpectError
-boolean = validator.isCurrency(string, { symbol: number });
-// $ExpectError
-boolean = validator.isCurrency(string, { require_symbol: number });
-// $ExpectError
-boolean = validator.isCurrency(string, { allow_space_after_symbol: number });
-// $ExpectError
-boolean = validator.isCurrency(string, { symbol_after_digits: number });
-// $ExpectError
-boolean = validator.isCurrency(string, { allow_negatives: number });
-// $ExpectError
-boolean = validator.isCurrency(string, { parens_for_negatives: number });
-// $ExpectError
-boolean = validator.isCurrency(string, { negative_sign_before_digits: number });
-// $ExpectError
-boolean = validator.isCurrency(string, { negative_sign_after_digits: number });
-// $ExpectError
-boolean = validator.isCurrency(string, { allow_negative_sign_placeholder: number });
-// $ExpectError
-boolean = validator.isCurrency(string, { thousands_separator: number });
-// $ExpectError
-boolean = validator.isCurrency(string, { decimal_separator: number });
-// $ExpectError
-boolean = validator.isCurrency(string, { allow_space_after_digits: number });
+  boolean = validator.isCurrency(string);
+  boolean = validator.isCurrency(string ,{
+    symbol: string,
+    require_symbol: boolean,
+    allow_space_after_symbol: boolean,
+    symbol_after_digits: boolean,
+    allow_negatives: boolean,
+    parens_for_negatives: boolean,
+    negative_sign_before_digits: boolean,
+    negative_sign_after_digits: boolean,
+    allow_negative_sign_placeholder: boolean,
+    thousands_separator: string,
+    decimal_separator: string,
+    allow_space_after_digits: boolean,
+  });
+  // $ExpectError
+  boolean = validator.isCurrency(boolean);
+  // $ExpectError
+  boolean = validator.isCurrency(string, { symbol: number });
+  // $ExpectError
+  boolean = validator.isCurrency(string, { require_symbol: number });
+  // $ExpectError
+  boolean = validator.isCurrency(string, { allow_space_after_symbol: number });
+  // $ExpectError
+  boolean = validator.isCurrency(string, { symbol_after_digits: number });
+  // $ExpectError
+  boolean = validator.isCurrency(string, { allow_negatives: number });
+  // $ExpectError
+  boolean = validator.isCurrency(string, { parens_for_negatives: number });
+  // $ExpectError
+  boolean = validator.isCurrency(string, { negative_sign_before_digits: number });
+  // $ExpectError
+  boolean = validator.isCurrency(string, { negative_sign_after_digits: number });
+  // $ExpectError
+  boolean = validator.isCurrency(string, { allow_negative_sign_placeholder: number });
+  // $ExpectError
+  boolean = validator.isCurrency(string, { thousands_separator: number });
+  // $ExpectError
+  boolean = validator.isCurrency(string, { decimal_separator: number });
+  // $ExpectError
+  boolean = validator.isCurrency(string, { allow_space_after_digits: number });
 
-boolean = validator.isEmail(string);
-boolean = validator.isEmail(string, {
-  allow_display_name: boolean,
-  require_display_name: boolean,
-  allow_utf8_local_part: boolean,
-  require_tld: boolean,
-})
-// $ExpectError
-boolean = validator.isEmail(boolean);
-// $ExpectError
-boolean = validator.isEmail(string, { allow_display_name: number });
-// $ExpectError
-boolean = validator.isEmail(string, { require_display_name: number });
-// $ExpectError
-boolean = validator.isEmail(string, { allow_utf8_local_part: number });
-// $ExpectError
-boolean = validator.isEmail(string, { require_tld: number });
+  boolean = validator.isEmail(string);
+  boolean = validator.isEmail(string, {
+    allow_display_name: boolean,
+    require_display_name: boolean,
+    allow_utf8_local_part: boolean,
+    require_tld: boolean,
+  })
+  // $ExpectError
+  boolean = validator.isEmail(boolean);
+  // $ExpectError
+  boolean = validator.isEmail(string, { allow_display_name: number });
+  // $ExpectError
+  boolean = validator.isEmail(string, { require_display_name: number });
+  // $ExpectError
+  boolean = validator.isEmail(string, { allow_utf8_local_part: number });
+  // $ExpectError
+  boolean = validator.isEmail(string, { require_tld: number });
 
-boolean = validator.isFQDN(string);
-boolean = validator.isFQDN(string, {
-  require_tld: boolean,
-  allow_underscores: boolean,
-  allow_trailing_dot: boolean,
-})
-// $ExpectError
-boolean = validator.isFQDN(boolean);
-// $ExpectError
-boolean = validator.isFQDN(string, { require_tld: number });
-// $ExpectError
-boolean = validator.isFQDN(string, { allow_underscores: number });
-// $ExpectError
-boolean = validator.isFQDN(string, { allow_trailing_dot: number });
+  boolean = validator.isFQDN(string);
+  boolean = validator.isFQDN(string, {
+    require_tld: boolean,
+    allow_underscores: boolean,
+    allow_trailing_dot: boolean,
+  })
+  // $ExpectError
+  boolean = validator.isFQDN(boolean);
+  // $ExpectError
+  boolean = validator.isFQDN(string, { require_tld: number });
+  // $ExpectError
+  boolean = validator.isFQDN(string, { allow_underscores: number });
+  // $ExpectError
+  boolean = validator.isFQDN(string, { allow_trailing_dot: number });
 
-boolean = validator.isURL(string);
-boolean = validator.isURL(string, {
-  protocols: [string],
-  require_tld: boolean,
-  require_protocol: boolean,
-  require_host: boolean,
-  require_valid_protocol: boolean,
-  allow_underscores: boolean,
-  host_whitelist: boolean,
-  host_blacklist: boolean,
-  allow_trailing_dot: boolean,
-  allow_protocol_relative_urls: boolean
-});
-// $ExpectError
-boolean = validator.isURL(boolean);
-// $ExpectError
-boolean = validator.isURL(boolean, { protocols: string });
-// $ExpectError
-boolean = validator.isURL(boolean, { protocols: [number] });
-// $ExpectError
-boolean = validator.isURL(string, { require_tld: number });
-// $ExpectError
-boolean = validator.isURL(string, { require_protocol: number });
-// $ExpectError
-boolean = validator.isURL(string, { require_host: number });
-// $ExpectError
-boolean = validator.isURL(string, { require_valid_protocol: number });
-// $ExpectError
-boolean = validator.isURL(string, { allow_underscores: number });
-// $ExpectError
-boolean = validator.isURL(string, { host_whitelist: number });
-// $ExpectError
-boolean = validator.isURL(string, { host_blacklist: number });
-// $ExpectError
-boolean = validator.isURL(string, { allow_trailing_dot: number });
-// $ExpectError
-boolean = validator.isURL(string, { allow_protocol_relative_urls: number });
+  boolean = validator.isURL(string);
+  boolean = validator.isURL(string, {
+    protocols: [string],
+    require_tld: boolean,
+    require_protocol: boolean,
+    require_host: boolean,
+    require_valid_protocol: boolean,
+    allow_underscores: boolean,
+    host_whitelist: boolean,
+    host_blacklist: boolean,
+    allow_trailing_dot: boolean,
+    allow_protocol_relative_urls: boolean
+  });
+  // $ExpectError
+  boolean = validator.isURL(boolean);
+  // $ExpectError
+  boolean = validator.isURL(boolean, { protocols: string });
+  // $ExpectError
+  boolean = validator.isURL(boolean, { protocols: [number] });
+  // $ExpectError
+  boolean = validator.isURL(string, { require_tld: number });
+  // $ExpectError
+  boolean = validator.isURL(string, { require_protocol: number });
+  // $ExpectError
+  boolean = validator.isURL(string, { require_host: number });
+  // $ExpectError
+  boolean = validator.isURL(string, { require_valid_protocol: number });
+  // $ExpectError
+  boolean = validator.isURL(string, { allow_underscores: number });
+  // $ExpectError
+  boolean = validator.isURL(string, { host_whitelist: number });
+  // $ExpectError
+  boolean = validator.isURL(string, { host_blacklist: number });
+  // $ExpectError
+  boolean = validator.isURL(string, { allow_trailing_dot: number });
+  // $ExpectError
+  boolean = validator.isURL(string, { allow_protocol_relative_urls: number });
 
 //TODO isDataURI
-// END TEST
+});
 
-// TEST: output->boolean input<-(string, string|regexp, string?)
-boolean = validator.matches(string, string);
-boolean = validator.matches(string, string, string);
-boolean = validator.matches(string, new RegExp(string), string);
-// $ExpectError
-boolean = validator.matches(string);
-// $ExpectError
-boolean = validator.matches(string, number);
-// $ExpectError
-boolean = validator.matches(string, string, number);
-// END TEST
+it('output->boolean input<-(string, string|regexp, string?)', () => {
+  boolean = validator.matches(string, string);
+  boolean = validator.matches(string, string, string);
+  boolean = validator.matches(string, new RegExp(string), string);
+  // $ExpectError
+  boolean = validator.matches(string);
+  // $ExpectError
+  boolean = validator.matches(string, number);
+  // $ExpectError
+  boolean = validator.matches(string, string, number);
+});
 
 /** Sanitizers */
-// TEST: output->string input<-(string)
-string = escape(string);
-// $ExpectError
-string = escape(number);
+it('output->string input<-(string)', () => {
+  string = escape(string);
+  // $ExpectError
+  string = escape(number);
 
-string = unescape(string);
-// $ExpectError
-string = unescape(number);
-// END TEST
+  string = unescape(string);
+  // $ExpectError
+  string = unescape(number);
+});
 
-// TEST: output->Date input<-(string)
-date = validator.toDate(string);
-// $ExpectError
-date = validator.toDate(number);
-// END TEST
+it('output->Date input<-(string)', () => {
+  date = validator.toDate(string);
+  // $ExpectError
+  date = validator.toDate(number);
+});
 
-// TEST: output->number input<-(string)
-number = validator.toFloat(string);
-// $ExpectError
-number = validator.toFloat(number);
-// END TEST
+it('output->number input<-(string)', () => {
+  number = validator.toFloat(string);
+  // $ExpectError
+  number = validator.toFloat(number);
+});
 
-// TEST: output->number input<-(string, (string | number)?)
-number = validator.toInt(string);
-number = validator.toInt(string, string);
-number = validator.toInt(string, number);
-// $ExpectError
-number = validator.toInt(boolean);
-// $ExpectError
-number = validator.toInt(string, boolean);
-// END TEST
+it('output->number input<-(string, (string | number)?)', () => {
+  number = validator.toInt(string);
+  number = validator.toInt(string, string);
+  number = validator.toInt(string, number);
+  // $ExpectError
+  number = validator.toInt(boolean);
+  // $ExpectError
+  number = validator.toInt(string, boolean);
+});
 
-// TEST: output->boolean input<-(string, boolean?)
-boolean = validator.toBoolean(string);
-boolean = validator.toBoolean(string, boolean);
-// $ExpectError
-boolean = validator.toBoolean(number);
-// $ExpectError
-boolean = validator.toBoolean(string, number);
-//END TEST
+it('output->boolean input<-(string, boolean?)', () => {
+  boolean = validator.toBoolean(string);
+  boolean = validator.toBoolean(string, boolean);
+  // $ExpectError
+  boolean = validator.toBoolean(number);
+  // $ExpectError
+  boolean = validator.toBoolean(string, number);
+});
 
+it('output->string input<-(string, string?)', () => {
+  string = validator.trim(string);
+  string = validator.trim(string, string);
+  // $ExpectError
+  string = validator.trim(number);
+  // $ExpectError
+  string = validator.trim(string, number);
 
-// TEST: output->string input<-(string, string?)
-string = validator.trim(string);
-string = validator.trim(string, string);
-// $ExpectError
-string = validator.trim(number);
-// $ExpectError
-string = validator.trim(string, number);
+  string = validator.ltrim(string);
+  string = validator.ltrim(string, string);
+  // $ExpectError
+  string = validator.ltrim(number);
+  // $ExpectError
+  string = validator.ltrim(string, number);
 
-string = validator.ltrim(string);
-string = validator.ltrim(string, string);
-// $ExpectError
-string = validator.ltrim(number);
-// $ExpectError
-string = validator.ltrim(string, number);
+  string = validator.trim(string);
+  string = validator.trim(string, string);
+  // $ExpectError
+  string = validator.trim(number);
+  // $ExpectError
+  string = validator.trim(string, number);
+});
 
-string = validator.trim(string);
-string = validator.trim(string, string);
-// $ExpectError
-string = validator.trim(number);
-// $ExpectError
-string = validator.trim(string, number);
-// END TEST
+it('output->string input<-(string, string)', () => {
+  string = validator.blacklist(string, string);
+  // $ExpectError
+  string = validator.blacklist(string);
+  // $ExpectError
+  string = validator.blacklist(number, string);
+  // $ExpectError
+  string = validator.blacklist(string, number);
 
-// TEST: output->string input<-(string, string)
-string = validator.blacklist(string, string);
-// $ExpectError
-string = validator.blacklist(string);
-// $ExpectError
-string = validator.blacklist(number, string);
-// $ExpectError
-string = validator.blacklist(string, number);
+  string = validator.whitelist(string, string);
+  // $ExpectError
+  string = validator.whitelist(string);
+  // $ExpectError
+  string = validator.whitelist(number, string);
+  // $ExpectError
+  string = validator.whitelist(string, number);
+});
 
-string = validator.whitelist(string, string);
-// $ExpectError
-string = validator.whitelist(string);
-// $ExpectError
-string = validator.whitelist(number, string);
-// $ExpectError
-string = validator.whitelist(string, number);
-// END TEST
+it('output->string input<-(string, boolean)', () => {
+  string = validator.stripLow(string);
+  string = validator.stripLow(string, boolean);
+  // $ExpectError
+  string = validator.stripLow(number);
+  // $ExpectError
+  string = validator.stripLow(string, number);
+});
 
-// TEST: output->string input<-(string, boolean)
-string = validator.stripLow(string);
-string = validator.stripLow(string, boolean);
-// $ExpectError
-string = validator.stripLow(number);
-// $ExpectError
-string = validator.stripLow(string, number);
-// END TEST
-
-// TEST: output->string input<-(string, options)
-string = validator.normalizeEmail(string)
-string = validator.normalizeEmail(string, {
-  all_lowercase: boolean,
-  gmail_lowercase: boolean,
-  gmail_remove_dots: boolean,
-  gmail_remove_subaddress: boolean,
-  gmail_convert_googlemaildotcom: boolean,
-  outlookdotcom_lowercase: boolean,
-  outlookdotcom_remove_subaddress: boolean,
-  yahoo_lowercase: boolean,
-  yahoo_remove_subaddress: boolean,
-  icloud_lowercase: boolean,
-  icloud_remove_subaddress: boolean,
-})
-// $ExpectError
-string = validator.normalizeEmail(boolean);
-// $ExpectError
-string = validator.normalizeEmail(string, boolean);
-// $ExpectError
-string = validator.normalizeEmail(string, { all_lowercase: number });
-// $ExpectError
-string = validator.normalizeEmail(string, { gmail_lowercase: number });
-// $ExpectError
-string = validator.normalizeEmail(string, { gmail_remove_dots: number });
-// $ExpectError
-string = validator.normalizeEmail(string, { gmail_remove_subaddress: number });
-// $ExpectError
-string = validator.normalizeEmail(string, { gmail_convert_googlemaildotcom: number });
-// $ExpectError
-string = validator.normalizeEmail(string, { outlookdotcom_lowercase: number });
-// $ExpectError
-string = validator.normalizeEmail(string, { outlookdotcom_remove_subaddress: number });
-// $ExpectError
-string = validator.normalizeEmail(string, { yahoo_lowercase: number });
-// $ExpectError
-string = validator.normalizeEmail(string, { yahoo_remove_subaddress: number });
-// $ExpectError
-string = validator.normalizeEmail(string, { icloud_lowercase: number });
-// $ExpectError
-string = validator.normalizeEmail(string, { icloud_remove_subaddress: number });
-// END TEST
+it('output->string input<-(string, options)', () => {
+  string = validator.normalizeEmail(string)
+  string = validator.normalizeEmail(string, {
+    all_lowercase: boolean,
+    gmail_lowercase: boolean,
+    gmail_remove_dots: boolean,
+    gmail_remove_subaddress: boolean,
+    gmail_convert_googlemaildotcom: boolean,
+    outlookdotcom_lowercase: boolean,
+    outlookdotcom_remove_subaddress: boolean,
+    yahoo_lowercase: boolean,
+    yahoo_remove_subaddress: boolean,
+    icloud_lowercase: boolean,
+    icloud_remove_subaddress: boolean,
+  })
+  // $ExpectError
+  string = validator.normalizeEmail(boolean);
+  // $ExpectError
+  string = validator.normalizeEmail(string, boolean);
+  // $ExpectError
+  string = validator.normalizeEmail(string, { all_lowercase: number });
+  // $ExpectError
+  string = validator.normalizeEmail(string, { gmail_lowercase: number });
+  // $ExpectError
+  string = validator.normalizeEmail(string, { gmail_remove_dots: number });
+  // $ExpectError
+  string = validator.normalizeEmail(string, { gmail_remove_subaddress: number });
+  // $ExpectError
+  string = validator.normalizeEmail(string, { gmail_convert_googlemaildotcom: number });
+  // $ExpectError
+  string = validator.normalizeEmail(string, { outlookdotcom_lowercase: number });
+  // $ExpectError
+  string = validator.normalizeEmail(string, { outlookdotcom_remove_subaddress: number });
+  // $ExpectError
+  string = validator.normalizeEmail(string, { yahoo_lowercase: number });
+  // $ExpectError
+  string = validator.normalizeEmail(string, { yahoo_remove_subaddress: number });
+  // $ExpectError
+  string = validator.normalizeEmail(string, { icloud_lowercase: number });
+  // $ExpectError
+  string = validator.normalizeEmail(string, { icloud_remove_subaddress: number });
+});


### PR DESCRIPTION
* Type of contribution: fix

Other notes:

Applying #3732 fix for reselect_v4 to reselect_v3 as well.
This fixes #3127, since the author had problem with reselect_v3.

