### PR TITLE
Update @sentry/browser flow types for 5.18

### DIFF
--- a/definitions/npm/@sentry/browser_v5.x.x/flow_v0.90.x-/browser_v5.x.x.js
+++ b/definitions/npm/@sentry/browser_v5.x.x/flow_v0.90.x-/browser_v5.x.x.js
@@ -394,8 +394,8 @@ declare module '@sentry/browser' {
             hint?: EventHint,
         ) => Promise<SentryEvent | null> | SentryEvent | null,
 
-        +blacklistUrls?: $ReadOnlyArray<string | RegExp>,
-        +whitelistUrls?: $ReadOnlyArray<string | RegExp>,
+        +denyUrls?: $ReadOnlyArray<string | RegExp>,
+        +allowUrls?: $ReadOnlyArray<string | RegExp>,
         // This really should be typed as:
         //    | $ReadOnlyArray<Integration<any>>
         //    | (($ReadOnlyArray<Integration<any>>) => $ReadOnlyArray<Integration<any>>)


### PR DESCRIPTION
Per the change below, Sentry has renamed their props to allowUrls and denyUrls to use inclusive language. Update flow typedef to respect that:

- Links to documentation: https://docs.sentry.io/platforms/javascript/
- Link to GitHub or NPM: https://github.com/getsentry/sentry-javascript/commit/1204302906bbe74edc8a18f8ded047b3041059d7
- Type of contribution: fix

Other notes:
Thanks for the ongoing work :)
