### PR TITLE
Minor fix to Bluebird's emptyPromise test

### DIFF
--- a/definitions/npm/bluebird_v3.x.x/flow_v0.104.x-/test_bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.104.x-/test_bluebird_v3.x.x.js
@@ -13,7 +13,7 @@ promise.reflect().then(inspection => {
 // $ExpectError
 new Bluebird();
 
-const emptyPromise: Promise<void> = Promise.resolve();
+const emptyPromise: Bluebird<void> = Bluebird.resolve();
 
 Bluebird.all([
   new Bluebird(() => {}),


### PR DESCRIPTION
Bluebird's emptyPromise test was previously testing the core Promise type instead of the Bluebird type. This is a fix for @pascalduez's comment on https://github.com/flow-typed/flow-typed/pull/3854

- Links to documentation: http://bluebirdjs.com/docs/api-reference.html
- Link to GitHub or NPM: https://www.npmjs.com/package/bluebird
- Type of contribution: fix
