### PR TITLE
Add snapshot diff

### DIFF
--- a/definitions/npm/jest_v17.x.x/test_jest-v17.x.x.js
+++ b/definitions/npm/jest_v17.x.x/test_jest-v17.x.x.js
@@ -48,8 +48,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   }
 });

--- a/definitions/npm/jest_v18.x.x/test_jest-v18.x.x.js
+++ b/definitions/npm/jest_v18.x.x/test_jest-v18.x.x.js
@@ -52,8 +52,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   }
 });

--- a/definitions/npm/jest_v19.x.x/test_jest-v19.x.x.js
+++ b/definitions/npm/jest_v19.x.x/test_jest-v19.x.x.js
@@ -55,8 +55,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   }
 });

--- a/definitions/npm/jest_v20.x.x/flow_v0.104.x-/test_jest-v20.x.x.js
+++ b/definitions/npm/jest_v20.x.x/flow_v0.104.x-/test_jest-v20.x.x.js
@@ -135,8 +135,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   }
 });

--- a/definitions/npm/jest_v20.x.x/flow_v0.25.x-v0.38.x/test_jest-v20.x.x.js
+++ b/definitions/npm/jest_v20.x.x/flow_v0.25.x-v0.38.x/test_jest-v20.x.x.js
@@ -59,8 +59,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   }
 });

--- a/definitions/npm/jest_v20.x.x/flow_v0.39.x-v0.103.x/test_jest-v20.x.x.js
+++ b/definitions/npm/jest_v20.x.x/flow_v0.39.x-v0.103.x/test_jest-v20.x.x.js
@@ -137,8 +137,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   }
 });

--- a/definitions/npm/jest_v21.x.x/flow_v0.104.x-/test_jest-v21.x.x.js
+++ b/definitions/npm/jest_v21.x.x/flow_v0.104.x-/test_jest-v21.x.x.js
@@ -135,8 +135,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   }
 });

--- a/definitions/npm/jest_v21.x.x/flow_v0.25.x-v0.38.x/test_jest-v21.x.x.js
+++ b/definitions/npm/jest_v21.x.x/flow_v0.25.x-v0.38.x/test_jest-v21.x.x.js
@@ -59,8 +59,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   }
 });

--- a/definitions/npm/jest_v21.x.x/flow_v0.39.x-v0.103.x/test_jest-v21.x.x.js
+++ b/definitions/npm/jest_v21.x.x/flow_v0.39.x-v0.103.x/test_jest-v21.x.x.js
@@ -137,8 +137,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   }
 });

--- a/definitions/npm/jest_v22.x.x/flow_v0.104.x-/test_jest-v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.104.x-/test_jest-v22.x.x.js
@@ -153,8 +153,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   }
 });

--- a/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/test_jest-v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/test_jest-v22.x.x.js
@@ -73,8 +73,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   }
 });

--- a/definitions/npm/jest_v22.x.x/flow_v0.39.x-v0.103.x/test_jest-v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.39.x-v0.103.x/test_jest-v22.x.x.js
@@ -155,8 +155,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   }
 });

--- a/definitions/npm/jest_v23.x.x/flow_v0.104.x-/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.104.x-/test_jest-v23.x.x.js
@@ -226,8 +226,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   }
 });

--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-v0.103.x/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-v0.103.x/test_jest-v23.x.x.js
@@ -225,8 +225,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   }
 });

--- a/definitions/npm/jest_v24.x.x/flow_v0.104.x-/jest_v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.104.x-/jest_v24.x.x.js
@@ -530,13 +530,36 @@ type JestExtendedMatchersType = {
  ...
 };
 
+// Diffing snapshot utility for Jest (snapshot-diff)
+// https://github.com/jest-community/snapshot-diff
+type SnapshotDiffType = {
+  /**
+   * Compare the difference between the actual in the `expect()`
+   * vs the object inside `valueB` with some extra options.
+   */
+  toMatchDiffSnapshot(
+    valueB: any,
+    options?: {|
+      expand?: boolean;
+      colors?: boolean;
+      contextLines?: number;
+      stablePatchmarks?: boolean;
+      aAnnotation?: string;
+      bAnnotation?: string;
+    |},
+    testName?: string
+  ): void,
+  ...
+}
+
 interface JestExpectType {
   not: JestExpectType &
     EnzymeMatchersType &
     DomTestingLibraryType &
     JestJQueryMatchersType &
     JestStyledComponentsMatchersType &
-    JestExtendedMatchersType;
+    JestExtendedMatchersType &
+    SnapshotDiffType;
   /**
    * If you have a mock function, you can use .lastCalledWith to test what
    * arguments it was last called with.
@@ -1127,7 +1150,8 @@ declare var expect: {
    DomTestingLibraryType &
    JestJQueryMatchersType &
    JestStyledComponentsMatchersType &
-   JestExtendedMatchersType,
+   JestExtendedMatchersType &
+   SnapshotDiffType,
  /** Add additional Jasmine matchers to Jest's roster */
  extend(matchers: { [name: string]: JestMatcher, ... }): void,
  /** Add a module that formats application-specific data structures. */

--- a/definitions/npm/jest_v24.x.x/flow_v0.104.x-/test_jest-v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.104.x-/test_jest-v24.x.x.js
@@ -243,8 +243,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   },
 });

