### PR TITLE
Improve `classnames` types

### DIFF
--- a/definitions/npm/classnames_v2.x.x/flow_v0.104.x-/classnames_v2.x.x.js
+++ b/definitions/npm/classnames_v2.x.x/flow_v0.104.x-/classnames_v2.x.x.js
@@ -1,14 +1,14 @@
 type $npm$classnames$Classes =
   | string
+  | number
   | { [className: string]: *, ... }
-  | false
+  | boolean
   | void
-  | null;
+  | null
+  | $ReadOnlyArray<$npm$classnames$Classes>;
 
 declare module "classnames" {
-  declare module.exports: (
-    ...classes: Array<$npm$classnames$Classes | $npm$classnames$Classes[]>
-  ) => string;
+  declare module.exports: (...classes: Array<$npm$classnames$Classes>) => string;
 }
 
 declare module "classnames/bind" {

--- a/definitions/npm/classnames_v2.x.x/test_classnames_v2.x.x.js
+++ b/definitions/npm/classnames_v2.x.x/test_classnames_v2.x.x.js
@@ -14,10 +14,9 @@ classnames({ a: true }, "b");
 classnames({ a: null, b: undefined });
 classnames(undefined);
 classnames(null);
+classnames(true);
+classnames(123);
 classnames("a", false);
 classnames("a", ["b", null, { c: "truthy", d: null }]);
-
-// $FlowExpectedError
-classnames(42);
-// $FlowExpectedError
-classnames("a", ["b", 42]);
+classnames((["a", "b"]: $ReadOnlyArray<string>));
+classnames(['a', ['b', ['c', ['d']]]]);


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/JedWatson/classnames
- TypeScript types: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/classnames/types.d.ts
- Type of contribution: fix

Other notes:
- It accepts a nested array of the same types
- It accepts numbers and `true` as well
- It should accept `$ReadOnlyArray`s instead of just `Array`s, since the
  values are not modified.

I had to remove the `$FlowExpectError`s now because basically everything
is accepted.
