### PR TITLE
Add uuid v8

### DIFF
--- a/definitions/npm/uuid_v8.x.x/flow_v0.104.x-/test_uuid_v8.x.x.js
+++ b/definitions/npm/uuid_v8.x.x/flow_v0.104.x-/test_uuid_v8.x.x.js
@@ -1,0 +1,47 @@
+// @flow
+import { v1, v3, v4, v5 } from 'uuid';
+
+(v1(): string);
+(v1({}): string);
+// $ExpectError if buffer is not passed the result is string
+(v1(): Array<number>);
+(v1(null, [0]): Array<number>);
+// $ExpectError if buffer is passed the result is buffer
+(v1(null, [0]): string);
+(v1({}, [0], 5): Array<number>);
+
+(v3([0], ''): string);
+// $ExpectError if buffer is not passed the result is string
+(v3('', ''): Array<number>);
+(v3('', [0]): string);
+(v3('', '', [0]): Array<number>);
+// $ExpectError if buffer is passed the result is buffer
+(v3('', '', [0]): string);
+(v3('', '', [0], 0): Array<number>);
+(v3.DNS: string);
+(v3.URL: string);
+// $ExpectError only DNS and URL static properties exist
+(v3.WRONG: string);
+
+(v4(): string);
+(v4({}): string);
+// $ExpectError if buffer is not passed the result is string
+(v4(): Array<number>);
+(v4(null, [0]): Array<number>);
+// $ExpectError if buffer is passed the result is buffer
+(v4(null, [0]): string);
+(v4({}, [0], 5): Array<number>);
+
+(v5([0], ''): string);
+// $ExpectError if buffer is not passed the result is string
+(v5('', ''): Array<number>);
+(v5('', [0]): string);
+(v5('', '', [0]): Array<number>);
+// $ExpectError if buffer is passed the result is buffer
+(v5('', '', [0]): string);
+(v5('', '', [0], 0): Array<number>);
+(v5.DNS: string);
+(v5.URL: string);
+// $ExpectError only DNS and URL static properties exist
+(v5.WRONG: string);
+

--- a/definitions/npm/uuid_v8.x.x/flow_v0.104.x-/uuid_v8.x.x.js
+++ b/definitions/npm/uuid_v8.x.x/flow_v0.104.x-/uuid_v8.x.x.js
@@ -1,0 +1,71 @@
+declare module 'uuid' {
+  // v1 (Timestamp)
+  declare type V1Options = {|
+    node?: $ReadOnlyArray<number>,
+    clockseq?: number,
+    msecs?: number,
+    nsecs?: number,
+    random?: $ReadOnlyArray<number>,
+    rng?: () => $ReadOnlyArray<number>,
+  |};
+
+  declare export function v1(options?: V1Options): string;
+
+  declare export function v1(
+    options: V1Options | null,
+    buffer: Array<number>,
+    offset?: number
+  ): Array<number>;
+
+  // v3 (Namespace)
+  declare function v3Impl(
+    name: string | $ReadOnlyArray<number>,
+    namespace: string | $ReadOnlyArray<number>
+  ): string;
+
+  declare function v3Impl(
+    name: string | $ReadOnlyArray<number>,
+    namespace: string | $ReadOnlyArray<number>,
+    buffer: Array<number>,
+    offset?: number
+  ): Array<number>;
+
+  declare export var v3: {|
+    [[call]]: typeof v3Impl,
+    DNS: string,
+    URL: string,
+  |};
+
+  // v4 (Random)
+  declare type V4Options = {|
+    random?: $ReadOnlyArray<number>,
+    rng?: () => $ReadOnlyArray<number>,
+  |};
+
+  declare export function v4(options?: V4Options): string;
+
+  declare export function v4(
+    options: V4Options | null,
+    buffer: Array<number>,
+    offset?: number
+  ): Array<number>;
+
+  // v5 (Namespace)
+  declare function v5Impl(
+    name: string | $ReadOnlyArray<number>,
+    namespace: string | $ReadOnlyArray<number>
+  ): string;
+
+  declare function v5Impl(
+    name: string | $ReadOnlyArray<number>,
+    namespace: string | $ReadOnlyArray<number>,
+    buffer: Array<number>,
+    offset?: number
+  ): Array<number>;
+
+  declare export var v5: {|
+    [[call]]: typeof v5Impl,
+    DNS: string,
+    URL: string,
+  |};
+}


### PR DESCRIPTION
All is the same. Only deprecated direct imports dropped and added native
node esm support.

- Link to GitHub or NPM: https://github.com/uuidjs/uuid
- Type of contribution: new definition | addition