### PR TITLE
Update luxon_v1.x.x.js

### DIFF
--- a/definitions/npm/luxon_v1.x.x/flow_v0.104.x-/luxon_v1.x.x.js
+++ b/definitions/npm/luxon_v1.x.x/flow_v0.104.x-/luxon_v1.x.x.js
@@ -272,6 +272,7 @@ declare module "luxon" {
       DurationConfig;
     toObject(options?: {| includeConfig?: boolean |}): DurationObject;
     toString(): string;
+    valueOf(): number;
   }
 
   declare type DateTimeFromOptions = {|

--- a/definitions/npm/luxon_v1.x.x/flow_v0.104.x-/test_luxon.js
+++ b/definitions/npm/luxon_v1.x.x/flow_v0.104.x-/test_luxon.js
@@ -780,6 +780,7 @@ dur.toObject({ includeConfig: false }).numberingSystem;
 dur.toObject({ includeConfig: false }).conversionAccuracy;
 
 (dur.toString(): string);
+(dur.valueOf(): number);
 
 (Interval.after(DateTime.utc(), Duration.fromObject({ year: 1 })): Interval);
 (Interval.after(DateTime.utc(), { year: 1 }): Interval);


### PR DESCRIPTION
An important method was missing. It is necessary to compare Durations.

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://moment.github.io/luxon/docs/class/src/duration.js~Duration.html#instance-method-valueOf
- Link to GitHub or NPM: 
- Type of contribution: addition
Other notes:

