### PR TITLE
[ramda_v0.27.x] Rename then in favor of thenAnd

### DIFF
--- a/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/ramda_v0.27.x.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.104.x-/ramda_v0.27.x.js
@@ -539,8 +539,8 @@ declare module ramda {
     (<A, B>(ab: UnaryFn<A, B>) => UnaryFn<A, B>);
   declare var compose: Compose;
 
-  declare function then<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>): CurriedFunction1<Promise<A>, Promise<R>>
-  declare function then<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>, p: Promise<A>): Promise<R>;
+  declare function andThen<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>): CurriedFunction1<Promise<A>, Promise<R>>
+  declare function andThen<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>, p: Promise<A>): Promise<R>;
   declare var curry: Curry;
   declare function curryN<A, R>(
     length: number,

--- a/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/ramda_v0.27.x.js
+++ b/definitions/npm/ramda_v0.27.x/flow_v0.76.x-v0.103.x/ramda_v0.27.x.js
@@ -513,8 +513,8 @@ declare module ramda {
 
   declare var compose: Compose;
 
-  declare function then<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>): CurriedFunction1<Promise<A>, Promise<R>>
-  declare function then<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>, p: Promise<A>): Promise<R>;
+  declare function andThen<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>): CurriedFunction1<Promise<A>, Promise<R>>
+  declare function andThen<A, R>(onSuccess: UnaryFn<A, R> | UnaryPromiseFn<A, R>, p: Promise<A>): Promise<R>;
   declare var curry: Curry;
   declare function curryN(
     length: number,


### PR DESCRIPTION
- Links to documentation: https://ramdajs.com/docs/#andThen
- Link to GitHub or NPM: https://github.com/ramda/ramda/issues/2978
- Type of contribution: fix

Other notes:

- andThen: https://github.com/ramda/ramda/blob/v0.27.0/source/andThen.js
- then: https://github.com/ramda/ramda/blob/v0.26.1/source/then.js