### PR TITLE
Fixed bluebird's Promise.all and Promise.resolve types

### DIFF
--- a/definitions/npm/bluebird_v3.x.x/flow_v0.104.x-/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.104.x-/bluebird_v3.x.x.js
@@ -56,9 +56,12 @@ declare class Bluebird$Promise<+R> extends Promise<R> {
   static Defer: Class<Bluebird$Defer>;
   static PromiseInspection: Class<Bluebird$PromiseInspection<*>>;
 
-  static all<T>(
-    Promises: $Promisable<Iterable<$Promisable<T>>>
-  ): Bluebird$Promise<Array<T>>;
+  static all<T: Iterable<mixed>>(promises: Promise<T>): Bluebird$Promise<
+    $TupleMap<T, <V>(p: Promise<V> | V) => V>
+  >;
+  static all<T: Iterable<mixed>>(promises: T): Bluebird$Promise<
+    $TupleMap<T, <V>(p: Promise<V> | V) => V>
+  >;
   static props(
     input: Object | Map<*, *> | $Promisable<Object | Map<*, *>>
   ): Bluebird$Promise<*>;
@@ -69,7 +72,9 @@ declare class Bluebird$Promise<+R> extends Promise<R> {
     Promises: Iterable<Elem> | $Promisable<Iterable<Elem>>
   ): Bluebird$Promise<T>;
   static reject<T>(error?: any): Bluebird$Promise<T>;
-  static resolve<T>(object?: $Promisable<T>): Bluebird$Promise<T>;
+  static resolve(): Bluebird$Promise<void>;
+  static resolve<T>(object: Promise<T>): Bluebird$Promise<T>;
+  static resolve<T>(object: T): Bluebird$Promise<T>;
   static some<T, Elem: $Promisable<T>>(
     Promises: Iterable<Elem> | $Promisable<Iterable<Elem>>,
     count: number

--- a/definitions/npm/bluebird_v3.x.x/flow_v0.104.x-/test_bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.104.x-/test_bluebird_v3.x.x.js
@@ -13,6 +13,8 @@ promise.reflect().then(inspection => {
 // $ExpectError
 new Bluebird();
 
+const emptyPromise: Promise<void> = Promise.resolve();
+
 Bluebird.all([
   new Bluebird(() => {}),
 ]);
@@ -47,6 +49,11 @@ Bluebird.resolve(response).then(function(responseBody: string) {
 
 Bluebird.all([1, Bluebird.resolve(1), Promise.resolve(1)]).then(function(r: Array<number>) { });
 Bluebird.all(['hello', Bluebird.resolve('world'), Promise.resolve('!')]).then(function(r: Array<string>) { });
+Bluebird.all(['hello', Bluebird.resolve('world'), Promise.resolve('!')]).then(function(r: [string, string, string]) { });
+
+// $ExpectError Wrong tuple type
+Bluebird.all(['hello', Bluebird.resolve('world'), Promise.resolve('!')]).then(function(r: [string, string, number]) { });
+Bluebird.all(['hello', Bluebird.resolve(3), Promise.resolve([1, 2, 3])]).then(function(r: [string, number, Array<number>]) { });
 
 Bluebird.join(1, Bluebird.resolve(2), function (a, b) { return a + b }).then(function (s) { return s + 1 })
 Bluebird.join(


### PR DESCRIPTION
1. Bluebird's `Promise.all` annotation was not inferring the correct type for tuples of promises. Switched to use `$TupleMap` so that the types are correctly inferred whether we use a tuple or an array as the argument. The type annotation is based off of JavaScript's builtin Promise.all annotation: https://github.com/facebook/flow/blob/v0.111.3/lib/core.js#L689
2. Bluebird's Promise.resolve was inferring `empty` as the generic type. Fixed by adding separate annotations for when `resolve` is called without any arguments.

Passes all tests with `quick_run_def_tests.sh`

Links to documentation: http://bluebirdjs.com/docs/api-reference.html
Link to GitHub or NPM: https://www.npmjs.com/package/bluebird
Type of contribution: fix