### PR TITLE
Fix the type of 'cache' prop for 'react-select_v1.x.x'

### DIFF
--- a/definitions/npm/react-select_v1.x.x/flow_v0.104.x-/react-select_v1.x.x.js
+++ b/definitions/npm/react-select_v1.x.x/flow_v0.104.x-/react-select_v1.x.x.js
@@ -170,7 +170,7 @@ declare module 'react-select' {
     wrapperStyle?: {...},
     isSearchable?: boolean,
     // whether to cache the search results
-    cache?: boolean
+    cache?: {...} | false
   |};
 
   declare type AsyncProps = {|

--- a/definitions/npm/react-select_v1.x.x/flow_v0.53.x-v0.103.x/react-select_v1.x.x.js
+++ b/definitions/npm/react-select_v1.x.x/flow_v0.53.x-v0.103.x/react-select_v1.x.x.js
@@ -172,7 +172,7 @@ declare module 'react-select' {
     wrapperStyle?: {},
     isSearchable?: boolean,
     // whether to cache the search results
-    cache?: boolean
+    cache?: {...} | false
   |};
 
   declare type AsyncProps = {|


### PR DESCRIPTION
I added the `cache` prop to `react-select` in another PR https://github.com/flow-typed/flow-typed/pull/3873 . However, the type was wrong. According to the documents, `cache` can be any object, or `false` to disable it.

Sorry for the previous mistake.

- Links to documentation: https://github.com/JedWatson/react-select/blob/v1.3.0/README.md?rgh-link-date=2020-08-04T04%3A11%3A08Z#L147
- Link to GitHub or NPM: https://github.com/JedWatson/react-select/blob/v1.3.0/src/Async.js?rgh-link-date=2020-08-04T04%3A11%3A08Z#L9
- Type of contribution: fix

