### PR TITLE
[@testing-library/react] update GetByBoundAttribute to accept generic

### DIFF
--- a/definitions/npm/@testing-library/react_v10.x.x/flow_v0.104.x-/react_v10.x.x.js
+++ b/definitions/npm/@testing-library/react_v10.x.x/flow_v0.104.x-/react_v10.x.x.js
@@ -51,10 +51,10 @@ declare module '@testing-library/react' {
     waitForElementOptions?: WaitForElementOptions
   ) => Promise<HTMLElement[]>;
 
-  declare type GetByBoundAttribute = (
+  declare type GetByBoundAttribute = <T: HTMLElement = HTMLElement>(
     text: TextMatch,
     options?: TextMatchOptions
-  ) => HTMLElement;
+  ) => T;
 
   declare type FindByBoundAttribute = (
     text: TextMatch,


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://testing-library.com/docs/dom-testing-library/api-queries
- Link to GitHub or NPM: https://www.npmjs.com/package/@testing-library/react
- Type of contribution: fix

Other notes:
Update queries to generics such as `getByTestId` which will remove query from returning `HTMLElement` until brackets are used.

Previous behaviour:
```
const element = getByTestId('test'); // element is HTMLElement
const element: HTMLSelectElement = getByTestId('test'); // errors
```

New behaviour
```
const element = getByTestId('test'); // element is any
const element: HTMLSelectElement = getByTestId('test'); // element is HTMLSelectElement
const element = getByTestId<>('test'); // element is HTMLElement
const element = getByTestId<HTMLSelectElement>('test'); // element is HTMLSelectElement
```

Seems like this is probably better behaviour and allows better type casting