### PR TITLE
@sentry/browser: Re-add deprecated props still usable in 5.x.x

### DIFF
--- a/definitions/npm/@sentry/browser_v5.x.x/flow_v0.90.x-/browser_v5.x.x.js
+++ b/definitions/npm/@sentry/browser_v5.x.x/flow_v0.90.x-/browser_v5.x.x.js
@@ -396,6 +396,9 @@ declare module '@sentry/browser' {
 
         +denyUrls?: $ReadOnlyArray<string | RegExp>,
         +allowUrls?: $ReadOnlyArray<string | RegExp>,
+        // Deprecated as of 5.18.0, prefer the allowUrls/denyUrls instead
+        +blacklistUrls?: $ReadOnlyArray<string | RegExp>,
+        +whitelistUrls?: $ReadOnlyArray<string | RegExp>,
         // This really should be typed as:
         //    | $ReadOnlyArray<Integration<any>>
         //    | (($ReadOnlyArray<Integration<any>>) => $ReadOnlyArray<Integration<any>>)


### PR DESCRIPTION
See discussion in #3869. Although the older props are deprecated, they will still work so should be re-added.

Links to documentation: https://docs.sentry.io/platforms/javascript/
Link to GitHub or NPM: https://github.com/getsentry/sentry-javascript/commit/1204302906bbe74edc8a18f8ded047b3041059d7
Type of contribution: fix