--- a/definitions/npm/jest_v24.x.x/flow_v0.104.x-/test_jest-v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.104.x-/test_jest-v24.x.x.js
@@ -112,6 +112,11 @@ Object {
 }
 `
 );
+// $ExpectError - options must be object or undefined
+expect('foo').toMatchDiffSnapshot('any', null, 'test name')
+expect('foo').toMatchDiffSnapshot('any', {}, 'test name')
+expect('foo').toMatchDiffSnapshot('foobar');
+expect('foo').toMatchDiffSnapshot('foobar', undefined, 'snapshot difference between two strings');
 
 expect({ foo: 1 }).toMatchInlineSnapshot([]);
 expect({ foo: 'bar' }).toMatchObject({ baz: 'qux' });
@@ -138,10 +143,22 @@ describe(aFunction, () => {});
 describe.only('name', () => {});
 describe.only(AClass, () => {});
 describe.only(aFunction, () => {});
-describe.each([['arg1', 2, true], ['arg2', 3, false]])('test', () =>
-  expect('foo').toMatchSnapshot()
+describe.each([['arg1'], ['arg2']])('test', (a) =>
+  expect(a).toMatchSnapshot()
 );
-describe.each(['arg1', 2, true])('test', () => expect('foo').toMatchSnapshot());
+describe.each(['arg1', 2, true])('test', (a) => expect(a).toMatchSnapshot());
+describe.each([['arg1', 'arg2'], ['arg2', 'arg3']])('test', (a, b) =>
+  expect(a).toMatchDiffSnapshot(b)
+);
+describe.each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+])('.add(%i, %i)', (a, b, expected) => {
+  test(`returns ${expected}`, () => {
+    expect(a + b).toBe(expected);
+  });
+});
 describe.each`
   a    | b    | expected
   ${1} | ${1} | ${2}

--- a/definitions/npm/jest_v24.x.x/flow_v0.39.x-v0.103.x/jest_v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.39.x-v0.103.x/jest_v24.x.x.js
@@ -571,13 +571,36 @@ type JestExtendedMatchersType = {
   toIncludeMultiple(substring: string[]): void,
 };
 
+// Diffing snapshot utility for Jest (snapshot-diff)
+// https://github.com/jest-community/snapshot-diff
+type SnapshotDiffType = {
+  /**
+   * Compare the difference between the actual in the `expect()`
+   * vs the object inside `valueB` with some extra options.
+   */
+  toMatchDiffSnapshot(
+    valueB: any,
+    options?: {|
+      expand?: boolean;
+      colors?: boolean;
+      contextLines?: number;
+      stablePatchmarks?: boolean;
+      aAnnotation?: string;
+      bAnnotation?: string;
+    |},
+    testName?: string
+  ): void,
+  ...
+}
+
 interface JestExpectType {
   not: JestExpectType &
     EnzymeMatchersType &
     DomTestingLibraryType &
     JestJQueryMatchersType &
     JestStyledComponentsMatchersType &
-    JestExtendedMatchersType;
+    JestExtendedMatchersType &
+    SnapshotDiffType;
   /**
    * If you have a mock function, you can use .lastCalledWith to test what
    * arguments it was last called with.
@@ -1155,7 +1178,8 @@ declare var expect: {
     DomTestingLibraryType &
     JestJQueryMatchersType &
     JestStyledComponentsMatchersType &
-    JestExtendedMatchersType,
+    JestExtendedMatchersType &
+    SnapshotDiffType,
 
   /** Add additional Jasmine matchers to Jest's roster */
   extend(matchers: { [name: string]: JestMatcher }): void,

--- a/definitions/npm/jest_v24.x.x/flow_v0.39.x-v0.103.x/test_jest-v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.39.x-v0.103.x/test_jest-v24.x.x.js
@@ -111,6 +111,11 @@ Object {
 }
 `
 );
+// $ExpectError - options must be object or undefined
+expect('foo').toMatchDiffSnapshot('any', null, 'test name')
+expect('foo').toMatchDiffSnapshot('any', {}, 'test name')
+expect('foo').toMatchDiffSnapshot('foobar');
+expect('foo').toMatchDiffSnapshot('foobar', undefined, 'snapshot difference between two strings');
 
 expect({ foo: 1 }).toMatchInlineSnapshot([]);
 expect({ foo: 'bar' }).toMatchObject({ baz: 'qux' });
@@ -137,10 +142,22 @@ describe(aFunction, () => {});
 describe.only('name', () => {});
 describe.only(AClass, () => {});
 describe.only(aFunction, () => {});
-describe.each([['arg1', 2, true], ['arg2', 3, false]])('test', () =>
-  expect('foo').toMatchSnapshot()
+describe.each([['arg1'], ['arg2']])('test', (a) =>
+  expect(a).toMatchSnapshot()
 );
-describe.each(['arg1', 2, true])('test', () => expect('foo').toMatchSnapshot());
+describe.each(['arg1', 2, true])('test', (a) => expect(a).toMatchSnapshot());
+describe.each([['arg1', 'arg2'], ['arg2', 'arg3']])('test', (a, b) =>
+  expect(a).toMatchDiffSnapshot(b)
+);
+describe.each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+])('.add(%i, %i)', (a, b, expected) => {
+  test(`returns ${expected}`, () => {
+    expect(a + b).toBe(expected);
+  });
+});
 describe.each`
   a    | b    | expected
   ${1} | ${1} | ${2}

--- a/definitions/npm/jest_v24.x.x/flow_v0.39.x-v0.103.x/test_jest-v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.39.x-v0.103.x/test_jest-v24.x.x.js
@@ -242,8 +242,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   },
 });

