### PR TITLE
Allow @sentry/browser setUser to accept null

### DIFF
--- a/definitions/npm/@sentry/browser_v5.x.x/flow_v0.84.x-/browser_v5.x.x.js
+++ b/definitions/npm/@sentry/browser_v5.x.x/flow_v0.84.x-/browser_v5.x.x.js
@@ -66,7 +66,7 @@ declare module '@sentry/browser' {
     declare export function setExtras(extras: { [key: string]: any, ... }): void;
     declare export function setTag(key: string, value: string): void;
     declare export function setTags(tags: {| [key: string]: string |}): void;
-    declare export function setUser(user: User): void;
+    declare export function setUser(user: User | null): void;
     declare export function withScope(callback: (scope: Scope) => void): void;
 
     declare export class BrowserClient<O: Options = Options> {


### PR DESCRIPTION
- Links to documentation: https://docs.sentry.io/enriching-error-data/additional-data/?platform=javascript
- Link to GitHub or NPM: https://github.com/getsentry/sentry-javascript/blob/645ff532941d9a23bb6531c6305e99544b356502/packages/minimal/src/index.ts#L136
- Type of contribution: fix

This is to match types in the original library. Also unsetting the user context is required and pretty common when logging users out of your application

