### PR TITLE
Revert "update GetByBoundAttribute to accept generic (#3837)"

### DIFF
--- a/definitions/npm/@testing-library/react_v10.x.x/flow_v0.104.x-/react_v10.x.x.js
+++ b/definitions/npm/@testing-library/react_v10.x.x/flow_v0.104.x-/react_v10.x.x.js
@@ -51,10 +51,10 @@ declare module '@testing-library/react' {
     waitForElementOptions?: WaitForElementOptions
   ) => Promise<HTMLElement[]>;
 
-  declare type GetByBoundAttribute = <T: HTMLElement = HTMLElement>(
+  declare type GetByBoundAttribute = (
     text: TextMatch,
     options?: TextMatchOptions
-  ) => T;
+  ) => HTMLElement;
 
   declare type FindByBoundAttribute = (
     text: TextMatch,


### PR DESCRIPTION
This reverts commit 7ad57fc0955eb95b8529b295b7d2b6ae6a488b6d (https://github.com/flow-typed/flow-typed/pull/3837). 

Recommended by the flow-team to revert this PR as although this flow def does not throw any errors, if it were bolted onto the real function it would not be sound because you cannot know ahead of time what T is to be returned so it would error out.

### Try flow to showcase issue
https://flow.org/try/#0MYewdgzgLgBFCm0YF4YB4AqA+AFAQwCcBzASgC4YMUsYBvAKBiZgPigFcCwYByACwCWPANwwA9GJgAzADYgA7jD54IMMCBgCAJvDwx5y2FEGqIfEOxlaYAI3gwIGgbHgECIAqouw8M+XgBPCHoAXyA