--- a/definitions/npm/jest_v25.x.x/flow_v0.104.x-/jest_v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.104.x-/jest_v25.x.x.js
@@ -530,13 +530,36 @@ type JestExtendedMatchersType = {
  ...
 };
 
+// Diffing snapshot utility for Jest (snapshot-diff)
+// https://github.com/jest-community/snapshot-diff
+type SnapshotDiffType = {
+  /**
+   * Compare the difference between the actual in the `expect()`
+   * vs the object inside `valueB` with some extra options.
+   */
+  toMatchDiffSnapshot(
+    valueB: any,
+    options?: {|
+      expand?: boolean;
+      colors?: boolean;
+      contextLines?: number;
+      stablePatchmarks?: boolean;
+      aAnnotation?: string;
+      bAnnotation?: string;
+    |},
+    testName?: string
+  ): void,
+  ...
+}
+
 interface JestExpectType {
   not: JestExpectType &
     EnzymeMatchersType &
     DomTestingLibraryType &
     JestJQueryMatchersType &
     JestStyledComponentsMatchersType &
-    JestExtendedMatchersType;
+    JestExtendedMatchersType &
+    SnapshotDiffType;
   /**
    * If you have a mock function, you can use .lastCalledWith to test what
    * arguments it was last called with.
@@ -1127,7 +1150,8 @@ declare var expect: {
    DomTestingLibraryType &
    JestJQueryMatchersType &
    JestStyledComponentsMatchersType &
-   JestExtendedMatchersType,
+   JestExtendedMatchersType &
+   SnapshotDiffType,
  /** Add additional Jasmine matchers to Jest's roster */
  extend(matchers: { [name: string]: JestMatcher, ... }): void,
  /** Add a module that formats application-specific data structures. */

--- a/definitions/npm/jest_v25.x.x/flow_v0.104.x-/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.104.x-/test_jest-v25.x.x.js
@@ -243,8 +243,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   },
 });

--- a/definitions/npm/jest_v25.x.x/flow_v0.104.x-/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.104.x-/test_jest-v25.x.x.js
@@ -112,6 +112,11 @@ Object {
 }
 `
 );
+// $ExpectError - options must be object or undefined
+expect('foo').toMatchDiffSnapshot('any', null, 'test name')
+expect('foo').toMatchDiffSnapshot('any', {}, 'test name')
+expect('foo').toMatchDiffSnapshot('foobar');
+expect('foo').toMatchDiffSnapshot('foobar', undefined, 'snapshot difference between two strings');
 
 expect({ foo: 1 }).toMatchInlineSnapshot([]);
 expect({ foo: 'bar' }).toMatchObject({ baz: 'qux' });
@@ -138,10 +143,22 @@ describe(aFunction, () => {});
 describe.only('name', () => {});
 describe.only(AClass, () => {});
 describe.only(aFunction, () => {});
-describe.each([['arg1', 2, true], ['arg2', 3, false]])('test', () =>
-  expect('foo').toMatchSnapshot()
+describe.each([['arg1'], ['arg2']])('test', (a) =>
+  expect(a).toMatchSnapshot()
 );
-describe.each(['arg1', 2, true])('test', () => expect('foo').toMatchSnapshot());
+describe.each(['arg1', 2, true])('test', (a) => expect(a).toMatchSnapshot());
+describe.each([['arg1', 'arg2'], ['arg2', 'arg3']])('test', (a, b) =>
+  expect(a).toMatchDiffSnapshot(b)
+);
+describe.each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+])('.add(%i, %i)', (a, b, expected) => {
+  test(`returns ${expected}`, () => {
+    expect(a + b).toBe(expected);
+  });
+});
 describe.each`
   a    | b    | expected
   ${1} | ${1} | ${2}

