### PR TITLE
redux-mock-store - use readonly type for covariance

### DIFF
--- a/definitions/npm/redux-mock-store_v1.2.x/flow_v0.104.x-/redux-mock-store_v1.2.x.js
+++ b/definitions/npm/redux-mock-store_v1.2.x/flow_v0.104.x-/redux-mock-store_v1.2.x.js
@@ -6,7 +6,7 @@ declare module "redux-mock-store" {
 
   declare type mockStore = { <S, A>(state: S): mockStoreWithoutMiddleware<S, A>, ... };
   declare type DispatchAPI<A> = (action: A) => A;
-  declare type Dispatch<A: { type: string, ... }> = DispatchAPI<A>;
+  declare type Dispatch<A: $ReadOnly<{ type: string, ... }>> = DispatchAPI<A>;
   declare type mockStoreWithoutMiddleware<S, A> = {
     getState(): S,
     getActions(): Array<A>,

--- a/definitions/npm/redux-mock-store_v1.2.x/test_redux-mock-store_v1.js
+++ b/definitions/npm/redux-mock-store_v1.2.x/test_redux-mock-store_v1.js
@@ -1,15 +1,50 @@
 // @flow
 
+import { describe, it } from 'flow-typed-test';
+
 import configureStore from 'redux-mock-store';
 
-// $ExpectError
-const mockStoreContainingInvalidMiddleware = configureStore(['not a middleware']);
-
 const mockStore = configureStore();
-
 const store = mockStore({ todos: [{ title: 'thing', done: false, id: 1 }] });
 
-// $ExpectError
-store.getState().somethingNotHere;
+describe('configureStore', () => {
+  it('should accept only Middleware', () => {
+    const mockMiddleware = spy => store => next => action => {
+      spy()
+      return next(action)
+    }
 
-store.getState().todos;
+    configureStore([mockMiddleware]);
+
+    // $ExpectError
+    configureStore(['not a middleware']);
+  });
+});
+
+
+describe('getState', () => {
+  it('returned state should be typed', () => {
+    store.getState().todos[0].title;
+
+    // $ExpectError
+    store.getState().todos.title;
+    // $ExpectError
+    store.getState().somethingNotHere;
+  });
+});
+
+describe('dispatch', () => {
+  it('should accept string', () => {
+    store.dispatch({ type: 'myActionType', anotherProp: 1 });
+  });
+
+  it('should accept subset of string', () => {
+    const TOGGLE: 'TOGGLE' = 'TOGGLE';
+    const f = (action: {| type: typeof TOGGLE |}) => {
+      store.dispatch(action);
+    };
+  });
+});
+
+
+

--- a/definitions/npm/redux-mock-store_v1.2.x/test_redux-mock-store_v1.js
+++ b/definitions/npm/redux-mock-store_v1.2.x/test_redux-mock-store_v1.js
@@ -38,7 +38,7 @@ describe('dispatch', () => {
     store.dispatch({ type: 'myActionType', anotherProp: 1 });
   });
 
-  it('should accept subset of string', () => {
+  it('should accept subtype of string', () => {
     const TOGGLE: 'TOGGLE' = 'TOGGLE';
     const f = (action: {| type: typeof TOGGLE |}) => {
       store.dispatch(action);


### PR DESCRIPTION
- Links to documentation: https://github.com/dmitry-zaets/redux-mock-store
- Link to GitHub or NPM: https://github.com/dmitry-zaets/redux-mock-store
- Type of contribution: fix

Other notes:
Allows to pass subtypes of string to the dispatch()
This change is in line with recommendation in CONTRIBUTING.md.
