### PR TITLE
[yargs_v15.x.x] Add demandCommand 0-arg overload

### DIFF
--- a/definitions/npm/yargs_v15.x.x/flow_v0.118.x-/yargs_v15.x.x.js
+++ b/definitions/npm/yargs_v15.x.x/flow_v0.118.x-/yargs_v15.x.x.js
@@ -150,6 +150,7 @@ declare module "yargs" {
 
     demandOption(key: string | Array<string>, msg?: string | boolean): this;
 
+    demandCommand(): this;
     demandCommand(min: number, minMsg?: string): this;
     demandCommand(
       min: number,


### PR DESCRIPTION
Adds a missing overload of [`demandCommand`](https://yargs.js.org/docs/#api-reference-demandcommandmin1-max-minmsg-maxmsg) to `yargs`.

- Links to documentation: https://yargs.js.org/docs/#api-reference-demandcommandmin1-max-minmsg-maxmsg
- Type of contribution: fix
