### PR TITLE
Jest: improve jest.requireActual type

### DIFF
--- a/definitions/npm/jest_v21.x.x/flow_v0.104.x-/jest_v21.x.x.js
+++ b/definitions/npm/jest_v21.x.x/flow_v0.104.x-/jest_v21.x.x.js
@@ -361,7 +361,7 @@ type JestObjectType = {
   * Returns the actual module instead of a mock, bypassing all checks on
   * whether the module should receive a mock implementation or not.
   */
- requireActual(moduleName: string): any,
+ requireActual<T>(m: $Flow$ModuleRef<T> | string): T,
  /**
   * Returns a mock module instead of the actual module, bypassing all checks
   * on whether the module should be required normally or not.

--- a/definitions/npm/jest_v21.x.x/flow_v0.104.x-/test_jest-v21.x.x.js
+++ b/definitions/npm/jest_v21.x.x/flow_v0.104.x-/test_jest-v21.x.x.js
@@ -290,3 +290,12 @@ expect(wrapper).toMatchSelector("span");
 expect(wrapper).toMatchSelector();
 // $ExpectError
 expect(wrapper).toMatchSelector(true);
+
+{
+  // Type hint becomes the returned type
+  const FooModule1: string = jest.requireActual<string>('FooModule');
+  // $ExpectError Type hint becomes the returned type
+  const FooModule2: number = jest.requireActual<string>('FooModule');
+  // No type hint means we return any
+  const FooModule3: boolean = jest.requireActual('FooModule');
+}

--- a/definitions/npm/jest_v21.x.x/flow_v0.25.x-v0.38.x/jest_v21.x.x.js
+++ b/definitions/npm/jest_v21.x.x/flow_v0.25.x-v0.38.x/jest_v21.x.x.js
@@ -349,7 +349,7 @@ type JestObjectType = {
    * Returns the actual module instead of a mock, bypassing all checks on
    * whether the module should receive a mock implementation or not.
    */
-  requireActual(moduleName: string): any,
+  requireActual<T>(m: $Flow$ModuleRef<T> | string): T,
   /**
    * Returns a mock module instead of the actual module, bypassing all checks
    * on whether the module should be required normally or not.

--- a/definitions/npm/jest_v21.x.x/flow_v0.25.x-v0.38.x/test_jest-v21.x.x.js
+++ b/definitions/npm/jest_v21.x.x/flow_v0.25.x-v0.38.x/test_jest-v21.x.x.js
@@ -207,3 +207,12 @@ expect(wrapper).toMatchSelector("span");
 expect(wrapper).toMatchSelector();
 // $ExpectError
 expect(wrapper).toMatchSelector(true);
+
+{
+  // Type hint becomes the returned type
+  const FooModule1: string = jest.requireActual<string>('FooModule');
+  // $ExpectError Type hint becomes the returned type
+  const FooModule2: number = jest.requireActual<string>('FooModule');
+  // No type hint means we return any
+  const FooModule3: boolean = jest.requireActual('FooModule');
+}

--- a/definitions/npm/jest_v21.x.x/flow_v0.39.x-v0.103.x/jest_v21.x.x.js
+++ b/definitions/npm/jest_v21.x.x/flow_v0.39.x-v0.103.x/jest_v21.x.x.js
@@ -355,7 +355,7 @@ type JestObjectType = {
    * Returns the actual module instead of a mock, bypassing all checks on
    * whether the module should receive a mock implementation or not.
    */
-  requireActual(moduleName: string): any,
+  requireActual<T>(m: $Flow$ModuleRef<T> | string): T,
   /**
    * Returns a mock module instead of the actual module, bypassing all checks
    * on whether the module should be required normally or not.

--- a/definitions/npm/jest_v21.x.x/flow_v0.39.x-v0.103.x/test_jest-v21.x.x.js
+++ b/definitions/npm/jest_v21.x.x/flow_v0.39.x-v0.103.x/test_jest-v21.x.x.js
@@ -292,3 +292,12 @@ expect(wrapper).toMatchSelector("span");
 expect(wrapper).toMatchSelector();
 // $ExpectError
 expect(wrapper).toMatchSelector(true);
+
+{
+  // Type hint becomes the returned type
+  const FooModule1: string = jest.requireActual<string>('FooModule');
+  // $ExpectError Type hint becomes the returned type
+  const FooModule2: number = jest.requireActual<string>('FooModule');
+  // No type hint means we return any
+  const FooModule3: boolean = jest.requireActual('FooModule');
+}

--- a/definitions/npm/jest_v22.x.x/flow_v0.104.x-/jest_v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.104.x-/jest_v22.x.x.js
@@ -673,7 +673,7 @@ type JestObjectType = {
   * Returns the actual module instead of a mock, bypassing all checks on
   * whether the module should receive a mock implementation or not.
   */
- requireActual(moduleName: string): any,
+ requireActual<T>(m: $Flow$ModuleRef<T> | string): T,
  /**
   * Returns a mock module instead of the actual module, bypassing all checks
   * on whether the module should be required normally or not.

--- a/definitions/npm/jest_v22.x.x/flow_v0.104.x-/test_jest-v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.104.x-/test_jest-v22.x.x.js
@@ -493,3 +493,12 @@ expect(wrapper).toMatchSelector(true);
   expect('hello hello world').toIncludeRepeated('hello', 2);
   expect('hello world').toIncludeMultiple(['world', 'hello']);
 }
+
+{
+  // Type hint becomes the returned type
+  const FooModule1: string = jest.requireActual<string>('FooModule');
+  // $ExpectError Type hint becomes the returned type
+  const FooModule2: number = jest.requireActual<string>('FooModule');
+  // No type hint means we return any
+  const FooModule3: boolean = jest.requireActual('FooModule');
+}

--- a/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/jest_v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/jest_v22.x.x.js
@@ -364,7 +364,7 @@ type JestObjectType = {
    * Returns the actual module instead of a mock, bypassing all checks on
    * whether the module should receive a mock implementation or not.
    */
-  requireActual(moduleName: string): any,
+  requireActual<T>(m: $Flow$ModuleRef<T> | string): T,
   /**
    * Returns a mock module instead of the actual module, bypassing all checks
    * on whether the module should be required normally or not.

--- a/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/test_jest-v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/test_jest-v22.x.x.js
@@ -221,3 +221,12 @@ expect(wrapper).toMatchSelector("span");
 expect(wrapper).toMatchSelector();
 // $ExpectError
 expect(wrapper).toMatchSelector(true);
+
+{
+  // Type hint becomes the returned type
+  const FooModule1: string = jest.requireActual<string>('FooModule');
+  // $ExpectError Type hint becomes the returned type
+  const FooModule2: number = jest.requireActual<string>('FooModule');
+  // No type hint means we return any
+  const FooModule3: boolean = jest.requireActual('FooModule');
+}

--- a/definitions/npm/jest_v22.x.x/flow_v0.39.x-v0.103.x/jest_v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.39.x-v0.103.x/jest_v22.x.x.js
@@ -706,7 +706,7 @@ type JestObjectType = {
    * Returns the actual module instead of a mock, bypassing all checks on
    * whether the module should receive a mock implementation or not.
    */
-  requireActual(moduleName: string): any,
+  requireActual<T>(m: $Flow$ModuleRef<T> | string): T,
   /**
    * Returns a mock module instead of the actual module, bypassing all checks
    * on whether the module should be required normally or not.

--- a/definitions/npm/jest_v22.x.x/flow_v0.39.x-v0.103.x/test_jest-v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.39.x-v0.103.x/test_jest-v22.x.x.js
@@ -495,3 +495,12 @@ expect(wrapper).toMatchSelector(true);
   expect('hello hello world').toIncludeRepeated('hello', 2);
   expect('hello world').toIncludeMultiple(['world', 'hello']);
 }
+
+{
+  // Type hint becomes the returned type
+  const FooModule1: string = jest.requireActual<string>('FooModule');
+  // $ExpectError Type hint becomes the returned type
+  const FooModule2: number = jest.requireActual<string>('FooModule');
+  // No type hint means we return any
+  const FooModule3: boolean = jest.requireActual('FooModule');
+}

--- a/definitions/npm/jest_v23.x.x/flow_v0.104.x-/jest_v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.104.x-/jest_v23.x.x.js
@@ -790,7 +790,7 @@ type JestObjectType = {
   * Returns the actual module instead of a mock, bypassing all checks on
   * whether the module should receive a mock implementation or not.
   */
- requireActual(moduleName: string): any,
+ requireActual<T>(m: $Flow$ModuleRef<T> | string): T,
  /**
   * Returns a mock module instead of the actual module, bypassing all checks
   * on whether the module should be required normally or not.

--- a/definitions/npm/jest_v23.x.x/flow_v0.104.x-/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.104.x-/test_jest-v23.x.x.js
@@ -688,3 +688,12 @@ expect(wrapper).toHaveDisplayName(true);
   expect('hello hello world').toIncludeRepeated('hello', 2);
   expect('hello world').toIncludeMultiple(['world', 'hello']);
 }
+
+{
+  // Type hint becomes the returned type
+  const FooModule1: string = jest.requireActual<string>('FooModule');
+  // $ExpectError Type hint becomes the returned type
+  const FooModule2: number = jest.requireActual<string>('FooModule');
+  // No type hint means we return any
+  const FooModule3: boolean = jest.requireActual('FooModule');
+}

--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-v0.103.x/jest_v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-v0.103.x/jest_v23.x.x.js
@@ -821,7 +821,7 @@ type JestObjectType = {
    * Returns the actual module instead of a mock, bypassing all checks on
    * whether the module should receive a mock implementation or not.
    */
-  requireActual(moduleName: string): any,
+  requireActual<T>(m: $Flow$ModuleRef<T> | string): T,
   /**
    * Returns a mock module instead of the actual module, bypassing all checks
    * on whether the module should be required normally or not.

--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-v0.103.x/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-v0.103.x/test_jest-v23.x.x.js
@@ -687,3 +687,12 @@ expect(wrapper).toHaveDisplayName(true);
   expect('hello hello world').toIncludeRepeated('hello', 2);
   expect('hello world').toIncludeMultiple(['world', 'hello']);
 }
+
+{
+  // Type hint becomes the returned type
+  const FooModule1: string = jest.requireActual<string>('FooModule');
+  // $ExpectError Type hint becomes the returned type
+  const FooModule2: number = jest.requireActual<string>('FooModule');
+  // No type hint means we return any
+  const FooModule3: boolean = jest.requireActual('FooModule');
+}

--- a/definitions/npm/jest_v24.x.x/flow_v0.104.x-/jest_v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.104.x-/jest_v24.x.x.js
@@ -830,7 +830,7 @@ type JestObjectType = {
   * Returns the actual module instead of a mock, bypassing all checks on
   * whether the module should receive a mock implementation or not.
   */
- requireActual(moduleName: string): any,
+ requireActual<T>(m: $Flow$ModuleRef<T> | string): T,
  /**
   * Returns a mock module instead of the actual module, bypassing all checks
   * on whether the module should be required normally or not.

--- a/definitions/npm/jest_v24.x.x/flow_v0.104.x-/test_jest-v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.104.x-/test_jest-v24.x.x.js
@@ -731,3 +731,12 @@ expect(wrapper).toHaveDisplayName(true);
   expect('hello hello world').toIncludeRepeated('hello', 2);
   expect('hello world').toIncludeMultiple(['world', 'hello']);
 }
+
+{
+  // Type hint becomes the returned type
+  const FooModule1: string = jest.requireActual<string>('FooModule');
+  // $ExpectError Type hint becomes the returned type
+  const FooModule2: number = jest.requireActual<string>('FooModule');
+  // No type hint means we return any
+  const FooModule3: boolean = jest.requireActual('FooModule');
+}

--- a/definitions/npm/jest_v24.x.x/flow_v0.61.x-v0.103.x/jest_v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.61.x-v0.103.x/jest_v24.x.x.js
@@ -870,7 +870,7 @@ type JestObjectType = {
    * Returns the actual module instead of a mock, bypassing all checks on
    * whether the module should receive a mock implementation or not.
    */
-  requireActual(moduleName: string): any,
+  requireActual<T>(m: $Flow$ModuleRef<T> | string): T,
   /**
    * Returns a mock module instead of the actual module, bypassing all checks
    * on whether the module should be required normally or not.

--- a/definitions/npm/jest_v24.x.x/flow_v0.61.x-v0.103.x/test_jest-v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.61.x-v0.103.x/test_jest-v24.x.x.js
@@ -730,3 +730,12 @@ expect(wrapper).toHaveDisplayName(true);
   expect('hello hello world').toIncludeRepeated('hello', 2);
   expect('hello world').toIncludeMultiple(['world', 'hello']);
 }
+
+{
+  // Type hint becomes the returned type
+  const FooModule1: string = jest.requireActual<string>('FooModule');
+  // $ExpectError Type hint becomes the returned type
+  const FooModule2: number = jest.requireActual<string>('FooModule');
+  // No type hint means we return any
+  const FooModule3: boolean = jest.requireActual('FooModule');
+}

--- a/definitions/npm/jest_v25.x.x/flow_v0.104.x-/jest_v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.104.x-/jest_v25.x.x.js
@@ -240,7 +240,7 @@ type DomTestingLibraryType = {
  toHaveClass(...classNames: string[]): void,
  toHaveFocus(): void,
  toHaveFormValues(expectedValues: { [name: string]: any, ... }): void,
- toHaveStyle(css: string | { [name: string]: any, ... }): void, 
+ toHaveStyle(css: string | { [name: string]: any, ... }): void,
  toHaveTextContent(
    text: string | RegExp,
    options?: {| normalizeWhitespace: boolean |}
@@ -836,7 +836,7 @@ type JestObjectType = {
   * Returns the actual module instead of a mock, bypassing all checks on
   * whether the module should receive a mock implementation or not.
   */
- requireActual(moduleName: string): any,
+ requireActual<T>(m: $Flow$ModuleRef<T> | string): T,
  /**
   * Returns a mock module instead of the actual module, bypassing all checks
   * on whether the module should be required normally or not.

--- a/definitions/npm/jest_v25.x.x/flow_v0.104.x-/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.104.x-/test_jest-v25.x.x.js
@@ -737,3 +737,12 @@ expect(wrapper).toHaveDisplayName(true);
   expect('hello hello world').toIncludeRepeated('hello', 2);
   expect('hello world').toIncludeMultiple(['world', 'hello']);
 }
+
+{
+  // Type hint becomes the returned type
+  const FooModule1: string = jest.requireActual<string>('FooModule');
+  // $ExpectError Type hint becomes the returned type
+  const FooModule2: number = jest.requireActual<string>('FooModule');
+  // No type hint means we return any
+  const FooModule3: boolean = jest.requireActual('FooModule');
+}

--- a/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/jest_v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/jest_v25.x.x.js
@@ -870,7 +870,7 @@ type JestObjectType = {
    * Returns the actual module instead of a mock, bypassing all checks on
    * whether the module should receive a mock implementation or not.
    */
-  requireActual(moduleName: string): any,
+  requireActual<T>(m: $Flow$ModuleRef<T> | string): T,
   /**
    * Returns a mock module instead of the actual module, bypassing all checks
    * on whether the module should be required normally or not.

--- a/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/test_jest-v25.x.x.js
@@ -730,3 +730,12 @@ expect(wrapper).toHaveDisplayName(true);
   expect('hello hello world').toIncludeRepeated('hello', 2);
   expect('hello world').toIncludeMultiple(['world', 'hello']);
 }
+
+{
+  // Type hint becomes the returned type
+  const FooModule1: string = jest.requireActual<string>('FooModule');
+  // $ExpectError Type hint becomes the returned type
+  const FooModule2: number = jest.requireActual<string>('FooModule');
+  // No type hint means we return any
+  const FooModule3: boolean = jest.requireActual('FooModule');
+}

--- a/definitions/npm/jest_v26.x.x/flow_v0.104.x-/jest_v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.104.x-/jest_v26.x.x.js
@@ -842,7 +842,7 @@ type JestObjectType = {
    * Returns the actual module instead of a mock, bypassing all checks on
    * whether the module should receive a mock implementation or not.
    */
-  requireActual(moduleName: string): any,
+  requireActual<T>(m: $Flow$ModuleRef<T> | string): T,
   /**
    * Returns a mock module instead of the actual module, bypassing all checks
    * on whether the module should be required normally or not.

--- a/definitions/npm/jest_v26.x.x/flow_v0.104.x-/test_jest-v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.104.x-/test_jest-v26.x.x.js
@@ -747,3 +747,12 @@ expect(wrapper).toHaveDisplayName(true);
   expect('hello hello world').toIncludeRepeated('hello', 2);
   expect('hello world').toIncludeMultiple(['world', 'hello']);
 }
+
+{
+  // Type hint becomes the returned type
+  const FooModule1: string = jest.requireActual<string>('FooModule');
+  // $ExpectError Type hint becomes the returned type
+  const FooModule2: number = jest.requireActual<string>('FooModule');
+  // No type hint means we return any
+  const FooModule3: boolean = jest.requireActual('FooModule');
+}


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://jestjs.io/docs/en/jest-object#jestrequireactualmodulename
- Link to GitHub or NPM: https://github.com/facebook/jest/blob/master/e2e/__tests__/jestRequireActual.test.ts
- Type of contribution: addition


W.r.t. `requireActual`, here's an example of how to use it with the new generic type argument:

```js
// Assuming you have:
import typeof MyModule from 'MyModule';
// where MyModule is a type like `{}`

// Before
const myModule = requireActual('MyModule');

// Casting myModule to arbitrary types
(myModule: MyModule) // OK, but we're actually not sure
(myModule: 'do not trust me') // Flow says it's ok, but it's not!

// After
const myModule = requireActual<MyModule>('MyModule');

// Casting myModule to arbitrary types
(myModule: MyModule) // OK
(myModule: 'do not trust me') // Flow error as expected
```