### PR TITLE
[lodash] _.compact typings

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.104.x-/lodash_v4.x.x.js
@@ -225,7 +225,7 @@ declare module "lodash" {
   declare class Lodash {
     // Array
     chunk<T>(array?: ?$ReadOnlyArray<T>, size?: ?number): Array<Array<T>>;
-    compact<T, N: ?T>(array?: ?$ReadOnlyArray<N>): Array<T>;
+    compact<T, N = ?T | boolean>(array?: ?$ReadOnlyArray<N>): Array<T>;
     concat<T>(
       base?: ?$ReadOnlyArray<T>,
       ...elements: $ReadOnlyArray<any>


### PR DESCRIPTION
- Links to documentation: https://lodash.com/docs/4.17.15#compact
- Type of contribution: fix

I'd like to discuss the correct fix for _.compact. Currently code like this is common in our code base:

```
const array = [
    condition && a,
];
return _.compact<A, A>(array);
```
which fails with the new typings (https://github.com/flow-typed/flow-typed/pull/3777).

As per the docs, the input type can include numbers and strings too, but I think its less common to have a mix of a particular object type and falsey number like `0`.

cc @GAntoine 

Option 1
---------
Don't change the current type definitions.
Users of flow have to write the above code like this instead:
```
const array = [
    condition ? a : null,
];
return _.compact<A, A>(array);
```

Option 2
---------
The solution in this PR - its non breaking - I kept the 2nd argument allowing an escape hatch, but the default allows booleans.
The risk is that someone passes true and booleans leak.
consumer code like this:
```
const array = [
    condition ? a : null,
];
return _.compact<A>(array);
```

Escape hatch allows:

```
const array = [
    number && a,
];
return _.compact<A, A | number>(array);
```

but escape hatch since not type checked allows incorrect types.

Option 3
----------
Breaking change - remove the 2nd argument altogether (no escape hatch).

Option 4
----------
Remove the type assertion that the input is a optional subclass of the output.
Example usage:
```
const array = [
    condition && a,
];
return _.compact<A, A | boolean>(array);
```