### PR TITLE
Avoid uncaught error when network fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ recent definitions into the cache for yourself.
 
 Creates `any`-typed libdef that you can fill in.
 
-If the `--typescript` flag was specified, TypeScript definition would be converted to flow-typed libdef format if possible.
+If the `--typescript` flag was set to `true`, TypeScript definition would be converted to flow-typed libdef format if possible.
 Please report any issues that you have encountered to [flowgen](https://github.com/joarwilk/flowgen/issues) repository.
 
 [flowgen](https://github.com/joarwilk/flowgen) supports most of the TypeScript syntax, however, in some cases manual changes may be needed before use.

--- a/cli/src/lib/stubUtils.js
+++ b/cli/src/lib/stubUtils.js
@@ -448,11 +448,21 @@ export async function createStub(
     }
 
     if (typescriptTypingsPath == null) {
-      const response = await getDefinitelyTypedPackage(
-        packageName,
-        explicitVersion,
-      );
-      typescriptTypingsContent = response.body;
+      try {
+        const response = await getDefinitelyTypedPackage(
+          packageName,
+          explicitVersion,
+        );
+        typescriptTypingsContent = response.body;
+      } catch (e) {
+        console.log(
+          colors.red("❌\t%s%s': %s"),
+          packageName,
+          version ? '@' + version : '',
+          e.message,
+        );
+        return false;
+      }
     }
   }
 


### PR DESCRIPTION
```
flow-typed create-stub ts-package package-not-in-definitely-typed --typescript
```

Will fail catastrophically with `UNCAUGHT ERROR: HTTPError: Response code 404 (Not Found)`