### PR TITLE
apollo-client - Export the correct NetworkStatus

### DIFF
--- a/definitions/npm/@apollo/react-common_v3.x.x/flow_v0.104.x-/react-common_v3.x.x.js
+++ b/definitions/npm/@apollo/react-common_v3.x.x/flow_v0.104.x-/react-common_v3.x.x.js
@@ -160,7 +160,7 @@ declare module '@apollo/react-common' {
     data: ?TData,
     error?: ApolloError,
     loading: boolean,
-    networkStatus: NetworkStatus,
+    networkStatus: NetworkStatusRaw,
     called: boolean,
     ...
   };
@@ -522,7 +522,7 @@ declare module '@apollo/react-common' {
     data: T | { ... },
     errors?: Array<GraphQLError>,
     loading: boolean,
-    networkStatus: NetworkStatus,
+    networkStatus: NetworkStatusRaw,
     error?: ApolloError,
     partial?: boolean,
     ...
@@ -607,7 +607,12 @@ declare module '@apollo/react-common' {
     mutationResult: FetchResult<T>
   ) => void;
 
-  declare type NetworkStatus = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+  declare type NetworkStatusRaw = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
+  declare export class NetworkStatus {
+    [NetworkStatusRaw]: string,
+    string: NetworkStatusRaw,
+  }
 
   declare type QueryListener = (
     queryStoreValue: QueryStoreValue,
@@ -618,7 +623,7 @@ declare module '@apollo/react-common' {
     document: DocumentNode,
     variables: any,
     previousVariables: any,
-    networkStatus: NetworkStatus,
+    networkStatus: NetworkStatusRaw,
     networkError: Error | null,
     graphQLErrors: GraphQLError[],
     metadata: any,
@@ -637,7 +642,7 @@ declare module '@apollo/react-common' {
     data: T,
     errors?: Array<GraphQLError>,
     loading: boolean,
-    networkStatus: NetworkStatus,
+    networkStatus: NetworkStatusRaw,
     stale: boolean,
     ...
   };

--- a/definitions/npm/apollo-client_v2.x.x/flow_v0.104.x-/apollo-client_v2.x.x.js
+++ b/definitions/npm/apollo-client_v2.x.x/flow_v0.104.x-/apollo-client_v2.x.x.js
@@ -274,7 +274,7 @@ declare module "apollo-client" {
     data: T | {...},
     errors?: Array<GraphQLError>,
     loading: boolean,
-    networkStatus: NetworkStatus,
+    networkStatus: NetworkStatusRaw,
     error?: ApolloError,
     partial?: boolean,
     ...
@@ -365,7 +365,12 @@ declare module "apollo-client" {
     mutationResult: FetchResult<T>
   ) => void;
 
-  declare export type NetworkStatus = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+  declare export type NetworkStatusRaw = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
+  declare export class NetworkStatus {
+    [NetworkStatusRaw]: string,
+    string: NetworkStatusRaw,
+  }
 
   declare export type QueryListener = (
     queryStoreValue: QueryStoreValue,
@@ -376,7 +381,7 @@ declare module "apollo-client" {
     document: DocumentNode,
     variables: Object,
     previousVariables: Object | null,
-    networkStatus: NetworkStatus,
+    networkStatus: NetworkStatusRaw,
     networkError: Error | null,
     graphQLErrors: GraphQLError[],
     metadata: any,
@@ -393,7 +398,7 @@ declare module "apollo-client" {
     data: T,
     errors?: Array<GraphQLError>,
     loading: boolean,
-    networkStatus: NetworkStatus,
+    networkStatus: NetworkStatusRaw,
     stale: boolean,
     ...
   };

--- a/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-v0.103.x/apollo-client_v2.x.x.js
+++ b/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-v0.103.x/apollo-client_v2.x.x.js
@@ -264,7 +264,7 @@ declare module "apollo-client" {
     data: T | {},
     errors?: Array<GraphQLError>,
     loading: boolean,
-    networkStatus: NetworkStatus,
+    networkStatus: NetworkStatusRaw,
     error?: ApolloError,
     partial?: boolean
   };
@@ -349,7 +349,12 @@ declare module "apollo-client" {
     mutationResult: FetchResult<T>
   ) => void;
 
-  declare export type NetworkStatus = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+  declare type NetworkStatusRaw = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
+  declare export class NetworkStatus {
+    [NetworkStatusRaw]: string,
+    string: NetworkStatusRaw,
+  }
 
   declare export type QueryListener = (
     queryStoreValue: QueryStoreValue,
@@ -360,7 +365,7 @@ declare module "apollo-client" {
     document: DocumentNode,
     variables: Object,
     previousVariables: Object | null,
-    networkStatus: NetworkStatus,
+    networkStatus: NetworkStatusRaw,
     networkError: Error | null,
     graphQLErrors: GraphQLError[],
     metadata: any
@@ -375,7 +380,7 @@ declare module "apollo-client" {
     data: T,
     errors?: Array<GraphQLError>,
     loading: boolean,
-    networkStatus: NetworkStatus,
+    networkStatus: NetworkStatusRaw,
     stale: boolean
   };
 


### PR DESCRIPTION
- Links to documentation: https://www.apollographql.com/docs/react/api/react-apollo/#datanetworkstatus
- Link to GitHub or NPM: https://github.com/apollographql/apollo-client/blob/3d6dc49e7c1c23daf0ac47cc9f91af271fbda2e4/src/core/networkStatus.ts
- Type of contribution: fix

Other notes:
Apollo exports a NetworkStatus object that is a mapping from
strings to the associated network status number. This was being
hidden by the type export that already existed in the library
definition.
