### PR TITLE
[yargs] Add showHelp(printCallback) overload

### DIFF
--- a/definitions/npm/yargs_v15.x.x/flow_v0.118.x-/yargs_v15.x.x.js
+++ b/definitions/npm/yargs_v15.x.x/flow_v0.118.x-/yargs_v15.x.x.js
@@ -260,6 +260,7 @@ declare module "yargs" {
     showCompletionScript(): this;
 
     showHelp(consoleLevel?: "error" | "warn" | "log"): this;
+    showHelp(printCallback: (usageData: string) => void): this;
 
     showHelpOnFail(enable: boolean, message?: string): this;
 


### PR DESCRIPTION
- Links to documentation: https://yargs.js.org/docs/#api-reference-showhelpconsolelevel-printcallback
- Type of contribution: fix
