### PR TITLE
[lodash] Allow flatmap iterator to return a read only array

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -194,9 +194,9 @@ declare module "lodash" {
   declare type OIteratee<O> = OIterateeWithResult<any, any, O, any>;
 
   declare type AFlatMapIteratee<V, O, R> =
-    | ((item: V, index: number, array: O) => Array<R> | R)
+    | ((item: V, index: number, array: O) => $ReadOnlyArray<R> | R)
     | string
-  declare type OFlatMapIteratee<V, K, O, R> = IterateeWithResult<V, K, O, Array<R> | R>;
+  declare type OFlatMapIteratee<V, K, O, R> = IterateeWithResult<V, K, O, $ReadOnlyArray<R> | R>;
 
   declare type Predicate<T> =
     | ((value: T, index: number, array: Array<T>) => any)


### PR DESCRIPTION
- Links to documentation:
https://lodash.com/docs/4.17.15#flatMap
```
(() => { const arrays = []; console.log(_.flatMap([1,2], (n) => { arrays[n] = [n]; return arrays[n]; })); console.log(arrays); })();
```
- Type of contribution: fix

Other notes:

This broke after updating our codebase after this pr: https://github.com/flow-typed/flow-typed/pull/3777

Since quite often we end up returning bits of redux-state from inside a flatMap, that is marked a as read only array. I am fairly sure lodash doesn't modify the arrays coming from a map.