### PR TITLE
[moment_v2.x.x] Support moment v2.25 strict string parsing feature

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_v0.104.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.104.x-/moment_v2.x.x.js
@@ -141,6 +141,12 @@ declare class moment$Moment {
   static (string: ?string, format: string | Array<string>): moment$Moment;
   static (
     string: ?string,
+    // Support for strict string parsing without format works since moment v2.25.0
+    // https://github.com/moment/moment/issues/2469
+    strict: boolean
+  ): moment$Moment;
+  static (
+    string: ?string,
     format: string | Array<string>,
     strict: boolean
   ): moment$Moment;
@@ -169,6 +175,12 @@ declare class moment$Moment {
       | void
   ): moment$Moment;
   static utc(string: string, format: string | Array<string>): moment$Moment;
+  static utc(
+    string: string,
+    // Support for strict string parsing without format works since moment v2.25.0
+    // https://github.com/moment/moment/issues/2469
+    strict: boolean
+  ): moment$Moment;
   static utc(
     string: string,
     format: string | Array<string>,

--- a/definitions/npm/moment_v2.x.x/flow_v0.25.x-v0.103.x/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.25.x-v0.103.x/moment_v2.x.x.js
@@ -137,6 +137,12 @@ declare class moment$Moment {
   static (string: ?string, format: string | Array<string>): moment$Moment;
   static (
     string: ?string,
+    // Support for strict string parsing without format works since moment v2.25.0
+    // https://github.com/moment/moment/issues/2469
+    strict: boolean
+  ): moment$Moment;
+  static (
+    string: ?string,
     format: string | Array<string>,
     strict: boolean
   ): moment$Moment;
@@ -165,6 +171,12 @@ declare class moment$Moment {
       | void
   ): moment$Moment;
   static utc(string: string, format: string | Array<string>): moment$Moment;
+  static utc(
+    string: string,
+    // Support for strict string parsing without format works since moment v2.25.0
+    // https://github.com/moment/moment/issues/2469
+    strict: boolean
+  ): moment$Moment;
   static utc(
     string: string,
     format: string | Array<string>,

--- a/definitions/npm/moment_v2.x.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.x.x/test_moment-v2.js
@@ -252,15 +252,14 @@ moment().calendar(null, {
 moment().calendar(null, {
   sameDay: () => "HH:mm"
 });
-// $ExpectError
 moment().calendar(null, {
+  // $ExpectError
   sameDay: (a: number) => "HH:mm"
 });
-// $ExpectError
 moment().calendar(null, {
+  // $ExpectError
   sameDay: 2
 });
-// $ExpectError
 moment().calendar(null, {
   // $ExpectError (>=0.56.0)
   sameElse: () => {}

--- a/definitions/npm/moment_v2.x.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.x.x/test_moment-v2.js
@@ -71,7 +71,6 @@ describe('Parse, moment()', () => {
   moment([2015, 0]); // This would equal 2015-01-01
   // $ExpectError only numbers are valid for Array API
   moment(["2015"]);
-  // $ExpectError needs a format string before the strictness flag
   moment('2015-01-01', true);
 
   // $ExpectError only string values can have formatting parameters
@@ -130,7 +129,6 @@ describe('Parse, moment.utc()', () => {
   moment.utc("05-06-1995", ["MM-DD-YYYY", "DD-MM-YYYY"], 'fr', true);
   // $ExpectError
   moment.utc("05-06-1995", ["MM-DD-YYYY", "DD-MM-YYYY"], 'fr', 1);
-  // $ExpectError needs a format string before the strictness flag
   moment.utc('2015-01-01', true);
 
   moment.utc({ hour: 15, minute: 10 });


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: N/A
- Link to GitHub or NPM: https://github.com/moment/moment/commit/022dc038af5ebafafa375f4566fb23366f4e4aa8, also [changelog](https://github.com/moment/moment/blob/master/CHANGELOG.md#2250-see-full-changelog)
- Type of contribution: addition

Other notes:

In moment v2.25, constructing a `Moment` object via `moment(someString, true)` got allowed.

Note that this PR intentionally _does not fork the `moment` type declarations_ on the `moment_v2.25.x` version boundary. Forking would make updating these type declarations a pain in the future.

Hopefully the small comments I left in the type declarations will help users that aren't running `moment` v2.25 yet to understand that the new API would not work for them.