### PR TITLE
[react-navigation] Libdefs for React Nav 5

### DIFF
--- a/definitions/npm/@react-navigation/bottom-tabs_v5.x.x/CONTRIBUTING.md
+++ b/definitions/npm/@react-navigation/bottom-tabs_v5.x.x/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to the React Navigation Flow libdef
+
+## Overview
+
+There are seven React Navigation libdefs in `flow-typed`:
+
+1. `@react-navigation/core`
+2. `@react-navigation/native`
+3. `@react-navigation/stack`
+4. `@react-navigation/bottom-tabs`
+5. `@react-navigation/material-bottom-tabs`
+6. `@react-navigation/material-top-tabs`
+7. `@react-navigation/drawer`
+
+It's not currently possible to import types between libdefs. Consequently, many of the same types are copy-pasted across the different libdefs.
+
+Each libdef is organized into two sections. The first section should be identical between all of the libdefs. If you make a change to this section, please make sure to mirror it across the other libdefs.
+
+## Contributors
+
+- @Ashoat

--- a/definitions/npm/@react-navigation/bottom-tabs_v5.x.x/flow_v0.104.x-/bottom-tabs_v5.x.x.js
+++ b/definitions/npm/@react-navigation/bottom-tabs_v5.x.x/flow_v0.104.x-/bottom-tabs_v5.x.x.js
@@ -1,0 +1,1975 @@
+declare module '@react-navigation/bottom-tabs' {
+
+  //---------------------------------------------------------------------------
+  // SECTION 1: IDENTICAL TYPE DEFINITIONS
+  // This section is identical across all React Navigation libdefs and contains
+  // shared definitions. We wish we could make it DRY and import from a shared
+  // definition, but that isn't yet possible.
+  //---------------------------------------------------------------------------
+
+  /**
+   * We start with some definitions that we have copy-pasted from React Native
+   * source files.
+   */
+
+  // This is a bastardization of the true StyleObj type located in
+  // react-native/Libraries/StyleSheet/StyleSheetTypes. We unfortunately can't
+  // import that here, and it's too lengthy (and consequently too brittle) to
+  // copy-paste here either.
+  declare type StyleObj =
+    | null
+    | void
+    | number
+    | false
+    | ''
+    | $ReadOnlyArray<StyleObj>
+    | { [name: string]: any, ... };
+  declare type ViewStyleProp = StyleObj;
+  declare type TextStyleProp = StyleObj;
+  declare type AnimatedViewStyleProp = StyleObj;
+  declare type AnimatedTextStyleProp = StyleObj;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/animations/Animation.js
+  declare type EndResult = { finished: boolean, ... };
+  declare type EndCallback = (result: EndResult) => void;
+  declare interface Animation {
+    start(
+      fromValue: number,
+      onUpdate: (value: number) => void,
+      onEnd: ?EndCallback,
+      previousAnimation: ?Animation,
+      animatedValue: AnimatedValue,
+    ): void;
+    stop(): void;
+  }
+  declare type AnimationConfig = {
+    isInteraction?: boolean,
+    useNativeDriver: boolean,
+    onComplete?: ?EndCallback,
+    iterations?: number,
+    ...
+  };
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedTracking.js
+  declare interface AnimatedTracking {
+    constructor(
+      value: AnimatedValue,
+      parent: any,
+      animationClass: any,
+      animationConfig: Object,
+      callback?: ?EndCallback,
+    ): void;
+    update(): void;
+  }
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedValue.js
+  declare type ValueListenerCallback = (state: { value: number, ... }) => void;
+  declare interface AnimatedValue {
+    constructor(value: number): void;
+    setValue(value: number): void;
+    setOffset(offset: number): void;
+    flattenOffset(): void;
+    extractOffset(): void;
+    addListener(callback: ValueListenerCallback): string;
+    removeListener(id: string): void;
+    removeAllListeners(): void;
+    stopAnimation(callback?: ?(value: number) => void): void;
+    resetAnimation(callback?: ?(value: number) => void): void;
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+    animate(animation: Animation, callback: ?EndCallback): void;
+    stopTracking(): void;
+    track(tracking: AnimatedTracking): void;
+  }
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/TimingAnimation.js
+  declare type TimingAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    easing?: (value: number) => number,
+    duration?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/SpringAnimation.js
+  declare type SpringAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    overshootClamping?: boolean,
+    restDisplacementThreshold?: number,
+    restSpeedThreshold?: number,
+    velocity?: number,
+    bounciness?: number,
+    speed?: number,
+    tension?: number,
+    friction?: number,
+    stiffness?: number,
+    damping?: number,
+    mass?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from react-native/Libraries/Types/CoreEventTypes.js
+  declare type SyntheticEvent<T> = $ReadOnly<{|
+    bubbles: ?boolean,
+    cancelable: ?boolean,
+    currentTarget: number,
+    defaultPrevented: ?boolean,
+    dispatchConfig: $ReadOnly<{|
+      registrationName: string,
+    |}>,
+    eventPhase: ?number,
+    preventDefault: () => void,
+    isDefaultPrevented: () => boolean,
+    stopPropagation: () => void,
+    isPropagationStopped: () => boolean,
+    isTrusted: ?boolean,
+    nativeEvent: T,
+    persist: () => void,
+    target: ?number,
+    timeStamp: number,
+    type: ?string,
+  |}>;
+  declare type Layout = $ReadOnly<{|
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  |}>;
+  declare type LayoutEvent = SyntheticEvent<
+    $ReadOnly<{|
+      layout: Layout,
+    |}>,
+  >;
+  declare type BlurEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type FocusEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type ResponderSyntheticEvent<T> = $ReadOnly<{|
+    ...SyntheticEvent<T>,
+    touchHistory: $ReadOnly<{|
+      indexOfSingleActiveTouch: number,
+      mostRecentTimeStamp: number,
+      numberActiveTouches: number,
+      touchBank: $ReadOnlyArray<
+        $ReadOnly<{|
+          touchActive: boolean,
+          startPageX: number,
+          startPageY: number,
+          startTimeStamp: number,
+          currentPageX: number,
+          currentPageY: number,
+          currentTimeStamp: number,
+          previousPageX: number,
+          previousPageY: number,
+          previousTimeStamp: number,
+        |}>,
+      >,
+    |}>,
+  |}>;
+  declare type PressEvent = ResponderSyntheticEvent<
+    $ReadOnly<{|
+      changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+      force: number,
+      identifier: number,
+      locationX: number,
+      locationY: number,
+      pageX: number,
+      pageY: number,
+      target: ?number,
+      timestamp: number,
+      touches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+    |}>,
+  >;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+  declare type ExtrapolateType = 'extend' | 'identity' | 'clamp';
+  declare type InterpolationConfigType = {
+    inputRange: Array<number>,
+    outputRange: Array<number> | Array<string>,
+    easing?: (input: number) => number,
+    extrapolate?: ExtrapolateType,
+    extrapolateLeft?: ExtrapolateType,
+    extrapolateRight?: ExtrapolateType,
+    ...
+  };
+  declare interface AnimatedInterpolation {
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+  }
+
+  // Copied from react-native/Libraries/Components/View/ViewAccessibility.js
+  declare type AccessibilityRole =
+    | 'none'
+    | 'button'
+    | 'link'
+    | 'search'
+    | 'image'
+    | 'keyboardkey'
+    | 'text'
+    | 'adjustable'
+    | 'imagebutton'
+    | 'header'
+    | 'summary'
+    | 'alert'
+    | 'checkbox'
+    | 'combobox'
+    | 'menu'
+    | 'menubar'
+    | 'menuitem'
+    | 'progressbar'
+    | 'radio'
+    | 'radiogroup'
+    | 'scrollbar'
+    | 'spinbutton'
+    | 'switch'
+    | 'tab'
+    | 'tablist'
+    | 'timer'
+    | 'toolbar';
+  declare type AccessibilityActionInfo = $ReadOnly<{
+    name: string,
+    label?: string,
+    ...
+  }>;
+  declare type AccessibilityActionEvent = SyntheticEvent<
+    $ReadOnly<{actionName: string, ...}>,
+  >;
+  declare type AccessibilityState = {
+    disabled?: boolean,
+    selected?: boolean,
+    checked?: ?boolean | 'mixed',
+    busy?: boolean,
+    expanded?: boolean,
+    ...
+  };
+  declare type AccessibilityValue = $ReadOnly<{|
+    min?: number,
+    max?: number,
+    now?: number,
+    text?: string,
+  |}>;
+
+  // Copied from
+  // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+  declare type Stringish = string;
+  declare type EdgeInsetsProp = $ReadOnly<$Shape<EdgeInsets>>;
+  declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
+    accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+    accessibilityElementsHidden?: ?boolean,
+    accessibilityHint?: ?Stringish,
+    accessibilityIgnoresInvertColors?: ?boolean,
+    accessibilityLabel?: ?Stringish,
+    accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
+    accessibilityRole?: ?AccessibilityRole,
+    accessibilityState?: ?AccessibilityState,
+    accessibilityValue?: ?AccessibilityValue,
+    accessibilityViewIsModal?: ?boolean,
+    accessible?: ?boolean,
+    children?: ?React$Node,
+    delayLongPress?: ?number,
+    delayPressIn?: ?number,
+    delayPressOut?: ?number,
+    disabled?: ?boolean,
+    focusable?: ?boolean,
+    hitSlop?: ?EdgeInsetsProp,
+    importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
+    nativeID?: ?string,
+    onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+    onBlur?: ?(event: BlurEvent) => mixed,
+    onFocus?: ?(event: FocusEvent) => mixed,
+    onLayout?: ?(event: LayoutEvent) => mixed,
+    onLongPress?: ?(event: PressEvent) => mixed,
+    onPress?: ?(event: PressEvent) => mixed,
+    onPressIn?: ?(event: PressEvent) => mixed,
+    onPressOut?: ?(event: PressEvent) => mixed,
+    pressRetentionOffset?: ?EdgeInsetsProp,
+    rejectResponderTermination?: ?boolean,
+    testID?: ?string,
+    touchSoundDisabled?: ?boolean,
+  |}>;
+
+  // Copied from react-native/Libraries/Image/ImageSource.js
+  declare type ImageURISource = $ReadOnly<{
+    uri?: ?string,
+    bundle?: ?string,
+    method?: ?string,
+    headers?: ?Object,
+    body?: ?string,
+    cache?: ?('default' | 'reload' | 'force-cache' | 'only-if-cached'),
+    width?: ?number,
+    height?: ?number,
+    scale?: ?number,
+    ...
+  }>;
+
+  /**
+   * The following is copied from react-native-gesture-handler's libdef
+   */
+
+  declare type $EventHandlers<ExtraProps: {...}> = {|
+    onGestureEvent?: ($Event<ExtraProps>) => mixed,
+    onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
+    onBegan?: ($Event<ExtraProps>) => mixed,
+    onFailed?: ($Event<ExtraProps>) => mixed,
+    onCancelled?: ($Event<ExtraProps>) => mixed,
+    onActivated?: ($Event<ExtraProps>) => mixed,
+    onEnded?: ($Event<ExtraProps>) => mixed,
+  |};
+
+  declare type HitSlop =
+    | number
+    | {|
+        left?: number,
+        top?: number,
+        right?: number,
+        bottom?: number,
+        vertical?: number,
+        horizontal?: number,
+        width?: number,
+        height?: number,
+      |}
+    | {|
+        width: number,
+        left: number,
+      |}
+    | {|
+        width: number,
+        right: number,
+      |}
+    | {|
+        height: number,
+        top: number,
+      |}
+    | {|
+        height: number,
+        bottom: number,
+      |};
+
+  declare type $GestureHandlerProps<
+    AdditionalProps: {...},
+    ExtraEventsProps: {...}
+  > = $ReadOnly<{|
+    ...$Exact<AdditionalProps>,
+    ...$EventHandlers<ExtraEventsProps>,
+    id?: string,
+    enabled?: boolean,
+    waitFor?: React$Ref<any> | Array<React$Ref<any>>,
+    simultaneousHandlers?: React$Ref<any> | Array<React$Ref<any>>,
+    shouldCancelWhenOutside?: boolean,
+    minPointers?: number,
+    hitSlop?: HitSlop,
+    children?: React$Node,
+  |}>;
+
+  declare type PanGestureHandlerProps = $GestureHandlerProps<
+    {
+      activeOffsetY?: number | [number, number],
+      activeOffsetX?: number | [number, number],
+      failOffsetY?: number | [number, number],
+      failOffsetX?: number | [number, number],
+      minDist?: number,
+      minVelocity?: number,
+      minVelocityX?: number,
+      minVelocityY?: number,
+      minPointers?: number,
+      maxPointers?: number,
+      avgTouches?: boolean,
+      ...
+    },
+    {
+      x: number,
+      y: number,
+      absoluteX: number,
+      absoluteY: number,
+      translationX: number,
+      translationY: number,
+      velocityX: number,
+      velocityY: number,
+      ...
+    }
+  >;
+
+  /**
+   * MAGIC
+   */
+
+  declare type $If<Test: boolean, Then, Else = empty> = $Call<
+    ((true, Then, Else) => Then) & ((false, Then, Else) => Else),
+    Test,
+    Then,
+    Else,
+  >;
+  declare type $IsA<X, Y> = $Call<
+    (Y => true) & (mixed => false),
+    X,
+  >;
+  declare type $IsUndefined<X> = $IsA<X, void>;
+
+  declare type $Partial<T> = $Rest<T, {...}>;
+
+  /**
+   * Actions, state, etc.
+   */
+
+  declare export type ScreenParams = { +[key: string]: mixed, ... };
+
+  declare export type BackAction = {|
+    +type: 'GO_BACK',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type NavigateAction = {|
+    +type: 'NAVIGATE',
+    +payload:
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ResetAction = {|
+    +type: 'RESET',
+    +payload: StaleNavigationState,
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type SetParamsAction = {|
+    +type: 'SET_PARAMS',
+    +payload: {| +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CommonAction =
+    | BackAction
+    | NavigateAction
+    | ResetAction
+    | SetParamsAction;
+
+  declare type NavigateActionCreator = {|
+    (routeName: string, params?: ScreenParams): NavigateAction,
+    (
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    ): NavigateAction,
+  |};
+  declare export type CommonActionsType = {|
+    +navigate: NavigateActionCreator,
+    +goBack: () => BackAction,
+    +reset: (state: PossiblyStaleNavigationState) => ResetAction,
+    +setParams: (params: ScreenParams) => SetParamsAction,
+  |};
+
+  declare export type GenericNavigationAction = {|
+    +type: string,
+    +payload?: { +[key: string]: mixed, ... },
+    +source?: string,
+    +target?: string,
+  |};
+
+  declare export type LeafRoute<RouteName: string = string> = {|
+    +key: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StateRoute<RouteName: string = string> = {|
+    ...LeafRoute<RouteName>,
+    +state: NavigationState | StaleNavigationState,
+  |};
+  declare export type Route<RouteName: string = string> =
+    | LeafRoute<RouteName>
+    | StateRoute<RouteName>;
+
+  declare export type NavigationState = {|
+    +key: string,
+    +index: number,
+    +routeNames: $ReadOnlyArray<string>,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<Route<>>,
+    +type: string,
+    +stale: false,
+  |};
+
+  declare export type StaleLeafRoute<RouteName: string = string> = {|
+    +key?: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StaleStateRoute<RouteName: string = string> = {|
+    ...StaleLeafRoute<RouteName>,
+    +state: StaleNavigationState,
+  |};
+  declare export type StaleRoute<RouteName: string = string> =
+    | StaleLeafRoute<RouteName>
+    | StaleStateRoute<RouteName>;
+  declare export type StaleNavigationState = {|
+    // It's possible to pass React Nav a StaleNavigationState with an undefined
+    // index, but React Nav will always return one with the index set. This is
+    // the same as for the type property below, but in the case of index we tend
+    // to rely on it being set more...
+    +index: number,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<StaleRoute<>>,
+    +type?: string,
+    +stale?: true,
+  |};
+
+  declare export type PossiblyStaleNavigationState =
+    | NavigationState
+    | StaleNavigationState;
+  declare export type PossiblyStaleRoute<RouteName: string = string> =
+    | Route<RouteName>
+    | StaleRoute<RouteName>;
+
+  /**
+   * Routers
+   */
+
+  declare type ActionCreators<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {
+    +[key: string]: (...args: any) => (Action | State => Action),
+    ...
+  };
+
+  declare export type DefaultRouterOptions = {
+    +initialRouteName?: string,
+    ...
+  };
+
+  declare export type RouterFactory<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    RouterOptions: DefaultRouterOptions,
+  > = (options: RouterOptions) => Router<State, Action>;
+
+  declare export type ParamListBase = { +[key: string]: ?ScreenParams, ... };
+
+  declare export type RouterConfigOptions = {|
+    +routeNames: $ReadOnlyArray<string>,
+    +routeParamList: ParamListBase,
+  |};
+
+  declare export type Router<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {|
+    +type: $PropertyType<State, 'type'>,
+    +getInitialState: (options: RouterConfigOptions) => State,
+    +getRehydratedState: (
+      partialState: PossibleStaleNavigationState,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteNamesChange: (
+      state: State,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteFocus: (state: State, key: string) => State,
+    +getStateForAction: (
+      state: State,
+      action: Action,
+      options: RouterConfigOptions,
+    ) => ?PossiblyStaleNavigationState;
+    +shouldActionChangeFocus: (action: GenericNavigationAction) => boolean,
+    +actionCreators?: ActionCreators<State, Action>,
+  |};
+
+  /**
+   * Stack actions and router
+   */
+
+  declare export type StackNavigationState = {|
+    ...NavigationState,
+    +type: 'stack',
+  |};
+
+  declare export type ReplaceAction = {|
+    +type: 'REPLACE',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PushAction = {|
+    +type: 'PUSH',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopAction = {|
+    +type: 'POP',
+    +payload: {| +count: number |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopToTopAction = {|
+    +type: 'POP_TO_TOP',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type StackAction =
+    | CommonAction
+    | ReplaceAction
+    | PushAction
+    | PopAction
+    | PopToTopAction;
+
+  declare export type StackActionsType = {|
+    +replace: (routeName: string, params?: ScreenParams) => ReplaceAction,
+    +push: (routeName: string, params?: ScreenParams) => PushAction,
+    +pop: (count?: number) => PopAction,
+    +popToTop: () => PopToTopAction,
+  |};
+
+  declare export type StackRouterOptions = $Exact<DefaultRouterOptions>;
+
+  /**
+   * Tab actions and router
+   */
+
+  declare export type TabNavigationState = {|
+    ...NavigationState,
+    +type: 'tab',
+    +history: $ReadOnlyArray<{| type: 'route', key: string |}>,
+  |};
+
+  declare export type JumpToAction = {|
+    +type: 'JUMP_TO',
+    +payload: {| +name: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type TabAction =
+    | CommonAction
+    | JumpToAction;
+
+  declare export type TabActionsType = {|
+    +jumpTo: string => JumpToAction,
+  |};
+
+  declare export type TabRouterOptions = {|
+    ...$Exact<DefaultRouterOptions>,
+    +backBehavior?: 'initialRoute' | 'order' | 'history' | 'none',
+  |};
+
+  /**
+   * Drawer actions and router
+   */
+
+  declare type DrawerHistoryEntry =
+    | {| +type: 'route', +key: string |}
+    | {| +type: 'drawer' |};
+  declare export type DrawerNavigationState = {|
+    ...NavigationState,
+    +type: 'drawer',
+    +history: $ReadOnlyArray<DrawerHistoryEntry>,
+  |};
+
+  declare export type OpenDrawerAction = {|
+    +type: 'OPEN_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CloseDrawerAction = {|
+    +type: 'CLOSE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ToggleDrawerAction = {|
+    +type: 'TOGGLE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type DrawerAction =
+    | TabAction
+    | OpenDrawerAction
+    | CloseDrawerAction
+    | ToggleDrawerAction;
+
+  declare export type DrawerActionsType = {|
+    ...TabActionsType,
+    +openDrawer: () => OpenDrawerAction,
+    +closeDrawer: () => CloseDrawerAction,
+    +toggleDrawer: () => ToggleDrawerAction,
+  |};
+
+  declare export type DrawerRouterOptions = {|
+    ...TabRouterOptions,
+    +openByDefault?: boolean,
+  |};
+
+  /**
+   * Events
+   */
+
+  declare export type EventMapBase = {
+    +[name: string]: {|
+      +data?: mixed,
+      +canPreventDefault?: boolean,
+    |},
+    ...
+  };
+  declare type EventPreventDefaultProperties<Test: boolean> = $If<
+    Test,
+    {| +defaultPrevented: boolean, +preventDefault: () => void |},
+    {| |},
+  >;
+  declare type EventDataProperties<Data> = $If<
+    $IsUndefined<Data>,
+    {| |},
+    {| +data: Data |},
+  >;
+  declare type EventArg<
+    EventName: string,
+    CanPreventDefault: ?boolean = false,
+    Data = void,
+  > = {|
+    ...EventPreventDefaultProperties<CanPreventDefault>,
+    ...EventDataProperties<Data>,
+    +type: EventName,
+    +target?: string,
+  |};
+  declare type GlobalEventMap<State: PossiblyStaleNavigationState> = {|
+    +state: {| +data: {| +state: State |}, +canPreventDefault: false |},
+  |};
+  declare type EventMapCore<State: PossiblyStaleNavigationState> = {|
+    ...GlobalEventMap<State>,
+    +focus: {| +data: void, +canPreventDefault: false |},
+    +blur: {| +data: void, +canPreventDefault: false |},
+  |};
+  declare type EventListenerCallback<
+    EventName: string,
+    State: NavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = (e: EventArg<
+    EventName,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'canPreventDefault',
+    >,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'data',
+    >,
+  >) => mixed;
+
+  /**
+   * Navigation prop
+   */
+
+  declare export type SimpleNavigate<ParamList> =
+    <DestinationRouteName: $Keys<ParamList>>(
+      routeName: DestinationRouteName,
+      params: $ElementType<ParamList, DestinationRouteName>,
+    ) => void;
+
+  declare export type Navigate<ParamList> =
+    & SimpleNavigate<ParamList>
+    & <DestinationRouteName: $Keys<ParamList>>(
+        route:
+          | {|
+              key: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |}
+          | {|
+              name: DestinationRouteName,
+              key?: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |},
+      ) => void;
+
+  declare type NavigationHelpers<
+    ParamList: ParamListBase,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    +navigate: Navigate<ParamList>,
+    +dispatch: (
+      action:
+        | GenericNavigationAction
+        | (State => GenericNavigationAction),
+    ) => void,
+    +reset: PossiblyStaleNavigationState => void,
+    +goBack: () => void,
+    +isFocused: () => boolean,
+    +canGoBack: () => boolean,
+    +dangerouslyGetParent: <Parent: NavigationProp<ParamListBase>>() => ?Parent,
+    +dangerouslyGetState: () => NavigationState,
+    +addListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => () => void,
+    +removeListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => void,
+    ...
+  };
+
+  declare export type NavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    ...$Exact<NavigationHelpers<
+      ParamList,
+      State,
+      EventMap,
+    >>,
+    +setOptions: (options: $Shape<ScreenOptions>) => void,
+    +setParams: (
+      params: $If<
+        $IsUndefined<$ElementType<ParamList, RouteName>>,
+        empty,
+        $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+      >,
+    ) => void,
+    ...
+  };
+
+  /**
+   * CreateNavigator
+   */
+
+  declare export type RouteProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+  > = {|
+    ...LeafRoute<RouteName>,
+    +params: $ElementType<ParamList, RouteName>,
+  |};
+
+  declare export type ScreenListeners<
+    EventMap: EventMapBase = EventMapCore<State>,
+    State: NavigationState = NavigationState,
+  > = $ObjMapi<
+    {| [name: $Keys<EventMap>]: empty |},
+    <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
+  >;
+
+  declare type BaseScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {|
+    +name: RouteName,
+    +options?:
+      | ScreenOptions
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenOptions,
+    +listeners?:
+      | ScreenListeners<EventMap, State>
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenListeners<EventMap, State>,
+    +initialParams?: $Shape<$ElementType<ParamList, RouteName>>,
+  |};
+
+  declare export type ScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > =
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +component: React$ComponentType<{|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}>,
+      |}
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +children: ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => React$Node,
+      |};
+
+  declare export type ScreenComponent<
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = <
+    RouteName: $Keys<ParamList>,
+    NavProp: NavigationProp<
+      GlobalParamList,
+      RouteName,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+  >(props: ScreenProps<
+    ParamList,
+    NavProp,
+    RouteName,
+    State,
+    ScreenOptions,
+    EventMap,
+  >) => React$Node;
+
+  declare type ScreenOptionsProp<ScreenOptions: {...}, NavProp> = {|
+    +screenOptions?:
+      | ScreenOptions
+      | ({| route: LeafRoute<>, navigation: NavProp |}) => ScreenOptions,
+  |};
+  declare export type ExtraNavigatorPropsBase = {
+    ...$Exact<DefaultRouterOptions>,
+    +children?: React$Node,
+    ...
+  };
+  declare export type NavigatorPropsBase<ScreenOptions: {...}, NavProp> = {
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    ...
+  };
+
+  declare export type CreateNavigator<
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  > = <
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    NavProp: NavigationHelpers<
+      GlobalParamList,
+      State,
+      EventMap,
+    >,
+  >() => {|
+    +Screen: ScreenComponent<
+      GlobalParamList,
+      ParamList,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+    +Navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorProps>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  |};
+
+  declare export type CreateNavigatorFactory = <
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    NavProp: NavigationHelpers<
+      ParamListBase,
+      State,
+      EventMap,
+    >,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  >(
+    navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorPropsBase>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  ) => CreateNavigator<State, ScreenOptions, EventMap, ExtraNavigatorProps>;
+
+  /**
+   * useNavigationBuilder
+   */
+
+  declare export type Descriptor<
+    NavProp,
+    ScreenOptions: {...} = {...},
+  > = {|
+    +render: () => React$Node,
+    +options: $ReadOnly<ScreenOptions>,
+    +navigation: NavProp,
+  |};
+
+  declare export type UseNavigationBuilder = <
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    ScreenOptions: {...},
+    RouterOptions: DefaultRouterOptions,
+    NavProp,
+  >(
+    routerFactory: RouterFactory<State, Action, RouterOptions>,
+    options: {|
+      ...$Exact<RouterOptions>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+      +children?: React$Node,
+    |},
+  ) => {|
+    +state: State,
+    +descriptors: {| +[key: string]: Descriptor<NavProp, ScreenOptions> |},
+    +navigation: NavProp,
+  |};
+
+  /**
+   * EdgeInsets
+   */
+
+  declare type EdgeInsets = {|
+    +top: number,
+    +right: number,
+    +bottom: number,
+    +left: number,
+  |};
+
+  /**
+   * TransitionPreset
+   */
+
+  declare export type TransitionSpec =
+    | {|
+        animation: 'spring',
+        config: $Diff<
+          SpringAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |}
+    | {|
+        animation: 'timing',
+        config: $Diff<
+          TimingAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |};
+
+  declare export type StackCardInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +index: number,
+    +closing: AnimatedInterpolation,
+    +swiping: AnimatedInterpolation,
+    +inverted: AnimatedInterpolation,
+    +layouts: {|
+      +screen: {| +width: number, +height: number |},
+    |},
+    +insets: EdgeInsets,
+  |};
+  declare export type StackCardInterpolatedStyle = {|
+    containerStyle?: AnimatedViewStyleProp,
+    cardStyle?: AnimatedViewStyleProp,
+    overlayStyle?: AnimatedViewStyleProp,
+    shadowStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackCardStyleInterpolator = (
+    props: StackCardInterpolationProps,
+  ) => StackCardInterpolatedStyle;
+
+  declare export type StackHeaderInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +layouts: {|
+      +header: {| +width: number, +height: number |},
+      +screen: {| +width: number, +height: number |},
+      +title?: {| +width: number, +height: number |},
+      +leftLabel?: {| +width: number, +height: number |},
+    |},
+  |};
+  declare export type StackHeaderInterpolatedStyle = {|
+    leftLabelStyle?: AnimatedViewStyleProp,
+    leftButtonStyle?: AnimatedViewStyleProp,
+    rightButtonStyle?: AnimatedViewStyleProp,
+    titleStyle?: AnimatedViewStyleProp,
+    backgroundStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackHeaderStyleInterpolator = (
+    props: StackHeaderInterpolationProps,
+  ) => StackHeaderInterpolatedStyle;
+
+  declare type GestureDirection =
+    | 'horizontal'
+    | 'horizontal-inverted'
+    | 'vertical'
+    | 'vertical-inverted';
+
+  declare export type TransitionPreset = {|
+    +gestureDirection: GestureDirection,
+    +transitionSpec: {|
+      +open: TransitionSpec,
+      +close: TransitionSpec,
+    |},
+    +cardStyleInterpolator: StackCardStyleInterpolator,
+    +headerStyleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  /**
+   * Stack options
+   */
+
+  declare export type StackDescriptor = Descriptor<
+    StackNavigationProp<>,
+    StackOptions,
+  >;
+
+  declare type Scene<T> = {|
+    +route: T,
+    +descriptor: StackDescriptor,
+    +progress: {|
+      +current: AnimatedInterpolation,
+      +next?: AnimatedInterpolation,
+      +previous?: AnimatedInterpolation,
+    |},
+  |};
+
+  declare export type StackHeaderProps = {|
+    +mode: 'float' | 'screen',
+    +layout: {| +width: number, +height: number |},
+    +insets: EdgeInsets,
+    +scene: Scene<Route<>>,
+    +previous?: Scene<Route<>>,
+    +navigation: StackNavigationProp<ParamListBase>,
+    +styleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  declare export type StackHeaderLeftButtonProps = $Shape<{|
+    +onPress: (() => void),
+    +pressColorAndroid: string;
+    +backImage: (props: {| tintColor: string |}) => React$Node,
+    +tintColor: string,
+    +label: string,
+    +truncatedLabel: string,
+    +labelVisible: boolean,
+    +labelStyle: AnimatedTextStyleProp,
+    +allowFontScaling: boolean,
+    +onLabelLayout: LayoutEvent => void,
+    +screenLayout: {| +width: number, +height: number |},
+    +titleLayout: {| +width: number, +height: number |},
+    +canGoBack: boolean,
+  |}>;
+
+  declare type StackHeaderTitleInputBase = {
+    +onLayout: LayoutEvent => void,
+    +children: string,
+    +allowFontScaling: ?boolean,
+    +tintColor: ?string,
+    +style: ?AnimatedTextStyleProp,
+    ...
+  };
+
+  declare export type StackHeaderTitleInputProps =
+    $Exact<StackHeaderTitleInputBase>;
+
+  declare export type StackOptions = $Shape<{|
+    +title: string,
+    +header: StackHeaderProps => React$Node,
+    +headerShown: boolean,
+    +cardShadowEnabled: boolean,
+    +cardOverlayEnabled: boolean,
+    +cardOverlay: {| style: ViewStyleProp |} => React$Node,
+    +cardStyle: ViewStyleProp,
+    +animationEnabled: boolean,
+    +animationTypeForReplace: 'push' | 'pop',
+    +gestureEnabled: boolean,
+    +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
+    +gestureVelocityImpact: number,
+    +safeAreaInsets: $Shape<EdgeInsets>,
+    // Transition
+    ...TransitionPreset,
+    // Header
+    +headerTitle: string | (StackHeaderTitleInputProps => React$Node),
+    +headerTitleAlign: 'left' | 'center',
+    +headerTitleStyle: AnimatedTextStyleProp,
+    +headerTitleContainerStyle: ViewStyleProp,
+    +headerTintColor: string,
+    +headerTitleAllowFontScaling: boolean,
+    +headerBackAllowFontScaling: boolean,
+    +headerBackTitle: string,
+    +headerBackTitleStyle: TextStyleProp,
+    +headerBackTitleVisible: boolean,
+    +headerTruncatedBackTitle: string,
+    +headerLeft: StackHeaderLeftButtonProps => React$Node,
+    +headerLeftContainerStyle: ViewStyleProp,
+    +headerRight: {| tintColor?: string |} => React$Node,
+    +headerRightContainerStyle: ViewStyleProp,
+    +headerBackImage: $PropertyType<StackHeaderLeftButtonProps, 'backImage'>,
+    +headerPressColorAndroid: string,
+    +headerBackground: ({| style: ViewStyleProp |}) => React$Node,
+    +headerStyle: ViewStyleProp,
+    +headerTransparent: boolean,
+    +headerStatusBarHeight: number,
+  |}>;
+
+  /**
+   * Stack navigation prop
+   */
+
+  declare export type StackNavigationEventMap = {|
+    ...EventMapCore<StackNavigationState>,
+    +transitionStart: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+    +transitionEnd: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+  |};
+
+  declare type InexactStackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      StackNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +replace: SimpleNavigate<ParamList>,
+    +push: SimpleNavigate<ParamList>,
+    +pop: (count?: number) => void,
+    +popToTop: () => void,
+    ...
+  };
+
+  declare export type StackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = $Exact<InexactStackNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous stack exports
+   */
+
+  declare type StackNavigationConfig = {|
+    +mode?: 'card' | 'modal',
+    +headerMode?: 'float' | 'screen' | 'none',
+    +keyboardHandlingEnabled?: boolean,
+  |};
+
+  declare export type ExtraStackNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...StackRouterOptions,
+    ...StackNavigationConfig,
+  |};
+
+  declare export type StackNavigatorProps<
+    NavProp: InexactStackNavigationProp<> = StackNavigationProp<>,
+  > = {|
+    ...ExtraStackNavigatorProps,
+    ...ScreenOptionsProp<StackOptions, NavProp>,
+  |};
+
+  /**
+   * Bottom tab options
+   */
+
+  declare export type BottomTabBarButtonProps = {|
+    ...$Diff<
+      TouchableWithoutFeedbackProps,
+      {| onPress?: ?(event: PressEvent) => mixed |},
+    >,
+    +to?: string,
+    +children: React$Node,
+    +onPress?: (MouseEvent | PressEvent) => void,
+  |};
+
+  declare export type BottomTabOptions = $Shape<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| focused: boolean, color: string |}) => React$Node,
+    +tabBarIcon: ({|
+      focused: boolean,
+      color: string,
+      size: number,
+    |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+    +tabBarVisible: boolean,
+    +tabBarButton: BottomTabBarButtonProps => React$Node,
+    +unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Bottom tab navigation prop
+   */
+
+  declare export type BottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare type InexactTabNavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+    Options: {...},
+    EventMap: EventMapBase,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      TabNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    ...
+  };
+
+  declare export type InexactBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type BottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = $Exact<InexactBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous bottom tab exports
+   */
+
+  declare export type BottomTabDescriptor = Descriptor<
+    BottomTabNavigationProp<>,
+    BottomTabOptions,
+  >;
+
+  declare export type BottomTabBarOptions = $Shape<{|
+    +keyboardHidesTabBar: boolean,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveBackgroundColor: string,
+    +allowFontScaling: boolean,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +labelStyle: TextStyleProp,
+    +tabStyle: ViewStyleProp,
+    +labelPosition: 'beside-icon' | 'below-icon',
+    +adaptive: boolean,
+    +safeAreaInsets: $Shape<EdgeInsets>,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type BottomTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: BottomTabNavigationProp<>,
+    +descriptors: {| +[key: string]: BottomTabDescriptor |},
+  |};
+
+  declare export type BottomTabBarProps = {|
+    ...BottomTabBarOptions,
+    ...BottomTabNavigationBuilderResult,
+  |}
+
+  declare type BottomTabNavigationConfig = {|
+    +lazy?: boolean,
+    +tabBar?: BottomTabBarProps => React$Node,
+    +tabBarOptions?: BottomTabBarOptions,
+  |};
+
+  declare export type ExtraBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...BottomTabNavigationConfig,
+  |};
+
+  declare export type BottomTabNavigatorProps<
+    NavProp: InexactBottomTabNavigationProp<> = BottomTabNavigationProp<>,
+  > = {|
+    ...ExtraBottomTabNavigatorProps,
+    ...ScreenOptionsProp<BottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material bottom tab options
+   */
+
+  declare export type MaterialBottomTabOptions = $Shape<{|
+    +title: string,
+    +tabBarColor: string,
+    +tabBarLabel: string,
+    +tabBarIcon:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarBadge: boolean | number | string,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material bottom tab navigation prop
+   */
+
+  declare export type MaterialBottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+  |};
+
+  declare export type InexactMaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = $Exact<InexactMaterialBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material bottom tab exports
+   */
+
+  declare export type PaperFont = {|
+    +fontFamily: string,
+    +fontWeight?:
+      | 'normal'
+      | 'bold'
+      | '100'
+      | '200'
+      | '300'
+      | '400'
+      | '500'
+      | '600'
+      | '700'
+      | '800'
+      | '900',
+  |};
+
+  declare export type PaperFonts = {|
+    +regular: Font,
+    +medium: Font,
+    +light: Font,
+    +thin: Font,
+  |};
+
+  declare export type PaperTheme = {|
+    +dark: boolean,
+    +mode?: 'adaptive' | 'exact',
+    +roundness: number,
+    +colors: {|
+      +primary: string,
+      +background: string,
+      +surface: string,
+      +accent: string,
+      +error: string,
+      +text: string,
+      +onSurface: string,
+      +onBackground: string,
+      +disabled: string,
+      +placeholder: string,
+      +backdrop: string,
+      +notification: string,
+    |},
+    +fonts: PaperFonts,
+    +animation: {|
+      +scale: number,
+    |},
+  |};
+
+  declare export type PaperRoute = {|
+    +key: string,
+    +title?: string,
+    +icon?: any,
+    +badge?: string | number | boolean,
+    +color?: string,
+    +accessibilityLabel?: string,
+    +testID?: string,
+  |};
+
+  declare export type PaperTouchableProps = {|
+    ...TouchableWithoutFeedbackProps,
+    +key: string,
+    +route: PaperRoute,
+    +children: React$Node,
+    +borderless?: boolean,
+    +centered?: boolean,
+    +rippleColor?: string,
+  |};
+
+  declare export type MaterialBottomTabNavigationConfig = {|
+    +shifting?: boolean,
+    +labeled?: boolean,
+    +renderTouchable?: PaperTouchableProps => React$Node,
+    +activeColor?: string,
+    +inactiveColor?: string,
+    +sceneAnimationEnabled?: boolean,
+    +keyboardHidesNavigationBar?: boolean,
+    +barStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +theme?: PaperTheme,
+  |};
+
+  declare export type ExtraMaterialBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialBottomTabNavigationConfig,
+  |};
+
+  declare export type MaterialBottomTabNavigatorProps<
+    NavProp: InexactMaterialBottomTabNavigationProp<> =
+      MaterialBottomTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialBottomTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialBottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material top tab options
+   */
+
+  declare export type MaterialTopTabOptions = $Shape<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarIcon: ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material top tab navigation prop
+   */
+
+  declare export type MaterialTopTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+    +swipeStart: {| +data: void, +canPreventDefault: false |},
+    +swipeEnd: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactMaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = $Exact<InexactMaterialTopTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material top tab exports
+   */
+
+  declare type MaterialTopTabPagerCommonProps = {|
+    +keyboardDismissMode: 'none' | 'on-drag' | 'auto',
+    +swipeEnabled: boolean,
+    +swipeVelocityImpact?: number,
+    +springVelocityScale?: number,
+    +springConfig: $Shape<{|
+      +damping: number,
+      +mass: number,
+      +stiffness: number,
+      +restSpeedThreshold: number,
+      +restDisplacementThreshold: number,
+    |}>,
+    +timingConfig: $Shape<{|
+      +duration: number,
+    |}>,
+  |};
+
+  declare export type MaterialTopTabPagerProps = {|
+    ...MaterialTopTabPagerCommonProps,
+    +onSwipeStart?: () => void,
+    +onSwipeEnd?: () => void,
+    +onIndexChange: (index: number) => void,
+    +navigationState: TabNavigationState,
+    +layout: {| +width: number, +height: number |},
+    +removeClippedSubviews: boolean,
+    +children: ({|
+      +addListener: (type: 'enter', listener: number => void) => void,
+      +removeListener: (type: 'enter', listener: number => void) => void,
+      +position: any, // Reanimated.Node<number>
+      +render: React$Node => React$Node,
+      +jumpTo: string => void,
+    |}) => React$Node,
+    +gestureHandlerProps: PanGestureHandlerProps,
+  |};
+
+  declare export type MaterialTopTabBarIndicatorProps = {|
+    +navigationState: TabNavigationState,
+    +width: string,
+    +style?: ViewStyleProp,
+    +getTabWidth: number => number,
+  |};
+
+  declare export type MaterialTopTabBarOptions = $Shape<{|
+    +scrollEnabled: boolean,
+    +bounces: boolean,
+    +pressColor: string,
+    +pressOpacity: number,
+    +getAccessible: ({| +route: Route<> |}) => boolean,
+    +renderBadge: ({| +route: Route<> |}) => React$Node,
+    +renderIndicator: MaterialTopTabBarIndicatorProps => React$Node,
+    +tabStyle: ViewStyleProp,
+    +indicatorStyle: ViewStyleProp,
+    +indicatorContainerStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +iconStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +allowFontScaling: boolean,
+  |}>;
+
+  declare export type MaterialTopTabDescriptor = Descriptor<
+    MaterialBottomTabNavigationProp<>,
+    MaterialBottomTabOptions,
+  >;
+
+  declare type MaterialTopTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: MaterialTopTabNavigationProp<>,
+    +descriptors: {| +[key: string]: MaterialTopTabDescriptor |},
+  |};
+
+  declare export type MaterialTopTabBarProps = {|
+    ...MaterialTopTabBarOptions,
+    ...MaterialTopTabNavigationBuilderResult,
+    +layout: {| +width: number, +height: number |},
+    +position: any, // Reanimated.Node<number>
+    +jumpTo: string => void,
+  |};
+
+  declare export type MaterialTopTabNavigationConfig = {|
+    ...$Partial<MaterialTopTabPagerCommonProps>,
+    +position?: any, // Reanimated.Value<number>
+    +tabBarPosition?: 'top' | 'bottom',
+    +initialLayout?: $Shape<{| +width: number, +height: number |}>,
+    +lazy?: boolean,
+    +lazyPreloadDistance?: number,
+    +removeClippedSubviews?: boolean,
+    +sceneContainerStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +pager?: MaterialTopTabPagerProps => React$Node,
+    +lazyPlaceholder?: ({| +route: Route<> |}) => React$Node,
+    +tabBar?: MaterialTopTabBarProps => React$Node,
+    +tabBarOptions?: MaterialTopTabBarOptions,
+  |};
+
+  declare export type ExtraMaterialTopTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialTopTabNavigationConfig,
+  |};
+
+  declare export type MaterialTopTabNavigatorProps<
+    NavProp: InexactMaterialTopTabNavigationProp<> =
+      MaterialTopTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialTopTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialTopTabOptions, NavProp>,
+  |};
+
+  /**
+   * Drawer options
+   */
+
+  declare export type DrawerOptions = $Shape<{|
+    title: string,
+    drawerLabel:
+      | string
+      | ({| +color: string, +focused: boolean |}) => React$Node,
+    drawerIcon: ({|
+      +color: string,
+      +size: number,
+      +focused: boolean,
+    |}) => React$Node,
+    gestureEnabled: boolean,
+    swipeEnabled: boolean,
+    unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Drawer navigation prop
+   */
+
+  declare export type DrawerNavigationEventMap = {|
+    ...EventMapCore<DrawerNavigationState>,
+    +drawerOpen: {| +data: void, +canPreventDefault: false |},
+    +drawerClose: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactDrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      DrawerNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    +openDrawer: () => void,
+    +closeDrawer: () => void,
+    +toggleDrawer: () => void,
+    ...
+  };
+
+  declare export type DrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = $Exact<InexactDrawerNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous drawer exports
+   */
+
+  declare export type DrawerDescriptor = Descriptor<
+    DrawerNavigationProp<>,
+    DrawerOptions,
+  >;
+
+  declare export type DrawerItemListBaseOptions = $Shape<{|
+    +activeTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveTintColor: string,
+    +inactiveBackgroundColor: string,
+    +itemStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+  |}>;
+
+  declare export type DrawerContentOptions = $Shape<{|
+    ...DrawerItemListBaseOptions,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type DrawerNavigationBuilderResult = {|
+    +state: DrawerNavigationState,
+    +navigation: DrawerNavigationProp<>,
+    +descriptors: {| +[key: string]: DrawerDescriptor |},
+  |};
+
+  declare export type DrawerContentProps = {|
+    ...DrawerContentOptions,
+    ...DrawerNavigationBuilderResult,
+    +progress: any, // Reanimated.Node<number>
+  |};
+
+  declare export type DrawerNavigationConfig = {|
+    +drawerPosition?: 'left' | 'right',
+    +drawerType?: 'front' | 'back' | 'slide' | 'permanent',
+    +edgeWidth?: number,
+    +hideStatusBar?: boolean,
+    +keyboardDismissMode?: 'on-drag' | 'none',
+    +minSwipeDistance?: number,
+    +overlayColor?: string,
+    +statusBarAnimation?: 'slide' | 'none' | 'fade',
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +lazy?: boolean,
+    +drawerContent?: DrawerContentProps => React$Node,
+    +drawerContentOptions?: DrawerContentOptions,
+    +sceneContainerStyle?: ViewStyleProp,
+    +drawerStyle?: ViewStyleProp,
+  |};
+
+  declare export type ExtraDrawerNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...DrawerRouterOptions,
+    ...DrawerNavigationConfig,
+  |};
+
+  declare export type DrawerNavigatorProps<
+    NavProp: InexactDrawerNavigationProp<> = DrawerNavigationProp<>,
+  > = {|
+    ...ExtraDrawerNavigatorProps,
+    ...ScreenOptionsProp<DrawerOptions, NavProp>,
+  |};
+
+  /**
+   * BaseNavigationContainer
+   */
+
+  declare export type BaseNavigationContainerProps = {|
+    +children: React$Node,
+    +initialState?: PossiblyStaleNavigationState,
+    +onStateChange?: (state: ?PossiblyStaleNavigationState) => void,
+    +independent?: boolean,
+  |};
+
+  declare export type BaseNavigationContainerInterface = {|
+    ...$Exact<NavigationHelpers<
+      ParamListBase,
+      PossiblyStaleNavigationState,
+      GlobalEventMap<PossiblyStaleNavigationState>,
+    >>,
+    +setParams: (params: ScreenParams) => void,
+    +resetRoot: (state?: ?PossiblyStaleNavigationState) => void,
+    +getRootState: () => PossiblyStaleNavigationState,
+  |};
+
+  /**
+   * State / path conversion
+   */
+
+  declare export type LinkingConfig = {|
+    +[routeName: string]:
+      | string
+      | {|
+          +path?: string,
+          +parse?: {| +[param: string]: string => mixed |},
+          +screens?: LinkingConfig,
+          +initialRouteName?: string,
+        |},
+  |};
+
+  declare export type GetPathFromStateOptions = {|
+    +[routeName: string]:
+      | string
+      | {|
+          +path?: string,
+          +stringify?: {| +[param: string]: mixed => string |},
+          +screens?: GetPathFromStateOptions,
+        |},
+  |};
+
+  //---------------------------------------------------------------------------
+  // SECTION 2: EXPORTED MODULE
+  // This section defines the module exports and contains exported types that
+  // are not present in any other React Navigation libdef.
+  //---------------------------------------------------------------------------
+
+  /**
+   * createBottomTabNavigator
+   */
+
+  declare export var createBottomTabNavigator: CreateNavigator<
+    TabNavigationState,
+    BottomTabOptions,
+    BottomTabNavigationEventMap,
+    ExtraBottomTabNavigatorProps,
+  >;
+
+  /**
+   * BottomTabBar
+   */
+
+  declare export var BottomTabBar: React$ComponentType<BottomTabBarProps>;
+
+  /**
+   * BottomTabView
+   */
+
+  declare export type BottomTabViewProps = {|
+    ...BottomTabNavigationConfig,
+    ...BottomTabNavigationBuilderResult,
+  |};
+  declare export var BottomTabView: React$ComponentType<BottomTabViewProps>;
+
+}

--- a/definitions/npm/@react-navigation/bottom-tabs_v5.x.x/test_bottom-tabs.js
+++ b/definitions/npm/@react-navigation/bottom-tabs_v5.x.x/test_bottom-tabs.js
@@ -1,0 +1,114 @@
+// @flow
+
+import * as React from 'react';
+import {
+  createBottomTabNavigator,
+  type NavigationProp,
+  type BottomTabNavigationProp,
+  type LeafRoute,
+  type TabNavigationState,
+  type BottomTabOptions,
+  type BottomTabNavigationEventMap,
+} from '@react-navigation/bottom-tabs';
+
+/**
+ * Navigator setup
+ */
+
+type LocalParamList = {|
+  One: {| hey: string |},
+  Two: void,
+  Three: ?{| sup: number |},
+|};
+
+type GlobalParamList = {|
+  ...LocalParamList,
+  Another: void,
+|};
+
+type NavProp<
+  RouteName: $Keys<LocalParamList> = $Keys<LocalParamList>,
+> = BottomTabNavigationProp<GlobalParamList, RouteName>;
+type NavRoute<
+  RouteName: $Keys<LocalParamList> = $Keys<LocalParamList>,
+> = {|
+  ...LeafRoute<RouteName>,
+  +params: $ElementType<LocalParamList, RouteName>,
+|};
+
+const Tab = createBottomTabNavigator<
+  GlobalParamList,
+  LocalParamList,
+  NavProp<>,
+>();
+
+/**
+ * Screens
+ */
+
+function ValidScreen(props: {|
+  navigation: NavProp<'One'>,
+  route: NavRoute<'One'>,
+|}) {
+  props.navigation.navigate('Another');
+  // $ExpectError invalid params
+  props.navigation.navigate('Another', {});
+  // $ExpectError invalid route
+  props.navigation.navigate('test', { sup: true, yo: null });
+  props.navigation.jumpTo('Three');
+  (props.navigation: NavigationProp<
+    GlobalParamList,
+    'One',
+    TabNavigationState,
+    BottomTabOptions,
+    BottomTabNavigationEventMap,
+  >);
+  return null;
+}
+
+function InvalidScreen(props: {|
+  navigation: NavProp<'One'>,
+  route: number,
+|}) {
+  props.navigation.setOptions({
+    title: 'sup',
+    tabBarLabel: 'SUP',
+    unmountOnBlur: true,
+  });
+  // $ExpectError invalid navigator props
+  props.navigation.setOptions({ fake: 12 });
+  React.useEffect(() => {
+    return props.navigation.addListener(
+      'tabPress',
+      e => {
+        (e.type: 'tabPress');
+        e.preventDefault();
+      },
+    );
+  });
+  return null;
+}
+
+<Tab.Screen name="One" component={ValidScreen} />;
+// $ExpectError non-matching component
+<Tab.Screen name="Two" component={ValidScreen} />;
+// $ExpectError invalid route name
+<Tab.Screen name="Four" component={ValidScreen} />;
+// $ExpectError invalid params
+<Tab.Screen name="One" component={ValidScreen} initialParams={{ hey: 5 }} />;
+// $ExpectError non-local route
+<Tab.Screen name="Another" component={ValidScreen} />;
+// $ExpectError invalid screen props
+<Tab.Screen name="One" component={InvalidScreen} />;
+
+/**
+ * Navigator
+ */
+
+<Tab.Navigator lazy={true} />;
+// $ExpectError invalid navigator props
+<Tab.Navigator
+  // $ExpectError invalid navigator props
+  lazy={5}
+  someOtherProp="fake"
+/>;

--- a/definitions/npm/@react-navigation/core_v5.x.x/CONTRIBUTING.md
+++ b/definitions/npm/@react-navigation/core_v5.x.x/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to the React Navigation Flow libdef
+
+## Overview
+
+There are seven React Navigation libdefs in `flow-typed`:
+
+1. `@react-navigation/core`
+2. `@react-navigation/native`
+3. `@react-navigation/stack`
+4. `@react-navigation/bottom-tabs`
+5. `@react-navigation/material-bottom-tabs`
+6. `@react-navigation/material-top-tabs`
+7. `@react-navigation/drawer`
+
+It's not currently possible to import types between libdefs. Consequently, many of the same types are copy-pasted across the different libdefs.
+
+Each libdef is organized into two sections. The first section should be identical between all of the libdefs. If you make a change to this section, please make sure to mirror it across the other libdefs.
+
+## Contributors
+
+- @Ashoat

--- a/definitions/npm/@react-navigation/core_v5.x.x/flow_v0.104.x-/core_v5.x.x.js
+++ b/definitions/npm/@react-navigation/core_v5.x.x/flow_v0.104.x-/core_v5.x.x.js
@@ -1,0 +1,2054 @@
+declare module '@react-navigation/core' {
+
+  //---------------------------------------------------------------------------
+  // SECTION 1: IDENTICAL TYPE DEFINITIONS
+  // This section is identical across all React Navigation libdefs and contains
+  // shared definitions. We wish we could make it DRY and import from a shared
+  // definition, but that isn't yet possible.
+  //---------------------------------------------------------------------------
+
+  /**
+   * We start with some definitions that we have copy-pasted from React Native
+   * source files.
+   */
+
+  // This is a bastardization of the true StyleObj type located in
+  // react-native/Libraries/StyleSheet/StyleSheetTypes. We unfortunately can't
+  // import that here, and it's too lengthy (and consequently too brittle) to
+  // copy-paste here either.
+  declare type StyleObj =
+    | null
+    | void
+    | number
+    | false
+    | ''
+    | $ReadOnlyArray<StyleObj>
+    | { [name: string]: any, ... };
+  declare type ViewStyleProp = StyleObj;
+  declare type TextStyleProp = StyleObj;
+  declare type AnimatedViewStyleProp = StyleObj;
+  declare type AnimatedTextStyleProp = StyleObj;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/animations/Animation.js
+  declare type EndResult = { finished: boolean, ... };
+  declare type EndCallback = (result: EndResult) => void;
+  declare interface Animation {
+    start(
+      fromValue: number,
+      onUpdate: (value: number) => void,
+      onEnd: ?EndCallback,
+      previousAnimation: ?Animation,
+      animatedValue: AnimatedValue,
+    ): void;
+    stop(): void;
+  }
+  declare type AnimationConfig = {
+    isInteraction?: boolean,
+    useNativeDriver: boolean,
+    onComplete?: ?EndCallback,
+    iterations?: number,
+    ...
+  };
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedTracking.js
+  declare interface AnimatedTracking {
+    constructor(
+      value: AnimatedValue,
+      parent: any,
+      animationClass: any,
+      animationConfig: Object,
+      callback?: ?EndCallback,
+    ): void;
+    update(): void;
+  }
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedValue.js
+  declare type ValueListenerCallback = (state: { value: number, ... }) => void;
+  declare interface AnimatedValue {
+    constructor(value: number): void;
+    setValue(value: number): void;
+    setOffset(offset: number): void;
+    flattenOffset(): void;
+    extractOffset(): void;
+    addListener(callback: ValueListenerCallback): string;
+    removeListener(id: string): void;
+    removeAllListeners(): void;
+    stopAnimation(callback?: ?(value: number) => void): void;
+    resetAnimation(callback?: ?(value: number) => void): void;
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+    animate(animation: Animation, callback: ?EndCallback): void;
+    stopTracking(): void;
+    track(tracking: AnimatedTracking): void;
+  }
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/TimingAnimation.js
+  declare type TimingAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    easing?: (value: number) => number,
+    duration?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/SpringAnimation.js
+  declare type SpringAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    overshootClamping?: boolean,
+    restDisplacementThreshold?: number,
+    restSpeedThreshold?: number,
+    velocity?: number,
+    bounciness?: number,
+    speed?: number,
+    tension?: number,
+    friction?: number,
+    stiffness?: number,
+    damping?: number,
+    mass?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from react-native/Libraries/Types/CoreEventTypes.js
+  declare type SyntheticEvent<T> = $ReadOnly<{|
+    bubbles: ?boolean,
+    cancelable: ?boolean,
+    currentTarget: number,
+    defaultPrevented: ?boolean,
+    dispatchConfig: $ReadOnly<{|
+      registrationName: string,
+    |}>,
+    eventPhase: ?number,
+    preventDefault: () => void,
+    isDefaultPrevented: () => boolean,
+    stopPropagation: () => void,
+    isPropagationStopped: () => boolean,
+    isTrusted: ?boolean,
+    nativeEvent: T,
+    persist: () => void,
+    target: ?number,
+    timeStamp: number,
+    type: ?string,
+  |}>;
+  declare type Layout = $ReadOnly<{|
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  |}>;
+  declare type LayoutEvent = SyntheticEvent<
+    $ReadOnly<{|
+      layout: Layout,
+    |}>,
+  >;
+  declare type BlurEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type FocusEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type ResponderSyntheticEvent<T> = $ReadOnly<{|
+    ...SyntheticEvent<T>,
+    touchHistory: $ReadOnly<{|
+      indexOfSingleActiveTouch: number,
+      mostRecentTimeStamp: number,
+      numberActiveTouches: number,
+      touchBank: $ReadOnlyArray<
+        $ReadOnly<{|
+          touchActive: boolean,
+          startPageX: number,
+          startPageY: number,
+          startTimeStamp: number,
+          currentPageX: number,
+          currentPageY: number,
+          currentTimeStamp: number,
+          previousPageX: number,
+          previousPageY: number,
+          previousTimeStamp: number,
+        |}>,
+      >,
+    |}>,
+  |}>;
+  declare type PressEvent = ResponderSyntheticEvent<
+    $ReadOnly<{|
+      changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+      force: number,
+      identifier: number,
+      locationX: number,
+      locationY: number,
+      pageX: number,
+      pageY: number,
+      target: ?number,
+      timestamp: number,
+      touches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+    |}>,
+  >;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+  declare type ExtrapolateType = 'extend' | 'identity' | 'clamp';
+  declare type InterpolationConfigType = {
+    inputRange: Array<number>,
+    outputRange: Array<number> | Array<string>,
+    easing?: (input: number) => number,
+    extrapolate?: ExtrapolateType,
+    extrapolateLeft?: ExtrapolateType,
+    extrapolateRight?: ExtrapolateType,
+    ...
+  };
+  declare interface AnimatedInterpolation {
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+  }
+
+  // Copied from react-native/Libraries/Components/View/ViewAccessibility.js
+  declare type AccessibilityRole =
+    | 'none'
+    | 'button'
+    | 'link'
+    | 'search'
+    | 'image'
+    | 'keyboardkey'
+    | 'text'
+    | 'adjustable'
+    | 'imagebutton'
+    | 'header'
+    | 'summary'
+    | 'alert'
+    | 'checkbox'
+    | 'combobox'
+    | 'menu'
+    | 'menubar'
+    | 'menuitem'
+    | 'progressbar'
+    | 'radio'
+    | 'radiogroup'
+    | 'scrollbar'
+    | 'spinbutton'
+    | 'switch'
+    | 'tab'
+    | 'tablist'
+    | 'timer'
+    | 'toolbar';
+  declare type AccessibilityActionInfo = $ReadOnly<{
+    name: string,
+    label?: string,
+    ...
+  }>;
+  declare type AccessibilityActionEvent = SyntheticEvent<
+    $ReadOnly<{actionName: string, ...}>,
+  >;
+  declare type AccessibilityState = {
+    disabled?: boolean,
+    selected?: boolean,
+    checked?: ?boolean | 'mixed',
+    busy?: boolean,
+    expanded?: boolean,
+    ...
+  };
+  declare type AccessibilityValue = $ReadOnly<{|
+    min?: number,
+    max?: number,
+    now?: number,
+    text?: string,
+  |}>;
+
+  // Copied from
+  // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+  declare type Stringish = string;
+  declare type EdgeInsetsProp = $ReadOnly<$Shape<EdgeInsets>>;
+  declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
+    accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+    accessibilityElementsHidden?: ?boolean,
+    accessibilityHint?: ?Stringish,
+    accessibilityIgnoresInvertColors?: ?boolean,
+    accessibilityLabel?: ?Stringish,
+    accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
+    accessibilityRole?: ?AccessibilityRole,
+    accessibilityState?: ?AccessibilityState,
+    accessibilityValue?: ?AccessibilityValue,
+    accessibilityViewIsModal?: ?boolean,
+    accessible?: ?boolean,
+    children?: ?React$Node,
+    delayLongPress?: ?number,
+    delayPressIn?: ?number,
+    delayPressOut?: ?number,
+    disabled?: ?boolean,
+    focusable?: ?boolean,
+    hitSlop?: ?EdgeInsetsProp,
+    importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
+    nativeID?: ?string,
+    onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+    onBlur?: ?(event: BlurEvent) => mixed,
+    onFocus?: ?(event: FocusEvent) => mixed,
+    onLayout?: ?(event: LayoutEvent) => mixed,
+    onLongPress?: ?(event: PressEvent) => mixed,
+    onPress?: ?(event: PressEvent) => mixed,
+    onPressIn?: ?(event: PressEvent) => mixed,
+    onPressOut?: ?(event: PressEvent) => mixed,
+    pressRetentionOffset?: ?EdgeInsetsProp,
+    rejectResponderTermination?: ?boolean,
+    testID?: ?string,
+    touchSoundDisabled?: ?boolean,
+  |}>;
+
+  // Copied from react-native/Libraries/Image/ImageSource.js
+  declare type ImageURISource = $ReadOnly<{
+    uri?: ?string,
+    bundle?: ?string,
+    method?: ?string,
+    headers?: ?Object,
+    body?: ?string,
+    cache?: ?('default' | 'reload' | 'force-cache' | 'only-if-cached'),
+    width?: ?number,
+    height?: ?number,
+    scale?: ?number,
+    ...
+  }>;
+
+  /**
+   * The following is copied from react-native-gesture-handler's libdef
+   */
+
+  declare type $EventHandlers<ExtraProps: {...}> = {|
+    onGestureEvent?: ($Event<ExtraProps>) => mixed,
+    onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
+    onBegan?: ($Event<ExtraProps>) => mixed,
+    onFailed?: ($Event<ExtraProps>) => mixed,
+    onCancelled?: ($Event<ExtraProps>) => mixed,
+    onActivated?: ($Event<ExtraProps>) => mixed,
+    onEnded?: ($Event<ExtraProps>) => mixed,
+  |};
+
+  declare type HitSlop =
+    | number
+    | {|
+        left?: number,
+        top?: number,
+        right?: number,
+        bottom?: number,
+        vertical?: number,
+        horizontal?: number,
+        width?: number,
+        height?: number,
+      |}
+    | {|
+        width: number,
+        left: number,
+      |}
+    | {|
+        width: number,
+        right: number,
+      |}
+    | {|
+        height: number,
+        top: number,
+      |}
+    | {|
+        height: number,
+        bottom: number,
+      |};
+
+  declare type $GestureHandlerProps<
+    AdditionalProps: {...},
+    ExtraEventsProps: {...}
+  > = $ReadOnly<{|
+    ...$Exact<AdditionalProps>,
+    ...$EventHandlers<ExtraEventsProps>,
+    id?: string,
+    enabled?: boolean,
+    waitFor?: React$Ref<any> | Array<React$Ref<any>>,
+    simultaneousHandlers?: React$Ref<any> | Array<React$Ref<any>>,
+    shouldCancelWhenOutside?: boolean,
+    minPointers?: number,
+    hitSlop?: HitSlop,
+    children?: React$Node,
+  |}>;
+
+  declare type PanGestureHandlerProps = $GestureHandlerProps<
+    {
+      activeOffsetY?: number | [number, number],
+      activeOffsetX?: number | [number, number],
+      failOffsetY?: number | [number, number],
+      failOffsetX?: number | [number, number],
+      minDist?: number,
+      minVelocity?: number,
+      minVelocityX?: number,
+      minVelocityY?: number,
+      minPointers?: number,
+      maxPointers?: number,
+      avgTouches?: boolean,
+      ...
+    },
+    {
+      x: number,
+      y: number,
+      absoluteX: number,
+      absoluteY: number,
+      translationX: number,
+      translationY: number,
+      velocityX: number,
+      velocityY: number,
+      ...
+    }
+  >;
+
+  /**
+   * MAGIC
+   */
+
+  declare type $If<Test: boolean, Then, Else = empty> = $Call<
+    ((true, Then, Else) => Then) & ((false, Then, Else) => Else),
+    Test,
+    Then,
+    Else,
+  >;
+  declare type $IsA<X, Y> = $Call<
+    (Y => true) & (mixed => false),
+    X,
+  >;
+  declare type $IsUndefined<X> = $IsA<X, void>;
+
+  declare type $Partial<T> = $Rest<T, {...}>;
+
+  /**
+   * Actions, state, etc.
+   */
+
+  declare export type ScreenParams = { +[key: string]: mixed, ... };
+
+  declare export type BackAction = {|
+    +type: 'GO_BACK',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type NavigateAction = {|
+    +type: 'NAVIGATE',
+    +payload:
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ResetAction = {|
+    +type: 'RESET',
+    +payload: StaleNavigationState,
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type SetParamsAction = {|
+    +type: 'SET_PARAMS',
+    +payload: {| +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CommonAction =
+    | BackAction
+    | NavigateAction
+    | ResetAction
+    | SetParamsAction;
+
+  declare type NavigateActionCreator = {|
+    (routeName: string, params?: ScreenParams): NavigateAction,
+    (
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    ): NavigateAction,
+  |};
+  declare export type CommonActionsType = {|
+    +navigate: NavigateActionCreator,
+    +goBack: () => BackAction,
+    +reset: (state: PossiblyStaleNavigationState) => ResetAction,
+    +setParams: (params: ScreenParams) => SetParamsAction,
+  |};
+
+  declare export type GenericNavigationAction = {|
+    +type: string,
+    +payload?: { +[key: string]: mixed, ... },
+    +source?: string,
+    +target?: string,
+  |};
+
+  declare export type LeafRoute<RouteName: string = string> = {|
+    +key: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StateRoute<RouteName: string = string> = {|
+    ...LeafRoute<RouteName>,
+    +state: NavigationState | StaleNavigationState,
+  |};
+  declare export type Route<RouteName: string = string> =
+    | LeafRoute<RouteName>
+    | StateRoute<RouteName>;
+
+  declare export type NavigationState = {|
+    +key: string,
+    +index: number,
+    +routeNames: $ReadOnlyArray<string>,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<Route<>>,
+    +type: string,
+    +stale: false,
+  |};
+
+  declare export type StaleLeafRoute<RouteName: string = string> = {|
+    +key?: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StaleStateRoute<RouteName: string = string> = {|
+    ...StaleLeafRoute<RouteName>,
+    +state: StaleNavigationState,
+  |};
+  declare export type StaleRoute<RouteName: string = string> =
+    | StaleLeafRoute<RouteName>
+    | StaleStateRoute<RouteName>;
+  declare export type StaleNavigationState = {|
+    // It's possible to pass React Nav a StaleNavigationState with an undefined
+    // index, but React Nav will always return one with the index set. This is
+    // the same as for the type property below, but in the case of index we tend
+    // to rely on it being set more...
+    +index: number,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<StaleRoute<>>,
+    +type?: string,
+    +stale?: true,
+  |};
+
+  declare export type PossiblyStaleNavigationState =
+    | NavigationState
+    | StaleNavigationState;
+  declare export type PossiblyStaleRoute<RouteName: string = string> =
+    | Route<RouteName>
+    | StaleRoute<RouteName>;
+
+  /**
+   * Routers
+   */
+
+  declare type ActionCreators<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {
+    +[key: string]: (...args: any) => (Action | State => Action),
+    ...
+  };
+
+  declare export type DefaultRouterOptions = {
+    +initialRouteName?: string,
+    ...
+  };
+
+  declare export type RouterFactory<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    RouterOptions: DefaultRouterOptions,
+  > = (options: RouterOptions) => Router<State, Action>;
+
+  declare export type ParamListBase = { +[key: string]: ?ScreenParams, ... };
+
+  declare export type RouterConfigOptions = {|
+    +routeNames: $ReadOnlyArray<string>,
+    +routeParamList: ParamListBase,
+  |};
+
+  declare export type Router<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {|
+    +type: $PropertyType<State, 'type'>,
+    +getInitialState: (options: RouterConfigOptions) => State,
+    +getRehydratedState: (
+      partialState: PossibleStaleNavigationState,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteNamesChange: (
+      state: State,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteFocus: (state: State, key: string) => State,
+    +getStateForAction: (
+      state: State,
+      action: Action,
+      options: RouterConfigOptions,
+    ) => ?PossiblyStaleNavigationState;
+    +shouldActionChangeFocus: (action: GenericNavigationAction) => boolean,
+    +actionCreators?: ActionCreators<State, Action>,
+  |};
+
+  /**
+   * Stack actions and router
+   */
+
+  declare export type StackNavigationState = {|
+    ...NavigationState,
+    +type: 'stack',
+  |};
+
+  declare export type ReplaceAction = {|
+    +type: 'REPLACE',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PushAction = {|
+    +type: 'PUSH',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopAction = {|
+    +type: 'POP',
+    +payload: {| +count: number |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopToTopAction = {|
+    +type: 'POP_TO_TOP',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type StackAction =
+    | CommonAction
+    | ReplaceAction
+    | PushAction
+    | PopAction
+    | PopToTopAction;
+
+  declare export type StackActionsType = {|
+    +replace: (routeName: string, params?: ScreenParams) => ReplaceAction,
+    +push: (routeName: string, params?: ScreenParams) => PushAction,
+    +pop: (count?: number) => PopAction,
+    +popToTop: () => PopToTopAction,
+  |};
+
+  declare export type StackRouterOptions = $Exact<DefaultRouterOptions>;
+
+  /**
+   * Tab actions and router
+   */
+
+  declare export type TabNavigationState = {|
+    ...NavigationState,
+    +type: 'tab',
+    +history: $ReadOnlyArray<{| type: 'route', key: string |}>,
+  |};
+
+  declare export type JumpToAction = {|
+    +type: 'JUMP_TO',
+    +payload: {| +name: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type TabAction =
+    | CommonAction
+    | JumpToAction;
+
+  declare export type TabActionsType = {|
+    +jumpTo: string => JumpToAction,
+  |};
+
+  declare export type TabRouterOptions = {|
+    ...$Exact<DefaultRouterOptions>,
+    +backBehavior?: 'initialRoute' | 'order' | 'history' | 'none',
+  |};
+
+  /**
+   * Drawer actions and router
+   */
+
+  declare type DrawerHistoryEntry =
+    | {| +type: 'route', +key: string |}
+    | {| +type: 'drawer' |};
+  declare export type DrawerNavigationState = {|
+    ...NavigationState,
+    +type: 'drawer',
+    +history: $ReadOnlyArray<DrawerHistoryEntry>,
+  |};
+
+  declare export type OpenDrawerAction = {|
+    +type: 'OPEN_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CloseDrawerAction = {|
+    +type: 'CLOSE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ToggleDrawerAction = {|
+    +type: 'TOGGLE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type DrawerAction =
+    | TabAction
+    | OpenDrawerAction
+    | CloseDrawerAction
+    | ToggleDrawerAction;
+
+  declare export type DrawerActionsType = {|
+    ...TabActionsType,
+    +openDrawer: () => OpenDrawerAction,
+    +closeDrawer: () => CloseDrawerAction,
+    +toggleDrawer: () => ToggleDrawerAction,
+  |};
+
+  declare export type DrawerRouterOptions = {|
+    ...TabRouterOptions,
+    +openByDefault?: boolean,
+  |};
+
+  /**
+   * Events
+   */
+
+  declare export type EventMapBase = {
+    +[name: string]: {|
+      +data?: mixed,
+      +canPreventDefault?: boolean,
+    |},
+    ...
+  };
+  declare type EventPreventDefaultProperties<Test: boolean> = $If<
+    Test,
+    {| +defaultPrevented: boolean, +preventDefault: () => void |},
+    {| |},
+  >;
+  declare type EventDataProperties<Data> = $If<
+    $IsUndefined<Data>,
+    {| |},
+    {| +data: Data |},
+  >;
+  declare type EventArg<
+    EventName: string,
+    CanPreventDefault: ?boolean = false,
+    Data = void,
+  > = {|
+    ...EventPreventDefaultProperties<CanPreventDefault>,
+    ...EventDataProperties<Data>,
+    +type: EventName,
+    +target?: string,
+  |};
+  declare type GlobalEventMap<State: PossiblyStaleNavigationState> = {|
+    +state: {| +data: {| +state: State |}, +canPreventDefault: false |},
+  |};
+  declare type EventMapCore<State: PossiblyStaleNavigationState> = {|
+    ...GlobalEventMap<State>,
+    +focus: {| +data: void, +canPreventDefault: false |},
+    +blur: {| +data: void, +canPreventDefault: false |},
+  |};
+  declare type EventListenerCallback<
+    EventName: string,
+    State: NavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = (e: EventArg<
+    EventName,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'canPreventDefault',
+    >,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'data',
+    >,
+  >) => mixed;
+
+  /**
+   * Navigation prop
+   */
+
+  declare export type SimpleNavigate<ParamList> =
+    <DestinationRouteName: $Keys<ParamList>>(
+      routeName: DestinationRouteName,
+      params: $ElementType<ParamList, DestinationRouteName>,
+    ) => void;
+
+  declare export type Navigate<ParamList> =
+    & SimpleNavigate<ParamList>
+    & <DestinationRouteName: $Keys<ParamList>>(
+        route:
+          | {|
+              key: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |}
+          | {|
+              name: DestinationRouteName,
+              key?: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |},
+      ) => void;
+
+  declare type NavigationHelpers<
+    ParamList: ParamListBase,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    +navigate: Navigate<ParamList>,
+    +dispatch: (
+      action:
+        | GenericNavigationAction
+        | (State => GenericNavigationAction),
+    ) => void,
+    +reset: PossiblyStaleNavigationState => void,
+    +goBack: () => void,
+    +isFocused: () => boolean,
+    +canGoBack: () => boolean,
+    +dangerouslyGetParent: <Parent: NavigationProp<ParamListBase>>() => ?Parent,
+    +dangerouslyGetState: () => NavigationState,
+    +addListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => () => void,
+    +removeListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => void,
+    ...
+  };
+
+  declare export type NavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    ...$Exact<NavigationHelpers<
+      ParamList,
+      State,
+      EventMap,
+    >>,
+    +setOptions: (options: $Shape<ScreenOptions>) => void,
+    +setParams: (
+      params: $If<
+        $IsUndefined<$ElementType<ParamList, RouteName>>,
+        empty,
+        $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+      >,
+    ) => void,
+    ...
+  };
+
+  /**
+   * CreateNavigator
+   */
+
+  declare export type RouteProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+  > = {|
+    ...LeafRoute<RouteName>,
+    +params: $ElementType<ParamList, RouteName>,
+  |};
+
+  declare export type ScreenListeners<
+    EventMap: EventMapBase = EventMapCore<State>,
+    State: NavigationState = NavigationState,
+  > = $ObjMapi<
+    {| [name: $Keys<EventMap>]: empty |},
+    <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
+  >;
+
+  declare type BaseScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {|
+    +name: RouteName,
+    +options?:
+      | ScreenOptions
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenOptions,
+    +listeners?:
+      | ScreenListeners<EventMap, State>
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenListeners<EventMap, State>,
+    +initialParams?: $Shape<$ElementType<ParamList, RouteName>>,
+  |};
+
+  declare export type ScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > =
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +component: React$ComponentType<{|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}>,
+      |}
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +children: ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => React$Node,
+      |};
+
+  declare export type ScreenComponent<
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = <
+    RouteName: $Keys<ParamList>,
+    NavProp: NavigationProp<
+      GlobalParamList,
+      RouteName,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+  >(props: ScreenProps<
+    ParamList,
+    NavProp,
+    RouteName,
+    State,
+    ScreenOptions,
+    EventMap,
+  >) => React$Node;
+
+  declare type ScreenOptionsProp<ScreenOptions: {...}, NavProp> = {|
+    +screenOptions?:
+      | ScreenOptions
+      | ({| route: LeafRoute<>, navigation: NavProp |}) => ScreenOptions,
+  |};
+  declare export type ExtraNavigatorPropsBase = {
+    ...$Exact<DefaultRouterOptions>,
+    +children?: React$Node,
+    ...
+  };
+  declare export type NavigatorPropsBase<ScreenOptions: {...}, NavProp> = {
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    ...
+  };
+
+  declare export type CreateNavigator<
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  > = <
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    NavProp: NavigationHelpers<
+      GlobalParamList,
+      State,
+      EventMap,
+    >,
+  >() => {|
+    +Screen: ScreenComponent<
+      GlobalParamList,
+      ParamList,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+    +Navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorProps>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  |};
+
+  declare export type CreateNavigatorFactory = <
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    NavProp: NavigationHelpers<
+      ParamListBase,
+      State,
+      EventMap,
+    >,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  >(
+    navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorPropsBase>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  ) => CreateNavigator<State, ScreenOptions, EventMap, ExtraNavigatorProps>;
+
+  /**
+   * useNavigationBuilder
+   */
+
+  declare export type Descriptor<
+    NavProp,
+    ScreenOptions: {...} = {...},
+  > = {|
+    +render: () => React$Node,
+    +options: $ReadOnly<ScreenOptions>,
+    +navigation: NavProp,
+  |};
+
+  declare export type UseNavigationBuilder = <
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    ScreenOptions: {...},
+    RouterOptions: DefaultRouterOptions,
+    NavProp,
+  >(
+    routerFactory: RouterFactory<State, Action, RouterOptions>,
+    options: {|
+      ...$Exact<RouterOptions>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+      +children?: React$Node,
+    |},
+  ) => {|
+    +state: State,
+    +descriptors: {| +[key: string]: Descriptor<NavProp, ScreenOptions> |},
+    +navigation: NavProp,
+  |};
+
+  /**
+   * EdgeInsets
+   */
+
+  declare type EdgeInsets = {|
+    +top: number,
+    +right: number,
+    +bottom: number,
+    +left: number,
+  |};
+
+  /**
+   * TransitionPreset
+   */
+
+  declare export type TransitionSpec =
+    | {|
+        animation: 'spring',
+        config: $Diff<
+          SpringAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |}
+    | {|
+        animation: 'timing',
+        config: $Diff<
+          TimingAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |};
+
+  declare export type StackCardInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +index: number,
+    +closing: AnimatedInterpolation,
+    +swiping: AnimatedInterpolation,
+    +inverted: AnimatedInterpolation,
+    +layouts: {|
+      +screen: {| +width: number, +height: number |},
+    |},
+    +insets: EdgeInsets,
+  |};
+  declare export type StackCardInterpolatedStyle = {|
+    containerStyle?: AnimatedViewStyleProp,
+    cardStyle?: AnimatedViewStyleProp,
+    overlayStyle?: AnimatedViewStyleProp,
+    shadowStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackCardStyleInterpolator = (
+    props: StackCardInterpolationProps,
+  ) => StackCardInterpolatedStyle;
+
+  declare export type StackHeaderInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +layouts: {|
+      +header: {| +width: number, +height: number |},
+      +screen: {| +width: number, +height: number |},
+      +title?: {| +width: number, +height: number |},
+      +leftLabel?: {| +width: number, +height: number |},
+    |},
+  |};
+  declare export type StackHeaderInterpolatedStyle = {|
+    leftLabelStyle?: AnimatedViewStyleProp,
+    leftButtonStyle?: AnimatedViewStyleProp,
+    rightButtonStyle?: AnimatedViewStyleProp,
+    titleStyle?: AnimatedViewStyleProp,
+    backgroundStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackHeaderStyleInterpolator = (
+    props: StackHeaderInterpolationProps,
+  ) => StackHeaderInterpolatedStyle;
+
+  declare type GestureDirection =
+    | 'horizontal'
+    | 'horizontal-inverted'
+    | 'vertical'
+    | 'vertical-inverted';
+
+  declare export type TransitionPreset = {|
+    +gestureDirection: GestureDirection,
+    +transitionSpec: {|
+      +open: TransitionSpec,
+      +close: TransitionSpec,
+    |},
+    +cardStyleInterpolator: StackCardStyleInterpolator,
+    +headerStyleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  /**
+   * Stack options
+   */
+
+  declare export type StackDescriptor = Descriptor<
+    StackNavigationProp<>,
+    StackOptions,
+  >;
+
+  declare type Scene<T> = {|
+    +route: T,
+    +descriptor: StackDescriptor,
+    +progress: {|
+      +current: AnimatedInterpolation,
+      +next?: AnimatedInterpolation,
+      +previous?: AnimatedInterpolation,
+    |},
+  |};
+
+  declare export type StackHeaderProps = {|
+    +mode: 'float' | 'screen',
+    +layout: {| +width: number, +height: number |},
+    +insets: EdgeInsets,
+    +scene: Scene<Route<>>,
+    +previous?: Scene<Route<>>,
+    +navigation: StackNavigationProp<ParamListBase>,
+    +styleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  declare export type StackHeaderLeftButtonProps = $Shape<{|
+    +onPress: (() => void),
+    +pressColorAndroid: string;
+    +backImage: (props: {| tintColor: string |}) => React$Node,
+    +tintColor: string,
+    +label: string,
+    +truncatedLabel: string,
+    +labelVisible: boolean,
+    +labelStyle: AnimatedTextStyleProp,
+    +allowFontScaling: boolean,
+    +onLabelLayout: LayoutEvent => void,
+    +screenLayout: {| +width: number, +height: number |},
+    +titleLayout: {| +width: number, +height: number |},
+    +canGoBack: boolean,
+  |}>;
+
+  declare type StackHeaderTitleInputBase = {
+    +onLayout: LayoutEvent => void,
+    +children: string,
+    +allowFontScaling: ?boolean,
+    +tintColor: ?string,
+    +style: ?AnimatedTextStyleProp,
+    ...
+  };
+
+  declare export type StackHeaderTitleInputProps =
+    $Exact<StackHeaderTitleInputBase>;
+
+  declare export type StackOptions = $Shape<{|
+    +title: string,
+    +header: StackHeaderProps => React$Node,
+    +headerShown: boolean,
+    +cardShadowEnabled: boolean,
+    +cardOverlayEnabled: boolean,
+    +cardOverlay: {| style: ViewStyleProp |} => React$Node,
+    +cardStyle: ViewStyleProp,
+    +animationEnabled: boolean,
+    +animationTypeForReplace: 'push' | 'pop',
+    +gestureEnabled: boolean,
+    +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
+    +gestureVelocityImpact: number,
+    +safeAreaInsets: $Shape<EdgeInsets>,
+    // Transition
+    ...TransitionPreset,
+    // Header
+    +headerTitle: string | (StackHeaderTitleInputProps => React$Node),
+    +headerTitleAlign: 'left' | 'center',
+    +headerTitleStyle: AnimatedTextStyleProp,
+    +headerTitleContainerStyle: ViewStyleProp,
+    +headerTintColor: string,
+    +headerTitleAllowFontScaling: boolean,
+    +headerBackAllowFontScaling: boolean,
+    +headerBackTitle: string,
+    +headerBackTitleStyle: TextStyleProp,
+    +headerBackTitleVisible: boolean,
+    +headerTruncatedBackTitle: string,
+    +headerLeft: StackHeaderLeftButtonProps => React$Node,
+    +headerLeftContainerStyle: ViewStyleProp,
+    +headerRight: {| tintColor?: string |} => React$Node,
+    +headerRightContainerStyle: ViewStyleProp,
+    +headerBackImage: $PropertyType<StackHeaderLeftButtonProps, 'backImage'>,
+    +headerPressColorAndroid: string,
+    +headerBackground: ({| style: ViewStyleProp |}) => React$Node,
+    +headerStyle: ViewStyleProp,
+    +headerTransparent: boolean,
+    +headerStatusBarHeight: number,
+  |}>;
+
+  /**
+   * Stack navigation prop
+   */
+
+  declare export type StackNavigationEventMap = {|
+    ...EventMapCore<StackNavigationState>,
+    +transitionStart: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+    +transitionEnd: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+  |};
+
+  declare type InexactStackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      StackNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +replace: SimpleNavigate<ParamList>,
+    +push: SimpleNavigate<ParamList>,
+    +pop: (count?: number) => void,
+    +popToTop: () => void,
+    ...
+  };
+
+  declare export type StackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = $Exact<InexactStackNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous stack exports
+   */
+
+  declare type StackNavigationConfig = {|
+    +mode?: 'card' | 'modal',
+    +headerMode?: 'float' | 'screen' | 'none',
+    +keyboardHandlingEnabled?: boolean,
+  |};
+
+  declare export type ExtraStackNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...StackRouterOptions,
+    ...StackNavigationConfig,
+  |};
+
+  declare export type StackNavigatorProps<
+    NavProp: InexactStackNavigationProp<> = StackNavigationProp<>,
+  > = {|
+    ...ExtraStackNavigatorProps,
+    ...ScreenOptionsProp<StackOptions, NavProp>,
+  |};
+
+  /**
+   * Bottom tab options
+   */
+
+  declare export type BottomTabBarButtonProps = {|
+    ...$Diff<
+      TouchableWithoutFeedbackProps,
+      {| onPress?: ?(event: PressEvent) => mixed |},
+    >,
+    +to?: string,
+    +children: React$Node,
+    +onPress?: (MouseEvent | PressEvent) => void,
+  |};
+
+  declare export type BottomTabOptions = $Shape<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| focused: boolean, color: string |}) => React$Node,
+    +tabBarIcon: ({|
+      focused: boolean,
+      color: string,
+      size: number,
+    |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+    +tabBarVisible: boolean,
+    +tabBarButton: BottomTabBarButtonProps => React$Node,
+    +unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Bottom tab navigation prop
+   */
+
+  declare export type BottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare type InexactTabNavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+    Options: {...},
+    EventMap: EventMapBase,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      TabNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    ...
+  };
+
+  declare export type InexactBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type BottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = $Exact<InexactBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous bottom tab exports
+   */
+
+  declare export type BottomTabDescriptor = Descriptor<
+    BottomTabNavigationProp<>,
+    BottomTabOptions,
+  >;
+
+  declare export type BottomTabBarOptions = $Shape<{|
+    +keyboardHidesTabBar: boolean,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveBackgroundColor: string,
+    +allowFontScaling: boolean,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +labelStyle: TextStyleProp,
+    +tabStyle: ViewStyleProp,
+    +labelPosition: 'beside-icon' | 'below-icon',
+    +adaptive: boolean,
+    +safeAreaInsets: $Shape<EdgeInsets>,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type BottomTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: BottomTabNavigationProp<>,
+    +descriptors: {| +[key: string]: BottomTabDescriptor |},
+  |};
+
+  declare export type BottomTabBarProps = {|
+    ...BottomTabBarOptions,
+    ...BottomTabNavigationBuilderResult,
+  |}
+
+  declare type BottomTabNavigationConfig = {|
+    +lazy?: boolean,
+    +tabBar?: BottomTabBarProps => React$Node,
+    +tabBarOptions?: BottomTabBarOptions,
+  |};
+
+  declare export type ExtraBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...BottomTabNavigationConfig,
+  |};
+
+  declare export type BottomTabNavigatorProps<
+    NavProp: InexactBottomTabNavigationProp<> = BottomTabNavigationProp<>,
+  > = {|
+    ...ExtraBottomTabNavigatorProps,
+    ...ScreenOptionsProp<BottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material bottom tab options
+   */
+
+  declare export type MaterialBottomTabOptions = $Shape<{|
+    +title: string,
+    +tabBarColor: string,
+    +tabBarLabel: string,
+    +tabBarIcon:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarBadge: boolean | number | string,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material bottom tab navigation prop
+   */
+
+  declare export type MaterialBottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+  |};
+
+  declare export type InexactMaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = $Exact<InexactMaterialBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material bottom tab exports
+   */
+
+  declare export type PaperFont = {|
+    +fontFamily: string,
+    +fontWeight?:
+      | 'normal'
+      | 'bold'
+      | '100'
+      | '200'
+      | '300'
+      | '400'
+      | '500'
+      | '600'
+      | '700'
+      | '800'
+      | '900',
+  |};
+
+  declare export type PaperFonts = {|
+    +regular: Font,
+    +medium: Font,
+    +light: Font,
+    +thin: Font,
+  |};
+
+  declare export type PaperTheme = {|
+    +dark: boolean,
+    +mode?: 'adaptive' | 'exact',
+    +roundness: number,
+    +colors: {|
+      +primary: string,
+      +background: string,
+      +surface: string,
+      +accent: string,
+      +error: string,
+      +text: string,
+      +onSurface: string,
+      +onBackground: string,
+      +disabled: string,
+      +placeholder: string,
+      +backdrop: string,
+      +notification: string,
+    |},
+    +fonts: PaperFonts,
+    +animation: {|
+      +scale: number,
+    |},
+  |};
+
+  declare export type PaperRoute = {|
+    +key: string,
+    +title?: string,
+    +icon?: any,
+    +badge?: string | number | boolean,
+    +color?: string,
+    +accessibilityLabel?: string,
+    +testID?: string,
+  |};
+
+  declare export type PaperTouchableProps = {|
+    ...TouchableWithoutFeedbackProps,
+    +key: string,
+    +route: PaperRoute,
+    +children: React$Node,
+    +borderless?: boolean,
+    +centered?: boolean,
+    +rippleColor?: string,
+  |};
+
+  declare export type MaterialBottomTabNavigationConfig = {|
+    +shifting?: boolean,
+    +labeled?: boolean,
+    +renderTouchable?: PaperTouchableProps => React$Node,
+    +activeColor?: string,
+    +inactiveColor?: string,
+    +sceneAnimationEnabled?: boolean,
+    +keyboardHidesNavigationBar?: boolean,
+    +barStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +theme?: PaperTheme,
+  |};
+
+  declare export type ExtraMaterialBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialBottomTabNavigationConfig,
+  |};
+
+  declare export type MaterialBottomTabNavigatorProps<
+    NavProp: InexactMaterialBottomTabNavigationProp<> =
+      MaterialBottomTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialBottomTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialBottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material top tab options
+   */
+
+  declare export type MaterialTopTabOptions = $Shape<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarIcon: ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material top tab navigation prop
+   */
+
+  declare export type MaterialTopTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+    +swipeStart: {| +data: void, +canPreventDefault: false |},
+    +swipeEnd: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactMaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = $Exact<InexactMaterialTopTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material top tab exports
+   */
+
+  declare type MaterialTopTabPagerCommonProps = {|
+    +keyboardDismissMode: 'none' | 'on-drag' | 'auto',
+    +swipeEnabled: boolean,
+    +swipeVelocityImpact?: number,
+    +springVelocityScale?: number,
+    +springConfig: $Shape<{|
+      +damping: number,
+      +mass: number,
+      +stiffness: number,
+      +restSpeedThreshold: number,
+      +restDisplacementThreshold: number,
+    |}>,
+    +timingConfig: $Shape<{|
+      +duration: number,
+    |}>,
+  |};
+
+  declare export type MaterialTopTabPagerProps = {|
+    ...MaterialTopTabPagerCommonProps,
+    +onSwipeStart?: () => void,
+    +onSwipeEnd?: () => void,
+    +onIndexChange: (index: number) => void,
+    +navigationState: TabNavigationState,
+    +layout: {| +width: number, +height: number |},
+    +removeClippedSubviews: boolean,
+    +children: ({|
+      +addListener: (type: 'enter', listener: number => void) => void,
+      +removeListener: (type: 'enter', listener: number => void) => void,
+      +position: any, // Reanimated.Node<number>
+      +render: React$Node => React$Node,
+      +jumpTo: string => void,
+    |}) => React$Node,
+    +gestureHandlerProps: PanGestureHandlerProps,
+  |};
+
+  declare export type MaterialTopTabBarIndicatorProps = {|
+    +navigationState: TabNavigationState,
+    +width: string,
+    +style?: ViewStyleProp,
+    +getTabWidth: number => number,
+  |};
+
+  declare export type MaterialTopTabBarOptions = $Shape<{|
+    +scrollEnabled: boolean,
+    +bounces: boolean,
+    +pressColor: string,
+    +pressOpacity: number,
+    +getAccessible: ({| +route: Route<> |}) => boolean,
+    +renderBadge: ({| +route: Route<> |}) => React$Node,
+    +renderIndicator: MaterialTopTabBarIndicatorProps => React$Node,
+    +tabStyle: ViewStyleProp,
+    +indicatorStyle: ViewStyleProp,
+    +indicatorContainerStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +iconStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +allowFontScaling: boolean,
+  |}>;
+
+  declare export type MaterialTopTabDescriptor = Descriptor<
+    MaterialBottomTabNavigationProp<>,
+    MaterialBottomTabOptions,
+  >;
+
+  declare type MaterialTopTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: MaterialTopTabNavigationProp<>,
+    +descriptors: {| +[key: string]: MaterialTopTabDescriptor |},
+  |};
+
+  declare export type MaterialTopTabBarProps = {|
+    ...MaterialTopTabBarOptions,
+    ...MaterialTopTabNavigationBuilderResult,
+    +layout: {| +width: number, +height: number |},
+    +position: any, // Reanimated.Node<number>
+    +jumpTo: string => void,
+  |};
+
+  declare export type MaterialTopTabNavigationConfig = {|
+    ...$Partial<MaterialTopTabPagerCommonProps>,
+    +position?: any, // Reanimated.Value<number>
+    +tabBarPosition?: 'top' | 'bottom',
+    +initialLayout?: $Shape<{| +width: number, +height: number |}>,
+    +lazy?: boolean,
+    +lazyPreloadDistance?: number,
+    +removeClippedSubviews?: boolean,
+    +sceneContainerStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +pager?: MaterialTopTabPagerProps => React$Node,
+    +lazyPlaceholder?: ({| +route: Route<> |}) => React$Node,
+    +tabBar?: MaterialTopTabBarProps => React$Node,
+    +tabBarOptions?: MaterialTopTabBarOptions,
+  |};
+
+  declare export type ExtraMaterialTopTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialTopTabNavigationConfig,
+  |};
+
+  declare export type MaterialTopTabNavigatorProps<
+    NavProp: InexactMaterialTopTabNavigationProp<> =
+      MaterialTopTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialTopTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialTopTabOptions, NavProp>,
+  |};
+
+  /**
+   * Drawer options
+   */
+
+  declare export type DrawerOptions = $Shape<{|
+    title: string,
+    drawerLabel:
+      | string
+      | ({| +color: string, +focused: boolean |}) => React$Node,
+    drawerIcon: ({|
+      +color: string,
+      +size: number,
+      +focused: boolean,
+    |}) => React$Node,
+    gestureEnabled: boolean,
+    swipeEnabled: boolean,
+    unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Drawer navigation prop
+   */
+
+  declare export type DrawerNavigationEventMap = {|
+    ...EventMapCore<DrawerNavigationState>,
+    +drawerOpen: {| +data: void, +canPreventDefault: false |},
+    +drawerClose: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactDrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      DrawerNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    +openDrawer: () => void,
+    +closeDrawer: () => void,
+    +toggleDrawer: () => void,
+    ...
+  };
+
+  declare export type DrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = $Exact<InexactDrawerNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous drawer exports
+   */
+
+  declare export type DrawerDescriptor = Descriptor<
+    DrawerNavigationProp<>,
+    DrawerOptions,
+  >;
+
+  declare export type DrawerItemListBaseOptions = $Shape<{|
+    +activeTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveTintColor: string,
+    +inactiveBackgroundColor: string,
+    +itemStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+  |}>;
+
+  declare export type DrawerContentOptions = $Shape<{|
+    ...DrawerItemListBaseOptions,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type DrawerNavigationBuilderResult = {|
+    +state: DrawerNavigationState,
+    +navigation: DrawerNavigationProp<>,
+    +descriptors: {| +[key: string]: DrawerDescriptor |},
+  |};
+
+  declare export type DrawerContentProps = {|
+    ...DrawerContentOptions,
+    ...DrawerNavigationBuilderResult,
+    +progress: any, // Reanimated.Node<number>
+  |};
+
+  declare export type DrawerNavigationConfig = {|
+    +drawerPosition?: 'left' | 'right',
+    +drawerType?: 'front' | 'back' | 'slide' | 'permanent',
+    +edgeWidth?: number,
+    +hideStatusBar?: boolean,
+    +keyboardDismissMode?: 'on-drag' | 'none',
+    +minSwipeDistance?: number,
+    +overlayColor?: string,
+    +statusBarAnimation?: 'slide' | 'none' | 'fade',
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +lazy?: boolean,
+    +drawerContent?: DrawerContentProps => React$Node,
+    +drawerContentOptions?: DrawerContentOptions,
+    +sceneContainerStyle?: ViewStyleProp,
+    +drawerStyle?: ViewStyleProp,
+  |};
+
+  declare export type ExtraDrawerNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...DrawerRouterOptions,
+    ...DrawerNavigationConfig,
+  |};
+
+  declare export type DrawerNavigatorProps<
+    NavProp: InexactDrawerNavigationProp<> = DrawerNavigationProp<>,
+  > = {|
+    ...ExtraDrawerNavigatorProps,
+    ...ScreenOptionsProp<DrawerOptions, NavProp>,
+  |};
+
+  /**
+   * BaseNavigationContainer
+   */
+
+  declare export type BaseNavigationContainerProps = {|
+    +children: React$Node,
+    +initialState?: PossiblyStaleNavigationState,
+    +onStateChange?: (state: ?PossiblyStaleNavigationState) => void,
+    +independent?: boolean,
+  |};
+
+  declare export type BaseNavigationContainerInterface = {|
+    ...$Exact<NavigationHelpers<
+      ParamListBase,
+      PossiblyStaleNavigationState,
+      GlobalEventMap<PossiblyStaleNavigationState>,
+    >>,
+    +setParams: (params: ScreenParams) => void,
+    +resetRoot: (state?: ?PossiblyStaleNavigationState) => void,
+    +getRootState: () => PossiblyStaleNavigationState,
+  |};
+
+  /**
+   * State / path conversion
+   */
+
+  declare export type LinkingConfig = {|
+    +[routeName: string]:
+      | string
+      | {|
+          +path?: string,
+          +parse?: {| +[param: string]: string => mixed |},
+          +screens?: LinkingConfig,
+          +initialRouteName?: string,
+        |},
+  |};
+
+  declare export type GetPathFromStateOptions = {|
+    +[routeName: string]:
+      | string
+      | {|
+          +path?: string,
+          +stringify?: {| +[param: string]: mixed => string |},
+          +screens?: GetPathFromStateOptions,
+        |},
+  |};
+
+  //---------------------------------------------------------------------------
+  // SECTION 2: EXPORTED MODULE
+  // This section defines the module exports and contains exported types that
+  // are not present in any other React Navigation libdef.
+  //---------------------------------------------------------------------------
+
+  /**
+   * Actions and routers
+   */
+
+  declare export var CommonActions: CommonActionsType;
+  declare export var StackActions: StackActionsType;
+  declare export var TabActions: TabActionsType;
+  declare export var DrawerActions: DrawerActionsType;
+
+  declare export var BaseRouter: RouterFactory<
+    NavigationState,
+    CommonAction,
+    DefaultRouterOptions,
+  >;
+  declare export var StackRouter: RouterFactory<
+    StackNavigationState,
+    StackAction,
+    StackRouterOptions,
+  >;
+  declare export var TabRouter: RouterFactory<
+    TabNavigationState,
+    TabAction,
+    TabRouterOptions,
+  >;
+  declare export var DrawerRouter: RouterFactory<
+    DrawerNavigationState,
+    DrawerAction,
+    DrawerRouterOptions,
+  >;
+
+  /**
+   * Navigator utils
+   */
+
+  declare export var BaseNavigationContainer: React$AbstractComponent<
+    BaseNavigationContainerProps,
+    BaseNavigationContainerInterface,
+  >;
+
+  declare export var createNavigatorFactory: CreateNavigatorFactory;
+
+  declare export var useNavigationBuilder: UseNavigationBuilder;
+
+  declare export var NavigationHelpersContext: React$Context<
+    ?NavigationHelpers<ParamListBase>,
+  >;
+
+  /**
+   * Navigation prop / route accessors
+   */
+
+  declare export var NavigationContext: React$Context<
+    ?NavigationProp<ParamListBase>,
+  >;
+  declare export function useNavigation(): NavigationProp<ParamListBase>;
+
+  declare export var NavigationRouteContext: React$Context<?LeafRoute<>>;
+  declare export function useRoute(): LeafRoute<>;
+
+  declare export function useNavigationState<T>(
+    selector: NavigationState => T,
+  ): T;
+
+  /**
+   * Focus utils
+   */
+
+  declare export function useFocusEffect(
+    effect: () => ?(() => mixed),
+  ): void;
+  declare export function useIsFocused(): boolean;
+
+  /**
+   * State utils
+   */
+
+  declare export function getStateFromPath(
+    path: string,
+    options?: LinkingConfig,
+  ): PossiblyStaleNavigationState;
+
+  declare export function getPathFromState(
+    state?: ?PossiblyStaleNavigationState,
+    options?: GetPathFromStateOptions,
+  ): string;
+
+  declare export function getActionFromState(
+    state: PossiblyStaleNavigationState,
+  ): ?NavigateAction;
+
+}
+
+declare module '@react-navigation/core/src/NavigationBuilderContext' {
+
+  declare type GenericNavigationAction = {|
+    +type: string,
+    +payload?: { +[key: string]: mixed, ... },
+    +source?: string,
+    +target?: string,
+  |};
+
+  declare export default React$Context<{
+    trackAction: (action: GenericNavigationAction) => void,
+    ...
+  }>;
+
+}

--- a/definitions/npm/@react-navigation/core_v5.x.x/test_core.js
+++ b/definitions/npm/@react-navigation/core_v5.x.x/test_core.js
@@ -1,0 +1,254 @@
+// @flow
+
+import * as React from 'react';
+import {
+  type NavigationProp,
+  type NavigationState,
+  type ParamListBase,
+  type StackRouterOptions,
+  type DefaultRouterOptions,
+  type Router,
+  type CommonAction,
+  type NavigatorPropsBase,
+  type ExtraNavigatorPropsBase,
+  type LeafRoute,
+  CommonActions,
+  BaseRouter,
+  StackRouter,
+  TabRouter,
+  useNavigationBuilder,
+  createNavigatorFactory,
+} from '@react-navigation/core';
+
+/**
+ * Navigation prop
+ */
+
+type LocalParamList = {|
+  CoolScreen: {|
+    sup: boolean,
+    yo: ?string,
+  |},
+  another: ?{|
+    eh: string,
+  |},
+|};
+type GlobalParamList = {|
+  ...LocalParamList,
+  globalRoute: void,
+|};
+
+declare var navProp: NavigationProp<
+  GlobalParamList,
+  'CoolScreen',
+  NavigationState,
+  {||},
+  {|
+    +test: {| +data: boolean, +canPreventDefault: true |},
+    +another: {| +data: string, +canPreventDefault: false |},
+    +third: {| +data: void, +canPreventDefault: true |},
+  |},
+>;
+
+const removeListener = navProp.addListener('test', e => {
+  (e.type: 'test');
+  (e.data: boolean);
+  e.preventDefault();
+});
+removeListener();
+navProp.addListener('another', e => {
+  (e.type: 'another');
+  (e.data: string);
+  // $ExpectError canPreventDefault set to false
+  e.preventDefault();
+});
+navProp.addListener('third', e => {
+  (e.type: 'third');
+  (e.target: ?string);
+  // $ExpectError there's no data field on this event
+  e.data;
+  e.preventDefault();
+});
+navProp.setParams({ sup: false });
+
+navProp.navigate('CoolScreen', { sup: true, yo: null });
+// $ExpectError CoolScreen route needs params
+navProp.navigate('CoolScreen');
+navProp.navigate({ name: 'CoolScreen', params: { sup: true, yo: null } });
+navProp.navigate('another');
+navProp.navigate('another', { eh: 'hello' });
+// $ExpectError wrong params
+navProp.navigate('another', { eh: 'yo', fake: 'hello' });
+// $ExpectError not a valid route name
+navProp.navigate('another2');
+
+navProp.dispatch(CommonActions.goBack());
+
+declare var inexactNavProp: NavigationProp<
+  {
+    ...ParamListBase,
+    CoolScreen: {
+      sup: boolean,
+      yo: ?string,
+      ...
+    },
+    another?: {
+      eh: string,
+      ...
+    },
+    ...
+  },
+  'test',
+  NavigationState,
+  {||},
+  {||},
+>;
+inexactNavProp.navigate('another2');
+// $ExpectError CoolScreen route needs params
+inexactNavProp.navigate('CoolScreen');
+inexactNavProp.navigate('another', { eh: 'yo', fake: 'hello' });
+
+/**
+ * Custom router & navigator setup
+ */
+
+function CustomRouter(
+  routerOptions: DefaultRouterOptions,
+): Router<NavigationState, CommonAction> {
+  const {
+    actionCreators: baseActionCreators,
+    ...rest
+  } = BaseRouter(routerOptions);
+  return {
+    ...rest,
+    actionCreators: {
+      ...baseActionCreators,
+      goBackOnce: () => state => ({
+       ...CommonActions.goBack(),
+       target: state.key,
+     }),
+    },
+  };
+}
+
+type CustomRouterNavigationProp<
+  ParamList: ParamListBase = ParamListBase,
+  RouteName: string = string,
+> = {|
+  ...$Exact<NavigationProp<ParamList, RouteName, NavigationState, {||}, {||}>>,
+  +goBackOnce: () => void,
+|};
+
+type CustomNavigatorProps = $Exact<NavigatorPropsBase<
+  {||},
+  CustomRouterNavigationProp<>,
+>>;
+function CustomNavigator(props: CustomNavigatorProps) {
+  const { initialRouteName, screenOptions, children } = props;
+  const { state, descriptors, navigation } = useNavigationBuilder(
+    CustomRouter,
+    {
+      children,
+      screenOptions,
+      initialRouteName,
+    },
+  );
+
+  const currentRouteKey = state.routes[state.index].key;
+  const descriptor = descriptors[currentRouteKey];
+
+  return descriptor.render();
+}
+
+const createCustomNavigator = createNavigatorFactory<
+  NavigationState,
+  {||},
+  {||},
+  CustomRouterNavigationProp<>,
+  ExtraNavigatorPropsBase,
+>(CustomNavigator);
+
+type ExampleNavigationProp<
+  RouteName: $Keys<LocalParamList> = $Keys<LocalParamList>,
+> = CustomRouterNavigationProp<GlobalParamList, RouteName>;
+type ExampleRoute<
+  RouteName: $Keys<LocalParamList> = $Keys<LocalParamList>,
+> = {|
+  ...LeafRoute<RouteName>,
+  +params: $ElementType<LocalParamList, RouteName>,
+|};
+
+const Example = createCustomNavigator<
+  GlobalParamList,
+  LocalParamList,
+  ExampleNavigationProp<>,
+>();
+
+function CoolScreen(props: {|
+  navigation: ExampleNavigationProp<'CoolScreen'>,
+  route: ExampleRoute<'CoolScreen'>,
+|}) {
+  return null;
+}
+
+function BadlyTypedCoolScreen(props: {|
+  navigation: ExampleNavigationProp<'CoolScreen'>,
+  route: number,
+|}) {
+  return null;
+}
+
+<Example.Screen name="CoolScreen" component={CoolScreen} />;
+// $ExpectError invalid route name
+<Example.Screen name="Fake" component={CoolScreen} />;
+// $ExpectError invalid screen props
+<Example.Screen name="CoolScreen" component={BadlyTypedCoolScreen} />;
+
+/**
+ * Routers
+ */
+
+const someState = {
+  routes: [],
+  index: 0,
+  routeNames: [],
+  key: '',
+  stale: false,
+  history: [],
+};
+const routerConfigOptions = {
+  routeNames: [],
+  routeParamList: {},
+};
+
+const stackRouter = StackRouter({});
+const stackState = { ...someState, type: 'stack' };
+stackRouter.getStateForAction(
+  stackState,
+  { type: 'NAVIGATE', payload: { name: 'Test3' } },
+  routerConfigOptions,
+);
+stackRouter.getStateForAction(
+  stackState,
+  { type: 'PUSH', payload: { name: 'Test3' } },
+  routerConfigOptions,
+);
+
+const tabRouter = TabRouter({});
+const tabState = { ...someState, type: 'tab' };
+tabRouter.getStateForAction(
+  tabState,
+  { type: 'NAVIGATE', payload: { name: 'Test1' } },
+  routerConfigOptions,
+);
+tabRouter.getStateForAction(
+  tabState,
+  { type: 'JUMP_TO', payload: { name: 'Test1' } },
+  routerConfigOptions,
+);
+tabRouter.getStateForAction(
+  tabState,
+  // $ExpectError not a valid action!
+  { fake: 'NAVIGATE', blah: 'Test1' },
+  routerConfigOptions,
+);

--- a/definitions/npm/@react-navigation/drawer_v5.x.x/CONTRIBUTING.md
+++ b/definitions/npm/@react-navigation/drawer_v5.x.x/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to the React Navigation Flow libdef
+
+## Overview
+
+There are seven React Navigation libdefs in `flow-typed`:
+
+1. `@react-navigation/core`
+2. `@react-navigation/native`
+3. `@react-navigation/stack`
+4. `@react-navigation/bottom-tabs`
+5. `@react-navigation/material-bottom-tabs`
+6. `@react-navigation/material-top-tabs`
+7. `@react-navigation/drawer`
+
+It's not currently possible to import types between libdefs. Consequently, many of the same types are copy-pasted across the different libdefs.
+
+Each libdef is organized into two sections. The first section should be identical between all of the libdefs. If you make a change to this section, please make sure to mirror it across the other libdefs.
+
+## Contributors
+
+- @Ashoat

--- a/definitions/npm/@react-navigation/drawer_v5.x.x/flow_v0.104.x-/drawer_v5.x.x.js
+++ b/definitions/npm/@react-navigation/drawer_v5.x.x/flow_v0.104.x-/drawer_v5.x.x.js
@@ -1,0 +1,2034 @@
+declare module '@react-navigation/drawer' {
+
+  //---------------------------------------------------------------------------
+  // SECTION 1: IDENTICAL TYPE DEFINITIONS
+  // This section is identical across all React Navigation libdefs and contains
+  // shared definitions. We wish we could make it DRY and import from a shared
+  // definition, but that isn't yet possible.
+  //---------------------------------------------------------------------------
+
+  /**
+   * We start with some definitions that we have copy-pasted from React Native
+   * source files.
+   */
+
+  // This is a bastardization of the true StyleObj type located in
+  // react-native/Libraries/StyleSheet/StyleSheetTypes. We unfortunately can't
+  // import that here, and it's too lengthy (and consequently too brittle) to
+  // copy-paste here either.
+  declare type StyleObj =
+    | null
+    | void
+    | number
+    | false
+    | ''
+    | $ReadOnlyArray<StyleObj>
+    | { [name: string]: any, ... };
+  declare type ViewStyleProp = StyleObj;
+  declare type TextStyleProp = StyleObj;
+  declare type AnimatedViewStyleProp = StyleObj;
+  declare type AnimatedTextStyleProp = StyleObj;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/animations/Animation.js
+  declare type EndResult = { finished: boolean, ... };
+  declare type EndCallback = (result: EndResult) => void;
+  declare interface Animation {
+    start(
+      fromValue: number,
+      onUpdate: (value: number) => void,
+      onEnd: ?EndCallback,
+      previousAnimation: ?Animation,
+      animatedValue: AnimatedValue,
+    ): void;
+    stop(): void;
+  }
+  declare type AnimationConfig = {
+    isInteraction?: boolean,
+    useNativeDriver: boolean,
+    onComplete?: ?EndCallback,
+    iterations?: number,
+    ...
+  };
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedTracking.js
+  declare interface AnimatedTracking {
+    constructor(
+      value: AnimatedValue,
+      parent: any,
+      animationClass: any,
+      animationConfig: Object,
+      callback?: ?EndCallback,
+    ): void;
+    update(): void;
+  }
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedValue.js
+  declare type ValueListenerCallback = (state: { value: number, ... }) => void;
+  declare interface AnimatedValue {
+    constructor(value: number): void;
+    setValue(value: number): void;
+    setOffset(offset: number): void;
+    flattenOffset(): void;
+    extractOffset(): void;
+    addListener(callback: ValueListenerCallback): string;
+    removeListener(id: string): void;
+    removeAllListeners(): void;
+    stopAnimation(callback?: ?(value: number) => void): void;
+    resetAnimation(callback?: ?(value: number) => void): void;
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+    animate(animation: Animation, callback: ?EndCallback): void;
+    stopTracking(): void;
+    track(tracking: AnimatedTracking): void;
+  }
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/TimingAnimation.js
+  declare type TimingAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    easing?: (value: number) => number,
+    duration?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/SpringAnimation.js
+  declare type SpringAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    overshootClamping?: boolean,
+    restDisplacementThreshold?: number,
+    restSpeedThreshold?: number,
+    velocity?: number,
+    bounciness?: number,
+    speed?: number,
+    tension?: number,
+    friction?: number,
+    stiffness?: number,
+    damping?: number,
+    mass?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from react-native/Libraries/Types/CoreEventTypes.js
+  declare type SyntheticEvent<T> = $ReadOnly<{|
+    bubbles: ?boolean,
+    cancelable: ?boolean,
+    currentTarget: number,
+    defaultPrevented: ?boolean,
+    dispatchConfig: $ReadOnly<{|
+      registrationName: string,
+    |}>,
+    eventPhase: ?number,
+    preventDefault: () => void,
+    isDefaultPrevented: () => boolean,
+    stopPropagation: () => void,
+    isPropagationStopped: () => boolean,
+    isTrusted: ?boolean,
+    nativeEvent: T,
+    persist: () => void,
+    target: ?number,
+    timeStamp: number,
+    type: ?string,
+  |}>;
+  declare type Layout = $ReadOnly<{|
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  |}>;
+  declare type LayoutEvent = SyntheticEvent<
+    $ReadOnly<{|
+      layout: Layout,
+    |}>,
+  >;
+  declare type BlurEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type FocusEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type ResponderSyntheticEvent<T> = $ReadOnly<{|
+    ...SyntheticEvent<T>,
+    touchHistory: $ReadOnly<{|
+      indexOfSingleActiveTouch: number,
+      mostRecentTimeStamp: number,
+      numberActiveTouches: number,
+      touchBank: $ReadOnlyArray<
+        $ReadOnly<{|
+          touchActive: boolean,
+          startPageX: number,
+          startPageY: number,
+          startTimeStamp: number,
+          currentPageX: number,
+          currentPageY: number,
+          currentTimeStamp: number,
+          previousPageX: number,
+          previousPageY: number,
+          previousTimeStamp: number,
+        |}>,
+      >,
+    |}>,
+  |}>;
+  declare type PressEvent = ResponderSyntheticEvent<
+    $ReadOnly<{|
+      changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+      force: number,
+      identifier: number,
+      locationX: number,
+      locationY: number,
+      pageX: number,
+      pageY: number,
+      target: ?number,
+      timestamp: number,
+      touches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+    |}>,
+  >;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+  declare type ExtrapolateType = 'extend' | 'identity' | 'clamp';
+  declare type InterpolationConfigType = {
+    inputRange: Array<number>,
+    outputRange: Array<number> | Array<string>,
+    easing?: (input: number) => number,
+    extrapolate?: ExtrapolateType,
+    extrapolateLeft?: ExtrapolateType,
+    extrapolateRight?: ExtrapolateType,
+    ...
+  };
+  declare interface AnimatedInterpolation {
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+  }
+
+  // Copied from react-native/Libraries/Components/View/ViewAccessibility.js
+  declare type AccessibilityRole =
+    | 'none'
+    | 'button'
+    | 'link'
+    | 'search'
+    | 'image'
+    | 'keyboardkey'
+    | 'text'
+    | 'adjustable'
+    | 'imagebutton'
+    | 'header'
+    | 'summary'
+    | 'alert'
+    | 'checkbox'
+    | 'combobox'
+    | 'menu'
+    | 'menubar'
+    | 'menuitem'
+    | 'progressbar'
+    | 'radio'
+    | 'radiogroup'
+    | 'scrollbar'
+    | 'spinbutton'
+    | 'switch'
+    | 'tab'
+    | 'tablist'
+    | 'timer'
+    | 'toolbar';
+  declare type AccessibilityActionInfo = $ReadOnly<{
+    name: string,
+    label?: string,
+    ...
+  }>;
+  declare type AccessibilityActionEvent = SyntheticEvent<
+    $ReadOnly<{actionName: string, ...}>,
+  >;
+  declare type AccessibilityState = {
+    disabled?: boolean,
+    selected?: boolean,
+    checked?: ?boolean | 'mixed',
+    busy?: boolean,
+    expanded?: boolean,
+    ...
+  };
+  declare type AccessibilityValue = $ReadOnly<{|
+    min?: number,
+    max?: number,
+    now?: number,
+    text?: string,
+  |}>;
+
+  // Copied from
+  // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+  declare type Stringish = string;
+  declare type EdgeInsetsProp = $ReadOnly<$Shape<EdgeInsets>>;
+  declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
+    accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+    accessibilityElementsHidden?: ?boolean,
+    accessibilityHint?: ?Stringish,
+    accessibilityIgnoresInvertColors?: ?boolean,
+    accessibilityLabel?: ?Stringish,
+    accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
+    accessibilityRole?: ?AccessibilityRole,
+    accessibilityState?: ?AccessibilityState,
+    accessibilityValue?: ?AccessibilityValue,
+    accessibilityViewIsModal?: ?boolean,
+    accessible?: ?boolean,
+    children?: ?React$Node,
+    delayLongPress?: ?number,
+    delayPressIn?: ?number,
+    delayPressOut?: ?number,
+    disabled?: ?boolean,
+    focusable?: ?boolean,
+    hitSlop?: ?EdgeInsetsProp,
+    importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
+    nativeID?: ?string,
+    onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+    onBlur?: ?(event: BlurEvent) => mixed,
+    onFocus?: ?(event: FocusEvent) => mixed,
+    onLayout?: ?(event: LayoutEvent) => mixed,
+    onLongPress?: ?(event: PressEvent) => mixed,
+    onPress?: ?(event: PressEvent) => mixed,
+    onPressIn?: ?(event: PressEvent) => mixed,
+    onPressOut?: ?(event: PressEvent) => mixed,
+    pressRetentionOffset?: ?EdgeInsetsProp,
+    rejectResponderTermination?: ?boolean,
+    testID?: ?string,
+    touchSoundDisabled?: ?boolean,
+  |}>;
+
+  // Copied from react-native/Libraries/Image/ImageSource.js
+  declare type ImageURISource = $ReadOnly<{
+    uri?: ?string,
+    bundle?: ?string,
+    method?: ?string,
+    headers?: ?Object,
+    body?: ?string,
+    cache?: ?('default' | 'reload' | 'force-cache' | 'only-if-cached'),
+    width?: ?number,
+    height?: ?number,
+    scale?: ?number,
+    ...
+  }>;
+
+  /**
+   * The following is copied from react-native-gesture-handler's libdef
+   */
+
+  declare type $EventHandlers<ExtraProps: {...}> = {|
+    onGestureEvent?: ($Event<ExtraProps>) => mixed,
+    onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
+    onBegan?: ($Event<ExtraProps>) => mixed,
+    onFailed?: ($Event<ExtraProps>) => mixed,
+    onCancelled?: ($Event<ExtraProps>) => mixed,
+    onActivated?: ($Event<ExtraProps>) => mixed,
+    onEnded?: ($Event<ExtraProps>) => mixed,
+  |};
+
+  declare type HitSlop =
+    | number
+    | {|
+        left?: number,
+        top?: number,
+        right?: number,
+        bottom?: number,
+        vertical?: number,
+        horizontal?: number,
+        width?: number,
+        height?: number,
+      |}
+    | {|
+        width: number,
+        left: number,
+      |}
+    | {|
+        width: number,
+        right: number,
+      |}
+    | {|
+        height: number,
+        top: number,
+      |}
+    | {|
+        height: number,
+        bottom: number,
+      |};
+
+  declare type $GestureHandlerProps<
+    AdditionalProps: {...},
+    ExtraEventsProps: {...}
+  > = $ReadOnly<{|
+    ...$Exact<AdditionalProps>,
+    ...$EventHandlers<ExtraEventsProps>,
+    id?: string,
+    enabled?: boolean,
+    waitFor?: React$Ref<any> | Array<React$Ref<any>>,
+    simultaneousHandlers?: React$Ref<any> | Array<React$Ref<any>>,
+    shouldCancelWhenOutside?: boolean,
+    minPointers?: number,
+    hitSlop?: HitSlop,
+    children?: React$Node,
+  |}>;
+
+  declare type PanGestureHandlerProps = $GestureHandlerProps<
+    {
+      activeOffsetY?: number | [number, number],
+      activeOffsetX?: number | [number, number],
+      failOffsetY?: number | [number, number],
+      failOffsetX?: number | [number, number],
+      minDist?: number,
+      minVelocity?: number,
+      minVelocityX?: number,
+      minVelocityY?: number,
+      minPointers?: number,
+      maxPointers?: number,
+      avgTouches?: boolean,
+      ...
+    },
+    {
+      x: number,
+      y: number,
+      absoluteX: number,
+      absoluteY: number,
+      translationX: number,
+      translationY: number,
+      velocityX: number,
+      velocityY: number,
+      ...
+    }
+  >;
+
+  /**
+   * MAGIC
+   */
+
+  declare type $If<Test: boolean, Then, Else = empty> = $Call<
+    ((true, Then, Else) => Then) & ((false, Then, Else) => Else),
+    Test,
+    Then,
+    Else,
+  >;
+  declare type $IsA<X, Y> = $Call<
+    (Y => true) & (mixed => false),
+    X,
+  >;
+  declare type $IsUndefined<X> = $IsA<X, void>;
+
+  declare type $Partial<T> = $Rest<T, {...}>;
+
+  /**
+   * Actions, state, etc.
+   */
+
+  declare export type ScreenParams = { +[key: string]: mixed, ... };
+
+  declare export type BackAction = {|
+    +type: 'GO_BACK',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type NavigateAction = {|
+    +type: 'NAVIGATE',
+    +payload:
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ResetAction = {|
+    +type: 'RESET',
+    +payload: StaleNavigationState,
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type SetParamsAction = {|
+    +type: 'SET_PARAMS',
+    +payload: {| +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CommonAction =
+    | BackAction
+    | NavigateAction
+    | ResetAction
+    | SetParamsAction;
+
+  declare type NavigateActionCreator = {|
+    (routeName: string, params?: ScreenParams): NavigateAction,
+    (
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    ): NavigateAction,
+  |};
+  declare export type CommonActionsType = {|
+    +navigate: NavigateActionCreator,
+    +goBack: () => BackAction,
+    +reset: (state: PossiblyStaleNavigationState) => ResetAction,
+    +setParams: (params: ScreenParams) => SetParamsAction,
+  |};
+
+  declare export type GenericNavigationAction = {|
+    +type: string,
+    +payload?: { +[key: string]: mixed, ... },
+    +source?: string,
+    +target?: string,
+  |};
+
+  declare export type LeafRoute<RouteName: string = string> = {|
+    +key: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StateRoute<RouteName: string = string> = {|
+    ...LeafRoute<RouteName>,
+    +state: NavigationState | StaleNavigationState,
+  |};
+  declare export type Route<RouteName: string = string> =
+    | LeafRoute<RouteName>
+    | StateRoute<RouteName>;
+
+  declare export type NavigationState = {|
+    +key: string,
+    +index: number,
+    +routeNames: $ReadOnlyArray<string>,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<Route<>>,
+    +type: string,
+    +stale: false,
+  |};
+
+  declare export type StaleLeafRoute<RouteName: string = string> = {|
+    +key?: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StaleStateRoute<RouteName: string = string> = {|
+    ...StaleLeafRoute<RouteName>,
+    +state: StaleNavigationState,
+  |};
+  declare export type StaleRoute<RouteName: string = string> =
+    | StaleLeafRoute<RouteName>
+    | StaleStateRoute<RouteName>;
+  declare export type StaleNavigationState = {|
+    // It's possible to pass React Nav a StaleNavigationState with an undefined
+    // index, but React Nav will always return one with the index set. This is
+    // the same as for the type property below, but in the case of index we tend
+    // to rely on it being set more...
+    +index: number,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<StaleRoute<>>,
+    +type?: string,
+    +stale?: true,
+  |};
+
+  declare export type PossiblyStaleNavigationState =
+    | NavigationState
+    | StaleNavigationState;
+  declare export type PossiblyStaleRoute<RouteName: string = string> =
+    | Route<RouteName>
+    | StaleRoute<RouteName>;
+
+  /**
+   * Routers
+   */
+
+  declare type ActionCreators<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {
+    +[key: string]: (...args: any) => (Action | State => Action),
+    ...
+  };
+
+  declare export type DefaultRouterOptions = {
+    +initialRouteName?: string,
+    ...
+  };
+
+  declare export type RouterFactory<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    RouterOptions: DefaultRouterOptions,
+  > = (options: RouterOptions) => Router<State, Action>;
+
+  declare export type ParamListBase = { +[key: string]: ?ScreenParams, ... };
+
+  declare export type RouterConfigOptions = {|
+    +routeNames: $ReadOnlyArray<string>,
+    +routeParamList: ParamListBase,
+  |};
+
+  declare export type Router<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {|
+    +type: $PropertyType<State, 'type'>,
+    +getInitialState: (options: RouterConfigOptions) => State,
+    +getRehydratedState: (
+      partialState: PossibleStaleNavigationState,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteNamesChange: (
+      state: State,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteFocus: (state: State, key: string) => State,
+    +getStateForAction: (
+      state: State,
+      action: Action,
+      options: RouterConfigOptions,
+    ) => ?PossiblyStaleNavigationState;
+    +shouldActionChangeFocus: (action: GenericNavigationAction) => boolean,
+    +actionCreators?: ActionCreators<State, Action>,
+  |};
+
+  /**
+   * Stack actions and router
+   */
+
+  declare export type StackNavigationState = {|
+    ...NavigationState,
+    +type: 'stack',
+  |};
+
+  declare export type ReplaceAction = {|
+    +type: 'REPLACE',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PushAction = {|
+    +type: 'PUSH',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopAction = {|
+    +type: 'POP',
+    +payload: {| +count: number |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopToTopAction = {|
+    +type: 'POP_TO_TOP',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type StackAction =
+    | CommonAction
+    | ReplaceAction
+    | PushAction
+    | PopAction
+    | PopToTopAction;
+
+  declare export type StackActionsType = {|
+    +replace: (routeName: string, params?: ScreenParams) => ReplaceAction,
+    +push: (routeName: string, params?: ScreenParams) => PushAction,
+    +pop: (count?: number) => PopAction,
+    +popToTop: () => PopToTopAction,
+  |};
+
+  declare export type StackRouterOptions = $Exact<DefaultRouterOptions>;
+
+  /**
+   * Tab actions and router
+   */
+
+  declare export type TabNavigationState = {|
+    ...NavigationState,
+    +type: 'tab',
+    +history: $ReadOnlyArray<{| type: 'route', key: string |}>,
+  |};
+
+  declare export type JumpToAction = {|
+    +type: 'JUMP_TO',
+    +payload: {| +name: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type TabAction =
+    | CommonAction
+    | JumpToAction;
+
+  declare export type TabActionsType = {|
+    +jumpTo: string => JumpToAction,
+  |};
+
+  declare export type TabRouterOptions = {|
+    ...$Exact<DefaultRouterOptions>,
+    +backBehavior?: 'initialRoute' | 'order' | 'history' | 'none',
+  |};
+
+  /**
+   * Drawer actions and router
+   */
+
+  declare type DrawerHistoryEntry =
+    | {| +type: 'route', +key: string |}
+    | {| +type: 'drawer' |};
+  declare export type DrawerNavigationState = {|
+    ...NavigationState,
+    +type: 'drawer',
+    +history: $ReadOnlyArray<DrawerHistoryEntry>,
+  |};
+
+  declare export type OpenDrawerAction = {|
+    +type: 'OPEN_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CloseDrawerAction = {|
+    +type: 'CLOSE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ToggleDrawerAction = {|
+    +type: 'TOGGLE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type DrawerAction =
+    | TabAction
+    | OpenDrawerAction
+    | CloseDrawerAction
+    | ToggleDrawerAction;
+
+  declare export type DrawerActionsType = {|
+    ...TabActionsType,
+    +openDrawer: () => OpenDrawerAction,
+    +closeDrawer: () => CloseDrawerAction,
+    +toggleDrawer: () => ToggleDrawerAction,
+  |};
+
+  declare export type DrawerRouterOptions = {|
+    ...TabRouterOptions,
+    +openByDefault?: boolean,
+  |};
+
+  /**
+   * Events
+   */
+
+  declare export type EventMapBase = {
+    +[name: string]: {|
+      +data?: mixed,
+      +canPreventDefault?: boolean,
+    |},
+    ...
+  };
+  declare type EventPreventDefaultProperties<Test: boolean> = $If<
+    Test,
+    {| +defaultPrevented: boolean, +preventDefault: () => void |},
+    {| |},
+  >;
+  declare type EventDataProperties<Data> = $If<
+    $IsUndefined<Data>,
+    {| |},
+    {| +data: Data |},
+  >;
+  declare type EventArg<
+    EventName: string,
+    CanPreventDefault: ?boolean = false,
+    Data = void,
+  > = {|
+    ...EventPreventDefaultProperties<CanPreventDefault>,
+    ...EventDataProperties<Data>,
+    +type: EventName,
+    +target?: string,
+  |};
+  declare type GlobalEventMap<State: PossiblyStaleNavigationState> = {|
+    +state: {| +data: {| +state: State |}, +canPreventDefault: false |},
+  |};
+  declare type EventMapCore<State: PossiblyStaleNavigationState> = {|
+    ...GlobalEventMap<State>,
+    +focus: {| +data: void, +canPreventDefault: false |},
+    +blur: {| +data: void, +canPreventDefault: false |},
+  |};
+  declare type EventListenerCallback<
+    EventName: string,
+    State: NavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = (e: EventArg<
+    EventName,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'canPreventDefault',
+    >,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'data',
+    >,
+  >) => mixed;
+
+  /**
+   * Navigation prop
+   */
+
+  declare export type SimpleNavigate<ParamList> =
+    <DestinationRouteName: $Keys<ParamList>>(
+      routeName: DestinationRouteName,
+      params: $ElementType<ParamList, DestinationRouteName>,
+    ) => void;
+
+  declare export type Navigate<ParamList> =
+    & SimpleNavigate<ParamList>
+    & <DestinationRouteName: $Keys<ParamList>>(
+        route:
+          | {|
+              key: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |}
+          | {|
+              name: DestinationRouteName,
+              key?: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |},
+      ) => void;
+
+  declare type NavigationHelpers<
+    ParamList: ParamListBase,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    +navigate: Navigate<ParamList>,
+    +dispatch: (
+      action:
+        | GenericNavigationAction
+        | (State => GenericNavigationAction),
+    ) => void,
+    +reset: PossiblyStaleNavigationState => void,
+    +goBack: () => void,
+    +isFocused: () => boolean,
+    +canGoBack: () => boolean,
+    +dangerouslyGetParent: <Parent: NavigationProp<ParamListBase>>() => ?Parent,
+    +dangerouslyGetState: () => NavigationState,
+    +addListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => () => void,
+    +removeListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => void,
+    ...
+  };
+
+  declare export type NavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    ...$Exact<NavigationHelpers<
+      ParamList,
+      State,
+      EventMap,
+    >>,
+    +setOptions: (options: $Shape<ScreenOptions>) => void,
+    +setParams: (
+      params: $If<
+        $IsUndefined<$ElementType<ParamList, RouteName>>,
+        empty,
+        $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+      >,
+    ) => void,
+    ...
+  };
+
+  /**
+   * CreateNavigator
+   */
+
+  declare export type RouteProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+  > = {|
+    ...LeafRoute<RouteName>,
+    +params: $ElementType<ParamList, RouteName>,
+  |};
+
+  declare export type ScreenListeners<
+    EventMap: EventMapBase = EventMapCore<State>,
+    State: NavigationState = NavigationState,
+  > = $ObjMapi<
+    {| [name: $Keys<EventMap>]: empty |},
+    <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
+  >;
+
+  declare type BaseScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {|
+    +name: RouteName,
+    +options?:
+      | ScreenOptions
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenOptions,
+    +listeners?:
+      | ScreenListeners<EventMap, State>
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenListeners<EventMap, State>,
+    +initialParams?: $Shape<$ElementType<ParamList, RouteName>>,
+  |};
+
+  declare export type ScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > =
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +component: React$ComponentType<{|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}>,
+      |}
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +children: ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => React$Node,
+      |};
+
+  declare export type ScreenComponent<
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = <
+    RouteName: $Keys<ParamList>,
+    NavProp: NavigationProp<
+      GlobalParamList,
+      RouteName,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+  >(props: ScreenProps<
+    ParamList,
+    NavProp,
+    RouteName,
+    State,
+    ScreenOptions,
+    EventMap,
+  >) => React$Node;
+
+  declare type ScreenOptionsProp<ScreenOptions: {...}, NavProp> = {|
+    +screenOptions?:
+      | ScreenOptions
+      | ({| route: LeafRoute<>, navigation: NavProp |}) => ScreenOptions,
+  |};
+  declare export type ExtraNavigatorPropsBase = {
+    ...$Exact<DefaultRouterOptions>,
+    +children?: React$Node,
+    ...
+  };
+  declare export type NavigatorPropsBase<ScreenOptions: {...}, NavProp> = {
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    ...
+  };
+
+  declare export type CreateNavigator<
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  > = <
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    NavProp: NavigationHelpers<
+      GlobalParamList,
+      State,
+      EventMap,
+    >,
+  >() => {|
+    +Screen: ScreenComponent<
+      GlobalParamList,
+      ParamList,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+    +Navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorProps>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  |};
+
+  declare export type CreateNavigatorFactory = <
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    NavProp: NavigationHelpers<
+      ParamListBase,
+      State,
+      EventMap,
+    >,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  >(
+    navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorPropsBase>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  ) => CreateNavigator<State, ScreenOptions, EventMap, ExtraNavigatorProps>;
+
+  /**
+   * useNavigationBuilder
+   */
+
+  declare export type Descriptor<
+    NavProp,
+    ScreenOptions: {...} = {...},
+  > = {|
+    +render: () => React$Node,
+    +options: $ReadOnly<ScreenOptions>,
+    +navigation: NavProp,
+  |};
+
+  declare export type UseNavigationBuilder = <
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    ScreenOptions: {...},
+    RouterOptions: DefaultRouterOptions,
+    NavProp,
+  >(
+    routerFactory: RouterFactory<State, Action, RouterOptions>,
+    options: {|
+      ...$Exact<RouterOptions>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+      +children?: React$Node,
+    |},
+  ) => {|
+    +state: State,
+    +descriptors: {| +[key: string]: Descriptor<NavProp, ScreenOptions> |},
+    +navigation: NavProp,
+  |};
+
+  /**
+   * EdgeInsets
+   */
+
+  declare type EdgeInsets = {|
+    +top: number,
+    +right: number,
+    +bottom: number,
+    +left: number,
+  |};
+
+  /**
+   * TransitionPreset
+   */
+
+  declare export type TransitionSpec =
+    | {|
+        animation: 'spring',
+        config: $Diff<
+          SpringAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |}
+    | {|
+        animation: 'timing',
+        config: $Diff<
+          TimingAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |};
+
+  declare export type StackCardInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +index: number,
+    +closing: AnimatedInterpolation,
+    +swiping: AnimatedInterpolation,
+    +inverted: AnimatedInterpolation,
+    +layouts: {|
+      +screen: {| +width: number, +height: number |},
+    |},
+    +insets: EdgeInsets,
+  |};
+  declare export type StackCardInterpolatedStyle = {|
+    containerStyle?: AnimatedViewStyleProp,
+    cardStyle?: AnimatedViewStyleProp,
+    overlayStyle?: AnimatedViewStyleProp,
+    shadowStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackCardStyleInterpolator = (
+    props: StackCardInterpolationProps,
+  ) => StackCardInterpolatedStyle;
+
+  declare export type StackHeaderInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +layouts: {|
+      +header: {| +width: number, +height: number |},
+      +screen: {| +width: number, +height: number |},
+      +title?: {| +width: number, +height: number |},
+      +leftLabel?: {| +width: number, +height: number |},
+    |},
+  |};
+  declare export type StackHeaderInterpolatedStyle = {|
+    leftLabelStyle?: AnimatedViewStyleProp,
+    leftButtonStyle?: AnimatedViewStyleProp,
+    rightButtonStyle?: AnimatedViewStyleProp,
+    titleStyle?: AnimatedViewStyleProp,
+    backgroundStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackHeaderStyleInterpolator = (
+    props: StackHeaderInterpolationProps,
+  ) => StackHeaderInterpolatedStyle;
+
+  declare type GestureDirection =
+    | 'horizontal'
+    | 'horizontal-inverted'
+    | 'vertical'
+    | 'vertical-inverted';
+
+  declare export type TransitionPreset = {|
+    +gestureDirection: GestureDirection,
+    +transitionSpec: {|
+      +open: TransitionSpec,
+      +close: TransitionSpec,
+    |},
+    +cardStyleInterpolator: StackCardStyleInterpolator,
+    +headerStyleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  /**
+   * Stack options
+   */
+
+  declare export type StackDescriptor = Descriptor<
+    StackNavigationProp<>,
+    StackOptions,
+  >;
+
+  declare type Scene<T> = {|
+    +route: T,
+    +descriptor: StackDescriptor,
+    +progress: {|
+      +current: AnimatedInterpolation,
+      +next?: AnimatedInterpolation,
+      +previous?: AnimatedInterpolation,
+    |},
+  |};
+
+  declare export type StackHeaderProps = {|
+    +mode: 'float' | 'screen',
+    +layout: {| +width: number, +height: number |},
+    +insets: EdgeInsets,
+    +scene: Scene<Route<>>,
+    +previous?: Scene<Route<>>,
+    +navigation: StackNavigationProp<ParamListBase>,
+    +styleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  declare export type StackHeaderLeftButtonProps = $Shape<{|
+    +onPress: (() => void),
+    +pressColorAndroid: string;
+    +backImage: (props: {| tintColor: string |}) => React$Node,
+    +tintColor: string,
+    +label: string,
+    +truncatedLabel: string,
+    +labelVisible: boolean,
+    +labelStyle: AnimatedTextStyleProp,
+    +allowFontScaling: boolean,
+    +onLabelLayout: LayoutEvent => void,
+    +screenLayout: {| +width: number, +height: number |},
+    +titleLayout: {| +width: number, +height: number |},
+    +canGoBack: boolean,
+  |}>;
+
+  declare type StackHeaderTitleInputBase = {
+    +onLayout: LayoutEvent => void,
+    +children: string,
+    +allowFontScaling: ?boolean,
+    +tintColor: ?string,
+    +style: ?AnimatedTextStyleProp,
+    ...
+  };
+
+  declare export type StackHeaderTitleInputProps =
+    $Exact<StackHeaderTitleInputBase>;
+
+  declare export type StackOptions = $Shape<{|
+    +title: string,
+    +header: StackHeaderProps => React$Node,
+    +headerShown: boolean,
+    +cardShadowEnabled: boolean,
+    +cardOverlayEnabled: boolean,
+    +cardOverlay: {| style: ViewStyleProp |} => React$Node,
+    +cardStyle: ViewStyleProp,
+    +animationEnabled: boolean,
+    +animationTypeForReplace: 'push' | 'pop',
+    +gestureEnabled: boolean,
+    +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
+    +gestureVelocityImpact: number,
+    +safeAreaInsets: $Shape<EdgeInsets>,
+    // Transition
+    ...TransitionPreset,
+    // Header
+    +headerTitle: string | (StackHeaderTitleInputProps => React$Node),
+    +headerTitleAlign: 'left' | 'center',
+    +headerTitleStyle: AnimatedTextStyleProp,
+    +headerTitleContainerStyle: ViewStyleProp,
+    +headerTintColor: string,
+    +headerTitleAllowFontScaling: boolean,
+    +headerBackAllowFontScaling: boolean,
+    +headerBackTitle: string,
+    +headerBackTitleStyle: TextStyleProp,
+    +headerBackTitleVisible: boolean,
+    +headerTruncatedBackTitle: string,
+    +headerLeft: StackHeaderLeftButtonProps => React$Node,
+    +headerLeftContainerStyle: ViewStyleProp,
+    +headerRight: {| tintColor?: string |} => React$Node,
+    +headerRightContainerStyle: ViewStyleProp,
+    +headerBackImage: $PropertyType<StackHeaderLeftButtonProps, 'backImage'>,
+    +headerPressColorAndroid: string,
+    +headerBackground: ({| style: ViewStyleProp |}) => React$Node,
+    +headerStyle: ViewStyleProp,
+    +headerTransparent: boolean,
+    +headerStatusBarHeight: number,
+  |}>;
+
+  /**
+   * Stack navigation prop
+   */
+
+  declare export type StackNavigationEventMap = {|
+    ...EventMapCore<StackNavigationState>,
+    +transitionStart: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+    +transitionEnd: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+  |};
+
+  declare type InexactStackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      StackNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +replace: SimpleNavigate<ParamList>,
+    +push: SimpleNavigate<ParamList>,
+    +pop: (count?: number) => void,
+    +popToTop: () => void,
+    ...
+  };
+
+  declare export type StackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = $Exact<InexactStackNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous stack exports
+   */
+
+  declare type StackNavigationConfig = {|
+    +mode?: 'card' | 'modal',
+    +headerMode?: 'float' | 'screen' | 'none',
+    +keyboardHandlingEnabled?: boolean,
+  |};
+
+  declare export type ExtraStackNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...StackRouterOptions,
+    ...StackNavigationConfig,
+  |};
+
+  declare export type StackNavigatorProps<
+    NavProp: InexactStackNavigationProp<> = StackNavigationProp<>,
+  > = {|
+    ...ExtraStackNavigatorProps,
+    ...ScreenOptionsProp<StackOptions, NavProp>,
+  |};
+
+  /**
+   * Bottom tab options
+   */
+
+  declare export type BottomTabBarButtonProps = {|
+    ...$Diff<
+      TouchableWithoutFeedbackProps,
+      {| onPress?: ?(event: PressEvent) => mixed |},
+    >,
+    +to?: string,
+    +children: React$Node,
+    +onPress?: (MouseEvent | PressEvent) => void,
+  |};
+
+  declare export type BottomTabOptions = $Shape<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| focused: boolean, color: string |}) => React$Node,
+    +tabBarIcon: ({|
+      focused: boolean,
+      color: string,
+      size: number,
+    |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+    +tabBarVisible: boolean,
+    +tabBarButton: BottomTabBarButtonProps => React$Node,
+    +unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Bottom tab navigation prop
+   */
+
+  declare export type BottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare type InexactTabNavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+    Options: {...},
+    EventMap: EventMapBase,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      TabNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    ...
+  };
+
+  declare export type InexactBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type BottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = $Exact<InexactBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous bottom tab exports
+   */
+
+  declare export type BottomTabDescriptor = Descriptor<
+    BottomTabNavigationProp<>,
+    BottomTabOptions,
+  >;
+
+  declare export type BottomTabBarOptions = $Shape<{|
+    +keyboardHidesTabBar: boolean,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveBackgroundColor: string,
+    +allowFontScaling: boolean,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +labelStyle: TextStyleProp,
+    +tabStyle: ViewStyleProp,
+    +labelPosition: 'beside-icon' | 'below-icon',
+    +adaptive: boolean,
+    +safeAreaInsets: $Shape<EdgeInsets>,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type BottomTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: BottomTabNavigationProp<>,
+    +descriptors: {| +[key: string]: BottomTabDescriptor |},
+  |};
+
+  declare export type BottomTabBarProps = {|
+    ...BottomTabBarOptions,
+    ...BottomTabNavigationBuilderResult,
+  |}
+
+  declare type BottomTabNavigationConfig = {|
+    +lazy?: boolean,
+    +tabBar?: BottomTabBarProps => React$Node,
+    +tabBarOptions?: BottomTabBarOptions,
+  |};
+
+  declare export type ExtraBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...BottomTabNavigationConfig,
+  |};
+
+  declare export type BottomTabNavigatorProps<
+    NavProp: InexactBottomTabNavigationProp<> = BottomTabNavigationProp<>,
+  > = {|
+    ...ExtraBottomTabNavigatorProps,
+    ...ScreenOptionsProp<BottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material bottom tab options
+   */
+
+  declare export type MaterialBottomTabOptions = $Shape<{|
+    +title: string,
+    +tabBarColor: string,
+    +tabBarLabel: string,
+    +tabBarIcon:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarBadge: boolean | number | string,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material bottom tab navigation prop
+   */
+
+  declare export type MaterialBottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+  |};
+
+  declare export type InexactMaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = $Exact<InexactMaterialBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material bottom tab exports
+   */
+
+  declare export type PaperFont = {|
+    +fontFamily: string,
+    +fontWeight?:
+      | 'normal'
+      | 'bold'
+      | '100'
+      | '200'
+      | '300'
+      | '400'
+      | '500'
+      | '600'
+      | '700'
+      | '800'
+      | '900',
+  |};
+
+  declare export type PaperFonts = {|
+    +regular: Font,
+    +medium: Font,
+    +light: Font,
+    +thin: Font,
+  |};
+
+  declare export type PaperTheme = {|
+    +dark: boolean,
+    +mode?: 'adaptive' | 'exact',
+    +roundness: number,
+    +colors: {|
+      +primary: string,
+      +background: string,
+      +surface: string,
+      +accent: string,
+      +error: string,
+      +text: string,
+      +onSurface: string,
+      +onBackground: string,
+      +disabled: string,
+      +placeholder: string,
+      +backdrop: string,
+      +notification: string,
+    |},
+    +fonts: PaperFonts,
+    +animation: {|
+      +scale: number,
+    |},
+  |};
+
+  declare export type PaperRoute = {|
+    +key: string,
+    +title?: string,
+    +icon?: any,
+    +badge?: string | number | boolean,
+    +color?: string,
+    +accessibilityLabel?: string,
+    +testID?: string,
+  |};
+
+  declare export type PaperTouchableProps = {|
+    ...TouchableWithoutFeedbackProps,
+    +key: string,
+    +route: PaperRoute,
+    +children: React$Node,
+    +borderless?: boolean,
+    +centered?: boolean,
+    +rippleColor?: string,
+  |};
+
+  declare export type MaterialBottomTabNavigationConfig = {|
+    +shifting?: boolean,
+    +labeled?: boolean,
+    +renderTouchable?: PaperTouchableProps => React$Node,
+    +activeColor?: string,
+    +inactiveColor?: string,
+    +sceneAnimationEnabled?: boolean,
+    +keyboardHidesNavigationBar?: boolean,
+    +barStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +theme?: PaperTheme,
+  |};
+
+  declare export type ExtraMaterialBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialBottomTabNavigationConfig,
+  |};
+
+  declare export type MaterialBottomTabNavigatorProps<
+    NavProp: InexactMaterialBottomTabNavigationProp<> =
+      MaterialBottomTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialBottomTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialBottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material top tab options
+   */
+
+  declare export type MaterialTopTabOptions = $Shape<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarIcon: ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material top tab navigation prop
+   */
+
+  declare export type MaterialTopTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+    +swipeStart: {| +data: void, +canPreventDefault: false |},
+    +swipeEnd: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactMaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = $Exact<InexactMaterialTopTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material top tab exports
+   */
+
+  declare type MaterialTopTabPagerCommonProps = {|
+    +keyboardDismissMode: 'none' | 'on-drag' | 'auto',
+    +swipeEnabled: boolean,
+    +swipeVelocityImpact?: number,
+    +springVelocityScale?: number,
+    +springConfig: $Shape<{|
+      +damping: number,
+      +mass: number,
+      +stiffness: number,
+      +restSpeedThreshold: number,
+      +restDisplacementThreshold: number,
+    |}>,
+    +timingConfig: $Shape<{|
+      +duration: number,
+    |}>,
+  |};
+
+  declare export type MaterialTopTabPagerProps = {|
+    ...MaterialTopTabPagerCommonProps,
+    +onSwipeStart?: () => void,
+    +onSwipeEnd?: () => void,
+    +onIndexChange: (index: number) => void,
+    +navigationState: TabNavigationState,
+    +layout: {| +width: number, +height: number |},
+    +removeClippedSubviews: boolean,
+    +children: ({|
+      +addListener: (type: 'enter', listener: number => void) => void,
+      +removeListener: (type: 'enter', listener: number => void) => void,
+      +position: any, // Reanimated.Node<number>
+      +render: React$Node => React$Node,
+      +jumpTo: string => void,
+    |}) => React$Node,
+    +gestureHandlerProps: PanGestureHandlerProps,
+  |};
+
+  declare export type MaterialTopTabBarIndicatorProps = {|
+    +navigationState: TabNavigationState,
+    +width: string,
+    +style?: ViewStyleProp,
+    +getTabWidth: number => number,
+  |};
+
+  declare export type MaterialTopTabBarOptions = $Shape<{|
+    +scrollEnabled: boolean,
+    +bounces: boolean,
+    +pressColor: string,
+    +pressOpacity: number,
+    +getAccessible: ({| +route: Route<> |}) => boolean,
+    +renderBadge: ({| +route: Route<> |}) => React$Node,
+    +renderIndicator: MaterialTopTabBarIndicatorProps => React$Node,
+    +tabStyle: ViewStyleProp,
+    +indicatorStyle: ViewStyleProp,
+    +indicatorContainerStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +iconStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +allowFontScaling: boolean,
+  |}>;
+
+  declare export type MaterialTopTabDescriptor = Descriptor<
+    MaterialBottomTabNavigationProp<>,
+    MaterialBottomTabOptions,
+  >;
+
+  declare type MaterialTopTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: MaterialTopTabNavigationProp<>,
+    +descriptors: {| +[key: string]: MaterialTopTabDescriptor |},
+  |};
+
+  declare export type MaterialTopTabBarProps = {|
+    ...MaterialTopTabBarOptions,
+    ...MaterialTopTabNavigationBuilderResult,
+    +layout: {| +width: number, +height: number |},
+    +position: any, // Reanimated.Node<number>
+    +jumpTo: string => void,
+  |};
+
+  declare export type MaterialTopTabNavigationConfig = {|
+    ...$Partial<MaterialTopTabPagerCommonProps>,
+    +position?: any, // Reanimated.Value<number>
+    +tabBarPosition?: 'top' | 'bottom',
+    +initialLayout?: $Shape<{| +width: number, +height: number |}>,
+    +lazy?: boolean,
+    +lazyPreloadDistance?: number,
+    +removeClippedSubviews?: boolean,
+    +sceneContainerStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +pager?: MaterialTopTabPagerProps => React$Node,
+    +lazyPlaceholder?: ({| +route: Route<> |}) => React$Node,
+    +tabBar?: MaterialTopTabBarProps => React$Node,
+    +tabBarOptions?: MaterialTopTabBarOptions,
+  |};
+
+  declare export type ExtraMaterialTopTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialTopTabNavigationConfig,
+  |};
+
+  declare export type MaterialTopTabNavigatorProps<
+    NavProp: InexactMaterialTopTabNavigationProp<> =
+      MaterialTopTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialTopTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialTopTabOptions, NavProp>,
+  |};
+
+  /**
+   * Drawer options
+   */
+
+  declare export type DrawerOptions = $Shape<{|
+    title: string,
+    drawerLabel:
+      | string
+      | ({| +color: string, +focused: boolean |}) => React$Node,
+    drawerIcon: ({|
+      +color: string,
+      +size: number,
+      +focused: boolean,
+    |}) => React$Node,
+    gestureEnabled: boolean,
+    swipeEnabled: boolean,
+    unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Drawer navigation prop
+   */
+
+  declare export type DrawerNavigationEventMap = {|
+    ...EventMapCore<DrawerNavigationState>,
+    +drawerOpen: {| +data: void, +canPreventDefault: false |},
+    +drawerClose: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactDrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      DrawerNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    +openDrawer: () => void,
+    +closeDrawer: () => void,
+    +toggleDrawer: () => void,
+    ...
+  };
+
+  declare export type DrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = $Exact<InexactDrawerNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous drawer exports
+   */
+
+  declare export type DrawerDescriptor = Descriptor<
+    DrawerNavigationProp<>,
+    DrawerOptions,
+  >;
+
+  declare export type DrawerItemListBaseOptions = $Shape<{|
+    +activeTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveTintColor: string,
+    +inactiveBackgroundColor: string,
+    +itemStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+  |}>;
+
+  declare export type DrawerContentOptions = $Shape<{|
+    ...DrawerItemListBaseOptions,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type DrawerNavigationBuilderResult = {|
+    +state: DrawerNavigationState,
+    +navigation: DrawerNavigationProp<>,
+    +descriptors: {| +[key: string]: DrawerDescriptor |},
+  |};
+
+  declare export type DrawerContentProps = {|
+    ...DrawerContentOptions,
+    ...DrawerNavigationBuilderResult,
+    +progress: any, // Reanimated.Node<number>
+  |};
+
+  declare export type DrawerNavigationConfig = {|
+    +drawerPosition?: 'left' | 'right',
+    +drawerType?: 'front' | 'back' | 'slide' | 'permanent',
+    +edgeWidth?: number,
+    +hideStatusBar?: boolean,
+    +keyboardDismissMode?: 'on-drag' | 'none',
+    +minSwipeDistance?: number,
+    +overlayColor?: string,
+    +statusBarAnimation?: 'slide' | 'none' | 'fade',
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +lazy?: boolean,
+    +drawerContent?: DrawerContentProps => React$Node,
+    +drawerContentOptions?: DrawerContentOptions,
+    +sceneContainerStyle?: ViewStyleProp,
+    +drawerStyle?: ViewStyleProp,
+  |};
+
+  declare export type ExtraDrawerNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...DrawerRouterOptions,
+    ...DrawerNavigationConfig,
+  |};
+
+  declare export type DrawerNavigatorProps<
+    NavProp: InexactDrawerNavigationProp<> = DrawerNavigationProp<>,
+  > = {|
+    ...ExtraDrawerNavigatorProps,
+    ...ScreenOptionsProp<DrawerOptions, NavProp>,
+  |};
+
+  /**
+   * BaseNavigationContainer
+   */
+
+  declare export type BaseNavigationContainerProps = {|
+    +children: React$Node,
+    +initialState?: PossiblyStaleNavigationState,
+    +onStateChange?: (state: ?PossiblyStaleNavigationState) => void,
+    +independent?: boolean,
+  |};
+
+  declare export type BaseNavigationContainerInterface = {|
+    ...$Exact<NavigationHelpers<
+      ParamListBase,
+      PossiblyStaleNavigationState,
+      GlobalEventMap<PossiblyStaleNavigationState>,
+    >>,
+    +setParams: (params: ScreenParams) => void,
+    +resetRoot: (state?: ?PossiblyStaleNavigationState) => void,
+    +getRootState: () => PossiblyStaleNavigationState,
+  |};
+
+  /**
+   * State / path conversion
+   */
+
+  declare export type LinkingConfig = {|
+    +[routeName: string]:
+      | string
+      | {|
+          +path?: string,
+          +parse?: {| +[param: string]: string => mixed |},
+          +screens?: LinkingConfig,
+          +initialRouteName?: string,
+        |},
+  |};
+
+  declare export type GetPathFromStateOptions = {|
+    +[routeName: string]:
+      | string
+      | {|
+          +path?: string,
+          +stringify?: {| +[param: string]: mixed => string |},
+          +screens?: GetPathFromStateOptions,
+        |},
+  |};
+
+  //---------------------------------------------------------------------------
+  // SECTION 2: EXPORTED MODULE
+  // This section defines the module exports and contains exported types that
+  // are not present in any other React Navigation libdef.
+  //---------------------------------------------------------------------------
+
+  /**
+   * createDrawerNavigator
+   */
+
+  declare export var createDrawerNavigator: CreateNavigator<
+    DrawerNavigationState,
+    DrawerOptions,
+    DrawerNavigationEventMap,
+    ExtraDrawerNavigatorProps,
+  >;
+
+  /**
+   * DrawerView
+   */
+
+  declare export type DrawerViewProps = {|
+    ...DrawerNavigationConfig,
+    ...DrawerNavigationBuilderResult,
+  |};
+  declare export var DrawerView: React$ComponentType<DrawerViewProps>;
+
+  /**
+   * DrawerItem
+   */
+
+  declare export type DrawerItemProps = {|
+    +label:
+      | string
+      | ({| +color: string, +focused: boolean |}) => React$Node,
+    +onPress: () => mixed,
+    +icon?: ({|
+      +color: string,
+      +size: number,
+      +focused: boolean,
+    |}) => React$Node,
+    +to?: string,
+    +focused?: boolean,
+    +activeTintColor?: string,
+    +inactiveTintColor?: string,
+    +activeBackgroundColor?: string,
+    +inactiveBackgroundColor?: string,
+    +labelStyle?: TextStyleProp,
+    +style?: ViewStyleProp,
+  |};
+  declare export var DrawerItem: React$ComponentType<DrawerItemProps>;
+
+  /**
+   * DrawerItemList
+   */
+
+  declare export type DrawerItemListProps = {|
+    ...DrawerItemListBaseOptions,
+    ...DrawerNavigationBuilderResult,
+  |};
+  declare export var DrawerItemList: React$ComponentType<DrawerItemListProps>;
+
+  /**
+   * DrawerContent
+   */
+
+  declare export var DrawerContent: React$ComponentType<DrawerContentProps>;
+
+  /**
+   * DrawerContentScrollView
+   */
+
+  declare export var DrawerContentScrollView: React$ComponentType<{
+    +children: React$Node,
+    ...
+  }>;
+
+  /**
+   * DrawerGestureContext
+   */
+
+  declare type GestureHandlerRef = React$Ref<
+    React$ComponentType<GestureHandlerProps>,
+  >;
+  declare export var DrawerGestureContext: React$Context<?GestureHandlerRef>;
+
+  /**
+   * useIsDrawerOpen
+   */
+
+  declare export function useIsDrawerOpen(): boolean;
+
+}

--- a/definitions/npm/@react-navigation/drawer_v5.x.x/test_drawer.js
+++ b/definitions/npm/@react-navigation/drawer_v5.x.x/test_drawer.js
@@ -1,0 +1,120 @@
+// @flow
+
+import * as React from 'react';
+import {
+  createDrawerNavigator,
+  type NavigationProp,
+  type DrawerNavigationProp,
+  type LeafRoute,
+  type DrawerNavigationState,
+  type DrawerOptions,
+  type DrawerNavigationEventMap,
+} from '@react-navigation/drawer';
+
+/**
+ * Navigator setup
+ */
+
+type LocalParamList = {|
+  One: {| hey: string |},
+  Two: void,
+  Three: ?{| sup: number |},
+|};
+
+type GlobalParamList = {|
+  ...LocalParamList,
+  Another: void,
+|};
+
+type NavProp<
+  RouteName: $Keys<LocalParamList> = $Keys<LocalParamList>,
+> = DrawerNavigationProp<GlobalParamList, RouteName>;
+type NavRoute<
+  RouteName: $Keys<LocalParamList> = $Keys<LocalParamList>,
+> = {|
+  ...LeafRoute<RouteName>,
+  +params: $ElementType<LocalParamList, RouteName>,
+|};
+
+const Drawer = createDrawerNavigator<
+  GlobalParamList,
+  LocalParamList,
+  NavProp<>,
+>();
+
+/**
+ * Screens
+ */
+
+function ValidScreen(props: {|
+  navigation: NavProp<'One'>,
+  route: NavRoute<'One'>,
+|}) {
+  props.navigation.navigate('Another');
+  // $ExpectError invalid params
+  props.navigation.navigate('Another', {});
+  // $ExpectError invalid route
+  props.navigation.navigate('test', { sup: true, yo: null });
+  props.navigation.jumpTo('Three');
+  props.navigation.openDrawer();
+  props.navigation.closeDrawer();
+  props.navigation.toggleDrawer();
+  (props.navigation: NavigationProp<
+    GlobalParamList,
+    'One',
+    DrawerNavigationState,
+    DrawerOptions,
+    DrawerNavigationEventMap,
+  >);
+  return null;
+}
+
+function InvalidScreen(props: {|
+  navigation: NavProp<'One'>,
+  route: number,
+|}) {
+  props.navigation.setOptions({
+    title: 'sup',
+    drawerLabel: 'ayyyy',
+    gestureEnabled: false,
+    swipeEnabled: false,
+  });
+  // $ExpectError invalid navigator props
+  props.navigation.setOptions({ fake: 12 });
+  React.useEffect(() => {
+    return props.navigation.addListener(
+      'drawerOpen',
+      e => {
+        (e.type: 'drawerOpen');
+        // $ExpectError swipeStart doesn't support preventDefault
+        e.preventDefault();
+      },
+    );
+  });
+  return null;
+}
+
+<Drawer.Screen name="One" component={ValidScreen} />;
+// $ExpectError non-matching component
+<Drawer.Screen name="Two" component={ValidScreen} />;
+// $ExpectError invalid route name
+<Drawer.Screen name="Four" component={ValidScreen} />;
+// $ExpectError invalid params
+<Drawer.Screen name="One" component={ValidScreen} initialParams={{ hey: 5 }} />;
+// $ExpectError non-local route
+<Drawer.Screen name="Another" component={ValidScreen} />;
+// $ExpectError invalid screen props
+<Drawer.Screen name="One" component={InvalidScreen} />;
+
+/**
+ * Navigator
+ */
+
+<Drawer.Navigator drawerPosition="left" hideStatusBar={true} />;
+<Drawer.Navigator drawerType="front" edgeWidth={5} />;
+// $ExpectError invalid navigator props
+<Drawer.Navigator
+  // $ExpectError invalid navigator props
+  edgeWidth="string"
+  someOtherProp="fake"
+/>;

--- a/definitions/npm/@react-navigation/material-bottom-tabs_v5.x.x/CONTRIBUTING.md
+++ b/definitions/npm/@react-navigation/material-bottom-tabs_v5.x.x/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to the React Navigation Flow libdef
+
+## Overview
+
+There are seven React Navigation libdefs in `flow-typed`:
+
+1. `@react-navigation/core`
+2. `@react-navigation/native`
+3. `@react-navigation/stack`
+4. `@react-navigation/bottom-tabs`
+5. `@react-navigation/material-bottom-tabs`
+6. `@react-navigation/material-top-tabs`
+7. `@react-navigation/drawer`
+
+It's not currently possible to import types between libdefs. Consequently, many of the same types are copy-pasted across the different libdefs.
+
+Each libdef is organized into two sections. The first section should be identical between all of the libdefs. If you make a change to this section, please make sure to mirror it across the other libdefs.
+
+## Contributors
+
+- @Ashoat

--- a/definitions/npm/@react-navigation/material-bottom-tabs_v5.x.x/flow_v0.104.x-/material-bottom-tabs_v5.x.x.js
+++ b/definitions/npm/@react-navigation/material-bottom-tabs_v5.x.x/flow_v0.104.x-/material-bottom-tabs_v5.x.x.js
@@ -1,0 +1,1977 @@
+declare module '@react-navigation/material-bottom-tabs' {
+
+  //---------------------------------------------------------------------------
+  // SECTION 1: IDENTICAL TYPE DEFINITIONS
+  // This section is identical across all React Navigation libdefs and contains
+  // shared definitions. We wish we could make it DRY and import from a shared
+  // definition, but that isn't yet possible.
+  //---------------------------------------------------------------------------
+
+  /**
+   * We start with some definitions that we have copy-pasted from React Native
+   * source files.
+   */
+
+  // This is a bastardization of the true StyleObj type located in
+  // react-native/Libraries/StyleSheet/StyleSheetTypes. We unfortunately can't
+  // import that here, and it's too lengthy (and consequently too brittle) to
+  // copy-paste here either.
+  declare type StyleObj =
+    | null
+    | void
+    | number
+    | false
+    | ''
+    | $ReadOnlyArray<StyleObj>
+    | { [name: string]: any, ... };
+  declare type ViewStyleProp = StyleObj;
+  declare type TextStyleProp = StyleObj;
+  declare type AnimatedViewStyleProp = StyleObj;
+  declare type AnimatedTextStyleProp = StyleObj;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/animations/Animation.js
+  declare type EndResult = { finished: boolean, ... };
+  declare type EndCallback = (result: EndResult) => void;
+  declare interface Animation {
+    start(
+      fromValue: number,
+      onUpdate: (value: number) => void,
+      onEnd: ?EndCallback,
+      previousAnimation: ?Animation,
+      animatedValue: AnimatedValue,
+    ): void;
+    stop(): void;
+  }
+  declare type AnimationConfig = {
+    isInteraction?: boolean,
+    useNativeDriver: boolean,
+    onComplete?: ?EndCallback,
+    iterations?: number,
+    ...
+  };
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedTracking.js
+  declare interface AnimatedTracking {
+    constructor(
+      value: AnimatedValue,
+      parent: any,
+      animationClass: any,
+      animationConfig: Object,
+      callback?: ?EndCallback,
+    ): void;
+    update(): void;
+  }
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedValue.js
+  declare type ValueListenerCallback = (state: { value: number, ... }) => void;
+  declare interface AnimatedValue {
+    constructor(value: number): void;
+    setValue(value: number): void;
+    setOffset(offset: number): void;
+    flattenOffset(): void;
+    extractOffset(): void;
+    addListener(callback: ValueListenerCallback): string;
+    removeListener(id: string): void;
+    removeAllListeners(): void;
+    stopAnimation(callback?: ?(value: number) => void): void;
+    resetAnimation(callback?: ?(value: number) => void): void;
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+    animate(animation: Animation, callback: ?EndCallback): void;
+    stopTracking(): void;
+    track(tracking: AnimatedTracking): void;
+  }
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/TimingAnimation.js
+  declare type TimingAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    easing?: (value: number) => number,
+    duration?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/SpringAnimation.js
+  declare type SpringAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    overshootClamping?: boolean,
+    restDisplacementThreshold?: number,
+    restSpeedThreshold?: number,
+    velocity?: number,
+    bounciness?: number,
+    speed?: number,
+    tension?: number,
+    friction?: number,
+    stiffness?: number,
+    damping?: number,
+    mass?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from react-native/Libraries/Types/CoreEventTypes.js
+  declare type SyntheticEvent<T> = $ReadOnly<{|
+    bubbles: ?boolean,
+    cancelable: ?boolean,
+    currentTarget: number,
+    defaultPrevented: ?boolean,
+    dispatchConfig: $ReadOnly<{|
+      registrationName: string,
+    |}>,
+    eventPhase: ?number,
+    preventDefault: () => void,
+    isDefaultPrevented: () => boolean,
+    stopPropagation: () => void,
+    isPropagationStopped: () => boolean,
+    isTrusted: ?boolean,
+    nativeEvent: T,
+    persist: () => void,
+    target: ?number,
+    timeStamp: number,
+    type: ?string,
+  |}>;
+  declare type Layout = $ReadOnly<{|
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  |}>;
+  declare type LayoutEvent = SyntheticEvent<
+    $ReadOnly<{|
+      layout: Layout,
+    |}>,
+  >;
+  declare type BlurEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type FocusEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type ResponderSyntheticEvent<T> = $ReadOnly<{|
+    ...SyntheticEvent<T>,
+    touchHistory: $ReadOnly<{|
+      indexOfSingleActiveTouch: number,
+      mostRecentTimeStamp: number,
+      numberActiveTouches: number,
+      touchBank: $ReadOnlyArray<
+        $ReadOnly<{|
+          touchActive: boolean,
+          startPageX: number,
+          startPageY: number,
+          startTimeStamp: number,
+          currentPageX: number,
+          currentPageY: number,
+          currentTimeStamp: number,
+          previousPageX: number,
+          previousPageY: number,
+          previousTimeStamp: number,
+        |}>,
+      >,
+    |}>,
+  |}>;
+  declare type PressEvent = ResponderSyntheticEvent<
+    $ReadOnly<{|
+      changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+      force: number,
+      identifier: number,
+      locationX: number,
+      locationY: number,
+      pageX: number,
+      pageY: number,
+      target: ?number,
+      timestamp: number,
+      touches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+    |}>,
+  >;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+  declare type ExtrapolateType = 'extend' | 'identity' | 'clamp';
+  declare type InterpolationConfigType = {
+    inputRange: Array<number>,
+    outputRange: Array<number> | Array<string>,
+    easing?: (input: number) => number,
+    extrapolate?: ExtrapolateType,
+    extrapolateLeft?: ExtrapolateType,
+    extrapolateRight?: ExtrapolateType,
+    ...
+  };
+  declare interface AnimatedInterpolation {
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+  }
+
+  // Copied from react-native/Libraries/Components/View/ViewAccessibility.js
+  declare type AccessibilityRole =
+    | 'none'
+    | 'button'
+    | 'link'
+    | 'search'
+    | 'image'
+    | 'keyboardkey'
+    | 'text'
+    | 'adjustable'
+    | 'imagebutton'
+    | 'header'
+    | 'summary'
+    | 'alert'
+    | 'checkbox'
+    | 'combobox'
+    | 'menu'
+    | 'menubar'
+    | 'menuitem'
+    | 'progressbar'
+    | 'radio'
+    | 'radiogroup'
+    | 'scrollbar'
+    | 'spinbutton'
+    | 'switch'
+    | 'tab'
+    | 'tablist'
+    | 'timer'
+    | 'toolbar';
+  declare type AccessibilityActionInfo = $ReadOnly<{
+    name: string,
+    label?: string,
+    ...
+  }>;
+  declare type AccessibilityActionEvent = SyntheticEvent<
+    $ReadOnly<{actionName: string, ...}>,
+  >;
+  declare type AccessibilityState = {
+    disabled?: boolean,
+    selected?: boolean,
+    checked?: ?boolean | 'mixed',
+    busy?: boolean,
+    expanded?: boolean,
+    ...
+  };
+  declare type AccessibilityValue = $ReadOnly<{|
+    min?: number,
+    max?: number,
+    now?: number,
+    text?: string,
+  |}>;
+
+  // Copied from
+  // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+  declare type Stringish = string;
+  declare type EdgeInsetsProp = $ReadOnly<$Shape<EdgeInsets>>;
+  declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
+    accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+    accessibilityElementsHidden?: ?boolean,
+    accessibilityHint?: ?Stringish,
+    accessibilityIgnoresInvertColors?: ?boolean,
+    accessibilityLabel?: ?Stringish,
+    accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
+    accessibilityRole?: ?AccessibilityRole,
+    accessibilityState?: ?AccessibilityState,
+    accessibilityValue?: ?AccessibilityValue,
+    accessibilityViewIsModal?: ?boolean,
+    accessible?: ?boolean,
+    children?: ?React$Node,
+    delayLongPress?: ?number,
+    delayPressIn?: ?number,
+    delayPressOut?: ?number,
+    disabled?: ?boolean,
+    focusable?: ?boolean,
+    hitSlop?: ?EdgeInsetsProp,
+    importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
+    nativeID?: ?string,
+    onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+    onBlur?: ?(event: BlurEvent) => mixed,
+    onFocus?: ?(event: FocusEvent) => mixed,
+    onLayout?: ?(event: LayoutEvent) => mixed,
+    onLongPress?: ?(event: PressEvent) => mixed,
+    onPress?: ?(event: PressEvent) => mixed,
+    onPressIn?: ?(event: PressEvent) => mixed,
+    onPressOut?: ?(event: PressEvent) => mixed,
+    pressRetentionOffset?: ?EdgeInsetsProp,
+    rejectResponderTermination?: ?boolean,
+    testID?: ?string,
+    touchSoundDisabled?: ?boolean,
+  |}>;
+
+  // Copied from react-native/Libraries/Image/ImageSource.js
+  declare type ImageURISource = $ReadOnly<{
+    uri?: ?string,
+    bundle?: ?string,
+    method?: ?string,
+    headers?: ?Object,
+    body?: ?string,
+    cache?: ?('default' | 'reload' | 'force-cache' | 'only-if-cached'),
+    width?: ?number,
+    height?: ?number,
+    scale?: ?number,
+    ...
+  }>;
+
+  /**
+   * The following is copied from react-native-gesture-handler's libdef
+   */
+
+  declare type $EventHandlers<ExtraProps: {...}> = {|
+    onGestureEvent?: ($Event<ExtraProps>) => mixed,
+    onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
+    onBegan?: ($Event<ExtraProps>) => mixed,
+    onFailed?: ($Event<ExtraProps>) => mixed,
+    onCancelled?: ($Event<ExtraProps>) => mixed,
+    onActivated?: ($Event<ExtraProps>) => mixed,
+    onEnded?: ($Event<ExtraProps>) => mixed,
+  |};
+
+  declare type HitSlop =
+    | number
+    | {|
+        left?: number,
+        top?: number,
+        right?: number,
+        bottom?: number,
+        vertical?: number,
+        horizontal?: number,
+        width?: number,
+        height?: number,
+      |}
+    | {|
+        width: number,
+        left: number,
+      |}
+    | {|
+        width: number,
+        right: number,
+      |}
+    | {|
+        height: number,
+        top: number,
+      |}
+    | {|
+        height: number,
+        bottom: number,
+      |};
+
+  declare type $GestureHandlerProps<
+    AdditionalProps: {...},
+    ExtraEventsProps: {...}
+  > = $ReadOnly<{|
+    ...$Exact<AdditionalProps>,
+    ...$EventHandlers<ExtraEventsProps>,
+    id?: string,
+    enabled?: boolean,
+    waitFor?: React$Ref<any> | Array<React$Ref<any>>,
+    simultaneousHandlers?: React$Ref<any> | Array<React$Ref<any>>,
+    shouldCancelWhenOutside?: boolean,
+    minPointers?: number,
+    hitSlop?: HitSlop,
+    children?: React$Node,
+  |}>;
+
+  declare type PanGestureHandlerProps = $GestureHandlerProps<
+    {
+      activeOffsetY?: number | [number, number],
+      activeOffsetX?: number | [number, number],
+      failOffsetY?: number | [number, number],
+      failOffsetX?: number | [number, number],
+      minDist?: number,
+      minVelocity?: number,
+      minVelocityX?: number,
+      minVelocityY?: number,
+      minPointers?: number,
+      maxPointers?: number,
+      avgTouches?: boolean,
+      ...
+    },
+    {
+      x: number,
+      y: number,
+      absoluteX: number,
+      absoluteY: number,
+      translationX: number,
+      translationY: number,
+      velocityX: number,
+      velocityY: number,
+      ...
+    }
+  >;
+
+  /**
+   * MAGIC
+   */
+
+  declare type $If<Test: boolean, Then, Else = empty> = $Call<
+    ((true, Then, Else) => Then) & ((false, Then, Else) => Else),
+    Test,
+    Then,
+    Else,
+  >;
+  declare type $IsA<X, Y> = $Call<
+    (Y => true) & (mixed => false),
+    X,
+  >;
+  declare type $IsUndefined<X> = $IsA<X, void>;
+
+  declare type $Partial<T> = $Rest<T, {...}>;
+
+  /**
+   * Actions, state, etc.
+   */
+
+  declare export type ScreenParams = { +[key: string]: mixed, ... };
+
+  declare export type BackAction = {|
+    +type: 'GO_BACK',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type NavigateAction = {|
+    +type: 'NAVIGATE',
+    +payload:
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ResetAction = {|
+    +type: 'RESET',
+    +payload: StaleNavigationState,
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type SetParamsAction = {|
+    +type: 'SET_PARAMS',
+    +payload: {| +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CommonAction =
+    | BackAction
+    | NavigateAction
+    | ResetAction
+    | SetParamsAction;
+
+  declare type NavigateActionCreator = {|
+    (routeName: string, params?: ScreenParams): NavigateAction,
+    (
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    ): NavigateAction,
+  |};
+  declare export type CommonActionsType = {|
+    +navigate: NavigateActionCreator,
+    +goBack: () => BackAction,
+    +reset: (state: PossiblyStaleNavigationState) => ResetAction,
+    +setParams: (params: ScreenParams) => SetParamsAction,
+  |};
+
+  declare export type GenericNavigationAction = {|
+    +type: string,
+    +payload?: { +[key: string]: mixed, ... },
+    +source?: string,
+    +target?: string,
+  |};
+
+  declare export type LeafRoute<RouteName: string = string> = {|
+    +key: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StateRoute<RouteName: string = string> = {|
+    ...LeafRoute<RouteName>,
+    +state: NavigationState | StaleNavigationState,
+  |};
+  declare export type Route<RouteName: string = string> =
+    | LeafRoute<RouteName>
+    | StateRoute<RouteName>;
+
+  declare export type NavigationState = {|
+    +key: string,
+    +index: number,
+    +routeNames: $ReadOnlyArray<string>,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<Route<>>,
+    +type: string,
+    +stale: false,
+  |};
+
+  declare export type StaleLeafRoute<RouteName: string = string> = {|
+    +key?: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StaleStateRoute<RouteName: string = string> = {|
+    ...StaleLeafRoute<RouteName>,
+    +state: StaleNavigationState,
+  |};
+  declare export type StaleRoute<RouteName: string = string> =
+    | StaleLeafRoute<RouteName>
+    | StaleStateRoute<RouteName>;
+  declare export type StaleNavigationState = {|
+    // It's possible to pass React Nav a StaleNavigationState with an undefined
+    // index, but React Nav will always return one with the index set. This is
+    // the same as for the type property below, but in the case of index we tend
+    // to rely on it being set more...
+    +index: number,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<StaleRoute<>>,
+    +type?: string,
+    +stale?: true,
+  |};
+
+  declare export type PossiblyStaleNavigationState =
+    | NavigationState
+    | StaleNavigationState;
+  declare export type PossiblyStaleRoute<RouteName: string = string> =
+    | Route<RouteName>
+    | StaleRoute<RouteName>;
+
+  /**
+   * Routers
+   */
+
+  declare type ActionCreators<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {
+    +[key: string]: (...args: any) => (Action | State => Action),
+    ...
+  };
+
+  declare export type DefaultRouterOptions = {
+    +initialRouteName?: string,
+    ...
+  };
+
+  declare export type RouterFactory<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    RouterOptions: DefaultRouterOptions,
+  > = (options: RouterOptions) => Router<State, Action>;
+
+  declare export type ParamListBase = { +[key: string]: ?ScreenParams, ... };
+
+  declare export type RouterConfigOptions = {|
+    +routeNames: $ReadOnlyArray<string>,
+    +routeParamList: ParamListBase,
+  |};
+
+  declare export type Router<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {|
+    +type: $PropertyType<State, 'type'>,
+    +getInitialState: (options: RouterConfigOptions) => State,
+    +getRehydratedState: (
+      partialState: PossibleStaleNavigationState,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteNamesChange: (
+      state: State,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteFocus: (state: State, key: string) => State,
+    +getStateForAction: (
+      state: State,
+      action: Action,
+      options: RouterConfigOptions,
+    ) => ?PossiblyStaleNavigationState;
+    +shouldActionChangeFocus: (action: GenericNavigationAction) => boolean,
+    +actionCreators?: ActionCreators<State, Action>,
+  |};
+
+  /**
+   * Stack actions and router
+   */
+
+  declare export type StackNavigationState = {|
+    ...NavigationState,
+    +type: 'stack',
+  |};
+
+  declare export type ReplaceAction = {|
+    +type: 'REPLACE',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PushAction = {|
+    +type: 'PUSH',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopAction = {|
+    +type: 'POP',
+    +payload: {| +count: number |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopToTopAction = {|
+    +type: 'POP_TO_TOP',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type StackAction =
+    | CommonAction
+    | ReplaceAction
+    | PushAction
+    | PopAction
+    | PopToTopAction;
+
+  declare export type StackActionsType = {|
+    +replace: (routeName: string, params?: ScreenParams) => ReplaceAction,
+    +push: (routeName: string, params?: ScreenParams) => PushAction,
+    +pop: (count?: number) => PopAction,
+    +popToTop: () => PopToTopAction,
+  |};
+
+  declare export type StackRouterOptions = $Exact<DefaultRouterOptions>;
+
+  /**
+   * Tab actions and router
+   */
+
+  declare export type TabNavigationState = {|
+    ...NavigationState,
+    +type: 'tab',
+    +history: $ReadOnlyArray<{| type: 'route', key: string |}>,
+  |};
+
+  declare export type JumpToAction = {|
+    +type: 'JUMP_TO',
+    +payload: {| +name: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type TabAction =
+    | CommonAction
+    | JumpToAction;
+
+  declare export type TabActionsType = {|
+    +jumpTo: string => JumpToAction,
+  |};
+
+  declare export type TabRouterOptions = {|
+    ...$Exact<DefaultRouterOptions>,
+    +backBehavior?: 'initialRoute' | 'order' | 'history' | 'none',
+  |};
+
+  /**
+   * Drawer actions and router
+   */
+
+  declare type DrawerHistoryEntry =
+    | {| +type: 'route', +key: string |}
+    | {| +type: 'drawer' |};
+  declare export type DrawerNavigationState = {|
+    ...NavigationState,
+    +type: 'drawer',
+    +history: $ReadOnlyArray<DrawerHistoryEntry>,
+  |};
+
+  declare export type OpenDrawerAction = {|
+    +type: 'OPEN_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CloseDrawerAction = {|
+    +type: 'CLOSE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ToggleDrawerAction = {|
+    +type: 'TOGGLE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type DrawerAction =
+    | TabAction
+    | OpenDrawerAction
+    | CloseDrawerAction
+    | ToggleDrawerAction;
+
+  declare export type DrawerActionsType = {|
+    ...TabActionsType,
+    +openDrawer: () => OpenDrawerAction,
+    +closeDrawer: () => CloseDrawerAction,
+    +toggleDrawer: () => ToggleDrawerAction,
+  |};
+
+  declare export type DrawerRouterOptions = {|
+    ...TabRouterOptions,
+    +openByDefault?: boolean,
+  |};
+
+  /**
+   * Events
+   */
+
+  declare export type EventMapBase = {
+    +[name: string]: {|
+      +data?: mixed,
+      +canPreventDefault?: boolean,
+    |},
+    ...
+  };
+  declare type EventPreventDefaultProperties<Test: boolean> = $If<
+    Test,
+    {| +defaultPrevented: boolean, +preventDefault: () => void |},
+    {| |},
+  >;
+  declare type EventDataProperties<Data> = $If<
+    $IsUndefined<Data>,
+    {| |},
+    {| +data: Data |},
+  >;
+  declare type EventArg<
+    EventName: string,
+    CanPreventDefault: ?boolean = false,
+    Data = void,
+  > = {|
+    ...EventPreventDefaultProperties<CanPreventDefault>,
+    ...EventDataProperties<Data>,
+    +type: EventName,
+    +target?: string,
+  |};
+  declare type GlobalEventMap<State: PossiblyStaleNavigationState> = {|
+    +state: {| +data: {| +state: State |}, +canPreventDefault: false |},
+  |};
+  declare type EventMapCore<State: PossiblyStaleNavigationState> = {|
+    ...GlobalEventMap<State>,
+    +focus: {| +data: void, +canPreventDefault: false |},
+    +blur: {| +data: void, +canPreventDefault: false |},
+  |};
+  declare type EventListenerCallback<
+    EventName: string,
+    State: NavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = (e: EventArg<
+    EventName,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'canPreventDefault',
+    >,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'data',
+    >,
+  >) => mixed;
+
+  /**
+   * Navigation prop
+   */
+
+  declare export type SimpleNavigate<ParamList> =
+    <DestinationRouteName: $Keys<ParamList>>(
+      routeName: DestinationRouteName,
+      params: $ElementType<ParamList, DestinationRouteName>,
+    ) => void;
+
+  declare export type Navigate<ParamList> =
+    & SimpleNavigate<ParamList>
+    & <DestinationRouteName: $Keys<ParamList>>(
+        route:
+          | {|
+              key: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |}
+          | {|
+              name: DestinationRouteName,
+              key?: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |},
+      ) => void;
+
+  declare type NavigationHelpers<
+    ParamList: ParamListBase,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    +navigate: Navigate<ParamList>,
+    +dispatch: (
+      action:
+        | GenericNavigationAction
+        | (State => GenericNavigationAction),
+    ) => void,
+    +reset: PossiblyStaleNavigationState => void,
+    +goBack: () => void,
+    +isFocused: () => boolean,
+    +canGoBack: () => boolean,
+    +dangerouslyGetParent: <Parent: NavigationProp<ParamListBase>>() => ?Parent,
+    +dangerouslyGetState: () => NavigationState,
+    +addListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => () => void,
+    +removeListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => void,
+    ...
+  };
+
+  declare export type NavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    ...$Exact<NavigationHelpers<
+      ParamList,
+      State,
+      EventMap,
+    >>,
+    +setOptions: (options: $Shape<ScreenOptions>) => void,
+    +setParams: (
+      params: $If<
+        $IsUndefined<$ElementType<ParamList, RouteName>>,
+        empty,
+        $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+      >,
+    ) => void,
+    ...
+  };
+
+  /**
+   * CreateNavigator
+   */
+
+  declare export type RouteProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+  > = {|
+    ...LeafRoute<RouteName>,
+    +params: $ElementType<ParamList, RouteName>,
+  |};
+
+  declare export type ScreenListeners<
+    EventMap: EventMapBase = EventMapCore<State>,
+    State: NavigationState = NavigationState,
+  > = $ObjMapi<
+    {| [name: $Keys<EventMap>]: empty |},
+    <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
+  >;
+
+  declare type BaseScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {|
+    +name: RouteName,
+    +options?:
+      | ScreenOptions
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenOptions,
+    +listeners?:
+      | ScreenListeners<EventMap, State>
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenListeners<EventMap, State>,
+    +initialParams?: $Shape<$ElementType<ParamList, RouteName>>,
+  |};
+
+  declare export type ScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > =
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +component: React$ComponentType<{|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}>,
+      |}
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +children: ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => React$Node,
+      |};
+
+  declare export type ScreenComponent<
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = <
+    RouteName: $Keys<ParamList>,
+    NavProp: NavigationProp<
+      GlobalParamList,
+      RouteName,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+  >(props: ScreenProps<
+    ParamList,
+    NavProp,
+    RouteName,
+    State,
+    ScreenOptions,
+    EventMap,
+  >) => React$Node;
+
+  declare type ScreenOptionsProp<ScreenOptions: {...}, NavProp> = {|
+    +screenOptions?:
+      | ScreenOptions
+      | ({| route: LeafRoute<>, navigation: NavProp |}) => ScreenOptions,
+  |};
+  declare export type ExtraNavigatorPropsBase = {
+    ...$Exact<DefaultRouterOptions>,
+    +children?: React$Node,
+    ...
+  };
+  declare export type NavigatorPropsBase<ScreenOptions: {...}, NavProp> = {
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    ...
+  };
+
+  declare export type CreateNavigator<
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  > = <
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    NavProp: NavigationHelpers<
+      GlobalParamList,
+      State,
+      EventMap,
+    >,
+  >() => {|
+    +Screen: ScreenComponent<
+      GlobalParamList,
+      ParamList,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+    +Navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorProps>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  |};
+
+  declare export type CreateNavigatorFactory = <
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    NavProp: NavigationHelpers<
+      ParamListBase,
+      State,
+      EventMap,
+    >,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  >(
+    navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorPropsBase>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  ) => CreateNavigator<State, ScreenOptions, EventMap, ExtraNavigatorProps>;
+
+  /**
+   * useNavigationBuilder
+   */
+
+  declare export type Descriptor<
+    NavProp,
+    ScreenOptions: {...} = {...},
+  > = {|
+    +render: () => React$Node,
+    +options: $ReadOnly<ScreenOptions>,
+    +navigation: NavProp,
+  |};
+
+  declare export type UseNavigationBuilder = <
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    ScreenOptions: {...},
+    RouterOptions: DefaultRouterOptions,
+    NavProp,
+  >(
+    routerFactory: RouterFactory<State, Action, RouterOptions>,
+    options: {|
+      ...$Exact<RouterOptions>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+      +children?: React$Node,
+    |},
+  ) => {|
+    +state: State,
+    +descriptors: {| +[key: string]: Descriptor<NavProp, ScreenOptions> |},
+    +navigation: NavProp,
+  |};
+
+  /**
+   * EdgeInsets
+   */
+
+  declare type EdgeInsets = {|
+    +top: number,
+    +right: number,
+    +bottom: number,
+    +left: number,
+  |};
+
+  /**
+   * TransitionPreset
+   */
+
+  declare export type TransitionSpec =
+    | {|
+        animation: 'spring',
+        config: $Diff<
+          SpringAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |}
+    | {|
+        animation: 'timing',
+        config: $Diff<
+          TimingAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |};
+
+  declare export type StackCardInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +index: number,
+    +closing: AnimatedInterpolation,
+    +swiping: AnimatedInterpolation,
+    +inverted: AnimatedInterpolation,
+    +layouts: {|
+      +screen: {| +width: number, +height: number |},
+    |},
+    +insets: EdgeInsets,
+  |};
+  declare export type StackCardInterpolatedStyle = {|
+    containerStyle?: AnimatedViewStyleProp,
+    cardStyle?: AnimatedViewStyleProp,
+    overlayStyle?: AnimatedViewStyleProp,
+    shadowStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackCardStyleInterpolator = (
+    props: StackCardInterpolationProps,
+  ) => StackCardInterpolatedStyle;
+
+  declare export type StackHeaderInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +layouts: {|
+      +header: {| +width: number, +height: number |},
+      +screen: {| +width: number, +height: number |},
+      +title?: {| +width: number, +height: number |},
+      +leftLabel?: {| +width: number, +height: number |},
+    |},
+  |};
+  declare export type StackHeaderInterpolatedStyle = {|
+    leftLabelStyle?: AnimatedViewStyleProp,
+    leftButtonStyle?: AnimatedViewStyleProp,
+    rightButtonStyle?: AnimatedViewStyleProp,
+    titleStyle?: AnimatedViewStyleProp,
+    backgroundStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackHeaderStyleInterpolator = (
+    props: StackHeaderInterpolationProps,
+  ) => StackHeaderInterpolatedStyle;
+
+  declare type GestureDirection =
+    | 'horizontal'
+    | 'horizontal-inverted'
+    | 'vertical'
+    | 'vertical-inverted';
+
+  declare export type TransitionPreset = {|
+    +gestureDirection: GestureDirection,
+    +transitionSpec: {|
+      +open: TransitionSpec,
+      +close: TransitionSpec,
+    |},
+    +cardStyleInterpolator: StackCardStyleInterpolator,
+    +headerStyleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  /**
+   * Stack options
+   */
+
+  declare export type StackDescriptor = Descriptor<
+    StackNavigationProp<>,
+    StackOptions,
+  >;
+
+  declare type Scene<T> = {|
+    +route: T,
+    +descriptor: StackDescriptor,
+    +progress: {|
+      +current: AnimatedInterpolation,
+      +next?: AnimatedInterpolation,
+      +previous?: AnimatedInterpolation,
+    |},
+  |};
+
+  declare export type StackHeaderProps = {|
+    +mode: 'float' | 'screen',
+    +layout: {| +width: number, +height: number |},
+    +insets: EdgeInsets,
+    +scene: Scene<Route<>>,
+    +previous?: Scene<Route<>>,
+    +navigation: StackNavigationProp<ParamListBase>,
+    +styleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  declare export type StackHeaderLeftButtonProps = $Shape<{|
+    +onPress: (() => void),
+    +pressColorAndroid: string;
+    +backImage: (props: {| tintColor: string |}) => React$Node,
+    +tintColor: string,
+    +label: string,
+    +truncatedLabel: string,
+    +labelVisible: boolean,
+    +labelStyle: AnimatedTextStyleProp,
+    +allowFontScaling: boolean,
+    +onLabelLayout: LayoutEvent => void,
+    +screenLayout: {| +width: number, +height: number |},
+    +titleLayout: {| +width: number, +height: number |},
+    +canGoBack: boolean,
+  |}>;
+
+  declare type StackHeaderTitleInputBase = {
+    +onLayout: LayoutEvent => void,
+    +children: string,
+    +allowFontScaling: ?boolean,
+    +tintColor: ?string,
+    +style: ?AnimatedTextStyleProp,
+    ...
+  };
+
+  declare export type StackHeaderTitleInputProps =
+    $Exact<StackHeaderTitleInputBase>;
+
+  declare export type StackOptions = $Shape<{|
+    +title: string,
+    +header: StackHeaderProps => React$Node,
+    +headerShown: boolean,
+    +cardShadowEnabled: boolean,
+    +cardOverlayEnabled: boolean,
+    +cardOverlay: {| style: ViewStyleProp |} => React$Node,
+    +cardStyle: ViewStyleProp,
+    +animationEnabled: boolean,
+    +animationTypeForReplace: 'push' | 'pop',
+    +gestureEnabled: boolean,
+    +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
+    +gestureVelocityImpact: number,
+    +safeAreaInsets: $Shape<EdgeInsets>,
+    // Transition
+    ...TransitionPreset,
+    // Header
+    +headerTitle: string | (StackHeaderTitleInputProps => React$Node),
+    +headerTitleAlign: 'left' | 'center',
+    +headerTitleStyle: AnimatedTextStyleProp,
+    +headerTitleContainerStyle: ViewStyleProp,
+    +headerTintColor: string,
+    +headerTitleAllowFontScaling: boolean,
+    +headerBackAllowFontScaling: boolean,
+    +headerBackTitle: string,
+    +headerBackTitleStyle: TextStyleProp,
+    +headerBackTitleVisible: boolean,
+    +headerTruncatedBackTitle: string,
+    +headerLeft: StackHeaderLeftButtonProps => React$Node,
+    +headerLeftContainerStyle: ViewStyleProp,
+    +headerRight: {| tintColor?: string |} => React$Node,
+    +headerRightContainerStyle: ViewStyleProp,
+    +headerBackImage: $PropertyType<StackHeaderLeftButtonProps, 'backImage'>,
+    +headerPressColorAndroid: string,
+    +headerBackground: ({| style: ViewStyleProp |}) => React$Node,
+    +headerStyle: ViewStyleProp,
+    +headerTransparent: boolean,
+    +headerStatusBarHeight: number,
+  |}>;
+
+  /**
+   * Stack navigation prop
+   */
+
+  declare export type StackNavigationEventMap = {|
+    ...EventMapCore<StackNavigationState>,
+    +transitionStart: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+    +transitionEnd: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+  |};
+
+  declare type InexactStackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      StackNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +replace: SimpleNavigate<ParamList>,
+    +push: SimpleNavigate<ParamList>,
+    +pop: (count?: number) => void,
+    +popToTop: () => void,
+    ...
+  };
+
+  declare export type StackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = $Exact<InexactStackNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous stack exports
+   */
+
+  declare type StackNavigationConfig = {|
+    +mode?: 'card' | 'modal',
+    +headerMode?: 'float' | 'screen' | 'none',
+    +keyboardHandlingEnabled?: boolean,
+  |};
+
+  declare export type ExtraStackNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...StackRouterOptions,
+    ...StackNavigationConfig,
+  |};
+
+  declare export type StackNavigatorProps<
+    NavProp: InexactStackNavigationProp<> = StackNavigationProp<>,
+  > = {|
+    ...ExtraStackNavigatorProps,
+    ...ScreenOptionsProp<StackOptions, NavProp>,
+  |};
+
+  /**
+   * Bottom tab options
+   */
+
+  declare export type BottomTabBarButtonProps = {|
+    ...$Diff<
+      TouchableWithoutFeedbackProps,
+      {| onPress?: ?(event: PressEvent) => mixed |},
+    >,
+    +to?: string,
+    +children: React$Node,
+    +onPress?: (MouseEvent | PressEvent) => void,
+  |};
+
+  declare export type BottomTabOptions = $Shape<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| focused: boolean, color: string |}) => React$Node,
+    +tabBarIcon: ({|
+      focused: boolean,
+      color: string,
+      size: number,
+    |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+    +tabBarVisible: boolean,
+    +tabBarButton: BottomTabBarButtonProps => React$Node,
+    +unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Bottom tab navigation prop
+   */
+
+  declare export type BottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare type InexactTabNavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+    Options: {...},
+    EventMap: EventMapBase,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      TabNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    ...
+  };
+
+  declare export type InexactBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type BottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = $Exact<InexactBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous bottom tab exports
+   */
+
+  declare export type BottomTabDescriptor = Descriptor<
+    BottomTabNavigationProp<>,
+    BottomTabOptions,
+  >;
+
+  declare export type BottomTabBarOptions = $Shape<{|
+    +keyboardHidesTabBar: boolean,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveBackgroundColor: string,
+    +allowFontScaling: boolean,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +labelStyle: TextStyleProp,
+    +tabStyle: ViewStyleProp,
+    +labelPosition: 'beside-icon' | 'below-icon',
+    +adaptive: boolean,
+    +safeAreaInsets: $Shape<EdgeInsets>,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type BottomTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: BottomTabNavigationProp<>,
+    +descriptors: {| +[key: string]: BottomTabDescriptor |},
+  |};
+
+  declare export type BottomTabBarProps = {|
+    ...BottomTabBarOptions,
+    ...BottomTabNavigationBuilderResult,
+  |}
+
+  declare type BottomTabNavigationConfig = {|
+    +lazy?: boolean,
+    +tabBar?: BottomTabBarProps => React$Node,
+    +tabBarOptions?: BottomTabBarOptions,
+  |};
+
+  declare export type ExtraBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...BottomTabNavigationConfig,
+  |};
+
+  declare export type BottomTabNavigatorProps<
+    NavProp: InexactBottomTabNavigationProp<> = BottomTabNavigationProp<>,
+  > = {|
+    ...ExtraBottomTabNavigatorProps,
+    ...ScreenOptionsProp<BottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material bottom tab options
+   */
+
+  declare export type MaterialBottomTabOptions = $Shape<{|
+    +title: string,
+    +tabBarColor: string,
+    +tabBarLabel: string,
+    +tabBarIcon:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarBadge: boolean | number | string,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material bottom tab navigation prop
+   */
+
+  declare export type MaterialBottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+  |};
+
+  declare export type InexactMaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = $Exact<InexactMaterialBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material bottom tab exports
+   */
+
+  declare export type PaperFont = {|
+    +fontFamily: string,
+    +fontWeight?:
+      | 'normal'
+      | 'bold'
+      | '100'
+      | '200'
+      | '300'
+      | '400'
+      | '500'
+      | '600'
+      | '700'
+      | '800'
+      | '900',
+  |};
+
+  declare export type PaperFonts = {|
+    +regular: Font,
+    +medium: Font,
+    +light: Font,
+    +thin: Font,
+  |};
+
+  declare export type PaperTheme = {|
+    +dark: boolean,
+    +mode?: 'adaptive' | 'exact',
+    +roundness: number,
+    +colors: {|
+      +primary: string,
+      +background: string,
+      +surface: string,
+      +accent: string,
+      +error: string,
+      +text: string,
+      +onSurface: string,
+      +onBackground: string,
+      +disabled: string,
+      +placeholder: string,
+      +backdrop: string,
+      +notification: string,
+    |},
+    +fonts: PaperFonts,
+    +animation: {|
+      +scale: number,
+    |},
+  |};
+
+  declare export type PaperRoute = {|
+    +key: string,
+    +title?: string,
+    +icon?: any,
+    +badge?: string | number | boolean,
+    +color?: string,
+    +accessibilityLabel?: string,
+    +testID?: string,
+  |};
+
+  declare export type PaperTouchableProps = {|
+    ...TouchableWithoutFeedbackProps,
+    +key: string,
+    +route: PaperRoute,
+    +children: React$Node,
+    +borderless?: boolean,
+    +centered?: boolean,
+    +rippleColor?: string,
+  |};
+
+  declare export type MaterialBottomTabNavigationConfig = {|
+    +shifting?: boolean,
+    +labeled?: boolean,
+    +renderTouchable?: PaperTouchableProps => React$Node,
+    +activeColor?: string,
+    +inactiveColor?: string,
+    +sceneAnimationEnabled?: boolean,
+    +keyboardHidesNavigationBar?: boolean,
+    +barStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +theme?: PaperTheme,
+  |};
+
+  declare export type ExtraMaterialBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialBottomTabNavigationConfig,
+  |};
+
+  declare export type MaterialBottomTabNavigatorProps<
+    NavProp: InexactMaterialBottomTabNavigationProp<> =
+      MaterialBottomTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialBottomTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialBottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material top tab options
+   */
+
+  declare export type MaterialTopTabOptions = $Shape<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarIcon: ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material top tab navigation prop
+   */
+
+  declare export type MaterialTopTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+    +swipeStart: {| +data: void, +canPreventDefault: false |},
+    +swipeEnd: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactMaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = $Exact<InexactMaterialTopTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material top tab exports
+   */
+
+  declare type MaterialTopTabPagerCommonProps = {|
+    +keyboardDismissMode: 'none' | 'on-drag' | 'auto',
+    +swipeEnabled: boolean,
+    +swipeVelocityImpact?: number,
+    +springVelocityScale?: number,
+    +springConfig: $Shape<{|
+      +damping: number,
+      +mass: number,
+      +stiffness: number,
+      +restSpeedThreshold: number,
+      +restDisplacementThreshold: number,
+    |}>,
+    +timingConfig: $Shape<{|
+      +duration: number,
+    |}>,
+  |};
+
+  declare export type MaterialTopTabPagerProps = {|
+    ...MaterialTopTabPagerCommonProps,
+    +onSwipeStart?: () => void,
+    +onSwipeEnd?: () => void,
+    +onIndexChange: (index: number) => void,
+    +navigationState: TabNavigationState,
+    +layout: {| +width: number, +height: number |},
+    +removeClippedSubviews: boolean,
+    +children: ({|
+      +addListener: (type: 'enter', listener: number => void) => void,
+      +removeListener: (type: 'enter', listener: number => void) => void,
+      +position: any, // Reanimated.Node<number>
+      +render: React$Node => React$Node,
+      +jumpTo: string => void,
+    |}) => React$Node,
+    +gestureHandlerProps: PanGestureHandlerProps,
+  |};
+
+  declare export type MaterialTopTabBarIndicatorProps = {|
+    +navigationState: TabNavigationState,
+    +width: string,
+    +style?: ViewStyleProp,
+    +getTabWidth: number => number,
+  |};
+
+  declare export type MaterialTopTabBarOptions = $Shape<{|
+    +scrollEnabled: boolean,
+    +bounces: boolean,
+    +pressColor: string,
+    +pressOpacity: number,
+    +getAccessible: ({| +route: Route<> |}) => boolean,
+    +renderBadge: ({| +route: Route<> |}) => React$Node,
+    +renderIndicator: MaterialTopTabBarIndicatorProps => React$Node,
+    +tabStyle: ViewStyleProp,
+    +indicatorStyle: ViewStyleProp,
+    +indicatorContainerStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +iconStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +allowFontScaling: boolean,
+  |}>;
+
+  declare export type MaterialTopTabDescriptor = Descriptor<
+    MaterialBottomTabNavigationProp<>,
+    MaterialBottomTabOptions,
+  >;
+
+  declare type MaterialTopTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: MaterialTopTabNavigationProp<>,
+    +descriptors: {| +[key: string]: MaterialTopTabDescriptor |},
+  |};
+
+  declare export type MaterialTopTabBarProps = {|
+    ...MaterialTopTabBarOptions,
+    ...MaterialTopTabNavigationBuilderResult,
+    +layout: {| +width: number, +height: number |},
+    +position: any, // Reanimated.Node<number>
+    +jumpTo: string => void,
+  |};
+
+  declare export type MaterialTopTabNavigationConfig = {|
+    ...$Partial<MaterialTopTabPagerCommonProps>,
+    +position?: any, // Reanimated.Value<number>
+    +tabBarPosition?: 'top' | 'bottom',
+    +initialLayout?: $Shape<{| +width: number, +height: number |}>,
+    +lazy?: boolean,
+    +lazyPreloadDistance?: number,
+    +removeClippedSubviews?: boolean,
+    +sceneContainerStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +pager?: MaterialTopTabPagerProps => React$Node,
+    +lazyPlaceholder?: ({| +route: Route<> |}) => React$Node,
+    +tabBar?: MaterialTopTabBarProps => React$Node,
+    +tabBarOptions?: MaterialTopTabBarOptions,
+  |};
+
+  declare export type ExtraMaterialTopTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialTopTabNavigationConfig,
+  |};
+
+  declare export type MaterialTopTabNavigatorProps<
+    NavProp: InexactMaterialTopTabNavigationProp<> =
+      MaterialTopTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialTopTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialTopTabOptions, NavProp>,
+  |};
+
+  /**
+   * Drawer options
+   */
+
+  declare export type DrawerOptions = $Shape<{|
+    title: string,
+    drawerLabel:
+      | string
+      | ({| +color: string, +focused: boolean |}) => React$Node,
+    drawerIcon: ({|
+      +color: string,
+      +size: number,
+      +focused: boolean,
+    |}) => React$Node,
+    gestureEnabled: boolean,
+    swipeEnabled: boolean,
+    unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Drawer navigation prop
+   */
+
+  declare export type DrawerNavigationEventMap = {|
+    ...EventMapCore<DrawerNavigationState>,
+    +drawerOpen: {| +data: void, +canPreventDefault: false |},
+    +drawerClose: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactDrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      DrawerNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    +openDrawer: () => void,
+    +closeDrawer: () => void,
+    +toggleDrawer: () => void,
+    ...
+  };
+
+  declare export type DrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = $Exact<InexactDrawerNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous drawer exports
+   */
+
+  declare export type DrawerDescriptor = Descriptor<
+    DrawerNavigationProp<>,
+    DrawerOptions,
+  >;
+
+  declare export type DrawerItemListBaseOptions = $Shape<{|
+    +activeTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveTintColor: string,
+    +inactiveBackgroundColor: string,
+    +itemStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+  |}>;
+
+  declare export type DrawerContentOptions = $Shape<{|
+    ...DrawerItemListBaseOptions,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type DrawerNavigationBuilderResult = {|
+    +state: DrawerNavigationState,
+    +navigation: DrawerNavigationProp<>,
+    +descriptors: {| +[key: string]: DrawerDescriptor |},
+  |};
+
+  declare export type DrawerContentProps = {|
+    ...DrawerContentOptions,
+    ...DrawerNavigationBuilderResult,
+    +progress: any, // Reanimated.Node<number>
+  |};
+
+  declare export type DrawerNavigationConfig = {|
+    +drawerPosition?: 'left' | 'right',
+    +drawerType?: 'front' | 'back' | 'slide' | 'permanent',
+    +edgeWidth?: number,
+    +hideStatusBar?: boolean,
+    +keyboardDismissMode?: 'on-drag' | 'none',
+    +minSwipeDistance?: number,
+    +overlayColor?: string,
+    +statusBarAnimation?: 'slide' | 'none' | 'fade',
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +lazy?: boolean,
+    +drawerContent?: DrawerContentProps => React$Node,
+    +drawerContentOptions?: DrawerContentOptions,
+    +sceneContainerStyle?: ViewStyleProp,
+    +drawerStyle?: ViewStyleProp,
+  |};
+
+  declare export type ExtraDrawerNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...DrawerRouterOptions,
+    ...DrawerNavigationConfig,
+  |};
+
+  declare export type DrawerNavigatorProps<
+    NavProp: InexactDrawerNavigationProp<> = DrawerNavigationProp<>,
+  > = {|
+    ...ExtraDrawerNavigatorProps,
+    ...ScreenOptionsProp<DrawerOptions, NavProp>,
+  |};
+
+  /**
+   * BaseNavigationContainer
+   */
+
+  declare export type BaseNavigationContainerProps = {|
+    +children: React$Node,
+    +initialState?: PossiblyStaleNavigationState,
+    +onStateChange?: (state: ?PossiblyStaleNavigationState) => void,
+    +independent?: boolean,
+  |};
+
+  declare export type BaseNavigationContainerInterface = {|
+    ...$Exact<NavigationHelpers<
+      ParamListBase,
+      PossiblyStaleNavigationState,
+      GlobalEventMap<PossiblyStaleNavigationState>,
+    >>,
+    +setParams: (params: ScreenParams) => void,
+    +resetRoot: (state?: ?PossiblyStaleNavigationState) => void,
+    +getRootState: () => PossiblyStaleNavigationState,
+  |};
+
+  /**
+   * State / path conversion
+   */
+
+  declare export type LinkingConfig = {|
+    +[routeName: string]:
+      | string
+      | {|
+          +path?: string,
+          +parse?: {| +[param: string]: string => mixed |},
+          +screens?: LinkingConfig,
+          +initialRouteName?: string,
+        |},
+  |};
+
+  declare export type GetPathFromStateOptions = {|
+    +[routeName: string]:
+      | string
+      | {|
+          +path?: string,
+          +stringify?: {| +[param: string]: mixed => string |},
+          +screens?: GetPathFromStateOptions,
+        |},
+  |};
+
+  //---------------------------------------------------------------------------
+  // SECTION 2: EXPORTED MODULE
+  // This section defines the module exports and contains exported types that
+  // are not present in any other React Navigation libdef.
+  //---------------------------------------------------------------------------
+
+  /**
+   * createMaterialBottomTabNavigator
+   */
+
+  declare export var createMaterialBottomTabNavigator: CreateNavigator<
+    TabNavigationState,
+    MaterialBottomTabOptions,
+    MaterialBottomTabNavigationEventMap,
+    ExtraMaterialBottomTabNavigatorProps,
+  >;
+
+  /**
+   * MaterialBottomTabView
+   */
+
+  declare export type MaterialBottomTabDescriptor = Descriptor<
+    MaterialBottomTabNavigationProp<>,
+    MaterialBottomTabOptions,
+  >;
+  declare export type MaterialBottomTabViewProps = {|
+    ...MaterialBottomTabNavigationConfig,
+    +state: TabNavigationState,
+    +navigation: MaterialBottomTabNavigationProp<>,
+    +descriptors: {| +[key: string]: MaterialBottomTabDescriptor |},
+  |};
+  declare export var MaterialBottomTabView: React$ComponentType<
+    MaterialBottomTabViewProps,
+  >;
+
+}

--- a/definitions/npm/@react-navigation/material-bottom-tabs_v5.x.x/test_material-bottom-tabs.js
+++ b/definitions/npm/@react-navigation/material-bottom-tabs_v5.x.x/test_material-bottom-tabs.js
@@ -1,0 +1,115 @@
+// @flow
+
+import * as React from 'react';
+import {
+  createMaterialBottomTabNavigator,
+  type NavigationProp,
+  type MaterialBottomTabNavigationProp,
+  type LeafRoute,
+  type TabNavigationState,
+  type MaterialBottomTabOptions,
+  type MaterialBottomTabNavigationEventMap,
+} from '@react-navigation/material-bottom-tabs';
+
+/**
+ * Navigator setup
+ */
+
+type LocalParamList = {|
+  One: {| hey: string |},
+  Two: void,
+  Three: ?{| sup: number |},
+|};
+
+type GlobalParamList = {|
+  ...LocalParamList,
+  Another: void,
+|};
+
+type NavProp<
+  RouteName: $Keys<LocalParamList> = $Keys<LocalParamList>,
+> = MaterialBottomTabNavigationProp<GlobalParamList, RouteName>;
+type NavRoute<
+  RouteName: $Keys<LocalParamList> = $Keys<LocalParamList>,
+> = {|
+  ...LeafRoute<RouteName>,
+  +params: $ElementType<LocalParamList, RouteName>,
+|};
+
+const Tab = createMaterialBottomTabNavigator<
+  GlobalParamList,
+  LocalParamList,
+  NavProp<>,
+>();
+
+/**
+ * Screens
+ */
+
+function ValidScreen(props: {|
+  navigation: NavProp<'One'>,
+  route: NavRoute<'One'>,
+|}) {
+  props.navigation.navigate('Another');
+  // $ExpectError invalid params
+  props.navigation.navigate('Another', {});
+  // $ExpectError invalid route
+  props.navigation.navigate('test', { sup: true, yo: null });
+  props.navigation.jumpTo('Three');
+  (props.navigation: NavigationProp<
+    GlobalParamList,
+    'One',
+    TabNavigationState,
+    MaterialBottomTabOptions,
+    MaterialBottomTabNavigationEventMap,
+  >);
+  return null;
+}
+
+function InvalidScreen(props: {|
+  navigation: NavProp<'One'>,
+  route: number,
+|}) {
+  props.navigation.setOptions({
+    title: 'sup',
+    tabBarLabel: 'SUP',
+    tabBarBadge: true,
+  });
+  // $ExpectError invalid navigator props
+  props.navigation.setOptions({ fake: 12 });
+  React.useEffect(() => {
+    return props.navigation.addListener(
+      'tabPress',
+      e => {
+        (e.type: 'tabPress');
+        e.preventDefault();
+      },
+    );
+  });
+  return null;
+}
+
+<Tab.Screen name="One" component={ValidScreen} />;
+// $ExpectError non-matching component
+<Tab.Screen name="Two" component={ValidScreen} />;
+// $ExpectError invalid route name
+<Tab.Screen name="Four" component={ValidScreen} />;
+// $ExpectError invalid params
+<Tab.Screen name="One" component={ValidScreen} initialParams={{ hey: 5 }} />;
+// $ExpectError non-local route
+<Tab.Screen name="Another" component={ValidScreen} />;
+// $ExpectError invalid screen props
+<Tab.Screen name="One" component={InvalidScreen} />;
+
+/**
+ * Navigator
+ */
+
+<Tab.Navigator shifting={true} />;
+<Tab.Navigator activeColor="blah" />;
+// $ExpectError invalid navigator props
+<Tab.Navigator
+  // $ExpectError invalid navigator props
+  shifting={5}
+  someOtherProp="fake"
+/>;

--- a/definitions/npm/@react-navigation/material-top-tabs_v5.x.x/CONTRIBUTING.md
+++ b/definitions/npm/@react-navigation/material-top-tabs_v5.x.x/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to the React Navigation Flow libdef
+
+## Overview
+
+There are seven React Navigation libdefs in `flow-typed`:
+
+1. `@react-navigation/core`
+2. `@react-navigation/native`
+3. `@react-navigation/stack`
+4. `@react-navigation/bottom-tabs`
+5. `@react-navigation/material-bottom-tabs`
+6. `@react-navigation/material-top-tabs`
+7. `@react-navigation/drawer`
+
+It's not currently possible to import types between libdefs. Consequently, many of the same types are copy-pasted across the different libdefs.
+
+Each libdef is organized into two sections. The first section should be identical between all of the libdefs. If you make a change to this section, please make sure to mirror it across the other libdefs.
+
+## Contributors
+
+- @Ashoat

--- a/definitions/npm/@react-navigation/material-top-tabs_v5.x.x/flow_v0.104.x-/material-top-tabs_v5.x.x.js
+++ b/definitions/npm/@react-navigation/material-top-tabs_v5.x.x/flow_v0.104.x-/material-top-tabs_v5.x.x.js
@@ -1,0 +1,1979 @@
+declare module '@react-navigation/material-top-tabs' {
+
+  //---------------------------------------------------------------------------
+  // SECTION 1: IDENTICAL TYPE DEFINITIONS
+  // This section is identical across all React Navigation libdefs and contains
+  // shared definitions. We wish we could make it DRY and import from a shared
+  // definition, but that isn't yet possible.
+  //---------------------------------------------------------------------------
+
+  /**
+   * We start with some definitions that we have copy-pasted from React Native
+   * source files.
+   */
+
+  // This is a bastardization of the true StyleObj type located in
+  // react-native/Libraries/StyleSheet/StyleSheetTypes. We unfortunately can't
+  // import that here, and it's too lengthy (and consequently too brittle) to
+  // copy-paste here either.
+  declare type StyleObj =
+    | null
+    | void
+    | number
+    | false
+    | ''
+    | $ReadOnlyArray<StyleObj>
+    | { [name: string]: any, ... };
+  declare type ViewStyleProp = StyleObj;
+  declare type TextStyleProp = StyleObj;
+  declare type AnimatedViewStyleProp = StyleObj;
+  declare type AnimatedTextStyleProp = StyleObj;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/animations/Animation.js
+  declare type EndResult = { finished: boolean, ... };
+  declare type EndCallback = (result: EndResult) => void;
+  declare interface Animation {
+    start(
+      fromValue: number,
+      onUpdate: (value: number) => void,
+      onEnd: ?EndCallback,
+      previousAnimation: ?Animation,
+      animatedValue: AnimatedValue,
+    ): void;
+    stop(): void;
+  }
+  declare type AnimationConfig = {
+    isInteraction?: boolean,
+    useNativeDriver: boolean,
+    onComplete?: ?EndCallback,
+    iterations?: number,
+    ...
+  };
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedTracking.js
+  declare interface AnimatedTracking {
+    constructor(
+      value: AnimatedValue,
+      parent: any,
+      animationClass: any,
+      animationConfig: Object,
+      callback?: ?EndCallback,
+    ): void;
+    update(): void;
+  }
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedValue.js
+  declare type ValueListenerCallback = (state: { value: number, ... }) => void;
+  declare interface AnimatedValue {
+    constructor(value: number): void;
+    setValue(value: number): void;
+    setOffset(offset: number): void;
+    flattenOffset(): void;
+    extractOffset(): void;
+    addListener(callback: ValueListenerCallback): string;
+    removeListener(id: string): void;
+    removeAllListeners(): void;
+    stopAnimation(callback?: ?(value: number) => void): void;
+    resetAnimation(callback?: ?(value: number) => void): void;
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+    animate(animation: Animation, callback: ?EndCallback): void;
+    stopTracking(): void;
+    track(tracking: AnimatedTracking): void;
+  }
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/TimingAnimation.js
+  declare type TimingAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    easing?: (value: number) => number,
+    duration?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/SpringAnimation.js
+  declare type SpringAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    overshootClamping?: boolean,
+    restDisplacementThreshold?: number,
+    restSpeedThreshold?: number,
+    velocity?: number,
+    bounciness?: number,
+    speed?: number,
+    tension?: number,
+    friction?: number,
+    stiffness?: number,
+    damping?: number,
+    mass?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from react-native/Libraries/Types/CoreEventTypes.js
+  declare type SyntheticEvent<T> = $ReadOnly<{|
+    bubbles: ?boolean,
+    cancelable: ?boolean,
+    currentTarget: number,
+    defaultPrevented: ?boolean,
+    dispatchConfig: $ReadOnly<{|
+      registrationName: string,
+    |}>,
+    eventPhase: ?number,
+    preventDefault: () => void,
+    isDefaultPrevented: () => boolean,
+    stopPropagation: () => void,
+    isPropagationStopped: () => boolean,
+    isTrusted: ?boolean,
+    nativeEvent: T,
+    persist: () => void,
+    target: ?number,
+    timeStamp: number,
+    type: ?string,
+  |}>;
+  declare type Layout = $ReadOnly<{|
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  |}>;
+  declare type LayoutEvent = SyntheticEvent<
+    $ReadOnly<{|
+      layout: Layout,
+    |}>,
+  >;
+  declare type BlurEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type FocusEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type ResponderSyntheticEvent<T> = $ReadOnly<{|
+    ...SyntheticEvent<T>,
+    touchHistory: $ReadOnly<{|
+      indexOfSingleActiveTouch: number,
+      mostRecentTimeStamp: number,
+      numberActiveTouches: number,
+      touchBank: $ReadOnlyArray<
+        $ReadOnly<{|
+          touchActive: boolean,
+          startPageX: number,
+          startPageY: number,
+          startTimeStamp: number,
+          currentPageX: number,
+          currentPageY: number,
+          currentTimeStamp: number,
+          previousPageX: number,
+          previousPageY: number,
+          previousTimeStamp: number,
+        |}>,
+      >,
+    |}>,
+  |}>;
+  declare type PressEvent = ResponderSyntheticEvent<
+    $ReadOnly<{|
+      changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+      force: number,
+      identifier: number,
+      locationX: number,
+      locationY: number,
+      pageX: number,
+      pageY: number,
+      target: ?number,
+      timestamp: number,
+      touches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+    |}>,
+  >;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+  declare type ExtrapolateType = 'extend' | 'identity' | 'clamp';
+  declare type InterpolationConfigType = {
+    inputRange: Array<number>,
+    outputRange: Array<number> | Array<string>,
+    easing?: (input: number) => number,
+    extrapolate?: ExtrapolateType,
+    extrapolateLeft?: ExtrapolateType,
+    extrapolateRight?: ExtrapolateType,
+    ...
+  };
+  declare interface AnimatedInterpolation {
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+  }
+
+  // Copied from react-native/Libraries/Components/View/ViewAccessibility.js
+  declare type AccessibilityRole =
+    | 'none'
+    | 'button'
+    | 'link'
+    | 'search'
+    | 'image'
+    | 'keyboardkey'
+    | 'text'
+    | 'adjustable'
+    | 'imagebutton'
+    | 'header'
+    | 'summary'
+    | 'alert'
+    | 'checkbox'
+    | 'combobox'
+    | 'menu'
+    | 'menubar'
+    | 'menuitem'
+    | 'progressbar'
+    | 'radio'
+    | 'radiogroup'
+    | 'scrollbar'
+    | 'spinbutton'
+    | 'switch'
+    | 'tab'
+    | 'tablist'
+    | 'timer'
+    | 'toolbar';
+  declare type AccessibilityActionInfo = $ReadOnly<{
+    name: string,
+    label?: string,
+    ...
+  }>;
+  declare type AccessibilityActionEvent = SyntheticEvent<
+    $ReadOnly<{actionName: string, ...}>,
+  >;
+  declare type AccessibilityState = {
+    disabled?: boolean,
+    selected?: boolean,
+    checked?: ?boolean | 'mixed',
+    busy?: boolean,
+    expanded?: boolean,
+    ...
+  };
+  declare type AccessibilityValue = $ReadOnly<{|
+    min?: number,
+    max?: number,
+    now?: number,
+    text?: string,
+  |}>;
+
+  // Copied from
+  // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+  declare type Stringish = string;
+  declare type EdgeInsetsProp = $ReadOnly<$Shape<EdgeInsets>>;
+  declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
+    accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+    accessibilityElementsHidden?: ?boolean,
+    accessibilityHint?: ?Stringish,
+    accessibilityIgnoresInvertColors?: ?boolean,
+    accessibilityLabel?: ?Stringish,
+    accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
+    accessibilityRole?: ?AccessibilityRole,
+    accessibilityState?: ?AccessibilityState,
+    accessibilityValue?: ?AccessibilityValue,
+    accessibilityViewIsModal?: ?boolean,
+    accessible?: ?boolean,
+    children?: ?React$Node,
+    delayLongPress?: ?number,
+    delayPressIn?: ?number,
+    delayPressOut?: ?number,
+    disabled?: ?boolean,
+    focusable?: ?boolean,
+    hitSlop?: ?EdgeInsetsProp,
+    importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
+    nativeID?: ?string,
+    onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+    onBlur?: ?(event: BlurEvent) => mixed,
+    onFocus?: ?(event: FocusEvent) => mixed,
+    onLayout?: ?(event: LayoutEvent) => mixed,
+    onLongPress?: ?(event: PressEvent) => mixed,
+    onPress?: ?(event: PressEvent) => mixed,
+    onPressIn?: ?(event: PressEvent) => mixed,
+    onPressOut?: ?(event: PressEvent) => mixed,
+    pressRetentionOffset?: ?EdgeInsetsProp,
+    rejectResponderTermination?: ?boolean,
+    testID?: ?string,
+    touchSoundDisabled?: ?boolean,
+  |}>;
+
+  // Copied from react-native/Libraries/Image/ImageSource.js
+  declare type ImageURISource = $ReadOnly<{
+    uri?: ?string,
+    bundle?: ?string,
+    method?: ?string,
+    headers?: ?Object,
+    body?: ?string,
+    cache?: ?('default' | 'reload' | 'force-cache' | 'only-if-cached'),
+    width?: ?number,
+    height?: ?number,
+    scale?: ?number,
+    ...
+  }>;
+
+  /**
+   * The following is copied from react-native-gesture-handler's libdef
+   */
+
+  declare type $EventHandlers<ExtraProps: {...}> = {|
+    onGestureEvent?: ($Event<ExtraProps>) => mixed,
+    onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
+    onBegan?: ($Event<ExtraProps>) => mixed,
+    onFailed?: ($Event<ExtraProps>) => mixed,
+    onCancelled?: ($Event<ExtraProps>) => mixed,
+    onActivated?: ($Event<ExtraProps>) => mixed,
+    onEnded?: ($Event<ExtraProps>) => mixed,
+  |};
+
+  declare type HitSlop =
+    | number
+    | {|
+        left?: number,
+        top?: number,
+        right?: number,
+        bottom?: number,
+        vertical?: number,
+        horizontal?: number,
+        width?: number,
+        height?: number,
+      |}
+    | {|
+        width: number,
+        left: number,
+      |}
+    | {|
+        width: number,
+        right: number,
+      |}
+    | {|
+        height: number,
+        top: number,
+      |}
+    | {|
+        height: number,
+        bottom: number,
+      |};
+
+  declare type $GestureHandlerProps<
+    AdditionalProps: {...},
+    ExtraEventsProps: {...}
+  > = $ReadOnly<{|
+    ...$Exact<AdditionalProps>,
+    ...$EventHandlers<ExtraEventsProps>,
+    id?: string,
+    enabled?: boolean,
+    waitFor?: React$Ref<any> | Array<React$Ref<any>>,
+    simultaneousHandlers?: React$Ref<any> | Array<React$Ref<any>>,
+    shouldCancelWhenOutside?: boolean,
+    minPointers?: number,
+    hitSlop?: HitSlop,
+    children?: React$Node,
+  |}>;
+
+  declare type PanGestureHandlerProps = $GestureHandlerProps<
+    {
+      activeOffsetY?: number | [number, number],
+      activeOffsetX?: number | [number, number],
+      failOffsetY?: number | [number, number],
+      failOffsetX?: number | [number, number],
+      minDist?: number,
+      minVelocity?: number,
+      minVelocityX?: number,
+      minVelocityY?: number,
+      minPointers?: number,
+      maxPointers?: number,
+      avgTouches?: boolean,
+      ...
+    },
+    {
+      x: number,
+      y: number,
+      absoluteX: number,
+      absoluteY: number,
+      translationX: number,
+      translationY: number,
+      velocityX: number,
+      velocityY: number,
+      ...
+    }
+  >;
+
+  /**
+   * MAGIC
+   */
+
+  declare type $If<Test: boolean, Then, Else = empty> = $Call<
+    ((true, Then, Else) => Then) & ((false, Then, Else) => Else),
+    Test,
+    Then,
+    Else,
+  >;
+  declare type $IsA<X, Y> = $Call<
+    (Y => true) & (mixed => false),
+    X,
+  >;
+  declare type $IsUndefined<X> = $IsA<X, void>;
+
+  declare type $Partial<T> = $Rest<T, {...}>;
+
+  /**
+   * Actions, state, etc.
+   */
+
+  declare export type ScreenParams = { +[key: string]: mixed, ... };
+
+  declare export type BackAction = {|
+    +type: 'GO_BACK',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type NavigateAction = {|
+    +type: 'NAVIGATE',
+    +payload:
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ResetAction = {|
+    +type: 'RESET',
+    +payload: StaleNavigationState,
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type SetParamsAction = {|
+    +type: 'SET_PARAMS',
+    +payload: {| +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CommonAction =
+    | BackAction
+    | NavigateAction
+    | ResetAction
+    | SetParamsAction;
+
+  declare type NavigateActionCreator = {|
+    (routeName: string, params?: ScreenParams): NavigateAction,
+    (
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    ): NavigateAction,
+  |};
+  declare export type CommonActionsType = {|
+    +navigate: NavigateActionCreator,
+    +goBack: () => BackAction,
+    +reset: (state: PossiblyStaleNavigationState) => ResetAction,
+    +setParams: (params: ScreenParams) => SetParamsAction,
+  |};
+
+  declare export type GenericNavigationAction = {|
+    +type: string,
+    +payload?: { +[key: string]: mixed, ... },
+    +source?: string,
+    +target?: string,
+  |};
+
+  declare export type LeafRoute<RouteName: string = string> = {|
+    +key: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StateRoute<RouteName: string = string> = {|
+    ...LeafRoute<RouteName>,
+    +state: NavigationState | StaleNavigationState,
+  |};
+  declare export type Route<RouteName: string = string> =
+    | LeafRoute<RouteName>
+    | StateRoute<RouteName>;
+
+  declare export type NavigationState = {|
+    +key: string,
+    +index: number,
+    +routeNames: $ReadOnlyArray<string>,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<Route<>>,
+    +type: string,
+    +stale: false,
+  |};
+
+  declare export type StaleLeafRoute<RouteName: string = string> = {|
+    +key?: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StaleStateRoute<RouteName: string = string> = {|
+    ...StaleLeafRoute<RouteName>,
+    +state: StaleNavigationState,
+  |};
+  declare export type StaleRoute<RouteName: string = string> =
+    | StaleLeafRoute<RouteName>
+    | StaleStateRoute<RouteName>;
+  declare export type StaleNavigationState = {|
+    // It's possible to pass React Nav a StaleNavigationState with an undefined
+    // index, but React Nav will always return one with the index set. This is
+    // the same as for the type property below, but in the case of index we tend
+    // to rely on it being set more...
+    +index: number,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<StaleRoute<>>,
+    +type?: string,
+    +stale?: true,
+  |};
+
+  declare export type PossiblyStaleNavigationState =
+    | NavigationState
+    | StaleNavigationState;
+  declare export type PossiblyStaleRoute<RouteName: string = string> =
+    | Route<RouteName>
+    | StaleRoute<RouteName>;
+
+  /**
+   * Routers
+   */
+
+  declare type ActionCreators<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {
+    +[key: string]: (...args: any) => (Action | State => Action),
+    ...
+  };
+
+  declare export type DefaultRouterOptions = {
+    +initialRouteName?: string,
+    ...
+  };
+
+  declare export type RouterFactory<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    RouterOptions: DefaultRouterOptions,
+  > = (options: RouterOptions) => Router<State, Action>;
+
+  declare export type ParamListBase = { +[key: string]: ?ScreenParams, ... };
+
+  declare export type RouterConfigOptions = {|
+    +routeNames: $ReadOnlyArray<string>,
+    +routeParamList: ParamListBase,
+  |};
+
+  declare export type Router<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {|
+    +type: $PropertyType<State, 'type'>,
+    +getInitialState: (options: RouterConfigOptions) => State,
+    +getRehydratedState: (
+      partialState: PossibleStaleNavigationState,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteNamesChange: (
+      state: State,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteFocus: (state: State, key: string) => State,
+    +getStateForAction: (
+      state: State,
+      action: Action,
+      options: RouterConfigOptions,
+    ) => ?PossiblyStaleNavigationState;
+    +shouldActionChangeFocus: (action: GenericNavigationAction) => boolean,
+    +actionCreators?: ActionCreators<State, Action>,
+  |};
+
+  /**
+   * Stack actions and router
+   */
+
+  declare export type StackNavigationState = {|
+    ...NavigationState,
+    +type: 'stack',
+  |};
+
+  declare export type ReplaceAction = {|
+    +type: 'REPLACE',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PushAction = {|
+    +type: 'PUSH',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopAction = {|
+    +type: 'POP',
+    +payload: {| +count: number |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopToTopAction = {|
+    +type: 'POP_TO_TOP',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type StackAction =
+    | CommonAction
+    | ReplaceAction
+    | PushAction
+    | PopAction
+    | PopToTopAction;
+
+  declare export type StackActionsType = {|
+    +replace: (routeName: string, params?: ScreenParams) => ReplaceAction,
+    +push: (routeName: string, params?: ScreenParams) => PushAction,
+    +pop: (count?: number) => PopAction,
+    +popToTop: () => PopToTopAction,
+  |};
+
+  declare export type StackRouterOptions = $Exact<DefaultRouterOptions>;
+
+  /**
+   * Tab actions and router
+   */
+
+  declare export type TabNavigationState = {|
+    ...NavigationState,
+    +type: 'tab',
+    +history: $ReadOnlyArray<{| type: 'route', key: string |}>,
+  |};
+
+  declare export type JumpToAction = {|
+    +type: 'JUMP_TO',
+    +payload: {| +name: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type TabAction =
+    | CommonAction
+    | JumpToAction;
+
+  declare export type TabActionsType = {|
+    +jumpTo: string => JumpToAction,
+  |};
+
+  declare export type TabRouterOptions = {|
+    ...$Exact<DefaultRouterOptions>,
+    +backBehavior?: 'initialRoute' | 'order' | 'history' | 'none',
+  |};
+
+  /**
+   * Drawer actions and router
+   */
+
+  declare type DrawerHistoryEntry =
+    | {| +type: 'route', +key: string |}
+    | {| +type: 'drawer' |};
+  declare export type DrawerNavigationState = {|
+    ...NavigationState,
+    +type: 'drawer',
+    +history: $ReadOnlyArray<DrawerHistoryEntry>,
+  |};
+
+  declare export type OpenDrawerAction = {|
+    +type: 'OPEN_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CloseDrawerAction = {|
+    +type: 'CLOSE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ToggleDrawerAction = {|
+    +type: 'TOGGLE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type DrawerAction =
+    | TabAction
+    | OpenDrawerAction
+    | CloseDrawerAction
+    | ToggleDrawerAction;
+
+  declare export type DrawerActionsType = {|
+    ...TabActionsType,
+    +openDrawer: () => OpenDrawerAction,
+    +closeDrawer: () => CloseDrawerAction,
+    +toggleDrawer: () => ToggleDrawerAction,
+  |};
+
+  declare export type DrawerRouterOptions = {|
+    ...TabRouterOptions,
+    +openByDefault?: boolean,
+  |};
+
+  /**
+   * Events
+   */
+
+  declare export type EventMapBase = {
+    +[name: string]: {|
+      +data?: mixed,
+      +canPreventDefault?: boolean,
+    |},
+    ...
+  };
+  declare type EventPreventDefaultProperties<Test: boolean> = $If<
+    Test,
+    {| +defaultPrevented: boolean, +preventDefault: () => void |},
+    {| |},
+  >;
+  declare type EventDataProperties<Data> = $If<
+    $IsUndefined<Data>,
+    {| |},
+    {| +data: Data |},
+  >;
+  declare type EventArg<
+    EventName: string,
+    CanPreventDefault: ?boolean = false,
+    Data = void,
+  > = {|
+    ...EventPreventDefaultProperties<CanPreventDefault>,
+    ...EventDataProperties<Data>,
+    +type: EventName,
+    +target?: string,
+  |};
+  declare type GlobalEventMap<State: PossiblyStaleNavigationState> = {|
+    +state: {| +data: {| +state: State |}, +canPreventDefault: false |},
+  |};
+  declare type EventMapCore<State: PossiblyStaleNavigationState> = {|
+    ...GlobalEventMap<State>,
+    +focus: {| +data: void, +canPreventDefault: false |},
+    +blur: {| +data: void, +canPreventDefault: false |},
+  |};
+  declare type EventListenerCallback<
+    EventName: string,
+    State: NavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = (e: EventArg<
+    EventName,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'canPreventDefault',
+    >,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'data',
+    >,
+  >) => mixed;
+
+  /**
+   * Navigation prop
+   */
+
+  declare export type SimpleNavigate<ParamList> =
+    <DestinationRouteName: $Keys<ParamList>>(
+      routeName: DestinationRouteName,
+      params: $ElementType<ParamList, DestinationRouteName>,
+    ) => void;
+
+  declare export type Navigate<ParamList> =
+    & SimpleNavigate<ParamList>
+    & <DestinationRouteName: $Keys<ParamList>>(
+        route:
+          | {|
+              key: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |}
+          | {|
+              name: DestinationRouteName,
+              key?: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |},
+      ) => void;
+
+  declare type NavigationHelpers<
+    ParamList: ParamListBase,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    +navigate: Navigate<ParamList>,
+    +dispatch: (
+      action:
+        | GenericNavigationAction
+        | (State => GenericNavigationAction),
+    ) => void,
+    +reset: PossiblyStaleNavigationState => void,
+    +goBack: () => void,
+    +isFocused: () => boolean,
+    +canGoBack: () => boolean,
+    +dangerouslyGetParent: <Parent: NavigationProp<ParamListBase>>() => ?Parent,
+    +dangerouslyGetState: () => NavigationState,
+    +addListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => () => void,
+    +removeListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => void,
+    ...
+  };
+
+  declare export type NavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    ...$Exact<NavigationHelpers<
+      ParamList,
+      State,
+      EventMap,
+    >>,
+    +setOptions: (options: $Shape<ScreenOptions>) => void,
+    +setParams: (
+      params: $If<
+        $IsUndefined<$ElementType<ParamList, RouteName>>,
+        empty,
+        $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+      >,
+    ) => void,
+    ...
+  };
+
+  /**
+   * CreateNavigator
+   */
+
+  declare export type RouteProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+  > = {|
+    ...LeafRoute<RouteName>,
+    +params: $ElementType<ParamList, RouteName>,
+  |};
+
+  declare export type ScreenListeners<
+    EventMap: EventMapBase = EventMapCore<State>,
+    State: NavigationState = NavigationState,
+  > = $ObjMapi<
+    {| [name: $Keys<EventMap>]: empty |},
+    <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
+  >;
+
+  declare type BaseScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {|
+    +name: RouteName,
+    +options?:
+      | ScreenOptions
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenOptions,
+    +listeners?:
+      | ScreenListeners<EventMap, State>
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenListeners<EventMap, State>,
+    +initialParams?: $Shape<$ElementType<ParamList, RouteName>>,
+  |};
+
+  declare export type ScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > =
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +component: React$ComponentType<{|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}>,
+      |}
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +children: ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => React$Node,
+      |};
+
+  declare export type ScreenComponent<
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = <
+    RouteName: $Keys<ParamList>,
+    NavProp: NavigationProp<
+      GlobalParamList,
+      RouteName,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+  >(props: ScreenProps<
+    ParamList,
+    NavProp,
+    RouteName,
+    State,
+    ScreenOptions,
+    EventMap,
+  >) => React$Node;
+
+  declare type ScreenOptionsProp<ScreenOptions: {...}, NavProp> = {|
+    +screenOptions?:
+      | ScreenOptions
+      | ({| route: LeafRoute<>, navigation: NavProp |}) => ScreenOptions,
+  |};
+  declare export type ExtraNavigatorPropsBase = {
+    ...$Exact<DefaultRouterOptions>,
+    +children?: React$Node,
+    ...
+  };
+  declare export type NavigatorPropsBase<ScreenOptions: {...}, NavProp> = {
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    ...
+  };
+
+  declare export type CreateNavigator<
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  > = <
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    NavProp: NavigationHelpers<
+      GlobalParamList,
+      State,
+      EventMap,
+    >,
+  >() => {|
+    +Screen: ScreenComponent<
+      GlobalParamList,
+      ParamList,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+    +Navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorProps>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  |};
+
+  declare export type CreateNavigatorFactory = <
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    NavProp: NavigationHelpers<
+      ParamListBase,
+      State,
+      EventMap,
+    >,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  >(
+    navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorPropsBase>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  ) => CreateNavigator<State, ScreenOptions, EventMap, ExtraNavigatorProps>;
+
+  /**
+   * useNavigationBuilder
+   */
+
+  declare export type Descriptor<
+    NavProp,
+    ScreenOptions: {...} = {...},
+  > = {|
+    +render: () => React$Node,
+    +options: $ReadOnly<ScreenOptions>,
+    +navigation: NavProp,
+  |};
+
+  declare export type UseNavigationBuilder = <
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    ScreenOptions: {...},
+    RouterOptions: DefaultRouterOptions,
+    NavProp,
+  >(
+    routerFactory: RouterFactory<State, Action, RouterOptions>,
+    options: {|
+      ...$Exact<RouterOptions>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+      +children?: React$Node,
+    |},
+  ) => {|
+    +state: State,
+    +descriptors: {| +[key: string]: Descriptor<NavProp, ScreenOptions> |},
+    +navigation: NavProp,
+  |};
+
+  /**
+   * EdgeInsets
+   */
+
+  declare type EdgeInsets = {|
+    +top: number,
+    +right: number,
+    +bottom: number,
+    +left: number,
+  |};
+
+  /**
+   * TransitionPreset
+   */
+
+  declare export type TransitionSpec =
+    | {|
+        animation: 'spring',
+        config: $Diff<
+          SpringAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |}
+    | {|
+        animation: 'timing',
+        config: $Diff<
+          TimingAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |};
+
+  declare export type StackCardInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +index: number,
+    +closing: AnimatedInterpolation,
+    +swiping: AnimatedInterpolation,
+    +inverted: AnimatedInterpolation,
+    +layouts: {|
+      +screen: {| +width: number, +height: number |},
+    |},
+    +insets: EdgeInsets,
+  |};
+  declare export type StackCardInterpolatedStyle = {|
+    containerStyle?: AnimatedViewStyleProp,
+    cardStyle?: AnimatedViewStyleProp,
+    overlayStyle?: AnimatedViewStyleProp,
+    shadowStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackCardStyleInterpolator = (
+    props: StackCardInterpolationProps,
+  ) => StackCardInterpolatedStyle;
+
+  declare export type StackHeaderInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +layouts: {|
+      +header: {| +width: number, +height: number |},
+      +screen: {| +width: number, +height: number |},
+      +title?: {| +width: number, +height: number |},
+      +leftLabel?: {| +width: number, +height: number |},
+    |},
+  |};
+  declare export type StackHeaderInterpolatedStyle = {|
+    leftLabelStyle?: AnimatedViewStyleProp,
+    leftButtonStyle?: AnimatedViewStyleProp,
+    rightButtonStyle?: AnimatedViewStyleProp,
+    titleStyle?: AnimatedViewStyleProp,
+    backgroundStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackHeaderStyleInterpolator = (
+    props: StackHeaderInterpolationProps,
+  ) => StackHeaderInterpolatedStyle;
+
+  declare type GestureDirection =
+    | 'horizontal'
+    | 'horizontal-inverted'
+    | 'vertical'
+    | 'vertical-inverted';
+
+  declare export type TransitionPreset = {|
+    +gestureDirection: GestureDirection,
+    +transitionSpec: {|
+      +open: TransitionSpec,
+      +close: TransitionSpec,
+    |},
+    +cardStyleInterpolator: StackCardStyleInterpolator,
+    +headerStyleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  /**
+   * Stack options
+   */
+
+  declare export type StackDescriptor = Descriptor<
+    StackNavigationProp<>,
+    StackOptions,
+  >;
+
+  declare type Scene<T> = {|
+    +route: T,
+    +descriptor: StackDescriptor,
+    +progress: {|
+      +current: AnimatedInterpolation,
+      +next?: AnimatedInterpolation,
+      +previous?: AnimatedInterpolation,
+    |},
+  |};
+
+  declare export type StackHeaderProps = {|
+    +mode: 'float' | 'screen',
+    +layout: {| +width: number, +height: number |},
+    +insets: EdgeInsets,
+    +scene: Scene<Route<>>,
+    +previous?: Scene<Route<>>,
+    +navigation: StackNavigationProp<ParamListBase>,
+    +styleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  declare export type StackHeaderLeftButtonProps = $Shape<{|
+    +onPress: (() => void),
+    +pressColorAndroid: string;
+    +backImage: (props: {| tintColor: string |}) => React$Node,
+    +tintColor: string,
+    +label: string,
+    +truncatedLabel: string,
+    +labelVisible: boolean,
+    +labelStyle: AnimatedTextStyleProp,
+    +allowFontScaling: boolean,
+    +onLabelLayout: LayoutEvent => void,
+    +screenLayout: {| +width: number, +height: number |},
+    +titleLayout: {| +width: number, +height: number |},
+    +canGoBack: boolean,
+  |}>;
+
+  declare type StackHeaderTitleInputBase = {
+    +onLayout: LayoutEvent => void,
+    +children: string,
+    +allowFontScaling: ?boolean,
+    +tintColor: ?string,
+    +style: ?AnimatedTextStyleProp,
+    ...
+  };
+
+  declare export type StackHeaderTitleInputProps =
+    $Exact<StackHeaderTitleInputBase>;
+
+  declare export type StackOptions = $Shape<{|
+    +title: string,
+    +header: StackHeaderProps => React$Node,
+    +headerShown: boolean,
+    +cardShadowEnabled: boolean,
+    +cardOverlayEnabled: boolean,
+    +cardOverlay: {| style: ViewStyleProp |} => React$Node,
+    +cardStyle: ViewStyleProp,
+    +animationEnabled: boolean,
+    +animationTypeForReplace: 'push' | 'pop',
+    +gestureEnabled: boolean,
+    +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
+    +gestureVelocityImpact: number,
+    +safeAreaInsets: $Shape<EdgeInsets>,
+    // Transition
+    ...TransitionPreset,
+    // Header
+    +headerTitle: string | (StackHeaderTitleInputProps => React$Node),
+    +headerTitleAlign: 'left' | 'center',
+    +headerTitleStyle: AnimatedTextStyleProp,
+    +headerTitleContainerStyle: ViewStyleProp,
+    +headerTintColor: string,
+    +headerTitleAllowFontScaling: boolean,
+    +headerBackAllowFontScaling: boolean,
+    +headerBackTitle: string,
+    +headerBackTitleStyle: TextStyleProp,
+    +headerBackTitleVisible: boolean,
+    +headerTruncatedBackTitle: string,
+    +headerLeft: StackHeaderLeftButtonProps => React$Node,
+    +headerLeftContainerStyle: ViewStyleProp,
+    +headerRight: {| tintColor?: string |} => React$Node,
+    +headerRightContainerStyle: ViewStyleProp,
+    +headerBackImage: $PropertyType<StackHeaderLeftButtonProps, 'backImage'>,
+    +headerPressColorAndroid: string,
+    +headerBackground: ({| style: ViewStyleProp |}) => React$Node,
+    +headerStyle: ViewStyleProp,
+    +headerTransparent: boolean,
+    +headerStatusBarHeight: number,
+  |}>;
+
+  /**
+   * Stack navigation prop
+   */
+
+  declare export type StackNavigationEventMap = {|
+    ...EventMapCore<StackNavigationState>,
+    +transitionStart: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+    +transitionEnd: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+  |};
+
+  declare type InexactStackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      StackNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +replace: SimpleNavigate<ParamList>,
+    +push: SimpleNavigate<ParamList>,
+    +pop: (count?: number) => void,
+    +popToTop: () => void,
+    ...
+  };
+
+  declare export type StackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = $Exact<InexactStackNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous stack exports
+   */
+
+  declare type StackNavigationConfig = {|
+    +mode?: 'card' | 'modal',
+    +headerMode?: 'float' | 'screen' | 'none',
+    +keyboardHandlingEnabled?: boolean,
+  |};
+
+  declare export type ExtraStackNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...StackRouterOptions,
+    ...StackNavigationConfig,
+  |};
+
+  declare export type StackNavigatorProps<
+    NavProp: InexactStackNavigationProp<> = StackNavigationProp<>,
+  > = {|
+    ...ExtraStackNavigatorProps,
+    ...ScreenOptionsProp<StackOptions, NavProp>,
+  |};
+
+  /**
+   * Bottom tab options
+   */
+
+  declare export type BottomTabBarButtonProps = {|
+    ...$Diff<
+      TouchableWithoutFeedbackProps,
+      {| onPress?: ?(event: PressEvent) => mixed |},
+    >,
+    +to?: string,
+    +children: React$Node,
+    +onPress?: (MouseEvent | PressEvent) => void,
+  |};
+
+  declare export type BottomTabOptions = $Shape<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| focused: boolean, color: string |}) => React$Node,
+    +tabBarIcon: ({|
+      focused: boolean,
+      color: string,
+      size: number,
+    |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+    +tabBarVisible: boolean,
+    +tabBarButton: BottomTabBarButtonProps => React$Node,
+    +unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Bottom tab navigation prop
+   */
+
+  declare export type BottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare type InexactTabNavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+    Options: {...},
+    EventMap: EventMapBase,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      TabNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    ...
+  };
+
+  declare export type InexactBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type BottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = $Exact<InexactBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous bottom tab exports
+   */
+
+  declare export type BottomTabDescriptor = Descriptor<
+    BottomTabNavigationProp<>,
+    BottomTabOptions,
+  >;
+
+  declare export type BottomTabBarOptions = $Shape<{|
+    +keyboardHidesTabBar: boolean,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveBackgroundColor: string,
+    +allowFontScaling: boolean,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +labelStyle: TextStyleProp,
+    +tabStyle: ViewStyleProp,
+    +labelPosition: 'beside-icon' | 'below-icon',
+    +adaptive: boolean,
+    +safeAreaInsets: $Shape<EdgeInsets>,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type BottomTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: BottomTabNavigationProp<>,
+    +descriptors: {| +[key: string]: BottomTabDescriptor |},
+  |};
+
+  declare export type BottomTabBarProps = {|
+    ...BottomTabBarOptions,
+    ...BottomTabNavigationBuilderResult,
+  |}
+
+  declare type BottomTabNavigationConfig = {|
+    +lazy?: boolean,
+    +tabBar?: BottomTabBarProps => React$Node,
+    +tabBarOptions?: BottomTabBarOptions,
+  |};
+
+  declare export type ExtraBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...BottomTabNavigationConfig,
+  |};
+
+  declare export type BottomTabNavigatorProps<
+    NavProp: InexactBottomTabNavigationProp<> = BottomTabNavigationProp<>,
+  > = {|
+    ...ExtraBottomTabNavigatorProps,
+    ...ScreenOptionsProp<BottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material bottom tab options
+   */
+
+  declare export type MaterialBottomTabOptions = $Shape<{|
+    +title: string,
+    +tabBarColor: string,
+    +tabBarLabel: string,
+    +tabBarIcon:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarBadge: boolean | number | string,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material bottom tab navigation prop
+   */
+
+  declare export type MaterialBottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+  |};
+
+  declare export type InexactMaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = $Exact<InexactMaterialBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material bottom tab exports
+   */
+
+  declare export type PaperFont = {|
+    +fontFamily: string,
+    +fontWeight?:
+      | 'normal'
+      | 'bold'
+      | '100'
+      | '200'
+      | '300'
+      | '400'
+      | '500'
+      | '600'
+      | '700'
+      | '800'
+      | '900',
+  |};
+
+  declare export type PaperFonts = {|
+    +regular: Font,
+    +medium: Font,
+    +light: Font,
+    +thin: Font,
+  |};
+
+  declare export type PaperTheme = {|
+    +dark: boolean,
+    +mode?: 'adaptive' | 'exact',
+    +roundness: number,
+    +colors: {|
+      +primary: string,
+      +background: string,
+      +surface: string,
+      +accent: string,
+      +error: string,
+      +text: string,
+      +onSurface: string,
+      +onBackground: string,
+      +disabled: string,
+      +placeholder: string,
+      +backdrop: string,
+      +notification: string,
+    |},
+    +fonts: PaperFonts,
+    +animation: {|
+      +scale: number,
+    |},
+  |};
+
+  declare export type PaperRoute = {|
+    +key: string,
+    +title?: string,
+    +icon?: any,
+    +badge?: string | number | boolean,
+    +color?: string,
+    +accessibilityLabel?: string,
+    +testID?: string,
+  |};
+
+  declare export type PaperTouchableProps = {|
+    ...TouchableWithoutFeedbackProps,
+    +key: string,
+    +route: PaperRoute,
+    +children: React$Node,
+    +borderless?: boolean,
+    +centered?: boolean,
+    +rippleColor?: string,
+  |};
+
+  declare export type MaterialBottomTabNavigationConfig = {|
+    +shifting?: boolean,
+    +labeled?: boolean,
+    +renderTouchable?: PaperTouchableProps => React$Node,
+    +activeColor?: string,
+    +inactiveColor?: string,
+    +sceneAnimationEnabled?: boolean,
+    +keyboardHidesNavigationBar?: boolean,
+    +barStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +theme?: PaperTheme,
+  |};
+
+  declare export type ExtraMaterialBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialBottomTabNavigationConfig,
+  |};
+
+  declare export type MaterialBottomTabNavigatorProps<
+    NavProp: InexactMaterialBottomTabNavigationProp<> =
+      MaterialBottomTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialBottomTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialBottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material top tab options
+   */
+
+  declare export type MaterialTopTabOptions = $Shape<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarIcon: ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material top tab navigation prop
+   */
+
+  declare export type MaterialTopTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+    +swipeStart: {| +data: void, +canPreventDefault: false |},
+    +swipeEnd: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactMaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = $Exact<InexactMaterialTopTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material top tab exports
+   */
+
+  declare type MaterialTopTabPagerCommonProps = {|
+    +keyboardDismissMode: 'none' | 'on-drag' | 'auto',
+    +swipeEnabled: boolean,
+    +swipeVelocityImpact?: number,
+    +springVelocityScale?: number,
+    +springConfig: $Shape<{|
+      +damping: number,
+      +mass: number,
+      +stiffness: number,
+      +restSpeedThreshold: number,
+      +restDisplacementThreshold: number,
+    |}>,
+    +timingConfig: $Shape<{|
+      +duration: number,
+    |}>,
+  |};
+
+  declare export type MaterialTopTabPagerProps = {|
+    ...MaterialTopTabPagerCommonProps,
+    +onSwipeStart?: () => void,
+    +onSwipeEnd?: () => void,
+    +onIndexChange: (index: number) => void,
+    +navigationState: TabNavigationState,
+    +layout: {| +width: number, +height: number |},
+    +removeClippedSubviews: boolean,
+    +children: ({|
+      +addListener: (type: 'enter', listener: number => void) => void,
+      +removeListener: (type: 'enter', listener: number => void) => void,
+      +position: any, // Reanimated.Node<number>
+      +render: React$Node => React$Node,
+      +jumpTo: string => void,
+    |}) => React$Node,
+    +gestureHandlerProps: PanGestureHandlerProps,
+  |};
+
+  declare export type MaterialTopTabBarIndicatorProps = {|
+    +navigationState: TabNavigationState,
+    +width: string,
+    +style?: ViewStyleProp,
+    +getTabWidth: number => number,
+  |};
+
+  declare export type MaterialTopTabBarOptions = $Shape<{|
+    +scrollEnabled: boolean,
+    +bounces: boolean,
+    +pressColor: string,
+    +pressOpacity: number,
+    +getAccessible: ({| +route: Route<> |}) => boolean,
+    +renderBadge: ({| +route: Route<> |}) => React$Node,
+    +renderIndicator: MaterialTopTabBarIndicatorProps => React$Node,
+    +tabStyle: ViewStyleProp,
+    +indicatorStyle: ViewStyleProp,
+    +indicatorContainerStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +iconStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +allowFontScaling: boolean,
+  |}>;
+
+  declare export type MaterialTopTabDescriptor = Descriptor<
+    MaterialBottomTabNavigationProp<>,
+    MaterialBottomTabOptions,
+  >;
+
+  declare type MaterialTopTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: MaterialTopTabNavigationProp<>,
+    +descriptors: {| +[key: string]: MaterialTopTabDescriptor |},
+  |};
+
+  declare export type MaterialTopTabBarProps = {|
+    ...MaterialTopTabBarOptions,
+    ...MaterialTopTabNavigationBuilderResult,
+    +layout: {| +width: number, +height: number |},
+    +position: any, // Reanimated.Node<number>
+    +jumpTo: string => void,
+  |};
+
+  declare export type MaterialTopTabNavigationConfig = {|
+    ...$Partial<MaterialTopTabPagerCommonProps>,
+    +position?: any, // Reanimated.Value<number>
+    +tabBarPosition?: 'top' | 'bottom',
+    +initialLayout?: $Shape<{| +width: number, +height: number |}>,
+    +lazy?: boolean,
+    +lazyPreloadDistance?: number,
+    +removeClippedSubviews?: boolean,
+    +sceneContainerStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +pager?: MaterialTopTabPagerProps => React$Node,
+    +lazyPlaceholder?: ({| +route: Route<> |}) => React$Node,
+    +tabBar?: MaterialTopTabBarProps => React$Node,
+    +tabBarOptions?: MaterialTopTabBarOptions,
+  |};
+
+  declare export type ExtraMaterialTopTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialTopTabNavigationConfig,
+  |};
+
+  declare export type MaterialTopTabNavigatorProps<
+    NavProp: InexactMaterialTopTabNavigationProp<> =
+      MaterialTopTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialTopTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialTopTabOptions, NavProp>,
+  |};
+
+  /**
+   * Drawer options
+   */
+
+  declare export type DrawerOptions = $Shape<{|
+    title: string,
+    drawerLabel:
+      | string
+      | ({| +color: string, +focused: boolean |}) => React$Node,
+    drawerIcon: ({|
+      +color: string,
+      +size: number,
+      +focused: boolean,
+    |}) => React$Node,
+    gestureEnabled: boolean,
+    swipeEnabled: boolean,
+    unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Drawer navigation prop
+   */
+
+  declare export type DrawerNavigationEventMap = {|
+    ...EventMapCore<DrawerNavigationState>,
+    +drawerOpen: {| +data: void, +canPreventDefault: false |},
+    +drawerClose: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactDrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      DrawerNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    +openDrawer: () => void,
+    +closeDrawer: () => void,
+    +toggleDrawer: () => void,
+    ...
+  };
+
+  declare export type DrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = $Exact<InexactDrawerNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous drawer exports
+   */
+
+  declare export type DrawerDescriptor = Descriptor<
+    DrawerNavigationProp<>,
+    DrawerOptions,
+  >;
+
+  declare export type DrawerItemListBaseOptions = $Shape<{|
+    +activeTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveTintColor: string,
+    +inactiveBackgroundColor: string,
+    +itemStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+  |}>;
+
+  declare export type DrawerContentOptions = $Shape<{|
+    ...DrawerItemListBaseOptions,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type DrawerNavigationBuilderResult = {|
+    +state: DrawerNavigationState,
+    +navigation: DrawerNavigationProp<>,
+    +descriptors: {| +[key: string]: DrawerDescriptor |},
+  |};
+
+  declare export type DrawerContentProps = {|
+    ...DrawerContentOptions,
+    ...DrawerNavigationBuilderResult,
+    +progress: any, // Reanimated.Node<number>
+  |};
+
+  declare export type DrawerNavigationConfig = {|
+    +drawerPosition?: 'left' | 'right',
+    +drawerType?: 'front' | 'back' | 'slide' | 'permanent',
+    +edgeWidth?: number,
+    +hideStatusBar?: boolean,
+    +keyboardDismissMode?: 'on-drag' | 'none',
+    +minSwipeDistance?: number,
+    +overlayColor?: string,
+    +statusBarAnimation?: 'slide' | 'none' | 'fade',
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +lazy?: boolean,
+    +drawerContent?: DrawerContentProps => React$Node,
+    +drawerContentOptions?: DrawerContentOptions,
+    +sceneContainerStyle?: ViewStyleProp,
+    +drawerStyle?: ViewStyleProp,
+  |};
+
+  declare export type ExtraDrawerNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...DrawerRouterOptions,
+    ...DrawerNavigationConfig,
+  |};
+
+  declare export type DrawerNavigatorProps<
+    NavProp: InexactDrawerNavigationProp<> = DrawerNavigationProp<>,
+  > = {|
+    ...ExtraDrawerNavigatorProps,
+    ...ScreenOptionsProp<DrawerOptions, NavProp>,
+  |};
+
+  /**
+   * BaseNavigationContainer
+   */
+
+  declare export type BaseNavigationContainerProps = {|
+    +children: React$Node,
+    +initialState?: PossiblyStaleNavigationState,
+    +onStateChange?: (state: ?PossiblyStaleNavigationState) => void,
+    +independent?: boolean,
+  |};
+
+  declare export type BaseNavigationContainerInterface = {|
+    ...$Exact<NavigationHelpers<
+      ParamListBase,
+      PossiblyStaleNavigationState,
+      GlobalEventMap<PossiblyStaleNavigationState>,
+    >>,
+    +setParams: (params: ScreenParams) => void,
+    +resetRoot: (state?: ?PossiblyStaleNavigationState) => void,
+    +getRootState: () => PossiblyStaleNavigationState,
+  |};
+
+  /**
+   * State / path conversion
+   */
+
+  declare export type LinkingConfig = {|
+    +[routeName: string]:
+      | string
+      | {|
+          +path?: string,
+          +parse?: {| +[param: string]: string => mixed |},
+          +screens?: LinkingConfig,
+          +initialRouteName?: string,
+        |},
+  |};
+
+  declare export type GetPathFromStateOptions = {|
+    +[routeName: string]:
+      | string
+      | {|
+          +path?: string,
+          +stringify?: {| +[param: string]: mixed => string |},
+          +screens?: GetPathFromStateOptions,
+        |},
+  |};
+
+  //---------------------------------------------------------------------------
+  // SECTION 2: EXPORTED MODULE
+  // This section defines the module exports and contains exported types that
+  // are not present in any other React Navigation libdef.
+  //---------------------------------------------------------------------------
+
+  /**
+   * createMaterialTopTabNavigator
+   */
+
+  declare export var createMaterialTopTabNavigator: CreateNavigator<
+    TabNavigationState,
+    MaterialTopTabOptions,
+    MaterialTopTabNavigationEventMap,
+    ExtraMaterialTopTabNavigatorProps,
+  >;
+
+  /**
+   * MaterialTopTabView
+   */
+
+  declare export type MaterialTopTabViewProps = {|
+    ...MaterialTopTabNavigationConfig,
+    ...MaterialTopTabNavigationBuilderResult,
+  |};
+  declare export var MaterialTopTabView: React$ComponentType<
+    MaterialTopTabViewProps,
+  >;
+
+  /**
+   * MaterialTopTabBar
+   */
+
+  declare export var MaterialTopTabBar: React$ComponentType<
+    MaterialTopTabBarProps,
+  >;
+
+}

--- a/definitions/npm/@react-navigation/material-top-tabs_v5.x.x/test_material-top-tabs.js
+++ b/definitions/npm/@react-navigation/material-top-tabs_v5.x.x/test_material-top-tabs.js
@@ -1,0 +1,126 @@
+// @flow
+
+import * as React from 'react';
+import {
+  createMaterialTopTabNavigator,
+  type NavigationProp,
+  type MaterialTopTabNavigationProp,
+  type LeafRoute,
+  type TabNavigationState,
+  type MaterialTopTabOptions,
+  type MaterialTopTabNavigationEventMap,
+} from '@react-navigation/material-top-tabs';
+
+/**
+ * Navigator setup
+ */
+
+type LocalParamList = {|
+  One: {| hey: string |},
+  Two: void,
+  Three: ?{| sup: number |},
+|};
+
+type GlobalParamList = {|
+  ...LocalParamList,
+  Another: void,
+|};
+
+type NavProp<
+  RouteName: $Keys<LocalParamList> = $Keys<LocalParamList>,
+> = MaterialTopTabNavigationProp<GlobalParamList, RouteName>;
+type NavRoute<
+  RouteName: $Keys<LocalParamList> = $Keys<LocalParamList>,
+> = {|
+  ...LeafRoute<RouteName>,
+  +params: $ElementType<LocalParamList, RouteName>,
+|};
+
+const Tab = createMaterialTopTabNavigator<
+  GlobalParamList,
+  LocalParamList,
+  NavProp<>,
+>();
+
+/**
+ * Screens
+ */
+
+function ValidScreen(props: {|
+  navigation: NavProp<'One'>,
+  route: NavRoute<'One'>,
+|}) {
+  props.navigation.navigate('Another');
+  // $ExpectError invalid params
+  props.navigation.navigate('Another', {});
+  // $ExpectError invalid route
+  props.navigation.navigate('test', { sup: true, yo: null });
+  props.navigation.jumpTo('Three');
+  (props.navigation: NavigationProp<
+    GlobalParamList,
+    'One',
+    TabNavigationState,
+    MaterialTopTabOptions,
+    MaterialTopTabNavigationEventMap,
+  >);
+  return null;
+}
+
+function InvalidScreen(props: {|
+  navigation: NavProp<'One'>,
+  route: number,
+|}) {
+  props.navigation.setOptions({
+    title: 'sup',
+    tabBarLabel: 'SUP',
+    tabBarTestID: '5',
+  });
+  // $ExpectError invalid navigator props
+  props.navigation.setOptions({ fake: 12 });
+  React.useEffect(() => {
+    return props.navigation.addListener(
+      'tabPress',
+      e => {
+        (e.type: 'tabPress');
+        e.preventDefault();
+      },
+    );
+  });
+  React.useEffect(() => {
+    return props.navigation.addListener(
+      'swipeStart',
+      e => {
+        (e.type: 'swipeStart');
+        // $ExpectError swipeStart doesn't support preventDefault
+        e.preventDefault();
+      },
+    );
+  });
+  return null;
+}
+
+<Tab.Screen name="One" component={ValidScreen} />;
+// $ExpectError non-matching component
+<Tab.Screen name="Two" component={ValidScreen} />;
+// $ExpectError invalid route name
+<Tab.Screen name="Four" component={ValidScreen} />;
+// $ExpectError invalid params
+<Tab.Screen name="One" component={ValidScreen} initialParams={{ hey: 5 }} />;
+// $ExpectError non-local route
+<Tab.Screen name="Another" component={ValidScreen} />;
+// $ExpectError invalid screen props
+<Tab.Screen name="One" component={InvalidScreen} />;
+
+/**
+ * Navigator
+ */
+
+<Tab.Navigator tabBarPosition="top" />;
+<Tab.Navigator lazy={false} />;
+<Tab.Navigator timingConfig={{ duration: 5 }} />;
+// $ExpectError invalid navigator props
+<Tab.Navigator
+  // $ExpectError invalid navigator props
+  lazy={5}
+  someOtherProp="fake"
+/>;

--- a/definitions/npm/@react-navigation/native_v5.x.x/CONTRIBUTING.md
+++ b/definitions/npm/@react-navigation/native_v5.x.x/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to the React Navigation Flow libdef
+
+## Overview
+
+There are seven React Navigation libdefs in `flow-typed`:
+
+1. `@react-navigation/core`
+2. `@react-navigation/native`
+3. `@react-navigation/stack`
+4. `@react-navigation/bottom-tabs`
+5. `@react-navigation/material-bottom-tabs`
+6. `@react-navigation/material-top-tabs`
+7. `@react-navigation/drawer`
+
+It's not currently possible to import types between libdefs. Consequently, many of the same types are copy-pasted across the different libdefs.
+
+Each libdef is organized into two sections. The first section should be identical between all of the libdefs. If you make a change to this section, please make sure to mirror it across the other libdefs.
+
+## Contributors
+
+- @Ashoat

--- a/definitions/npm/@react-navigation/native_v5.x.x/flow_v0.104.x-/native_v5.x.x.js
+++ b/definitions/npm/@react-navigation/native_v5.x.x/flow_v0.104.x-/native_v5.x.x.js
@@ -1,0 +1,2146 @@
+declare module '@react-navigation/native' {
+
+  //---------------------------------------------------------------------------
+  // SECTION 1: IDENTICAL TYPE DEFINITIONS
+  // This section is identical across all React Navigation libdefs and contains
+  // shared definitions. We wish we could make it DRY and import from a shared
+  // definition, but that isn't yet possible.
+  //---------------------------------------------------------------------------
+
+  /**
+   * We start with some definitions that we have copy-pasted from React Native
+   * source files.
+   */
+
+  // This is a bastardization of the true StyleObj type located in
+  // react-native/Libraries/StyleSheet/StyleSheetTypes. We unfortunately can't
+  // import that here, and it's too lengthy (and consequently too brittle) to
+  // copy-paste here either.
+  declare type StyleObj =
+    | null
+    | void
+    | number
+    | false
+    | ''
+    | $ReadOnlyArray<StyleObj>
+    | { [name: string]: any, ... };
+  declare type ViewStyleProp = StyleObj;
+  declare type TextStyleProp = StyleObj;
+  declare type AnimatedViewStyleProp = StyleObj;
+  declare type AnimatedTextStyleProp = StyleObj;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/animations/Animation.js
+  declare type EndResult = { finished: boolean, ... };
+  declare type EndCallback = (result: EndResult) => void;
+  declare interface Animation {
+    start(
+      fromValue: number,
+      onUpdate: (value: number) => void,
+      onEnd: ?EndCallback,
+      previousAnimation: ?Animation,
+      animatedValue: AnimatedValue,
+    ): void;
+    stop(): void;
+  }
+  declare type AnimationConfig = {
+    isInteraction?: boolean,
+    useNativeDriver: boolean,
+    onComplete?: ?EndCallback,
+    iterations?: number,
+    ...
+  };
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedTracking.js
+  declare interface AnimatedTracking {
+    constructor(
+      value: AnimatedValue,
+      parent: any,
+      animationClass: any,
+      animationConfig: Object,
+      callback?: ?EndCallback,
+    ): void;
+    update(): void;
+  }
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedValue.js
+  declare type ValueListenerCallback = (state: { value: number, ... }) => void;
+  declare interface AnimatedValue {
+    constructor(value: number): void;
+    setValue(value: number): void;
+    setOffset(offset: number): void;
+    flattenOffset(): void;
+    extractOffset(): void;
+    addListener(callback: ValueListenerCallback): string;
+    removeListener(id: string): void;
+    removeAllListeners(): void;
+    stopAnimation(callback?: ?(value: number) => void): void;
+    resetAnimation(callback?: ?(value: number) => void): void;
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+    animate(animation: Animation, callback: ?EndCallback): void;
+    stopTracking(): void;
+    track(tracking: AnimatedTracking): void;
+  }
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/TimingAnimation.js
+  declare type TimingAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    easing?: (value: number) => number,
+    duration?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/SpringAnimation.js
+  declare type SpringAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    overshootClamping?: boolean,
+    restDisplacementThreshold?: number,
+    restSpeedThreshold?: number,
+    velocity?: number,
+    bounciness?: number,
+    speed?: number,
+    tension?: number,
+    friction?: number,
+    stiffness?: number,
+    damping?: number,
+    mass?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from react-native/Libraries/Types/CoreEventTypes.js
+  declare type SyntheticEvent<T> = $ReadOnly<{|
+    bubbles: ?boolean,
+    cancelable: ?boolean,
+    currentTarget: number,
+    defaultPrevented: ?boolean,
+    dispatchConfig: $ReadOnly<{|
+      registrationName: string,
+    |}>,
+    eventPhase: ?number,
+    preventDefault: () => void,
+    isDefaultPrevented: () => boolean,
+    stopPropagation: () => void,
+    isPropagationStopped: () => boolean,
+    isTrusted: ?boolean,
+    nativeEvent: T,
+    persist: () => void,
+    target: ?number,
+    timeStamp: number,
+    type: ?string,
+  |}>;
+  declare type Layout = $ReadOnly<{|
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  |}>;
+  declare type LayoutEvent = SyntheticEvent<
+    $ReadOnly<{|
+      layout: Layout,
+    |}>,
+  >;
+  declare type BlurEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type FocusEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type ResponderSyntheticEvent<T> = $ReadOnly<{|
+    ...SyntheticEvent<T>,
+    touchHistory: $ReadOnly<{|
+      indexOfSingleActiveTouch: number,
+      mostRecentTimeStamp: number,
+      numberActiveTouches: number,
+      touchBank: $ReadOnlyArray<
+        $ReadOnly<{|
+          touchActive: boolean,
+          startPageX: number,
+          startPageY: number,
+          startTimeStamp: number,
+          currentPageX: number,
+          currentPageY: number,
+          currentTimeStamp: number,
+          previousPageX: number,
+          previousPageY: number,
+          previousTimeStamp: number,
+        |}>,
+      >,
+    |}>,
+  |}>;
+  declare type PressEvent = ResponderSyntheticEvent<
+    $ReadOnly<{|
+      changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+      force: number,
+      identifier: number,
+      locationX: number,
+      locationY: number,
+      pageX: number,
+      pageY: number,
+      target: ?number,
+      timestamp: number,
+      touches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+    |}>,
+  >;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+  declare type ExtrapolateType = 'extend' | 'identity' | 'clamp';
+  declare type InterpolationConfigType = {
+    inputRange: Array<number>,
+    outputRange: Array<number> | Array<string>,
+    easing?: (input: number) => number,
+    extrapolate?: ExtrapolateType,
+    extrapolateLeft?: ExtrapolateType,
+    extrapolateRight?: ExtrapolateType,
+    ...
+  };
+  declare interface AnimatedInterpolation {
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+  }
+
+  // Copied from react-native/Libraries/Components/View/ViewAccessibility.js
+  declare type AccessibilityRole =
+    | 'none'
+    | 'button'
+    | 'link'
+    | 'search'
+    | 'image'
+    | 'keyboardkey'
+    | 'text'
+    | 'adjustable'
+    | 'imagebutton'
+    | 'header'
+    | 'summary'
+    | 'alert'
+    | 'checkbox'
+    | 'combobox'
+    | 'menu'
+    | 'menubar'
+    | 'menuitem'
+    | 'progressbar'
+    | 'radio'
+    | 'radiogroup'
+    | 'scrollbar'
+    | 'spinbutton'
+    | 'switch'
+    | 'tab'
+    | 'tablist'
+    | 'timer'
+    | 'toolbar';
+  declare type AccessibilityActionInfo = $ReadOnly<{
+    name: string,
+    label?: string,
+    ...
+  }>;
+  declare type AccessibilityActionEvent = SyntheticEvent<
+    $ReadOnly<{actionName: string, ...}>,
+  >;
+  declare type AccessibilityState = {
+    disabled?: boolean,
+    selected?: boolean,
+    checked?: ?boolean | 'mixed',
+    busy?: boolean,
+    expanded?: boolean,
+    ...
+  };
+  declare type AccessibilityValue = $ReadOnly<{|
+    min?: number,
+    max?: number,
+    now?: number,
+    text?: string,
+  |}>;
+
+  // Copied from
+  // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+  declare type Stringish = string;
+  declare type EdgeInsetsProp = $ReadOnly<$Shape<EdgeInsets>>;
+  declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
+    accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+    accessibilityElementsHidden?: ?boolean,
+    accessibilityHint?: ?Stringish,
+    accessibilityIgnoresInvertColors?: ?boolean,
+    accessibilityLabel?: ?Stringish,
+    accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
+    accessibilityRole?: ?AccessibilityRole,
+    accessibilityState?: ?AccessibilityState,
+    accessibilityValue?: ?AccessibilityValue,
+    accessibilityViewIsModal?: ?boolean,
+    accessible?: ?boolean,
+    children?: ?React$Node,
+    delayLongPress?: ?number,
+    delayPressIn?: ?number,
+    delayPressOut?: ?number,
+    disabled?: ?boolean,
+    focusable?: ?boolean,
+    hitSlop?: ?EdgeInsetsProp,
+    importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
+    nativeID?: ?string,
+    onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+    onBlur?: ?(event: BlurEvent) => mixed,
+    onFocus?: ?(event: FocusEvent) => mixed,
+    onLayout?: ?(event: LayoutEvent) => mixed,
+    onLongPress?: ?(event: PressEvent) => mixed,
+    onPress?: ?(event: PressEvent) => mixed,
+    onPressIn?: ?(event: PressEvent) => mixed,
+    onPressOut?: ?(event: PressEvent) => mixed,
+    pressRetentionOffset?: ?EdgeInsetsProp,
+    rejectResponderTermination?: ?boolean,
+    testID?: ?string,
+    touchSoundDisabled?: ?boolean,
+  |}>;
+
+  // Copied from react-native/Libraries/Image/ImageSource.js
+  declare type ImageURISource = $ReadOnly<{
+    uri?: ?string,
+    bundle?: ?string,
+    method?: ?string,
+    headers?: ?Object,
+    body?: ?string,
+    cache?: ?('default' | 'reload' | 'force-cache' | 'only-if-cached'),
+    width?: ?number,
+    height?: ?number,
+    scale?: ?number,
+    ...
+  }>;
+
+  /**
+   * The following is copied from react-native-gesture-handler's libdef
+   */
+
+  declare type $EventHandlers<ExtraProps: {...}> = {|
+    onGestureEvent?: ($Event<ExtraProps>) => mixed,
+    onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
+    onBegan?: ($Event<ExtraProps>) => mixed,
+    onFailed?: ($Event<ExtraProps>) => mixed,
+    onCancelled?: ($Event<ExtraProps>) => mixed,
+    onActivated?: ($Event<ExtraProps>) => mixed,
+    onEnded?: ($Event<ExtraProps>) => mixed,
+  |};
+
+  declare type HitSlop =
+    | number
+    | {|
+        left?: number,
+        top?: number,
+        right?: number,
+        bottom?: number,
+        vertical?: number,
+        horizontal?: number,
+        width?: number,
+        height?: number,
+      |}
+    | {|
+        width: number,
+        left: number,
+      |}
+    | {|
+        width: number,
+        right: number,
+      |}
+    | {|
+        height: number,
+        top: number,
+      |}
+    | {|
+        height: number,
+        bottom: number,
+      |};
+
+  declare type $GestureHandlerProps<
+    AdditionalProps: {...},
+    ExtraEventsProps: {...}
+  > = $ReadOnly<{|
+    ...$Exact<AdditionalProps>,
+    ...$EventHandlers<ExtraEventsProps>,
+    id?: string,
+    enabled?: boolean,
+    waitFor?: React$Ref<any> | Array<React$Ref<any>>,
+    simultaneousHandlers?: React$Ref<any> | Array<React$Ref<any>>,
+    shouldCancelWhenOutside?: boolean,
+    minPointers?: number,
+    hitSlop?: HitSlop,
+    children?: React$Node,
+  |}>;
+
+  declare type PanGestureHandlerProps = $GestureHandlerProps<
+    {
+      activeOffsetY?: number | [number, number],
+      activeOffsetX?: number | [number, number],
+      failOffsetY?: number | [number, number],
+      failOffsetX?: number | [number, number],
+      minDist?: number,
+      minVelocity?: number,
+      minVelocityX?: number,
+      minVelocityY?: number,
+      minPointers?: number,
+      maxPointers?: number,
+      avgTouches?: boolean,
+      ...
+    },
+    {
+      x: number,
+      y: number,
+      absoluteX: number,
+      absoluteY: number,
+      translationX: number,
+      translationY: number,
+      velocityX: number,
+      velocityY: number,
+      ...
+    }
+  >;
+
+  /**
+   * MAGIC
+   */
+
+  declare type $If<Test: boolean, Then, Else = empty> = $Call<
+    ((true, Then, Else) => Then) & ((false, Then, Else) => Else),
+    Test,
+    Then,
+    Else,
+  >;
+  declare type $IsA<X, Y> = $Call<
+    (Y => true) & (mixed => false),
+    X,
+  >;
+  declare type $IsUndefined<X> = $IsA<X, void>;
+
+  declare type $Partial<T> = $Rest<T, {...}>;
+
+  /**
+   * Actions, state, etc.
+   */
+
+  declare export type ScreenParams = { +[key: string]: mixed, ... };
+
+  declare export type BackAction = {|
+    +type: 'GO_BACK',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type NavigateAction = {|
+    +type: 'NAVIGATE',
+    +payload:
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ResetAction = {|
+    +type: 'RESET',
+    +payload: StaleNavigationState,
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type SetParamsAction = {|
+    +type: 'SET_PARAMS',
+    +payload: {| +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CommonAction =
+    | BackAction
+    | NavigateAction
+    | ResetAction
+    | SetParamsAction;
+
+  declare type NavigateActionCreator = {|
+    (routeName: string, params?: ScreenParams): NavigateAction,
+    (
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    ): NavigateAction,
+  |};
+  declare export type CommonActionsType = {|
+    +navigate: NavigateActionCreator,
+    +goBack: () => BackAction,
+    +reset: (state: PossiblyStaleNavigationState) => ResetAction,
+    +setParams: (params: ScreenParams) => SetParamsAction,
+  |};
+
+  declare export type GenericNavigationAction = {|
+    +type: string,
+    +payload?: { +[key: string]: mixed, ... },
+    +source?: string,
+    +target?: string,
+  |};
+
+  declare export type LeafRoute<RouteName: string = string> = {|
+    +key: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StateRoute<RouteName: string = string> = {|
+    ...LeafRoute<RouteName>,
+    +state: NavigationState | StaleNavigationState,
+  |};
+  declare export type Route<RouteName: string = string> =
+    | LeafRoute<RouteName>
+    | StateRoute<RouteName>;
+
+  declare export type NavigationState = {|
+    +key: string,
+    +index: number,
+    +routeNames: $ReadOnlyArray<string>,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<Route<>>,
+    +type: string,
+    +stale: false,
+  |};
+
+  declare export type StaleLeafRoute<RouteName: string = string> = {|
+    +key?: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StaleStateRoute<RouteName: string = string> = {|
+    ...StaleLeafRoute<RouteName>,
+    +state: StaleNavigationState,
+  |};
+  declare export type StaleRoute<RouteName: string = string> =
+    | StaleLeafRoute<RouteName>
+    | StaleStateRoute<RouteName>;
+  declare export type StaleNavigationState = {|
+    // It's possible to pass React Nav a StaleNavigationState with an undefined
+    // index, but React Nav will always return one with the index set. This is
+    // the same as for the type property below, but in the case of index we tend
+    // to rely on it being set more...
+    +index: number,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<StaleRoute<>>,
+    +type?: string,
+    +stale?: true,
+  |};
+
+  declare export type PossiblyStaleNavigationState =
+    | NavigationState
+    | StaleNavigationState;
+  declare export type PossiblyStaleRoute<RouteName: string = string> =
+    | Route<RouteName>
+    | StaleRoute<RouteName>;
+
+  /**
+   * Routers
+   */
+
+  declare type ActionCreators<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {
+    +[key: string]: (...args: any) => (Action | State => Action),
+    ...
+  };
+
+  declare export type DefaultRouterOptions = {
+    +initialRouteName?: string,
+    ...
+  };
+
+  declare export type RouterFactory<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    RouterOptions: DefaultRouterOptions,
+  > = (options: RouterOptions) => Router<State, Action>;
+
+  declare export type ParamListBase = { +[key: string]: ?ScreenParams, ... };
+
+  declare export type RouterConfigOptions = {|
+    +routeNames: $ReadOnlyArray<string>,
+    +routeParamList: ParamListBase,
+  |};
+
+  declare export type Router<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {|
+    +type: $PropertyType<State, 'type'>,
+    +getInitialState: (options: RouterConfigOptions) => State,
+    +getRehydratedState: (
+      partialState: PossibleStaleNavigationState,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteNamesChange: (
+      state: State,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteFocus: (state: State, key: string) => State,
+    +getStateForAction: (
+      state: State,
+      action: Action,
+      options: RouterConfigOptions,
+    ) => ?PossiblyStaleNavigationState;
+    +shouldActionChangeFocus: (action: GenericNavigationAction) => boolean,
+    +actionCreators?: ActionCreators<State, Action>,
+  |};
+
+  /**
+   * Stack actions and router
+   */
+
+  declare export type StackNavigationState = {|
+    ...NavigationState,
+    +type: 'stack',
+  |};
+
+  declare export type ReplaceAction = {|
+    +type: 'REPLACE',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PushAction = {|
+    +type: 'PUSH',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopAction = {|
+    +type: 'POP',
+    +payload: {| +count: number |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopToTopAction = {|
+    +type: 'POP_TO_TOP',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type StackAction =
+    | CommonAction
+    | ReplaceAction
+    | PushAction
+    | PopAction
+    | PopToTopAction;
+
+  declare export type StackActionsType = {|
+    +replace: (routeName: string, params?: ScreenParams) => ReplaceAction,
+    +push: (routeName: string, params?: ScreenParams) => PushAction,
+    +pop: (count?: number) => PopAction,
+    +popToTop: () => PopToTopAction,
+  |};
+
+  declare export type StackRouterOptions = $Exact<DefaultRouterOptions>;
+
+  /**
+   * Tab actions and router
+   */
+
+  declare export type TabNavigationState = {|
+    ...NavigationState,
+    +type: 'tab',
+    +history: $ReadOnlyArray<{| type: 'route', key: string |}>,
+  |};
+
+  declare export type JumpToAction = {|
+    +type: 'JUMP_TO',
+    +payload: {| +name: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type TabAction =
+    | CommonAction
+    | JumpToAction;
+
+  declare export type TabActionsType = {|
+    +jumpTo: string => JumpToAction,
+  |};
+
+  declare export type TabRouterOptions = {|
+    ...$Exact<DefaultRouterOptions>,
+    +backBehavior?: 'initialRoute' | 'order' | 'history' | 'none',
+  |};
+
+  /**
+   * Drawer actions and router
+   */
+
+  declare type DrawerHistoryEntry =
+    | {| +type: 'route', +key: string |}
+    | {| +type: 'drawer' |};
+  declare export type DrawerNavigationState = {|
+    ...NavigationState,
+    +type: 'drawer',
+    +history: $ReadOnlyArray<DrawerHistoryEntry>,
+  |};
+
+  declare export type OpenDrawerAction = {|
+    +type: 'OPEN_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CloseDrawerAction = {|
+    +type: 'CLOSE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ToggleDrawerAction = {|
+    +type: 'TOGGLE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type DrawerAction =
+    | TabAction
+    | OpenDrawerAction
+    | CloseDrawerAction
+    | ToggleDrawerAction;
+
+  declare export type DrawerActionsType = {|
+    ...TabActionsType,
+    +openDrawer: () => OpenDrawerAction,
+    +closeDrawer: () => CloseDrawerAction,
+    +toggleDrawer: () => ToggleDrawerAction,
+  |};
+
+  declare export type DrawerRouterOptions = {|
+    ...TabRouterOptions,
+    +openByDefault?: boolean,
+  |};
+
+  /**
+   * Events
+   */
+
+  declare export type EventMapBase = {
+    +[name: string]: {|
+      +data?: mixed,
+      +canPreventDefault?: boolean,
+    |},
+    ...
+  };
+  declare type EventPreventDefaultProperties<Test: boolean> = $If<
+    Test,
+    {| +defaultPrevented: boolean, +preventDefault: () => void |},
+    {| |},
+  >;
+  declare type EventDataProperties<Data> = $If<
+    $IsUndefined<Data>,
+    {| |},
+    {| +data: Data |},
+  >;
+  declare type EventArg<
+    EventName: string,
+    CanPreventDefault: ?boolean = false,
+    Data = void,
+  > = {|
+    ...EventPreventDefaultProperties<CanPreventDefault>,
+    ...EventDataProperties<Data>,
+    +type: EventName,
+    +target?: string,
+  |};
+  declare type GlobalEventMap<State: PossiblyStaleNavigationState> = {|
+    +state: {| +data: {| +state: State |}, +canPreventDefault: false |},
+  |};
+  declare type EventMapCore<State: PossiblyStaleNavigationState> = {|
+    ...GlobalEventMap<State>,
+    +focus: {| +data: void, +canPreventDefault: false |},
+    +blur: {| +data: void, +canPreventDefault: false |},
+  |};
+  declare type EventListenerCallback<
+    EventName: string,
+    State: NavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = (e: EventArg<
+    EventName,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'canPreventDefault',
+    >,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'data',
+    >,
+  >) => mixed;
+
+  /**
+   * Navigation prop
+   */
+
+  declare export type SimpleNavigate<ParamList> =
+    <DestinationRouteName: $Keys<ParamList>>(
+      routeName: DestinationRouteName,
+      params: $ElementType<ParamList, DestinationRouteName>,
+    ) => void;
+
+  declare export type Navigate<ParamList> =
+    & SimpleNavigate<ParamList>
+    & <DestinationRouteName: $Keys<ParamList>>(
+        route:
+          | {|
+              key: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |}
+          | {|
+              name: DestinationRouteName,
+              key?: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |},
+      ) => void;
+
+  declare type NavigationHelpers<
+    ParamList: ParamListBase,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    +navigate: Navigate<ParamList>,
+    +dispatch: (
+      action:
+        | GenericNavigationAction
+        | (State => GenericNavigationAction),
+    ) => void,
+    +reset: PossiblyStaleNavigationState => void,
+    +goBack: () => void,
+    +isFocused: () => boolean,
+    +canGoBack: () => boolean,
+    +dangerouslyGetParent: <Parent: NavigationProp<ParamListBase>>() => ?Parent,
+    +dangerouslyGetState: () => NavigationState,
+    +addListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => () => void,
+    +removeListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => void,
+    ...
+  };
+
+  declare export type NavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    ...$Exact<NavigationHelpers<
+      ParamList,
+      State,
+      EventMap,
+    >>,
+    +setOptions: (options: $Shape<ScreenOptions>) => void,
+    +setParams: (
+      params: $If<
+        $IsUndefined<$ElementType<ParamList, RouteName>>,
+        empty,
+        $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+      >,
+    ) => void,
+    ...
+  };
+
+  /**
+   * CreateNavigator
+   */
+
+  declare export type RouteProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+  > = {|
+    ...LeafRoute<RouteName>,
+    +params: $ElementType<ParamList, RouteName>,
+  |};
+
+  declare export type ScreenListeners<
+    EventMap: EventMapBase = EventMapCore<State>,
+    State: NavigationState = NavigationState,
+  > = $ObjMapi<
+    {| [name: $Keys<EventMap>]: empty |},
+    <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
+  >;
+
+  declare type BaseScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {|
+    +name: RouteName,
+    +options?:
+      | ScreenOptions
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenOptions,
+    +listeners?:
+      | ScreenListeners<EventMap, State>
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenListeners<EventMap, State>,
+    +initialParams?: $Shape<$ElementType<ParamList, RouteName>>,
+  |};
+
+  declare export type ScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > =
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +component: React$ComponentType<{|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}>,
+      |}
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +children: ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => React$Node,
+      |};
+
+  declare export type ScreenComponent<
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = <
+    RouteName: $Keys<ParamList>,
+    NavProp: NavigationProp<
+      GlobalParamList,
+      RouteName,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+  >(props: ScreenProps<
+    ParamList,
+    NavProp,
+    RouteName,
+    State,
+    ScreenOptions,
+    EventMap,
+  >) => React$Node;
+
+  declare type ScreenOptionsProp<ScreenOptions: {...}, NavProp> = {|
+    +screenOptions?:
+      | ScreenOptions
+      | ({| route: LeafRoute<>, navigation: NavProp |}) => ScreenOptions,
+  |};
+  declare export type ExtraNavigatorPropsBase = {
+    ...$Exact<DefaultRouterOptions>,
+    +children?: React$Node,
+    ...
+  };
+  declare export type NavigatorPropsBase<ScreenOptions: {...}, NavProp> = {
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    ...
+  };
+
+  declare export type CreateNavigator<
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  > = <
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    NavProp: NavigationHelpers<
+      GlobalParamList,
+      State,
+      EventMap,
+    >,
+  >() => {|
+    +Screen: ScreenComponent<
+      GlobalParamList,
+      ParamList,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+    +Navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorProps>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  |};
+
+  declare export type CreateNavigatorFactory = <
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    NavProp: NavigationHelpers<
+      ParamListBase,
+      State,
+      EventMap,
+    >,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  >(
+    navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorPropsBase>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  ) => CreateNavigator<State, ScreenOptions, EventMap, ExtraNavigatorProps>;
+
+  /**
+   * useNavigationBuilder
+   */
+
+  declare export type Descriptor<
+    NavProp,
+    ScreenOptions: {...} = {...},
+  > = {|
+    +render: () => React$Node,
+    +options: $ReadOnly<ScreenOptions>,
+    +navigation: NavProp,
+  |};
+
+  declare export type UseNavigationBuilder = <
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    ScreenOptions: {...},
+    RouterOptions: DefaultRouterOptions,
+    NavProp,
+  >(
+    routerFactory: RouterFactory<State, Action, RouterOptions>,
+    options: {|
+      ...$Exact<RouterOptions>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+      +children?: React$Node,
+    |},
+  ) => {|
+    +state: State,
+    +descriptors: {| +[key: string]: Descriptor<NavProp, ScreenOptions> |},
+    +navigation: NavProp,
+  |};
+
+  /**
+   * EdgeInsets
+   */
+
+  declare type EdgeInsets = {|
+    +top: number,
+    +right: number,
+    +bottom: number,
+    +left: number,
+  |};
+
+  /**
+   * TransitionPreset
+   */
+
+  declare export type TransitionSpec =
+    | {|
+        animation: 'spring',
+        config: $Diff<
+          SpringAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |}
+    | {|
+        animation: 'timing',
+        config: $Diff<
+          TimingAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |};
+
+  declare export type StackCardInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +index: number,
+    +closing: AnimatedInterpolation,
+    +swiping: AnimatedInterpolation,
+    +inverted: AnimatedInterpolation,
+    +layouts: {|
+      +screen: {| +width: number, +height: number |},
+    |},
+    +insets: EdgeInsets,
+  |};
+  declare export type StackCardInterpolatedStyle = {|
+    containerStyle?: AnimatedViewStyleProp,
+    cardStyle?: AnimatedViewStyleProp,
+    overlayStyle?: AnimatedViewStyleProp,
+    shadowStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackCardStyleInterpolator = (
+    props: StackCardInterpolationProps,
+  ) => StackCardInterpolatedStyle;
+
+  declare export type StackHeaderInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +layouts: {|
+      +header: {| +width: number, +height: number |},
+      +screen: {| +width: number, +height: number |},
+      +title?: {| +width: number, +height: number |},
+      +leftLabel?: {| +width: number, +height: number |},
+    |},
+  |};
+  declare export type StackHeaderInterpolatedStyle = {|
+    leftLabelStyle?: AnimatedViewStyleProp,
+    leftButtonStyle?: AnimatedViewStyleProp,
+    rightButtonStyle?: AnimatedViewStyleProp,
+    titleStyle?: AnimatedViewStyleProp,
+    backgroundStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackHeaderStyleInterpolator = (
+    props: StackHeaderInterpolationProps,
+  ) => StackHeaderInterpolatedStyle;
+
+  declare type GestureDirection =
+    | 'horizontal'
+    | 'horizontal-inverted'
+    | 'vertical'
+    | 'vertical-inverted';
+
+  declare export type TransitionPreset = {|
+    +gestureDirection: GestureDirection,
+    +transitionSpec: {|
+      +open: TransitionSpec,
+      +close: TransitionSpec,
+    |},
+    +cardStyleInterpolator: StackCardStyleInterpolator,
+    +headerStyleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  /**
+   * Stack options
+   */
+
+  declare export type StackDescriptor = Descriptor<
+    StackNavigationProp<>,
+    StackOptions,
+  >;
+
+  declare type Scene<T> = {|
+    +route: T,
+    +descriptor: StackDescriptor,
+    +progress: {|
+      +current: AnimatedInterpolation,
+      +next?: AnimatedInterpolation,
+      +previous?: AnimatedInterpolation,
+    |},
+  |};
+
+  declare export type StackHeaderProps = {|
+    +mode: 'float' | 'screen',
+    +layout: {| +width: number, +height: number |},
+    +insets: EdgeInsets,
+    +scene: Scene<Route<>>,
+    +previous?: Scene<Route<>>,
+    +navigation: StackNavigationProp<ParamListBase>,
+    +styleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  declare export type StackHeaderLeftButtonProps = $Shape<{|
+    +onPress: (() => void),
+    +pressColorAndroid: string;
+    +backImage: (props: {| tintColor: string |}) => React$Node,
+    +tintColor: string,
+    +label: string,
+    +truncatedLabel: string,
+    +labelVisible: boolean,
+    +labelStyle: AnimatedTextStyleProp,
+    +allowFontScaling: boolean,
+    +onLabelLayout: LayoutEvent => void,
+    +screenLayout: {| +width: number, +height: number |},
+    +titleLayout: {| +width: number, +height: number |},
+    +canGoBack: boolean,
+  |}>;
+
+  declare type StackHeaderTitleInputBase = {
+    +onLayout: LayoutEvent => void,
+    +children: string,
+    +allowFontScaling: ?boolean,
+    +tintColor: ?string,
+    +style: ?AnimatedTextStyleProp,
+    ...
+  };
+
+  declare export type StackHeaderTitleInputProps =
+    $Exact<StackHeaderTitleInputBase>;
+
+  declare export type StackOptions = $Shape<{|
+    +title: string,
+    +header: StackHeaderProps => React$Node,
+    +headerShown: boolean,
+    +cardShadowEnabled: boolean,
+    +cardOverlayEnabled: boolean,
+    +cardOverlay: {| style: ViewStyleProp |} => React$Node,
+    +cardStyle: ViewStyleProp,
+    +animationEnabled: boolean,
+    +animationTypeForReplace: 'push' | 'pop',
+    +gestureEnabled: boolean,
+    +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
+    +gestureVelocityImpact: number,
+    +safeAreaInsets: $Shape<EdgeInsets>,
+    // Transition
+    ...TransitionPreset,
+    // Header
+    +headerTitle: string | (StackHeaderTitleInputProps => React$Node),
+    +headerTitleAlign: 'left' | 'center',
+    +headerTitleStyle: AnimatedTextStyleProp,
+    +headerTitleContainerStyle: ViewStyleProp,
+    +headerTintColor: string,
+    +headerTitleAllowFontScaling: boolean,
+    +headerBackAllowFontScaling: boolean,
+    +headerBackTitle: string,
+    +headerBackTitleStyle: TextStyleProp,
+    +headerBackTitleVisible: boolean,
+    +headerTruncatedBackTitle: string,
+    +headerLeft: StackHeaderLeftButtonProps => React$Node,
+    +headerLeftContainerStyle: ViewStyleProp,
+    +headerRight: {| tintColor?: string |} => React$Node,
+    +headerRightContainerStyle: ViewStyleProp,
+    +headerBackImage: $PropertyType<StackHeaderLeftButtonProps, 'backImage'>,
+    +headerPressColorAndroid: string,
+    +headerBackground: ({| style: ViewStyleProp |}) => React$Node,
+    +headerStyle: ViewStyleProp,
+    +headerTransparent: boolean,
+    +headerStatusBarHeight: number,
+  |}>;
+
+  /**
+   * Stack navigation prop
+   */
+
+  declare export type StackNavigationEventMap = {|
+    ...EventMapCore<StackNavigationState>,
+    +transitionStart: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+    +transitionEnd: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+  |};
+
+  declare type InexactStackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      StackNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +replace: SimpleNavigate<ParamList>,
+    +push: SimpleNavigate<ParamList>,
+    +pop: (count?: number) => void,
+    +popToTop: () => void,
+    ...
+  };
+
+  declare export type StackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = $Exact<InexactStackNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous stack exports
+   */
+
+  declare type StackNavigationConfig = {|
+    +mode?: 'card' | 'modal',
+    +headerMode?: 'float' | 'screen' | 'none',
+    +keyboardHandlingEnabled?: boolean,
+  |};
+
+  declare export type ExtraStackNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...StackRouterOptions,
+    ...StackNavigationConfig,
+  |};
+
+  declare export type StackNavigatorProps<
+    NavProp: InexactStackNavigationProp<> = StackNavigationProp<>,
+  > = {|
+    ...ExtraStackNavigatorProps,
+    ...ScreenOptionsProp<StackOptions, NavProp>,
+  |};
+
+  /**
+   * Bottom tab options
+   */
+
+  declare export type BottomTabBarButtonProps = {|
+    ...$Diff<
+      TouchableWithoutFeedbackProps,
+      {| onPress?: ?(event: PressEvent) => mixed |},
+    >,
+    +to?: string,
+    +children: React$Node,
+    +onPress?: (MouseEvent | PressEvent) => void,
+  |};
+
+  declare export type BottomTabOptions = $Shape<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| focused: boolean, color: string |}) => React$Node,
+    +tabBarIcon: ({|
+      focused: boolean,
+      color: string,
+      size: number,
+    |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+    +tabBarVisible: boolean,
+    +tabBarButton: BottomTabBarButtonProps => React$Node,
+    +unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Bottom tab navigation prop
+   */
+
+  declare export type BottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare type InexactTabNavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+    Options: {...},
+    EventMap: EventMapBase,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      TabNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    ...
+  };
+
+  declare export type InexactBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type BottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = $Exact<InexactBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous bottom tab exports
+   */
+
+  declare export type BottomTabDescriptor = Descriptor<
+    BottomTabNavigationProp<>,
+    BottomTabOptions,
+  >;
+
+  declare export type BottomTabBarOptions = $Shape<{|
+    +keyboardHidesTabBar: boolean,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveBackgroundColor: string,
+    +allowFontScaling: boolean,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +labelStyle: TextStyleProp,
+    +tabStyle: ViewStyleProp,
+    +labelPosition: 'beside-icon' | 'below-icon',
+    +adaptive: boolean,
+    +safeAreaInsets: $Shape<EdgeInsets>,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type BottomTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: BottomTabNavigationProp<>,
+    +descriptors: {| +[key: string]: BottomTabDescriptor |},
+  |};
+
+  declare export type BottomTabBarProps = {|
+    ...BottomTabBarOptions,
+    ...BottomTabNavigationBuilderResult,
+  |}
+
+  declare type BottomTabNavigationConfig = {|
+    +lazy?: boolean,
+    +tabBar?: BottomTabBarProps => React$Node,
+    +tabBarOptions?: BottomTabBarOptions,
+  |};
+
+  declare export type ExtraBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...BottomTabNavigationConfig,
+  |};
+
+  declare export type BottomTabNavigatorProps<
+    NavProp: InexactBottomTabNavigationProp<> = BottomTabNavigationProp<>,
+  > = {|
+    ...ExtraBottomTabNavigatorProps,
+    ...ScreenOptionsProp<BottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material bottom tab options
+   */
+
+  declare export type MaterialBottomTabOptions = $Shape<{|
+    +title: string,
+    +tabBarColor: string,
+    +tabBarLabel: string,
+    +tabBarIcon:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarBadge: boolean | number | string,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material bottom tab navigation prop
+   */
+
+  declare export type MaterialBottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+  |};
+
+  declare export type InexactMaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = $Exact<InexactMaterialBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material bottom tab exports
+   */
+
+  declare export type PaperFont = {|
+    +fontFamily: string,
+    +fontWeight?:
+      | 'normal'
+      | 'bold'
+      | '100'
+      | '200'
+      | '300'
+      | '400'
+      | '500'
+      | '600'
+      | '700'
+      | '800'
+      | '900',
+  |};
+
+  declare export type PaperFonts = {|
+    +regular: Font,
+    +medium: Font,
+    +light: Font,
+    +thin: Font,
+  |};
+
+  declare export type PaperTheme = {|
+    +dark: boolean,
+    +mode?: 'adaptive' | 'exact',
+    +roundness: number,
+    +colors: {|
+      +primary: string,
+      +background: string,
+      +surface: string,
+      +accent: string,
+      +error: string,
+      +text: string,
+      +onSurface: string,
+      +onBackground: string,
+      +disabled: string,
+      +placeholder: string,
+      +backdrop: string,
+      +notification: string,
+    |},
+    +fonts: PaperFonts,
+    +animation: {|
+      +scale: number,
+    |},
+  |};
+
+  declare export type PaperRoute = {|
+    +key: string,
+    +title?: string,
+    +icon?: any,
+    +badge?: string | number | boolean,
+    +color?: string,
+    +accessibilityLabel?: string,
+    +testID?: string,
+  |};
+
+  declare export type PaperTouchableProps = {|
+    ...TouchableWithoutFeedbackProps,
+    +key: string,
+    +route: PaperRoute,
+    +children: React$Node,
+    +borderless?: boolean,
+    +centered?: boolean,
+    +rippleColor?: string,
+  |};
+
+  declare export type MaterialBottomTabNavigationConfig = {|
+    +shifting?: boolean,
+    +labeled?: boolean,
+    +renderTouchable?: PaperTouchableProps => React$Node,
+    +activeColor?: string,
+    +inactiveColor?: string,
+    +sceneAnimationEnabled?: boolean,
+    +keyboardHidesNavigationBar?: boolean,
+    +barStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +theme?: PaperTheme,
+  |};
+
+  declare export type ExtraMaterialBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialBottomTabNavigationConfig,
+  |};
+
+  declare export type MaterialBottomTabNavigatorProps<
+    NavProp: InexactMaterialBottomTabNavigationProp<> =
+      MaterialBottomTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialBottomTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialBottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material top tab options
+   */
+
+  declare export type MaterialTopTabOptions = $Shape<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarIcon: ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material top tab navigation prop
+   */
+
+  declare export type MaterialTopTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+    +swipeStart: {| +data: void, +canPreventDefault: false |},
+    +swipeEnd: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactMaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = $Exact<InexactMaterialTopTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material top tab exports
+   */
+
+  declare type MaterialTopTabPagerCommonProps = {|
+    +keyboardDismissMode: 'none' | 'on-drag' | 'auto',
+    +swipeEnabled: boolean,
+    +swipeVelocityImpact?: number,
+    +springVelocityScale?: number,
+    +springConfig: $Shape<{|
+      +damping: number,
+      +mass: number,
+      +stiffness: number,
+      +restSpeedThreshold: number,
+      +restDisplacementThreshold: number,
+    |}>,
+    +timingConfig: $Shape<{|
+      +duration: number,
+    |}>,
+  |};
+
+  declare export type MaterialTopTabPagerProps = {|
+    ...MaterialTopTabPagerCommonProps,
+    +onSwipeStart?: () => void,
+    +onSwipeEnd?: () => void,
+    +onIndexChange: (index: number) => void,
+    +navigationState: TabNavigationState,
+    +layout: {| +width: number, +height: number |},
+    +removeClippedSubviews: boolean,
+    +children: ({|
+      +addListener: (type: 'enter', listener: number => void) => void,
+      +removeListener: (type: 'enter', listener: number => void) => void,
+      +position: any, // Reanimated.Node<number>
+      +render: React$Node => React$Node,
+      +jumpTo: string => void,
+    |}) => React$Node,
+    +gestureHandlerProps: PanGestureHandlerProps,
+  |};
+
+  declare export type MaterialTopTabBarIndicatorProps = {|
+    +navigationState: TabNavigationState,
+    +width: string,
+    +style?: ViewStyleProp,
+    +getTabWidth: number => number,
+  |};
+
+  declare export type MaterialTopTabBarOptions = $Shape<{|
+    +scrollEnabled: boolean,
+    +bounces: boolean,
+    +pressColor: string,
+    +pressOpacity: number,
+    +getAccessible: ({| +route: Route<> |}) => boolean,
+    +renderBadge: ({| +route: Route<> |}) => React$Node,
+    +renderIndicator: MaterialTopTabBarIndicatorProps => React$Node,
+    +tabStyle: ViewStyleProp,
+    +indicatorStyle: ViewStyleProp,
+    +indicatorContainerStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +iconStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +allowFontScaling: boolean,
+  |}>;
+
+  declare export type MaterialTopTabDescriptor = Descriptor<
+    MaterialBottomTabNavigationProp<>,
+    MaterialBottomTabOptions,
+  >;
+
+  declare type MaterialTopTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: MaterialTopTabNavigationProp<>,
+    +descriptors: {| +[key: string]: MaterialTopTabDescriptor |},
+  |};
+
+  declare export type MaterialTopTabBarProps = {|
+    ...MaterialTopTabBarOptions,
+    ...MaterialTopTabNavigationBuilderResult,
+    +layout: {| +width: number, +height: number |},
+    +position: any, // Reanimated.Node<number>
+    +jumpTo: string => void,
+  |};
+
+  declare export type MaterialTopTabNavigationConfig = {|
+    ...$Partial<MaterialTopTabPagerCommonProps>,
+    +position?: any, // Reanimated.Value<number>
+    +tabBarPosition?: 'top' | 'bottom',
+    +initialLayout?: $Shape<{| +width: number, +height: number |}>,
+    +lazy?: boolean,
+    +lazyPreloadDistance?: number,
+    +removeClippedSubviews?: boolean,
+    +sceneContainerStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +pager?: MaterialTopTabPagerProps => React$Node,
+    +lazyPlaceholder?: ({| +route: Route<> |}) => React$Node,
+    +tabBar?: MaterialTopTabBarProps => React$Node,
+    +tabBarOptions?: MaterialTopTabBarOptions,
+  |};
+
+  declare export type ExtraMaterialTopTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialTopTabNavigationConfig,
+  |};
+
+  declare export type MaterialTopTabNavigatorProps<
+    NavProp: InexactMaterialTopTabNavigationProp<> =
+      MaterialTopTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialTopTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialTopTabOptions, NavProp>,
+  |};
+
+  /**
+   * Drawer options
+   */
+
+  declare export type DrawerOptions = $Shape<{|
+    title: string,
+    drawerLabel:
+      | string
+      | ({| +color: string, +focused: boolean |}) => React$Node,
+    drawerIcon: ({|
+      +color: string,
+      +size: number,
+      +focused: boolean,
+    |}) => React$Node,
+    gestureEnabled: boolean,
+    swipeEnabled: boolean,
+    unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Drawer navigation prop
+   */
+
+  declare export type DrawerNavigationEventMap = {|
+    ...EventMapCore<DrawerNavigationState>,
+    +drawerOpen: {| +data: void, +canPreventDefault: false |},
+    +drawerClose: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactDrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      DrawerNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    +openDrawer: () => void,
+    +closeDrawer: () => void,
+    +toggleDrawer: () => void,
+    ...
+  };
+
+  declare export type DrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = $Exact<InexactDrawerNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous drawer exports
+   */
+
+  declare export type DrawerDescriptor = Descriptor<
+    DrawerNavigationProp<>,
+    DrawerOptions,
+  >;
+
+  declare export type DrawerItemListBaseOptions = $Shape<{|
+    +activeTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveTintColor: string,
+    +inactiveBackgroundColor: string,
+    +itemStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+  |}>;
+
+  declare export type DrawerContentOptions = $Shape<{|
+    ...DrawerItemListBaseOptions,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type DrawerNavigationBuilderResult = {|
+    +state: DrawerNavigationState,
+    +navigation: DrawerNavigationProp<>,
+    +descriptors: {| +[key: string]: DrawerDescriptor |},
+  |};
+
+  declare export type DrawerContentProps = {|
+    ...DrawerContentOptions,
+    ...DrawerNavigationBuilderResult,
+    +progress: any, // Reanimated.Node<number>
+  |};
+
+  declare export type DrawerNavigationConfig = {|
+    +drawerPosition?: 'left' | 'right',
+    +drawerType?: 'front' | 'back' | 'slide' | 'permanent',
+    +edgeWidth?: number,
+    +hideStatusBar?: boolean,
+    +keyboardDismissMode?: 'on-drag' | 'none',
+    +minSwipeDistance?: number,
+    +overlayColor?: string,
+    +statusBarAnimation?: 'slide' | 'none' | 'fade',
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +lazy?: boolean,
+    +drawerContent?: DrawerContentProps => React$Node,
+    +drawerContentOptions?: DrawerContentOptions,
+    +sceneContainerStyle?: ViewStyleProp,
+    +drawerStyle?: ViewStyleProp,
+  |};
+
+  declare export type ExtraDrawerNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...DrawerRouterOptions,
+    ...DrawerNavigationConfig,
+  |};
+
+  declare export type DrawerNavigatorProps<
+    NavProp: InexactDrawerNavigationProp<> = DrawerNavigationProp<>,
+  > = {|
+    ...ExtraDrawerNavigatorProps,
+    ...ScreenOptionsProp<DrawerOptions, NavProp>,
+  |};
+
+  /**
+   * BaseNavigationContainer
+   */
+
+  declare export type BaseNavigationContainerProps = {|
+    +children: React$Node,
+    +initialState?: PossiblyStaleNavigationState,
+    +onStateChange?: (state: ?PossiblyStaleNavigationState) => void,
+    +independent?: boolean,
+  |};
+
+  declare export type BaseNavigationContainerInterface = {|
+    ...$Exact<NavigationHelpers<
+      ParamListBase,
+      PossiblyStaleNavigationState,
+      GlobalEventMap<PossiblyStaleNavigationState>,
+    >>,
+    +setParams: (params: ScreenParams) => void,
+    +resetRoot: (state?: ?PossiblyStaleNavigationState) => void,
+    +getRootState: () => PossiblyStaleNavigationState,
+  |};
+
+  /**
+   * State / path conversion
+   */
+
+  declare export type LinkingConfig = {|
+    +[routeName: string]:
+      | string
+      | {|
+          +path?: string,
+          +parse?: {| +[param: string]: string => mixed |},
+          +screens?: LinkingConfig,
+          +initialRouteName?: string,
+        |},
+  |};
+
+  declare export type GetPathFromStateOptions = {|
+    +[routeName: string]:
+      | string
+      | {|
+          +path?: string,
+          +stringify?: {| +[param: string]: mixed => string |},
+          +screens?: GetPathFromStateOptions,
+        |},
+  |};
+
+  //---------------------------------------------------------------------------
+  // SECTION 2: EXPORTED MODULE
+  // This section defines the module exports and contains exported types that
+  // are not present in any other React Navigation libdef.
+  //---------------------------------------------------------------------------
+
+  /**
+   * Actions and routers
+   */
+
+  declare export var CommonActions: CommonActionsType;
+  declare export var StackActions: StackActionsType;
+  declare export var TabActions: TabActionsType;
+  declare export var DrawerActions: DrawerActionsType;
+
+  declare export var BaseRouter: RouterFactory<
+    NavigationState,
+    CommonAction,
+    DefaultRouterOptions,
+  >;
+  declare export var StackRouter: RouterFactory<
+    StackNavigationState,
+    StackAction,
+    StackRouterOptions,
+  >;
+  declare export var TabRouter: RouterFactory<
+    TabNavigationState,
+    TabAction,
+    TabRouterOptions,
+  >;
+  declare export var DrawerRouter: RouterFactory<
+    DrawerNavigationState,
+    DrawerAction,
+    DrawerRouterOptions,
+  >;
+
+  /**
+   * Navigator utils
+   */
+
+  declare export var BaseNavigationContainer: React$AbstractComponent<
+    BaseNavigationContainerProps,
+    BaseNavigationContainerInterface,
+  >;
+
+  declare export var createNavigatorFactory: CreateNavigatorFactory;
+
+  declare export var useNavigationBuilder: UseNavigationBuilder;
+
+  declare export var NavigationHelpersContext: React$Context<
+    ?NavigationHelpers<ParamListBase>,
+  >;
+
+  /**
+   * Navigation prop / route accessors
+   */
+
+  declare export var NavigationContext: React$Context<
+    ?NavigationProp<ParamListBase>,
+  >;
+  declare export function useNavigation(): NavigationProp<ParamListBase>;
+
+  declare export var NavigationRouteContext: React$Context<?LeafRoute<>>;
+  declare export function useRoute(): LeafRoute<>;
+
+  declare export function useNavigationState<T>(
+    selector: NavigationState => T,
+  ): T;
+
+  /**
+   * Focus utils
+   */
+
+  declare export function useFocusEffect(
+    effect: () => ?(() => mixed),
+  ): void;
+  declare export function useIsFocused(): boolean;
+
+  /**
+   * State utils
+   */
+
+  declare export function getStateFromPath(
+    path: string,
+    options?: LinkingConfig,
+  ): PossiblyStaleNavigationState;
+
+  declare export function getPathFromState(
+    state?: ?PossiblyStaleNavigationState,
+    options?: GetPathFromStateOptions,
+  ): string;
+
+  declare export function getActionFromState(
+    state: PossiblyStaleNavigationState,
+  ): ?NavigateAction;
+
+  /**
+   * useScrollToTop
+   */
+
+  declare type ScrollToOptions = { y?: number, animated?: boolean, ... };
+  declare type ScrollToOffsetOptions = {
+    offset: number,
+    animated?: boolean,
+    ...
+  };
+  declare type ScrollableView =
+    | { scrollToTop(): void, ... }
+    | { scrollTo(options: ScrollToOptions): void, ... }
+    | { scrollToOffset(options: ScrollToOffsetOptions): void, ... }
+    | { scrollResponderScrollTo(options: ScrollToOptions): void, ... };
+  declare type ScrollableWrapper =
+    | { getScrollResponder(): React$Node, ... }
+    | { getNode(): ScrollableView, ... }
+    | ScrollableView;
+  declare export function useScrollToTop(
+    ref: { +current: ?ScrollableWrapper, ... },
+  ): void;
+
+  /**
+   * Themes
+   */
+
+  declare export type Theme = {|
+    +dark: boolean,
+    +colors: {|
+      +primary: string,
+      +background: string,
+      +card: string,
+      +text: string,
+      +border: string,
+    |},
+  |};
+  declare export var DefaultTheme: Theme & { +dark: false, ... };
+  declare export var DarkTheme: Theme & { +dark: true, ... };
+  declare export function useTheme(): Theme;
+  declare export var ThemeProvider: React$ComponentType<{|
+    +value: Theme,
+    +children: React$Node,
+  |}>;
+
+  /**
+   * Linking
+   */
+
+  declare export type LinkingOptions = {|
+    +enabled?: boolean,
+    +prefixes: $ReadOnlyArray<string>,
+    +config?: LinkingConfig,
+    +getStateFromPath?: typeof getStateFromPath,
+    +getPathFromState?: typeof getPathFromState,
+  |};
+
+  declare export var Link: React$ComponentType<{
+    +to: string,
+    +action?: GenericNavigationAction,
+    +target?: string,
+    +children: React$Node,
+    ...
+  }>;
+
+  declare export function useLinking(
+    container: { +current: ?React$ElementRef<typeof NavigationContainer>, ... },
+    options: LinkingOptions,
+  ): {| +getInitialState: () => Promise<?PossiblyStaleNavigationState> |};
+
+  declare export function useLinkTo(): (path: string) => void;
+
+  declare export function useLinkProps<To: string>(props: {|
+    +to: Top,
+    +action?: GenericNavigationAction,
+  |}): {|
+    +href: To,
+    +accessibilityRole: 'link',
+    +onPress: (MouseEvent | PressEvent) => void,
+  |};
+
+  declare export function useLinkBuilder(): (
+    name: string,
+    params?: ScreenParams,
+  ) => ?string;
+
+  /**
+   * NavigationContainer
+   */
+
+  declare export var NavigationContainer: React$AbstractComponent<
+    {|
+      ...BaseNavigationContainerProps,
+      +theme?: Theme,
+      +linking?: LinkingOptions,
+      +fallback?: React$Node,
+    |},
+    BaseNavigationContainerInterface,
+  >;
+
+  /**
+   * useBackButton
+   */
+
+  declare export function useBackButton(
+    container: { +current: ?React$ElementRef<typeof NavigationContainer>, ... },
+  ): void;
+
+}

--- a/definitions/npm/@react-navigation/native_v5.x.x/test_native.js
+++ b/definitions/npm/@react-navigation/native_v5.x.x/test_native.js
@@ -1,0 +1,64 @@
+// @flow
+
+import * as React from 'react';
+import {
+  NavigationContainer,
+  DarkTheme,
+  useLinking,
+  useBackButton,
+} from '@react-navigation/native';
+
+/**
+ * NavigationContainer
+ */
+
+const linking = {
+  enabled: true,
+  prefixes: [],
+};
+
+class Root extends React.Component<{||}> {
+
+  container: ?React.ElementRef<typeof NavigationContainer>;
+
+  render() {
+    return (
+      <NavigationContainer
+        theme={DarkTheme}
+        linking={linking}
+        ref={this.containerRef}
+      >
+        Blah
+      </NavigationContainer>
+    );
+  }
+
+  containerRef = (container: ?React.ElementRef<typeof NavigationContainer>) => {
+    this.container = container;
+  }
+
+}
+
+/**
+ * useLinking/useBackButton
+ */
+
+function AnotherRoot() {
+  const containerRef = React.useRef<
+    ?React.ElementRef<typeof NavigationContainer>,
+  >();
+  
+  const { getInitialState } = useLinking(containerRef, linking);
+
+  useBackButton(containerRef);
+
+  return (
+    <NavigationContainer
+      theme={DarkTheme}
+      linking={linking}
+      ref={containerRef}
+    >
+      Blah
+    </NavigationContainer>
+  );
+}

--- a/definitions/npm/@react-navigation/stack_v5.x.x/CONTRIBUTING.md
+++ b/definitions/npm/@react-navigation/stack_v5.x.x/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to the React Navigation Flow libdef
+
+## Overview
+
+There are seven React Navigation libdefs in `flow-typed`:
+
+1. `@react-navigation/core`
+2. `@react-navigation/native`
+3. `@react-navigation/stack`
+4. `@react-navigation/bottom-tabs`
+5. `@react-navigation/material-bottom-tabs`
+6. `@react-navigation/material-top-tabs`
+7. `@react-navigation/drawer`
+
+It's not currently possible to import types between libdefs. Consequently, many of the same types are copy-pasted across the different libdefs.
+
+Each libdef is organized into two sections. The first section should be identical between all of the libdefs. If you make a change to this section, please make sure to mirror it across the other libdefs.
+
+## Contributors
+
+- @Ashoat

--- a/definitions/npm/@react-navigation/stack_v5.x.x/flow_v0.104.x-/stack_v5.x.x.js
+++ b/definitions/npm/@react-navigation/stack_v5.x.x/flow_v0.104.x-/stack_v5.x.x.js
@@ -1,0 +1,2070 @@
+declare module '@react-navigation/stack' {
+
+  //---------------------------------------------------------------------------
+  // SECTION 1: IDENTICAL TYPE DEFINITIONS
+  // This section is identical across all React Navigation libdefs and contains
+  // shared definitions. We wish we could make it DRY and import from a shared
+  // definition, but that isn't yet possible.
+  //---------------------------------------------------------------------------
+
+  /**
+   * We start with some definitions that we have copy-pasted from React Native
+   * source files.
+   */
+
+  // This is a bastardization of the true StyleObj type located in
+  // react-native/Libraries/StyleSheet/StyleSheetTypes. We unfortunately can't
+  // import that here, and it's too lengthy (and consequently too brittle) to
+  // copy-paste here either.
+  declare type StyleObj =
+    | null
+    | void
+    | number
+    | false
+    | ''
+    | $ReadOnlyArray<StyleObj>
+    | { [name: string]: any, ... };
+  declare type ViewStyleProp = StyleObj;
+  declare type TextStyleProp = StyleObj;
+  declare type AnimatedViewStyleProp = StyleObj;
+  declare type AnimatedTextStyleProp = StyleObj;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/animations/Animation.js
+  declare type EndResult = { finished: boolean, ... };
+  declare type EndCallback = (result: EndResult) => void;
+  declare interface Animation {
+    start(
+      fromValue: number,
+      onUpdate: (value: number) => void,
+      onEnd: ?EndCallback,
+      previousAnimation: ?Animation,
+      animatedValue: AnimatedValue,
+    ): void;
+    stop(): void;
+  }
+  declare type AnimationConfig = {
+    isInteraction?: boolean,
+    useNativeDriver: boolean,
+    onComplete?: ?EndCallback,
+    iterations?: number,
+    ...
+  };
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedTracking.js
+  declare interface AnimatedTracking {
+    constructor(
+      value: AnimatedValue,
+      parent: any,
+      animationClass: any,
+      animationConfig: Object,
+      callback?: ?EndCallback,
+    ): void;
+    update(): void;
+  }
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedValue.js
+  declare type ValueListenerCallback = (state: { value: number, ... }) => void;
+  declare interface AnimatedValue {
+    constructor(value: number): void;
+    setValue(value: number): void;
+    setOffset(offset: number): void;
+    flattenOffset(): void;
+    extractOffset(): void;
+    addListener(callback: ValueListenerCallback): string;
+    removeListener(id: string): void;
+    removeAllListeners(): void;
+    stopAnimation(callback?: ?(value: number) => void): void;
+    resetAnimation(callback?: ?(value: number) => void): void;
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+    animate(animation: Animation, callback: ?EndCallback): void;
+    stopTracking(): void;
+    track(tracking: AnimatedTracking): void;
+  }
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/TimingAnimation.js
+  declare type TimingAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    easing?: (value: number) => number,
+    duration?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from
+  // react-native/Libraries/Animated/src/animations/SpringAnimation.js
+  declare type SpringAnimationConfigSingle = AnimationConfig & {
+    toValue: number | AnimatedValue,
+    overshootClamping?: boolean,
+    restDisplacementThreshold?: number,
+    restSpeedThreshold?: number,
+    velocity?: number,
+    bounciness?: number,
+    speed?: number,
+    tension?: number,
+    friction?: number,
+    stiffness?: number,
+    damping?: number,
+    mass?: number,
+    delay?: number,
+    ...
+  };
+
+  // Copied from react-native/Libraries/Types/CoreEventTypes.js
+  declare type SyntheticEvent<T> = $ReadOnly<{|
+    bubbles: ?boolean,
+    cancelable: ?boolean,
+    currentTarget: number,
+    defaultPrevented: ?boolean,
+    dispatchConfig: $ReadOnly<{|
+      registrationName: string,
+    |}>,
+    eventPhase: ?number,
+    preventDefault: () => void,
+    isDefaultPrevented: () => boolean,
+    stopPropagation: () => void,
+    isPropagationStopped: () => boolean,
+    isTrusted: ?boolean,
+    nativeEvent: T,
+    persist: () => void,
+    target: ?number,
+    timeStamp: number,
+    type: ?string,
+  |}>;
+  declare type Layout = $ReadOnly<{|
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  |}>;
+  declare type LayoutEvent = SyntheticEvent<
+    $ReadOnly<{|
+      layout: Layout,
+    |}>,
+  >;
+  declare type BlurEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type FocusEvent = SyntheticEvent<
+    $ReadOnly<{|
+      target: number,
+    |}>,
+  >;
+  declare type ResponderSyntheticEvent<T> = $ReadOnly<{|
+    ...SyntheticEvent<T>,
+    touchHistory: $ReadOnly<{|
+      indexOfSingleActiveTouch: number,
+      mostRecentTimeStamp: number,
+      numberActiveTouches: number,
+      touchBank: $ReadOnlyArray<
+        $ReadOnly<{|
+          touchActive: boolean,
+          startPageX: number,
+          startPageY: number,
+          startTimeStamp: number,
+          currentPageX: number,
+          currentPageY: number,
+          currentTimeStamp: number,
+          previousPageX: number,
+          previousPageY: number,
+          previousTimeStamp: number,
+        |}>,
+      >,
+    |}>,
+  |}>;
+  declare type PressEvent = ResponderSyntheticEvent<
+    $ReadOnly<{|
+      changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+      force: number,
+      identifier: number,
+      locationX: number,
+      locationY: number,
+      pageX: number,
+      pageY: number,
+      target: ?number,
+      timestamp: number,
+      touches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
+    |}>,
+  >;
+
+  // Vaguely copied from
+  // react-native/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+  declare type ExtrapolateType = 'extend' | 'identity' | 'clamp';
+  declare type InterpolationConfigType = {
+    inputRange: Array<number>,
+    outputRange: Array<number> | Array<string>,
+    easing?: (input: number) => number,
+    extrapolate?: ExtrapolateType,
+    extrapolateLeft?: ExtrapolateType,
+    extrapolateRight?: ExtrapolateType,
+    ...
+  };
+  declare interface AnimatedInterpolation {
+    interpolate(config: InterpolationConfigType): AnimatedInterpolation;
+  }
+
+  // Copied from react-native/Libraries/Components/View/ViewAccessibility.js
+  declare type AccessibilityRole =
+    | 'none'
+    | 'button'
+    | 'link'
+    | 'search'
+    | 'image'
+    | 'keyboardkey'
+    | 'text'
+    | 'adjustable'
+    | 'imagebutton'
+    | 'header'
+    | 'summary'
+    | 'alert'
+    | 'checkbox'
+    | 'combobox'
+    | 'menu'
+    | 'menubar'
+    | 'menuitem'
+    | 'progressbar'
+    | 'radio'
+    | 'radiogroup'
+    | 'scrollbar'
+    | 'spinbutton'
+    | 'switch'
+    | 'tab'
+    | 'tablist'
+    | 'timer'
+    | 'toolbar';
+  declare type AccessibilityActionInfo = $ReadOnly<{
+    name: string,
+    label?: string,
+    ...
+  }>;
+  declare type AccessibilityActionEvent = SyntheticEvent<
+    $ReadOnly<{actionName: string, ...}>,
+  >;
+  declare type AccessibilityState = {
+    disabled?: boolean,
+    selected?: boolean,
+    checked?: ?boolean | 'mixed',
+    busy?: boolean,
+    expanded?: boolean,
+    ...
+  };
+  declare type AccessibilityValue = $ReadOnly<{|
+    min?: number,
+    max?: number,
+    now?: number,
+    text?: string,
+  |}>;
+
+  // Copied from
+  // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+  declare type Stringish = string;
+  declare type EdgeInsetsProp = $ReadOnly<$Shape<EdgeInsets>>;
+  declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
+    accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+    accessibilityElementsHidden?: ?boolean,
+    accessibilityHint?: ?Stringish,
+    accessibilityIgnoresInvertColors?: ?boolean,
+    accessibilityLabel?: ?Stringish,
+    accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
+    accessibilityRole?: ?AccessibilityRole,
+    accessibilityState?: ?AccessibilityState,
+    accessibilityValue?: ?AccessibilityValue,
+    accessibilityViewIsModal?: ?boolean,
+    accessible?: ?boolean,
+    children?: ?React$Node,
+    delayLongPress?: ?number,
+    delayPressIn?: ?number,
+    delayPressOut?: ?number,
+    disabled?: ?boolean,
+    focusable?: ?boolean,
+    hitSlop?: ?EdgeInsetsProp,
+    importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
+    nativeID?: ?string,
+    onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+    onBlur?: ?(event: BlurEvent) => mixed,
+    onFocus?: ?(event: FocusEvent) => mixed,
+    onLayout?: ?(event: LayoutEvent) => mixed,
+    onLongPress?: ?(event: PressEvent) => mixed,
+    onPress?: ?(event: PressEvent) => mixed,
+    onPressIn?: ?(event: PressEvent) => mixed,
+    onPressOut?: ?(event: PressEvent) => mixed,
+    pressRetentionOffset?: ?EdgeInsetsProp,
+    rejectResponderTermination?: ?boolean,
+    testID?: ?string,
+    touchSoundDisabled?: ?boolean,
+  |}>;
+
+  // Copied from react-native/Libraries/Image/ImageSource.js
+  declare type ImageURISource = $ReadOnly<{
+    uri?: ?string,
+    bundle?: ?string,
+    method?: ?string,
+    headers?: ?Object,
+    body?: ?string,
+    cache?: ?('default' | 'reload' | 'force-cache' | 'only-if-cached'),
+    width?: ?number,
+    height?: ?number,
+    scale?: ?number,
+    ...
+  }>;
+
+  /**
+   * The following is copied from react-native-gesture-handler's libdef
+   */
+
+  declare type $EventHandlers<ExtraProps: {...}> = {|
+    onGestureEvent?: ($Event<ExtraProps>) => mixed,
+    onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
+    onBegan?: ($Event<ExtraProps>) => mixed,
+    onFailed?: ($Event<ExtraProps>) => mixed,
+    onCancelled?: ($Event<ExtraProps>) => mixed,
+    onActivated?: ($Event<ExtraProps>) => mixed,
+    onEnded?: ($Event<ExtraProps>) => mixed,
+  |};
+
+  declare type HitSlop =
+    | number
+    | {|
+        left?: number,
+        top?: number,
+        right?: number,
+        bottom?: number,
+        vertical?: number,
+        horizontal?: number,
+        width?: number,
+        height?: number,
+      |}
+    | {|
+        width: number,
+        left: number,
+      |}
+    | {|
+        width: number,
+        right: number,
+      |}
+    | {|
+        height: number,
+        top: number,
+      |}
+    | {|
+        height: number,
+        bottom: number,
+      |};
+
+  declare type $GestureHandlerProps<
+    AdditionalProps: {...},
+    ExtraEventsProps: {...}
+  > = $ReadOnly<{|
+    ...$Exact<AdditionalProps>,
+    ...$EventHandlers<ExtraEventsProps>,
+    id?: string,
+    enabled?: boolean,
+    waitFor?: React$Ref<any> | Array<React$Ref<any>>,
+    simultaneousHandlers?: React$Ref<any> | Array<React$Ref<any>>,
+    shouldCancelWhenOutside?: boolean,
+    minPointers?: number,
+    hitSlop?: HitSlop,
+    children?: React$Node,
+  |}>;
+
+  declare type PanGestureHandlerProps = $GestureHandlerProps<
+    {
+      activeOffsetY?: number | [number, number],
+      activeOffsetX?: number | [number, number],
+      failOffsetY?: number | [number, number],
+      failOffsetX?: number | [number, number],
+      minDist?: number,
+      minVelocity?: number,
+      minVelocityX?: number,
+      minVelocityY?: number,
+      minPointers?: number,
+      maxPointers?: number,
+      avgTouches?: boolean,
+      ...
+    },
+    {
+      x: number,
+      y: number,
+      absoluteX: number,
+      absoluteY: number,
+      translationX: number,
+      translationY: number,
+      velocityX: number,
+      velocityY: number,
+      ...
+    }
+  >;
+
+  /**
+   * MAGIC
+   */
+
+  declare type $If<Test: boolean, Then, Else = empty> = $Call<
+    ((true, Then, Else) => Then) & ((false, Then, Else) => Else),
+    Test,
+    Then,
+    Else,
+  >;
+  declare type $IsA<X, Y> = $Call<
+    (Y => true) & (mixed => false),
+    X,
+  >;
+  declare type $IsUndefined<X> = $IsA<X, void>;
+
+  declare type $Partial<T> = $Rest<T, {...}>;
+
+  /**
+   * Actions, state, etc.
+   */
+
+  declare export type ScreenParams = { +[key: string]: mixed, ... };
+
+  declare export type BackAction = {|
+    +type: 'GO_BACK',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type NavigateAction = {|
+    +type: 'NAVIGATE',
+    +payload:
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ResetAction = {|
+    +type: 'RESET',
+    +payload: StaleNavigationState,
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type SetParamsAction = {|
+    +type: 'SET_PARAMS',
+    +payload: {| +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CommonAction =
+    | BackAction
+    | NavigateAction
+    | ResetAction
+    | SetParamsAction;
+
+  declare type NavigateActionCreator = {|
+    (routeName: string, params?: ScreenParams): NavigateAction,
+    (
+      | {| +key: string, +params?: ScreenParams |}
+      | {| +name: string, +key?: string, +params?: ScreenParams |},
+    ): NavigateAction,
+  |};
+  declare export type CommonActionsType = {|
+    +navigate: NavigateActionCreator,
+    +goBack: () => BackAction,
+    +reset: (state: PossiblyStaleNavigationState) => ResetAction,
+    +setParams: (params: ScreenParams) => SetParamsAction,
+  |};
+
+  declare export type GenericNavigationAction = {|
+    +type: string,
+    +payload?: { +[key: string]: mixed, ... },
+    +source?: string,
+    +target?: string,
+  |};
+
+  declare export type LeafRoute<RouteName: string = string> = {|
+    +key: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StateRoute<RouteName: string = string> = {|
+    ...LeafRoute<RouteName>,
+    +state: NavigationState | StaleNavigationState,
+  |};
+  declare export type Route<RouteName: string = string> =
+    | LeafRoute<RouteName>
+    | StateRoute<RouteName>;
+
+  declare export type NavigationState = {|
+    +key: string,
+    +index: number,
+    +routeNames: $ReadOnlyArray<string>,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<Route<>>,
+    +type: string,
+    +stale: false,
+  |};
+
+  declare export type StaleLeafRoute<RouteName: string = string> = {|
+    +key?: string,
+    +name: RouteName,
+    +params?: ScreenParams,
+  |};
+  declare export type StaleStateRoute<RouteName: string = string> = {|
+    ...StaleLeafRoute<RouteName>,
+    +state: StaleNavigationState,
+  |};
+  declare export type StaleRoute<RouteName: string = string> =
+    | StaleLeafRoute<RouteName>
+    | StaleStateRoute<RouteName>;
+  declare export type StaleNavigationState = {|
+    // It's possible to pass React Nav a StaleNavigationState with an undefined
+    // index, but React Nav will always return one with the index set. This is
+    // the same as for the type property below, but in the case of index we tend
+    // to rely on it being set more...
+    +index: number,
+    +history?: $ReadOnlyArray<mixed>,
+    +routes: $ReadOnlyArray<StaleRoute<>>,
+    +type?: string,
+    +stale?: true,
+  |};
+
+  declare export type PossiblyStaleNavigationState =
+    | NavigationState
+    | StaleNavigationState;
+  declare export type PossiblyStaleRoute<RouteName: string = string> =
+    | Route<RouteName>
+    | StaleRoute<RouteName>;
+
+  /**
+   * Routers
+   */
+
+  declare type ActionCreators<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {
+    +[key: string]: (...args: any) => (Action | State => Action),
+    ...
+  };
+
+  declare export type DefaultRouterOptions = {
+    +initialRouteName?: string,
+    ...
+  };
+
+  declare export type RouterFactory<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    RouterOptions: DefaultRouterOptions,
+  > = (options: RouterOptions) => Router<State, Action>;
+
+  declare export type ParamListBase = { +[key: string]: ?ScreenParams, ... };
+
+  declare export type RouterConfigOptions = {|
+    +routeNames: $ReadOnlyArray<string>,
+    +routeParamList: ParamListBase,
+  |};
+
+  declare export type Router<
+    State: NavigationState,
+    Action: GenericNavigationAction,
+  > = {|
+    +type: $PropertyType<State, 'type'>,
+    +getInitialState: (options: RouterConfigOptions) => State,
+    +getRehydratedState: (
+      partialState: PossibleStaleNavigationState,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteNamesChange: (
+      state: State,
+      options: RouterConfigOptions,
+    ) => State,
+    +getStateForRouteFocus: (state: State, key: string) => State,
+    +getStateForAction: (
+      state: State,
+      action: Action,
+      options: RouterConfigOptions,
+    ) => ?PossiblyStaleNavigationState;
+    +shouldActionChangeFocus: (action: GenericNavigationAction) => boolean,
+    +actionCreators?: ActionCreators<State, Action>,
+  |};
+
+  /**
+   * Stack actions and router
+   */
+
+  declare export type StackNavigationState = {|
+    ...NavigationState,
+    +type: 'stack',
+  |};
+
+  declare export type ReplaceAction = {|
+    +type: 'REPLACE',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PushAction = {|
+    +type: 'PUSH',
+    +payload: {| +name: string, +key?: ?string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopAction = {|
+    +type: 'POP',
+    +payload: {| +count: number |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type PopToTopAction = {|
+    +type: 'POP_TO_TOP',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type StackAction =
+    | CommonAction
+    | ReplaceAction
+    | PushAction
+    | PopAction
+    | PopToTopAction;
+
+  declare export type StackActionsType = {|
+    +replace: (routeName: string, params?: ScreenParams) => ReplaceAction,
+    +push: (routeName: string, params?: ScreenParams) => PushAction,
+    +pop: (count?: number) => PopAction,
+    +popToTop: () => PopToTopAction,
+  |};
+
+  declare export type StackRouterOptions = $Exact<DefaultRouterOptions>;
+
+  /**
+   * Tab actions and router
+   */
+
+  declare export type TabNavigationState = {|
+    ...NavigationState,
+    +type: 'tab',
+    +history: $ReadOnlyArray<{| type: 'route', key: string |}>,
+  |};
+
+  declare export type JumpToAction = {|
+    +type: 'JUMP_TO',
+    +payload: {| +name: string, +params?: ScreenParams |},
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type TabAction =
+    | CommonAction
+    | JumpToAction;
+
+  declare export type TabActionsType = {|
+    +jumpTo: string => JumpToAction,
+  |};
+
+  declare export type TabRouterOptions = {|
+    ...$Exact<DefaultRouterOptions>,
+    +backBehavior?: 'initialRoute' | 'order' | 'history' | 'none',
+  |};
+
+  /**
+   * Drawer actions and router
+   */
+
+  declare type DrawerHistoryEntry =
+    | {| +type: 'route', +key: string |}
+    | {| +type: 'drawer' |};
+  declare export type DrawerNavigationState = {|
+    ...NavigationState,
+    +type: 'drawer',
+    +history: $ReadOnlyArray<DrawerHistoryEntry>,
+  |};
+
+  declare export type OpenDrawerAction = {|
+    +type: 'OPEN_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type CloseDrawerAction = {|
+    +type: 'CLOSE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type ToggleDrawerAction = {|
+    +type: 'TOGGLE_DRAWER',
+    +source?: string,
+    +target?: string,
+  |};
+  declare export type DrawerAction =
+    | TabAction
+    | OpenDrawerAction
+    | CloseDrawerAction
+    | ToggleDrawerAction;
+
+  declare export type DrawerActionsType = {|
+    ...TabActionsType,
+    +openDrawer: () => OpenDrawerAction,
+    +closeDrawer: () => CloseDrawerAction,
+    +toggleDrawer: () => ToggleDrawerAction,
+  |};
+
+  declare export type DrawerRouterOptions = {|
+    ...TabRouterOptions,
+    +openByDefault?: boolean,
+  |};
+
+  /**
+   * Events
+   */
+
+  declare export type EventMapBase = {
+    +[name: string]: {|
+      +data?: mixed,
+      +canPreventDefault?: boolean,
+    |},
+    ...
+  };
+  declare type EventPreventDefaultProperties<Test: boolean> = $If<
+    Test,
+    {| +defaultPrevented: boolean, +preventDefault: () => void |},
+    {| |},
+  >;
+  declare type EventDataProperties<Data> = $If<
+    $IsUndefined<Data>,
+    {| |},
+    {| +data: Data |},
+  >;
+  declare type EventArg<
+    EventName: string,
+    CanPreventDefault: ?boolean = false,
+    Data = void,
+  > = {|
+    ...EventPreventDefaultProperties<CanPreventDefault>,
+    ...EventDataProperties<Data>,
+    +type: EventName,
+    +target?: string,
+  |};
+  declare type GlobalEventMap<State: PossiblyStaleNavigationState> = {|
+    +state: {| +data: {| +state: State |}, +canPreventDefault: false |},
+  |};
+  declare type EventMapCore<State: PossiblyStaleNavigationState> = {|
+    ...GlobalEventMap<State>,
+    +focus: {| +data: void, +canPreventDefault: false |},
+    +blur: {| +data: void, +canPreventDefault: false |},
+  |};
+  declare type EventListenerCallback<
+    EventName: string,
+    State: NavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = (e: EventArg<
+    EventName,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'canPreventDefault',
+    >,
+    $PropertyType<
+      $ElementType<
+        {| ...EventMap, ...EventMapCore<State> |},
+        EventName,
+      >,
+      'data',
+    >,
+  >) => mixed;
+
+  /**
+   * Navigation prop
+   */
+
+  declare export type SimpleNavigate<ParamList> =
+    <DestinationRouteName: $Keys<ParamList>>(
+      routeName: DestinationRouteName,
+      params: $ElementType<ParamList, DestinationRouteName>,
+    ) => void;
+
+  declare export type Navigate<ParamList> =
+    & SimpleNavigate<ParamList>
+    & <DestinationRouteName: $Keys<ParamList>>(
+        route:
+          | {|
+              key: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |}
+          | {|
+              name: DestinationRouteName,
+              key?: string,
+              params?: $ElementType<ParamList, DestinationRouteName>,
+            |},
+      ) => void;
+
+  declare type NavigationHelpers<
+    ParamList: ParamListBase,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    +navigate: Navigate<ParamList>,
+    +dispatch: (
+      action:
+        | GenericNavigationAction
+        | (State => GenericNavigationAction),
+    ) => void,
+    +reset: PossiblyStaleNavigationState => void,
+    +goBack: () => void,
+    +isFocused: () => boolean,
+    +canGoBack: () => boolean,
+    +dangerouslyGetParent: <Parent: NavigationProp<ParamListBase>>() => ?Parent,
+    +dangerouslyGetState: () => NavigationState,
+    +addListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => () => void,
+    +removeListener: <EventName: $Keys<
+      {| ...EventMap, ...EventMapCore<State> |},
+    >>(
+      name: EventName,
+      callback: EventListenerCallback<EventName, State, EventMap>,
+    ) => void,
+    ...
+  };
+
+  declare export type NavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: PossiblyStaleNavigationState = PossiblyStaleNavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {
+    ...$Exact<NavigationHelpers<
+      ParamList,
+      State,
+      EventMap,
+    >>,
+    +setOptions: (options: $Shape<ScreenOptions>) => void,
+    +setParams: (
+      params: $If<
+        $IsUndefined<$ElementType<ParamList, RouteName>>,
+        empty,
+        $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+      >,
+    ) => void,
+    ...
+  };
+
+  /**
+   * CreateNavigator
+   */
+
+  declare export type RouteProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+  > = {|
+    ...LeafRoute<RouteName>,
+    +params: $ElementType<ParamList, RouteName>,
+  |};
+
+  declare export type ScreenListeners<
+    EventMap: EventMapBase = EventMapCore<State>,
+    State: NavigationState = NavigationState,
+  > = $ObjMapi<
+    {| [name: $Keys<EventMap>]: empty |},
+    <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
+  >;
+
+  declare type BaseScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = {|
+    +name: RouteName,
+    +options?:
+      | ScreenOptions
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenOptions,
+    +listeners?:
+      | ScreenListeners<EventMap, State>
+      | ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => ScreenListeners<EventMap, State>,
+    +initialParams?: $Shape<$ElementType<ParamList, RouteName>>,
+  |};
+
+  declare export type ScreenProps<
+    ParamList: ParamListBase,
+    NavProp,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > =
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +component: React$ComponentType<{|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}>,
+      |}
+    | {|
+        ...BaseScreenProps<
+          ParamList,
+          NavProp,
+          RouteName,
+          State,
+          ScreenOptions,
+          EventMap,
+        >,
+        +children: ({|
+          route: RouteProp<ParamList, RouteName>,
+          navigation: NavProp,
+        |}) => React$Node,
+      |};
+
+  declare export type ScreenComponent<
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    State: NavigationState = NavigationState,
+    ScreenOptions: {...} = {...},
+    EventMap: EventMapBase = EventMapCore<State>,
+  > = <
+    RouteName: $Keys<ParamList>,
+    NavProp: NavigationProp<
+      GlobalParamList,
+      RouteName,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+  >(props: ScreenProps<
+    ParamList,
+    NavProp,
+    RouteName,
+    State,
+    ScreenOptions,
+    EventMap,
+  >) => React$Node;
+
+  declare type ScreenOptionsProp<ScreenOptions: {...}, NavProp> = {|
+    +screenOptions?:
+      | ScreenOptions
+      | ({| route: LeafRoute<>, navigation: NavProp |}) => ScreenOptions,
+  |};
+  declare export type ExtraNavigatorPropsBase = {
+    ...$Exact<DefaultRouterOptions>,
+    +children?: React$Node,
+    ...
+  };
+  declare export type NavigatorPropsBase<ScreenOptions: {...}, NavProp> = {
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    ...
+  };
+
+  declare export type CreateNavigator<
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  > = <
+    GlobalParamList: ParamListBase,
+    ParamList: ParamListBase,
+    NavProp: NavigationHelpers<
+      GlobalParamList,
+      State,
+      EventMap,
+    >,
+  >() => {|
+    +Screen: ScreenComponent<
+      GlobalParamList,
+      ParamList,
+      State,
+      ScreenOptions,
+      EventMap,
+    >,
+    +Navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorProps>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  |};
+
+  declare export type CreateNavigatorFactory = <
+    State: NavigationState,
+    ScreenOptions: {...},
+    EventMap: EventMapBase,
+    NavProp: NavigationHelpers<
+      ParamListBase,
+      State,
+      EventMap,
+    >,
+    ExtraNavigatorProps: ExtraNavigatorPropsBase,
+  >(
+    navigator: React$ComponentType<{|
+      ...$Exact<ExtraNavigatorPropsBase>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+    |}>,
+  ) => CreateNavigator<State, ScreenOptions, EventMap, ExtraNavigatorProps>;
+
+  /**
+   * useNavigationBuilder
+   */
+
+  declare export type Descriptor<
+    NavProp,
+    ScreenOptions: {...} = {...},
+  > = {|
+    +render: () => React$Node,
+    +options: $ReadOnly<ScreenOptions>,
+    +navigation: NavProp,
+  |};
+
+  declare export type UseNavigationBuilder = <
+    State: NavigationState,
+    Action: GenericNavigationAction,
+    ScreenOptions: {...},
+    RouterOptions: DefaultRouterOptions,
+    NavProp,
+  >(
+    routerFactory: RouterFactory<State, Action, RouterOptions>,
+    options: {|
+      ...$Exact<RouterOptions>,
+      ...ScreenOptionsProp<ScreenOptions, NavProp>,
+      +children?: React$Node,
+    |},
+  ) => {|
+    +state: State,
+    +descriptors: {| +[key: string]: Descriptor<NavProp, ScreenOptions> |},
+    +navigation: NavProp,
+  |};
+
+  /**
+   * EdgeInsets
+   */
+
+  declare type EdgeInsets = {|
+    +top: number,
+    +right: number,
+    +bottom: number,
+    +left: number,
+  |};
+
+  /**
+   * TransitionPreset
+   */
+
+  declare export type TransitionSpec =
+    | {|
+        animation: 'spring',
+        config: $Diff<
+          SpringAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |}
+    | {|
+        animation: 'timing',
+        config: $Diff<
+          TimingAnimationConfigSingle,
+          { toValue: number | AnimatedValue, ... },
+        >,
+      |};
+
+  declare export type StackCardInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +index: number,
+    +closing: AnimatedInterpolation,
+    +swiping: AnimatedInterpolation,
+    +inverted: AnimatedInterpolation,
+    +layouts: {|
+      +screen: {| +width: number, +height: number |},
+    |},
+    +insets: EdgeInsets,
+  |};
+  declare export type StackCardInterpolatedStyle = {|
+    containerStyle?: AnimatedViewStyleProp,
+    cardStyle?: AnimatedViewStyleProp,
+    overlayStyle?: AnimatedViewStyleProp,
+    shadowStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackCardStyleInterpolator = (
+    props: StackCardInterpolationProps,
+  ) => StackCardInterpolatedStyle;
+
+  declare export type StackHeaderInterpolationProps = {|
+    +current: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +next?: {|
+      +progress: AnimatedInterpolation,
+    |},
+    +layouts: {|
+      +header: {| +width: number, +height: number |},
+      +screen: {| +width: number, +height: number |},
+      +title?: {| +width: number, +height: number |},
+      +leftLabel?: {| +width: number, +height: number |},
+    |},
+  |};
+  declare export type StackHeaderInterpolatedStyle = {|
+    leftLabelStyle?: AnimatedViewStyleProp,
+    leftButtonStyle?: AnimatedViewStyleProp,
+    rightButtonStyle?: AnimatedViewStyleProp,
+    titleStyle?: AnimatedViewStyleProp,
+    backgroundStyle?: AnimatedViewStyleProp,
+  |};
+  declare export type StackHeaderStyleInterpolator = (
+    props: StackHeaderInterpolationProps,
+  ) => StackHeaderInterpolatedStyle;
+
+  declare type GestureDirection =
+    | 'horizontal'
+    | 'horizontal-inverted'
+    | 'vertical'
+    | 'vertical-inverted';
+
+  declare export type TransitionPreset = {|
+    +gestureDirection: GestureDirection,
+    +transitionSpec: {|
+      +open: TransitionSpec,
+      +close: TransitionSpec,
+    |},
+    +cardStyleInterpolator: StackCardStyleInterpolator,
+    +headerStyleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  /**
+   * Stack options
+   */
+
+  declare export type StackDescriptor = Descriptor<
+    StackNavigationProp<>,
+    StackOptions,
+  >;
+
+  declare type Scene<T> = {|
+    +route: T,
+    +descriptor: StackDescriptor,
+    +progress: {|
+      +current: AnimatedInterpolation,
+      +next?: AnimatedInterpolation,
+      +previous?: AnimatedInterpolation,
+    |},
+  |};
+
+  declare export type StackHeaderProps = {|
+    +mode: 'float' | 'screen',
+    +layout: {| +width: number, +height: number |},
+    +insets: EdgeInsets,
+    +scene: Scene<Route<>>,
+    +previous?: Scene<Route<>>,
+    +navigation: StackNavigationProp<ParamListBase>,
+    +styleInterpolator: StackHeaderStyleInterpolator,
+  |};
+
+  declare export type StackHeaderLeftButtonProps = $Shape<{|
+    +onPress: (() => void),
+    +pressColorAndroid: string;
+    +backImage: (props: {| tintColor: string |}) => React$Node,
+    +tintColor: string,
+    +label: string,
+    +truncatedLabel: string,
+    +labelVisible: boolean,
+    +labelStyle: AnimatedTextStyleProp,
+    +allowFontScaling: boolean,
+    +onLabelLayout: LayoutEvent => void,
+    +screenLayout: {| +width: number, +height: number |},
+    +titleLayout: {| +width: number, +height: number |},
+    +canGoBack: boolean,
+  |}>;
+
+  declare type StackHeaderTitleInputBase = {
+    +onLayout: LayoutEvent => void,
+    +children: string,
+    +allowFontScaling: ?boolean,
+    +tintColor: ?string,
+    +style: ?AnimatedTextStyleProp,
+    ...
+  };
+
+  declare export type StackHeaderTitleInputProps =
+    $Exact<StackHeaderTitleInputBase>;
+
+  declare export type StackOptions = $Shape<{|
+    +title: string,
+    +header: StackHeaderProps => React$Node,
+    +headerShown: boolean,
+    +cardShadowEnabled: boolean,
+    +cardOverlayEnabled: boolean,
+    +cardOverlay: {| style: ViewStyleProp |} => React$Node,
+    +cardStyle: ViewStyleProp,
+    +animationEnabled: boolean,
+    +animationTypeForReplace: 'push' | 'pop',
+    +gestureEnabled: boolean,
+    +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
+    +gestureVelocityImpact: number,
+    +safeAreaInsets: $Shape<EdgeInsets>,
+    // Transition
+    ...TransitionPreset,
+    // Header
+    +headerTitle: string | (StackHeaderTitleInputProps => React$Node),
+    +headerTitleAlign: 'left' | 'center',
+    +headerTitleStyle: AnimatedTextStyleProp,
+    +headerTitleContainerStyle: ViewStyleProp,
+    +headerTintColor: string,
+    +headerTitleAllowFontScaling: boolean,
+    +headerBackAllowFontScaling: boolean,
+    +headerBackTitle: string,
+    +headerBackTitleStyle: TextStyleProp,
+    +headerBackTitleVisible: boolean,
+    +headerTruncatedBackTitle: string,
+    +headerLeft: StackHeaderLeftButtonProps => React$Node,
+    +headerLeftContainerStyle: ViewStyleProp,
+    +headerRight: {| tintColor?: string |} => React$Node,
+    +headerRightContainerStyle: ViewStyleProp,
+    +headerBackImage: $PropertyType<StackHeaderLeftButtonProps, 'backImage'>,
+    +headerPressColorAndroid: string,
+    +headerBackground: ({| style: ViewStyleProp |}) => React$Node,
+    +headerStyle: ViewStyleProp,
+    +headerTransparent: boolean,
+    +headerStatusBarHeight: number,
+  |}>;
+
+  /**
+   * Stack navigation prop
+   */
+
+  declare export type StackNavigationEventMap = {|
+    ...EventMapCore<StackNavigationState>,
+    +transitionStart: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+    +transitionEnd: {|
+      +data: {| +closing: boolean |},
+      +canPreventDefault: false,
+    |},
+  |};
+
+  declare type InexactStackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      StackNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +replace: SimpleNavigate<ParamList>,
+    +push: SimpleNavigate<ParamList>,
+    +pop: (count?: number) => void,
+    +popToTop: () => void,
+    ...
+  };
+
+  declare export type StackNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = StackOptions,
+    EventMap: EventMapBase = StackNavigationEventMap,
+  > = $Exact<InexactStackNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous stack exports
+   */
+
+  declare type StackNavigationConfig = {|
+    +mode?: 'card' | 'modal',
+    +headerMode?: 'float' | 'screen' | 'none',
+    +keyboardHandlingEnabled?: boolean,
+  |};
+
+  declare export type ExtraStackNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...StackRouterOptions,
+    ...StackNavigationConfig,
+  |};
+
+  declare export type StackNavigatorProps<
+    NavProp: InexactStackNavigationProp<> = StackNavigationProp<>,
+  > = {|
+    ...ExtraStackNavigatorProps,
+    ...ScreenOptionsProp<StackOptions, NavProp>,
+  |};
+
+  /**
+   * Bottom tab options
+   */
+
+  declare export type BottomTabBarButtonProps = {|
+    ...$Diff<
+      TouchableWithoutFeedbackProps,
+      {| onPress?: ?(event: PressEvent) => mixed |},
+    >,
+    +to?: string,
+    +children: React$Node,
+    +onPress?: (MouseEvent | PressEvent) => void,
+  |};
+
+  declare export type BottomTabOptions = $Shape<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| focused: boolean, color: string |}) => React$Node,
+    +tabBarIcon: ({|
+      focused: boolean,
+      color: string,
+      size: number,
+    |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+    +tabBarVisible: boolean,
+    +tabBarButton: BottomTabBarButtonProps => React$Node,
+    +unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Bottom tab navigation prop
+   */
+
+  declare export type BottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare type InexactTabNavigationProp<
+    ParamList: ParamListBase,
+    RouteName: $Keys<ParamList>,
+    Options: {...},
+    EventMap: EventMapBase,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      TabNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    ...
+  };
+
+  declare export type InexactBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type BottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = BottomTabOptions,
+    EventMap: EventMapBase = BottomTabNavigationEventMap,
+  > = $Exact<InexactBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous bottom tab exports
+   */
+
+  declare export type BottomTabDescriptor = Descriptor<
+    BottomTabNavigationProp<>,
+    BottomTabOptions,
+  >;
+
+  declare export type BottomTabBarOptions = $Shape<{|
+    +keyboardHidesTabBar: boolean,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveBackgroundColor: string,
+    +allowFontScaling: boolean,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +labelStyle: TextStyleProp,
+    +tabStyle: ViewStyleProp,
+    +labelPosition: 'beside-icon' | 'below-icon',
+    +adaptive: boolean,
+    +safeAreaInsets: $Shape<EdgeInsets>,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type BottomTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: BottomTabNavigationProp<>,
+    +descriptors: {| +[key: string]: BottomTabDescriptor |},
+  |};
+
+  declare export type BottomTabBarProps = {|
+    ...BottomTabBarOptions,
+    ...BottomTabNavigationBuilderResult,
+  |}
+
+  declare type BottomTabNavigationConfig = {|
+    +lazy?: boolean,
+    +tabBar?: BottomTabBarProps => React$Node,
+    +tabBarOptions?: BottomTabBarOptions,
+  |};
+
+  declare export type ExtraBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...BottomTabNavigationConfig,
+  |};
+
+  declare export type BottomTabNavigatorProps<
+    NavProp: InexactBottomTabNavigationProp<> = BottomTabNavigationProp<>,
+  > = {|
+    ...ExtraBottomTabNavigatorProps,
+    ...ScreenOptionsProp<BottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material bottom tab options
+   */
+
+  declare export type MaterialBottomTabOptions = $Shape<{|
+    +title: string,
+    +tabBarColor: string,
+    +tabBarLabel: string,
+    +tabBarIcon:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarBadge: boolean | number | string,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material bottom tab navigation prop
+   */
+
+  declare export type MaterialBottomTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+  |};
+
+  declare export type InexactMaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialBottomTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialBottomTabOptions,
+    EventMap: EventMapBase = MaterialBottomTabNavigationEventMap,
+  > = $Exact<InexactMaterialBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material bottom tab exports
+   */
+
+  declare export type PaperFont = {|
+    +fontFamily: string,
+    +fontWeight?:
+      | 'normal'
+      | 'bold'
+      | '100'
+      | '200'
+      | '300'
+      | '400'
+      | '500'
+      | '600'
+      | '700'
+      | '800'
+      | '900',
+  |};
+
+  declare export type PaperFonts = {|
+    +regular: Font,
+    +medium: Font,
+    +light: Font,
+    +thin: Font,
+  |};
+
+  declare export type PaperTheme = {|
+    +dark: boolean,
+    +mode?: 'adaptive' | 'exact',
+    +roundness: number,
+    +colors: {|
+      +primary: string,
+      +background: string,
+      +surface: string,
+      +accent: string,
+      +error: string,
+      +text: string,
+      +onSurface: string,
+      +onBackground: string,
+      +disabled: string,
+      +placeholder: string,
+      +backdrop: string,
+      +notification: string,
+    |},
+    +fonts: PaperFonts,
+    +animation: {|
+      +scale: number,
+    |},
+  |};
+
+  declare export type PaperRoute = {|
+    +key: string,
+    +title?: string,
+    +icon?: any,
+    +badge?: string | number | boolean,
+    +color?: string,
+    +accessibilityLabel?: string,
+    +testID?: string,
+  |};
+
+  declare export type PaperTouchableProps = {|
+    ...TouchableWithoutFeedbackProps,
+    +key: string,
+    +route: PaperRoute,
+    +children: React$Node,
+    +borderless?: boolean,
+    +centered?: boolean,
+    +rippleColor?: string,
+  |};
+
+  declare export type MaterialBottomTabNavigationConfig = {|
+    +shifting?: boolean,
+    +labeled?: boolean,
+    +renderTouchable?: PaperTouchableProps => React$Node,
+    +activeColor?: string,
+    +inactiveColor?: string,
+    +sceneAnimationEnabled?: boolean,
+    +keyboardHidesNavigationBar?: boolean,
+    +barStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +theme?: PaperTheme,
+  |};
+
+  declare export type ExtraMaterialBottomTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialBottomTabNavigationConfig,
+  |};
+
+  declare export type MaterialBottomTabNavigatorProps<
+    NavProp: InexactMaterialBottomTabNavigationProp<> =
+      MaterialBottomTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialBottomTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialBottomTabOptions, NavProp>,
+  |};
+
+  /**
+   * Material top tab options
+   */
+
+  declare export type MaterialTopTabOptions = $Shape<{|
+    +title: string,
+    +tabBarLabel:
+      | string
+      | ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarIcon: ({| +focused: boolean, +color: string |}) => React$Node,
+    +tabBarAccessibilityLabel: string,
+    +tabBarTestID: string,
+  |}>;
+
+  /**
+   * Material top tab navigation prop
+   */
+
+  declare export type MaterialTopTabNavigationEventMap = {|
+    ...EventMapCore<TabNavigationState>,
+    +tabPress: {| +data: void, +canPreventDefault: true |},
+    +tabLongPress: {| +data: void, +canPreventDefault: false |},
+    +swipeStart: {| +data: void, +canPreventDefault: false |},
+    +swipeEnd: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactMaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = InexactTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >;
+
+  declare export type MaterialTopTabNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = MaterialTopTabOptions,
+    EventMap: EventMapBase = MaterialTopTabNavigationEventMap,
+  > = $Exact<InexactMaterialTopTabNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous material top tab exports
+   */
+
+  declare type MaterialTopTabPagerCommonProps = {|
+    +keyboardDismissMode: 'none' | 'on-drag' | 'auto',
+    +swipeEnabled: boolean,
+    +swipeVelocityImpact?: number,
+    +springVelocityScale?: number,
+    +springConfig: $Shape<{|
+      +damping: number,
+      +mass: number,
+      +stiffness: number,
+      +restSpeedThreshold: number,
+      +restDisplacementThreshold: number,
+    |}>,
+    +timingConfig: $Shape<{|
+      +duration: number,
+    |}>,
+  |};
+
+  declare export type MaterialTopTabPagerProps = {|
+    ...MaterialTopTabPagerCommonProps,
+    +onSwipeStart?: () => void,
+    +onSwipeEnd?: () => void,
+    +onIndexChange: (index: number) => void,
+    +navigationState: TabNavigationState,
+    +layout: {| +width: number, +height: number |},
+    +removeClippedSubviews: boolean,
+    +children: ({|
+      +addListener: (type: 'enter', listener: number => void) => void,
+      +removeListener: (type: 'enter', listener: number => void) => void,
+      +position: any, // Reanimated.Node<number>
+      +render: React$Node => React$Node,
+      +jumpTo: string => void,
+    |}) => React$Node,
+    +gestureHandlerProps: PanGestureHandlerProps,
+  |};
+
+  declare export type MaterialTopTabBarIndicatorProps = {|
+    +navigationState: TabNavigationState,
+    +width: string,
+    +style?: ViewStyleProp,
+    +getTabWidth: number => number,
+  |};
+
+  declare export type MaterialTopTabBarOptions = $Shape<{|
+    +scrollEnabled: boolean,
+    +bounces: boolean,
+    +pressColor: string,
+    +pressOpacity: number,
+    +getAccessible: ({| +route: Route<> |}) => boolean,
+    +renderBadge: ({| +route: Route<> |}) => React$Node,
+    +renderIndicator: MaterialTopTabBarIndicatorProps => React$Node,
+    +tabStyle: ViewStyleProp,
+    +indicatorStyle: ViewStyleProp,
+    +indicatorContainerStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+    +activeTintColor: string,
+    +inactiveTintColor: string,
+    +iconStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+    +showLabel: boolean,
+    +showIcon: boolean,
+    +allowFontScaling: boolean,
+  |}>;
+
+  declare export type MaterialTopTabDescriptor = Descriptor<
+    MaterialBottomTabNavigationProp<>,
+    MaterialBottomTabOptions,
+  >;
+
+  declare type MaterialTopTabNavigationBuilderResult = {|
+    +state: TabNavigationState,
+    +navigation: MaterialTopTabNavigationProp<>,
+    +descriptors: {| +[key: string]: MaterialTopTabDescriptor |},
+  |};
+
+  declare export type MaterialTopTabBarProps = {|
+    ...MaterialTopTabBarOptions,
+    ...MaterialTopTabNavigationBuilderResult,
+    +layout: {| +width: number, +height: number |},
+    +position: any, // Reanimated.Node<number>
+    +jumpTo: string => void,
+  |};
+
+  declare export type MaterialTopTabNavigationConfig = {|
+    ...$Partial<MaterialTopTabPagerCommonProps>,
+    +position?: any, // Reanimated.Value<number>
+    +tabBarPosition?: 'top' | 'bottom',
+    +initialLayout?: $Shape<{| +width: number, +height: number |}>,
+    +lazy?: boolean,
+    +lazyPreloadDistance?: number,
+    +removeClippedSubviews?: boolean,
+    +sceneContainerStyle?: ViewStyleProp,
+    +style?: ViewStyleProp,
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +pager?: MaterialTopTabPagerProps => React$Node,
+    +lazyPlaceholder?: ({| +route: Route<> |}) => React$Node,
+    +tabBar?: MaterialTopTabBarProps => React$Node,
+    +tabBarOptions?: MaterialTopTabBarOptions,
+  |};
+
+  declare export type ExtraMaterialTopTabNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...TabRouterOptions,
+    ...MaterialTopTabNavigationConfig,
+  |};
+
+  declare export type MaterialTopTabNavigatorProps<
+    NavProp: InexactMaterialTopTabNavigationProp<> =
+      MaterialTopTabNavigationProp<>,
+  > = {|
+    ...ExtraMaterialTopTabNavigatorProps,
+    ...ScreenOptionsProp<MaterialTopTabOptions, NavProp>,
+  |};
+
+  /**
+   * Drawer options
+   */
+
+  declare export type DrawerOptions = $Shape<{|
+    title: string,
+    drawerLabel:
+      | string
+      | ({| +color: string, +focused: boolean |}) => React$Node,
+    drawerIcon: ({|
+      +color: string,
+      +size: number,
+      +focused: boolean,
+    |}) => React$Node,
+    gestureEnabled: boolean,
+    swipeEnabled: boolean,
+    unmountOnBlur: boolean,
+  |}>;
+
+  /**
+   * Drawer navigation prop
+   */
+
+  declare export type DrawerNavigationEventMap = {|
+    ...EventMapCore<DrawerNavigationState>,
+    +drawerOpen: {| +data: void, +canPreventDefault: false |},
+    +drawerClose: {| +data: void, +canPreventDefault: false |},
+  |};
+
+  declare export type InexactDrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = {
+    ...$Exact<NavigationProp<
+      ParamList,
+      RouteName,
+      DrawerNavigationState,
+      Options,
+      EventMap,
+    >>,
+    +jumpTo: SimpleNavigate<ParamList>,
+    +openDrawer: () => void,
+    +closeDrawer: () => void,
+    +toggleDrawer: () => void,
+    ...
+  };
+
+  declare export type DrawerNavigationProp<
+    ParamList: ParamListBase = ParamListBase,
+    RouteName: $Keys<ParamList> = $Keys<ParamList>,
+    Options: {...} = DrawerOptions,
+    EventMap: EventMapBase = DrawerNavigationEventMap,
+  > = $Exact<InexactDrawerNavigationProp<
+    ParamList,
+    RouteName,
+    Options,
+    EventMap,
+  >>;
+
+  /**
+   * Miscellaneous drawer exports
+   */
+
+  declare export type DrawerDescriptor = Descriptor<
+    DrawerNavigationProp<>,
+    DrawerOptions,
+  >;
+
+  declare export type DrawerItemListBaseOptions = $Shape<{|
+    +activeTintColor: string,
+    +activeBackgroundColor: string,
+    +inactiveTintColor: string,
+    +inactiveBackgroundColor: string,
+    +itemStyle: ViewStyleProp,
+    +labelStyle: TextStyleProp,
+  |}>;
+
+  declare export type DrawerContentOptions = $Shape<{|
+    ...DrawerItemListBaseOptions,
+    +contentContainerStyle: ViewStyleProp,
+    +style: ViewStyleProp,
+  |}>;
+
+  declare type DrawerNavigationBuilderResult = {|
+    +state: DrawerNavigationState,
+    +navigation: DrawerNavigationProp<>,
+    +descriptors: {| +[key: string]: DrawerDescriptor |},
+  |};
+
+  declare export type DrawerContentProps = {|
+    ...DrawerContentOptions,
+    ...DrawerNavigationBuilderResult,
+    +progress: any, // Reanimated.Node<number>
+  |};
+
+  declare export type DrawerNavigationConfig = {|
+    +drawerPosition?: 'left' | 'right',
+    +drawerType?: 'front' | 'back' | 'slide' | 'permanent',
+    +edgeWidth?: number,
+    +hideStatusBar?: boolean,
+    +keyboardDismissMode?: 'on-drag' | 'none',
+    +minSwipeDistance?: number,
+    +overlayColor?: string,
+    +statusBarAnimation?: 'slide' | 'none' | 'fade',
+    +gestureHandlerProps?: PanGestureHandlerProps,
+    +lazy?: boolean,
+    +drawerContent?: DrawerContentProps => React$Node,
+    +drawerContentOptions?: DrawerContentOptions,
+    +sceneContainerStyle?: ViewStyleProp,
+    +drawerStyle?: ViewStyleProp,
+  |};
+
+  declare export type ExtraDrawerNavigatorProps = {|
+    ...$Exact<ExtraNavigatorPropsBase>,
+    ...DrawerRouterOptions,
+    ...DrawerNavigationConfig,
+  |};
+
+  declare export type DrawerNavigatorProps<
+    NavProp: InexactDrawerNavigationProp<> = DrawerNavigationProp<>,
+  > = {|
+    ...ExtraDrawerNavigatorProps,
+    ...ScreenOptionsProp<DrawerOptions, NavProp>,
+  |};
+
+  /**
+   * BaseNavigationContainer
+   */
+
+  declare export type BaseNavigationContainerProps = {|
+    +children: React$Node,
+    +initialState?: PossiblyStaleNavigationState,
+    +onStateChange?: (state: ?PossiblyStaleNavigationState) => void,
+    +independent?: boolean,
+  |};
+
+  declare export type BaseNavigationContainerInterface = {|
+    ...$Exact<NavigationHelpers<
+      ParamListBase,
+      PossiblyStaleNavigationState,
+      GlobalEventMap<PossiblyStaleNavigationState>,
+    >>,
+    +setParams: (params: ScreenParams) => void,
+    +resetRoot: (state?: ?PossiblyStaleNavigationState) => void,
+    +getRootState: () => PossiblyStaleNavigationState,
+  |};
+
+  /**
+   * State / path conversion
+   */
+
+  declare export type LinkingConfig = {|
+    +[routeName: string]:
+      | string
+      | {|
+          +path?: string,
+          +parse?: {| +[param: string]: string => mixed |},
+          +screens?: LinkingConfig,
+          +initialRouteName?: string,
+        |},
+  |};
+
+  declare export type GetPathFromStateOptions = {|
+    +[routeName: string]:
+      | string
+      | {|
+          +path?: string,
+          +stringify?: {| +[param: string]: mixed => string |},
+          +screens?: GetPathFromStateOptions,
+        |},
+  |};
+
+  //---------------------------------------------------------------------------
+  // SECTION 2: EXPORTED MODULE
+  // This section defines the module exports and contains exported types that
+  // are not present in any other React Navigation libdef.
+  //---------------------------------------------------------------------------
+
+  /**
+   * StackView
+   */
+
+  declare export var StackView: React$ComponentType<{|
+    ...StackNavigationConfig,
+    +state: StackNavigationState,
+    +navigation: StackNavigationProp<>,
+    +descriptors: {| +[key: string]: StackDescriptor |},
+  |}>;
+
+  /**
+   * createStackNavigator
+   */
+
+  declare export var createStackNavigator: CreateNavigator<
+    StackNavigationState,
+    StackOptions,
+    StackNavigationEventMap,
+    ExtraStackNavigatorProps,
+  >;
+
+  /**
+   * Header components
+   */
+
+  declare export var Header: React$ComponentType<StackHeaderProps>;
+
+  declare export type StackHeaderTitleProps = $Shape<StackHeaderTitleInputBase>;
+  declare export var HeaderTitle: React$ComponentType<StackHeaderTitleProps>;
+
+  declare export type HeaderBackButtonProps = $Shape<{|
+    ...StackHeaderLeftButtonProps,
+    +disabled: boolean,
+    +accessibilityLabel: string,
+  |}>;
+  declare export var HeaderBackButton: React$ComponentType<
+    HeaderBackButtonProps,
+  >;
+
+  declare export type HeaderBackgroundProps = $Shape<{
+    +children: React$Node,
+    +style: AnimatedViewStyleProp,
+    ...
+  }>;
+  declare export var HeaderBackground: React$ComponentType<
+    HeaderBackgroundProps,
+  >;
+
+  /**
+   * Style/animation options
+   */
+
+  declare export var CardStyleInterpolators: {|
+    +forHorizontalIOS: StackCardStyleInterpolator,
+    +forVerticalIOS: StackCardStyleInterpolator,
+    +forModalPresentationIOS: StackCardStyleInterpolator,
+    +forFadeFromBottomAndroid: StackCardStyleInterpolator,
+    +forRevealFromBottomAndroid: StackCardStyleInterpolator,
+    +forScaleFromCenterAndroid: StackCardStyleInterpolator,
+    +forNoAnimation: StackCardStyleInterpolator,
+  |};
+  declare export var HeaderStyleInterpolators: {|
+    +forUIKit: StackHeaderStyleInterpolator,
+    +forFade: StackHeaderStyleInterpolator,
+    +forSlideLeft: StackHeaderStyleInterpolator,
+    +forSlideRight: StackHeaderStyleInterpolator,
+    +forSlideUp: StackHeaderStyleInterpolator,
+    +forNoAnimation: StackHeaderStyleInterpolator,
+  |};
+  declare export var TransitionSpecs: {|
+    +TransitionIOSSpec: TransitionSpec,
+    +FadeInFromBottomAndroidSpec: TransitionSpec,
+    +FadeOutToBottomAndroidSpec: TransitionSpec,
+    +RevealFromBottomAndroidSpec: TransitionSpec,
+    +ScaleFromCenterAndroidSpec: TransitionSpec,
+  |};
+  declare export var TransitionPresets: {|
+    +SlideFromRightIOS: TransitionPreset,
+    +ModalSlideFromBottomIOS: TransitionPreset,
+    +ModalPresentationIOS: TransitionPreset,
+    +FadeFromBottomAndroid: TransitionPreset,
+    +RevealFromBottomAndroid: TransitionPreset,
+    +ScaleFromCenterAndroid: TransitionPreset,
+    +DefaultTransition: TransitionPreset,
+    +ModalTransition: TransitionPreset,
+  |};
+
+  /**
+   * Image assets
+   */
+
+  declare export var Assets: $ReadOnlyArray<ImageURISource>;
+
+  /**
+   * CardAnimation accessors
+   */
+
+  declare export var CardAnimationContext: React$Context<
+    ?StackCardInterpolationProps,
+  >;
+  declare export function useCardAnimation(): StackCardInterpolationProps
+
+  /**
+   * HeaderHeight accessors
+   */
+
+  declare export var HeaderHeightContext: React$Context<?number>;
+  declare export function useHeaderHeight(): number;
+
+  /**
+   * GestureHandler accessors
+   */
+
+  declare type GestureHandlerRef = React$Ref<
+    React$ComponentType<GestureHandlerProps>,
+  >;
+  declare export var GestureHandlerRefContext: React$Context<
+    ?GestureHandlerRef,
+  >;
+  declare export function useGestureHandlerRef(): GestureHandlerRef;
+
+}

--- a/definitions/npm/@react-navigation/stack_v5.x.x/test_stack.js
+++ b/definitions/npm/@react-navigation/stack_v5.x.x/test_stack.js
@@ -1,0 +1,123 @@
+// @flow
+
+import * as React from 'react';
+import {
+  createStackNavigator,
+  type NavigationProp,
+  type StackNavigationProp,
+  type LeafRoute,
+  type StackNavigationState,
+  type StackOptions,
+  type StackNavigationEventMap,
+} from '@react-navigation/stack';
+
+/**
+ * Navigator setup
+ */
+
+type LocalParamList = {|
+  One: {| hey: string |},
+  Two: void,
+  Three: ?{| sup: number |},
+|};
+
+type GlobalParamList = {|
+  ...LocalParamList,
+  Another: void,
+|};
+
+type NavProp<
+  RouteName: $Keys<LocalParamList> = $Keys<LocalParamList>,
+> = StackNavigationProp<GlobalParamList, RouteName>;
+type NavRoute<
+  RouteName: $Keys<LocalParamList> = $Keys<LocalParamList>,
+> = {|
+  ...LeafRoute<RouteName>,
+  +params: $ElementType<LocalParamList, RouteName>,
+|};
+
+const Stack = createStackNavigator<
+  GlobalParamList,
+  LocalParamList,
+  NavProp<>,
+>();
+
+/**
+ * Screens
+ */
+
+function ValidScreen(props: {|
+  navigation: NavProp<'One'>,
+  route: NavRoute<'One'>,
+|}) {
+  props.navigation.navigate('Another');
+  // $ExpectError invalid params
+  props.navigation.navigate('Another', {});
+  // $ExpectError invalid route
+  props.navigation.navigate('test', { sup: true, yo: null });
+  props.navigation.push('One', { hey: 'sup' });
+  props.navigation.pop(5);
+  props.navigation.popToTop();
+  (props.navigation: NavigationProp<
+    GlobalParamList,
+    'One',
+    StackNavigationState,
+    StackOptions,
+    StackNavigationEventMap,
+  >);
+  return null;
+}
+
+function InvalidScreen(props: {|
+  navigation: NavProp<'One'>,
+  route: number,
+|}) {
+  props.navigation.setOptions({
+    title: 'sup',
+    headerTitle: 'ayyyy',
+    headerStatusBarHeight: 5,
+  });
+  // $ExpectError invalid navigator props
+  props.navigation.setOptions({ fake: 12 });
+  React.useEffect(() => {
+    return props.navigation.addListener(
+      'transitionStart',
+      e => {
+        (e.type: 'transitionStart');
+        // $ExpectError swipeStart doesn't support preventDefault
+        e.preventDefault();
+      },
+    );
+  });
+  return null;
+}
+
+<Stack.Screen name="One" component={ValidScreen} />;
+// $ExpectError non-matching component
+<Stack.Screen name="Two" component={ValidScreen} />;
+// $ExpectError invalid route name
+<Stack.Screen name="Four" component={ValidScreen} />;
+// $ExpectError invalid params
+<Stack.Screen name="One" component={ValidScreen} initialParams={{ hey: 5 }} />;
+// $ExpectError non-local route
+<Stack.Screen name="Another" component={ValidScreen} />;
+// $ExpectError invalid screen props
+<Stack.Screen name="One" component={InvalidScreen} />;
+
+/**
+ * Navigator
+ */
+
+<Stack.Navigator
+  mode="card"
+  headerMode="float"
+  keyboardHandlingEnabled={true}
+/>;
+// $ExpectError invalid navigator props
+<Stack.Navigator
+  // $ExpectError invalid navigator props
+  mode="FAKE"
+  headerMode="float"
+  keyboardHandlingEnabled={true}
+  someOtherProp="fake"
+/>;


### PR DESCRIPTION
React Nav 5 is a complete rewrite, so I went ahead and completely rewrote the types. A lot more stuff can now be typechecked!

Note that we now have seven different packages users can import from. To make contributing to the libdefs easier I've simplified them into just two sections. This means the libdefs are longer than they need to be sometimes, as Section 1 may have some types not necessarily for a given libdef.