### PR TITLE
Allow function within styled(..) for styled-components v5

### DIFF
--- a/definitions/npm/styled-components_v5.x.x/flow_v0.104.x-/styled-components_v5.x.x.js
+++ b/definitions/npm/styled-components_v5.x.x/flow_v0.104.x-/styled-components_v5.x.x.js
@@ -27,10 +27,11 @@ declare module 'styled-components' {
     | Styles
     | Class<InterpolatableComponent<any>>; // eslint-disable-line flowtype/no-weak-types
 
-  declare export type TaggedTemplateLiteral<I, R> = (
-    strings: string[],
-    ...interpolations: Interpolation<I>[]
-  ) => R;
+  declare export type TaggedTemplateLiteral<I, R> = {
+    [[call]]: (strings: string[], ...interpolations: Interpolation<I>[]) => R,
+    [[call]]: ((props: I) => Interpolation<any>) => R,
+    ...
+  };
 
   // Should this be `mixed` perhaps?
   declare export type CSSRules = Interpolation<any>[]; // eslint-disable-line flowtype/no-weak-types

--- a/definitions/npm/styled-components_v5.x.x/flow_v0.104.x-/test_styled-components_v5.x.x.js
+++ b/definitions/npm/styled-components_v5.x.x/flow_v0.104.x-/test_styled-components_v5.x.x.js
@@ -200,6 +200,16 @@ describe('styled builtins', () => {
     // $FlowExpectedError
     const test3 = <AttrsInputExtra size="2em" type={1} />; // error
   });
+
+  it('should destructure a prop, as a function within styled(Component)', () => {
+    const Div = ({ ...rest }) => <div {...rest} />;
+
+    const StyledDiv: StyledComponent<{ color: string, ... }, *, *> = styled(Div)(({ color }) => `
+      color: ${color};
+    `);
+
+    const test = <StyledDiv color="#000">Test</StyledDiv>
+  })
 });
 
 // @NOTE: Not sure how to better test this


### PR DESCRIPTION
As described in https://github.com/flow-typed/flow-typed/issues/3880 it looks like the code which got added by @kyleknighted for the styled-components v4 interface (https://github.com/flow-typed/flow-typed/pull/3779) is not part of the v5 interface definition.

This PR reimplements the code for the v5 interface definition and adds a test for the related use case.
I also tried to add a test which includes `// $FlowExpectedError` but didn't find a suitable one.

There are still some other tests which fail when running `flow-typed run-tests styled-components_v5`, but they are not related to this change. I made sure the test is failing with the previous styled-component v5 interface definition.

Fixes: https://github.com/flow-typed/flow-typed/issues/3880