### PR TITLE
lodash - remove unused generic type parameter

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -596,7 +596,7 @@ declare module "lodash" {
       predicate?: ?OPredicate<A, T>,
       fromIndex?: ?number
     ): R;
-    flatMap<A, K, U, T: $ReadOnlyArray<A> = Array<A>>(
+    flatMap<A, U, T: $ReadOnlyArray<A> = Array<A>>(
       array: T,
       iteratee?: ?AFlatMapIteratee<A, T, U>
     ): Array<U>;


### PR DESCRIPTION
- Type of contribution: fix

Other notes:
Removing unused generic type parameter as mentioned in the comment to my previous PR https://github.com/flow-typed/flow-typed/pull/3777#issuecomment-609843093.

Checked - no other method has unused `K` parameter.
