### PR TITLE
A better fix for the semver issues

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -37,7 +37,7 @@
     "mkdirp": "^1.0.3",
     "prettier": "^1.19.1",
     "rimraf": "^3.0.2",
-    "semver": "^7.1.3",
+    "semver": "^7.3.2",
     "table": "^5.4.6",
     "through": "^2.3.8",
     "unzipper": "^0.10.8",

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -321,12 +321,7 @@ async function installNpmLibDefs({
       } else {
         libDefsToInstall.set(name, libDef);
 
-        // Fix for Semver updates not able to handle versions 'v0.x.x'
-        const libDefVersion =
-          libDef.version === 'v0.x.x' ? 'v0.0.0' : libDef.version;
-        // If the libdef is outdated (but still compatible), note this so we can
-        // warn the user
-        const libDefLower = getRangeLowerBound(libDefVersion);
+        const libDefLower = getRangeLowerBound(libDef.version);
         const depLower = getRangeLowerBound(ver);
         if (semver.lt(libDefLower, depLower)) {
           outdatedLibDefsToInstall.push([libDef, {name, ver}]);

--- a/cli/src/lib/__tests__/semver-test.js
+++ b/cli/src/lib/__tests__/semver-test.js
@@ -1,6 +1,7 @@
 // @flow
 
-import {stringToVersion} from '../semver.js';
+import {stringToVersion, getRangeLowerBound} from '../semver.js';
+import {Range} from 'semver';
 
 describe('semver', () => {
   describe('stringToVersion', () => {
@@ -41,6 +42,18 @@ describe('semver', () => {
         minor: 2,
         patch: 'x',
       });
+    });
+  });
+  describe('getRangeLowerBound', () => {
+    it('gets correct lower bound for string', () => {
+      expect(getRangeLowerBound('v1.2.x')).toEqual('1.2.0');
+      expect(getRangeLowerBound('v1.x.x')).toEqual('1.0.0');
+      expect(getRangeLowerBound('^v0.x.x')).toEqual('0.0.0');
+    });
+    it('gets correct lower bound for string', () => {
+      expect(getRangeLowerBound(new Range('v1.2.x'))).toEqual('1.2.0');
+      expect(getRangeLowerBound(new Range('v1.x.x'))).toEqual('1.0.0');
+      expect(getRangeLowerBound(new Range('^v0.x.x'))).toEqual('0.0.0');
     });
   });
 });

--- a/cli/src/lib/semver.js
+++ b/cli/src/lib/semver.js
@@ -25,7 +25,8 @@ export function emptyVersion(): Version {
 export function getRangeLowerBound(rangeRaw: string | semver.Range): string {
   const range =
     typeof rangeRaw === 'string' ? new semver.Range(rangeRaw) : rangeRaw;
-  return range.set[0][0].semver.version;
+  // Fix for semver returning a bad comparator when the range is 'v0.x.x'
+  return range.set[0][0].semver.version || '0.0.0';
 }
 
 export function getRangeUpperBound(rangeRaw: string | semver.Range): string {

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -4506,10 +4506,15 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.1.1, semver@^7.1.3:
+semver@^7.1.1:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
   integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==
+
+semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://nexus.msuccess.org/repository/npm-group/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 set-blocking@^2.0.0:
   version "2.0.0"

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -4513,7 +4513,7 @@ semver@^7.1.1:
 
 semver@^7.3.2:
   version "7.3.2"
-  resolved "https://nexus.msuccess.org/repository/npm-group/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 set-blocking@^2.0.0:


### PR DESCRIPTION
Better fix for #3809 

- added fix in `src/lib/semver.js`
- upgraded semver version in package.json/yarn.lock: when installing `flow-typed` with npm/yarn, the newer version of semver is installed
- added tests for semver issue
- removed prior poor fix in `src/commands/install.js` in favor of a fix in `src/lib/semver.js`