### PR TITLE
react-router-dom - use readonly types for covariance

### DIFF
--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.104.x-/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.104.x-/react-router-dom_v4.x.x.js
@@ -15,23 +15,23 @@ declare module "react-router-dom" {
   |}>
 
   declare export var Link: React$ComponentType<{
-    className?: string,
-    to: string | LocationShape,
-    replace?: boolean,
-    children?: React$Node,
+    +className?: string,
+    +to: string | LocationShape,
+    +replace?: boolean,
+    +children?: React$Node,
     ...
   }>
 
   declare export var NavLink: React$ComponentType<{
-    to: string | LocationShape,
-    activeClassName?: string,
-    className?: string,
-    activeStyle?: Object,
-    style?: Object,
-    isActive?: (match: Match, location: Location) => boolean,
-    children?: React$Node,
-    exact?: boolean,
-    strict?: boolean,
+    +to: string | LocationShape,
+    +activeClassName?: string,
+    +className?: string,
+    +activeStyle?: Object,
+    +style?: Object,
+    +isActive?: (match: Match, location: Location) => boolean,
+    +children?: React$Node,
+    +exact?: boolean,
+    +strict?: boolean,
     ...
   }>
 

--- a/definitions/npm/react-router-dom_v5.x.x/flow_v0.104.x-/react-router-dom_v5.x.x.js
+++ b/definitions/npm/react-router-dom_v5.x.x/flow_v0.104.x-/react-router-dom_v5.x.x.js
@@ -15,23 +15,23 @@ declare module "react-router-dom" {
   |}>
 
   declare export var Link: React$ComponentType<{
-    className?: string,
-    to: string | LocationShape,
-    replace?: boolean,
-    children?: React$Node,
+    +className?: string,
+    +to: string | LocationShape,
+    +replace?: boolean,
+    +children?: React$Node,
     ...
   }>
 
   declare export var NavLink: React$ComponentType<{
-    to: string | LocationShape,
-    activeClassName?: string,
-    className?: string,
-    activeStyle?: { +[string]: mixed, ... },
-    style?: { +[string]: mixed, ... },
-    isActive?: (match: Match, location: Location) => boolean,
-    children?: React$Node,
-    exact?: boolean,
-    strict?: boolean,
+    +to: string | LocationShape,
+    +activeClassName?: string,
+    +className?: string,
+    +activeStyle?: { +[string]: mixed, ... },
+    +style?: { +[string]: mixed, ... },
+    +isActive?: (match: Match, location: Location) => boolean,
+    +children?: React$Node,
+    +exact?: boolean,
+    +strict?: boolean,
     ...
   }>
 


### PR DESCRIPTION
- Links to documentation:https://reacttraining.com/react-router/web/api/Link
- Link to GitHub or NPM: https://github.com/ReactTraining/react-router
- Type of contribution: fix

Other notes:
Since Link does not change its props (except for `innerRef`), this change is in line with "prefer immutability for input args" recommendation in CONTRIBUTING.md.

This change is needed to allow to conditionally replace <Link> with another component which has `type: string` prop.

```
type Props = {|
   type: string
  // etc.
|}

(props: Props) => x ? <MyCustomLink {...props} /> : <Link {...props} />;
```

Without the change, there is an error that `type: string` in Props is not compatible with `type: string | LocationShape` in the libdef