--- a/definitions/npm/jest_v25.x.x/flow_v0.39.x-v0.103.x/jest_v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.39.x-v0.103.x/jest_v25.x.x.js
@@ -571,13 +571,36 @@ type JestExtendedMatchersType = {
   toIncludeMultiple(substring: string[]): void,
 };
 
+// Diffing snapshot utility for Jest (snapshot-diff)
+// https://github.com/jest-community/snapshot-diff
+type SnapshotDiffType = {
+  /**
+   * Compare the difference between the actual in the `expect()`
+   * vs the object inside `valueB` with some extra options.
+   */
+  toMatchDiffSnapshot(
+    valueB: any,
+    options?: {|
+      expand?: boolean;
+      colors?: boolean;
+      contextLines?: number;
+      stablePatchmarks?: boolean;
+      aAnnotation?: string;
+      bAnnotation?: string;
+    |},
+    testName?: string
+  ): void,
+  ...
+}
+
 interface JestExpectType {
   not: JestExpectType &
     EnzymeMatchersType &
     DomTestingLibraryType &
     JestJQueryMatchersType &
     JestStyledComponentsMatchersType &
-    JestExtendedMatchersType;
+    JestExtendedMatchersType &
+    SnapshotDiffType;
   /**
    * If you have a mock function, you can use .lastCalledWith to test what
    * arguments it was last called with.
@@ -1155,7 +1178,8 @@ declare var expect: {
     DomTestingLibraryType &
     JestJQueryMatchersType &
     JestStyledComponentsMatchersType &
-    JestExtendedMatchersType,
+    JestExtendedMatchersType &
+    SnapshotDiffType,
 
   /** Add additional Jasmine matchers to Jest's roster */
   extend(matchers: { [name: string]: JestMatcher }): void,

--- a/definitions/npm/jest_v25.x.x/flow_v0.39.x-v0.103.x/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.39.x-v0.103.x/test_jest-v25.x.x.js
@@ -111,6 +111,11 @@ Object {
 }
 `
 );
+// $ExpectError - options must be object or undefined
+expect('foo').toMatchDiffSnapshot('any', null, 'test name')
+expect('foo').toMatchDiffSnapshot('any', {}, 'test name')
+expect('foo').toMatchDiffSnapshot('foobar');
+expect('foo').toMatchDiffSnapshot('foobar', undefined, 'snapshot difference between two strings');
 
 expect({ foo: 1 }).toMatchInlineSnapshot([]);
 expect({ foo: 'bar' }).toMatchObject({ baz: 'qux' });
@@ -137,10 +142,22 @@ describe(aFunction, () => {});
 describe.only('name', () => {});
 describe.only(AClass, () => {});
 describe.only(aFunction, () => {});
-describe.each([['arg1', 2, true], ['arg2', 3, false]])('test', () =>
-  expect('foo').toMatchSnapshot()
+describe.each([['arg1'], ['arg2']])('test', (a) =>
+  expect(a).toMatchSnapshot()
 );
-describe.each(['arg1', 2, true])('test', () => expect('foo').toMatchSnapshot());
+describe.each(['arg1', 2, true])('test', (a) => expect(a).toMatchSnapshot());
+describe.each([['arg1', 'arg2'], ['arg2', 'arg3']])('test', (a, b) =>
+  expect(a).toMatchDiffSnapshot(b)
+);
+describe.each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+])('.add(%i, %i)', (a, b, expected) => {
+  test(`returns ${expected}`, () => {
+    expect(a + b).toBe(expected);
+  });
+});
 describe.each`
   a    | b    | expected
   ${1} | ${1} | ${2}

--- a/definitions/npm/jest_v25.x.x/flow_v0.39.x-v0.103.x/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.39.x-v0.103.x/test_jest-v25.x.x.js
@@ -242,8 +242,8 @@ expect.extend({
 });
 
 expect.extend({
+  // $ExpectError property `pass` not found in object literal
   foo(actual, expected) {
-    // $ExpectError property `pass` not found in object literal
     return {};
   },
 });


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

Adds `toMatchDiffSnapshot` to Jest custom matchers

- Link to GitHub or NPM: https://github.com/jest-community/snapshot-diff
[Typescript](https://github.com/jest-community/snapshot-diff/blob/master/index.d.ts#L18)
- Type of contribution: addition | fix

Other notes:
Fix location of $ExpectError for all Jest versions with the issue
