### PR TITLE
Jest: add the done(Error) functionality

### DIFF
--- a/definitions/npm/jest_v24.x.x/flow_v0.104.x-/jest_v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.104.x-/jest_v24.x.x.js
@@ -921,7 +921,7 @@ type JestObjectType = {
 type JestSpyType = { calls: JestCallsType, ... };
 
 type JestDoneFn = {|
- (): void,
+ (error?: Error): void,
  fail: (error: Error) => void,
 |};
 

--- a/definitions/npm/jest_v24.x.x/flow_v0.104.x-/test_jest-v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.104.x-/test_jest-v24.x.x.js
@@ -212,6 +212,11 @@ test.skip('name', done => {
 });
 test('name', done => {
   done.fail(new Error('fail'));
+  // $ExpectError
+  done.fail();
+  done(new Error('fail'));
+  // $ExpectError
+  done("foo");
 });
 
 test.todo('');

--- a/definitions/npm/jest_v24.x.x/flow_v0.61.x-v0.103.x/jest_v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.61.x-v0.103.x/jest_v24.x.x.js
@@ -590,7 +590,6 @@ type SnapshotDiffType = {
     |},
     testName?: string
   ): void,
-  ...
 }
 
 interface JestExpectType {
@@ -965,7 +964,7 @@ type JestSpyType = {
 };
 
 type JestDoneFn = {|
-  (): void,
+  (error?: Error): void,
   fail: (error: Error) => void,
 |};
 

--- a/definitions/npm/jest_v24.x.x/flow_v0.61.x-v0.103.x/test_jest-v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.61.x-v0.103.x/test_jest-v24.x.x.js
@@ -211,6 +211,11 @@ test.skip('name', done => {
 });
 test('name', done => {
   done.fail(new Error('fail'));
+  // $ExpectError
+  done.fail();
+  done(new Error('fail'));
+  // $ExpectError
+  done("foo");
 });
 
 test.todo('');

--- a/definitions/npm/jest_v25.x.x/flow_v0.104.x-/jest_v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.104.x-/jest_v25.x.x.js
@@ -927,8 +927,8 @@ type JestObjectType = {
 type JestSpyType = { calls: JestCallsType, ... };
 
 type JestDoneFn = {|
- (): void,
- fail: (error: Error) => void,
+  (error?: Error): void,
+  fail: (error: Error) => void,
 |};
 
 /** Runs this function after every test inside this context */

--- a/definitions/npm/jest_v25.x.x/flow_v0.104.x-/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.104.x-/test_jest-v25.x.x.js
@@ -212,6 +212,11 @@ test.skip('name', done => {
 });
 test('name', done => {
   done.fail(new Error('fail'));
+  // $ExpectError
+  done.fail();
+  done(new Error('fail'));
+  // $ExpectError
+  done("foo");
 });
 
 test.todo('');

--- a/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/jest_v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/jest_v25.x.x.js
@@ -964,7 +964,7 @@ type JestSpyType = {
 };
 
 type JestDoneFn = {|
-  (): void,
+  (error?: Error): void,
   fail: (error: Error) => void,
 |};
 

--- a/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/test_jest-v25.x.x.js
@@ -211,6 +211,11 @@ test.skip('name', done => {
 });
 test('name', done => {
   done.fail(new Error('fail'));
+  // $ExpectError
+  done.fail();
+  done(new Error('fail'));
+  // $ExpectError
+  done("foo");
 });
 
 test.todo('');

--- a/definitions/npm/jest_v26.x.x/flow_v0.104.x-/jest_v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.104.x-/jest_v26.x.x.js
@@ -933,7 +933,7 @@ type JestObjectType = {
 type JestSpyType = { calls: JestCallsType, ... };
 
 type JestDoneFn = {|
-  (): void,
+  (error?: Error): void,
   fail: (error: Error) => void,
 |};
 

--- a/definitions/npm/jest_v26.x.x/flow_v0.104.x-/test_jest-v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.104.x-/test_jest-v26.x.x.js
@@ -217,6 +217,11 @@ test.skip('name', (done) => {
 });
 test('name', (done) => {
   done.fail(new Error('fail'));
+  // $ExpectError
+  done.fail();
+  done(new Error('fail'));
+  // $ExpectError
+  done("foo");
 });
 
 test.todo('');


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

Since Jest v21 it's possible to call `done` with an Error (implemented in https://github.com/facebook/jest/pull/4016). Before one had to do either `done()` or `done.fail(Error)`.

- Links to documentation: https://jestjs.io/docs/en/asynchronous#callbacks
- Type of contribution: addition & fix

Other notes:
* This is existing since Jest v21 but it was easier to do it only since Jest v24. If others need it they'll be able to change it by following the example.
* I also realized that the libdefs weren't working for some older flow versions, so I changed the directory names accordingly. Because that's from very old flow versions I didn't bother fixing that.
* `done.fail` isn't documented but I noticed it's supported by test cases there, so I decided to leave it. Also I didn't want to bring new errors to users for things that are working even if obscure.