### PR TITLE
Move type import inside of declaration

### DIFF
--- a/definitions/npm/redux-observable_v0.14.x/flow_v0.104.x-/redux-observable_v0.14.x.js
+++ b/definitions/npm/redux-observable_v0.14.x/flow_v0.104.x-/redux-observable_v0.14.x.js
@@ -1,6 +1,5 @@
-import { Observable } from 'rxjs';
-
 declare module 'redux-observable' {
+  import type { Observable } from 'rxjs';
   import type { MiddlewareAPI, Dispatch } from 'redux';
 
   declare export type Epic<S, A, D> = (action$: ActionsObservable<A>, store: MiddlewareAPI<S, A>, dependencies: D) => Observable<A>;


### PR DESCRIPTION
Updating to flow 0.132 results in this being an error. I think moving it inside of the module and make it a type import would fix it right?