### PR TITLE
[@testing-library/react_v10.x.x] add missing getNodeText helper function

### DIFF
--- a/definitions/npm/@testing-library/react_v10.x.x/flow_v0.104.x-/react_v10.x.x.js
+++ b/definitions/npm/@testing-library/react_v10.x.x/flow_v0.104.x-/react_v10.x.x.js
@@ -440,5 +440,8 @@ declare module '@testing-library/react' {
     text: TextMatch,
     options?: TextMatchOptions
   ): HTMLElement;
+  declare export function getNodeText(
+    node: HTMLElement,
+  ): string;
   declare export var screen: Screen<>;
 }

--- a/definitions/npm/@testing-library/react_v10.x.x/flow_v0.104.x-/test_react_v10.x.x.js
+++ b/definitions/npm/@testing-library/react_v10.x.x/flow_v0.104.x-/test_react_v10.x.x.js
@@ -12,6 +12,7 @@ import {
   waitForElementToBeRemoved,
   within,
   screen,
+  getNodeText,
 } from '@testing-library/react';
 import { describe, it } from 'flow-typed-test';
 
@@ -887,6 +888,15 @@ describe('fireEvent', () => {
     fireEvent.animationEnd(htmlEl);
     fireEvent.animationIteration(htmlEl);
     fireEvent.transitionEnd(htmlEl);
+  });
+});
+
+describe('getNodeText', () => {
+  class Component extends React.Component<{ ... }> {};
+  const { container } = render(<Component />);
+
+  it('should return string', () => {
+    const a: string = getNodeText(container);
   });
 });
 


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://testing-library.com/docs/dom-testing-library/api-helpers#getnodetext
- Link to GitHub or NPM: https://www.npmjs.com/package/@testing-library/react
- Type of contribution: addition

Other notes: Add missing function to main export

