### PR TITLE
Include libdef for supertest v5 and fix the type for the retry function

### DIFF
--- a/definitions/npm/supertest_v4.x.x/flow_v0.94.x-/supertest_v4.x.x.js
+++ b/definitions/npm/supertest_v4.x.x/flow_v0.94.x-/supertest_v4.x.x.js
@@ -158,7 +158,7 @@ declare module 'supertest' {
     query(val: { ... } | string): this;
     redirects(n: number): this;
     responseType(type: string): this;
-    retry(count?: number, callback?: superagent$CallbackHandler): this;
+    retry(count?: number, callback?: (err: any, res: superagent$Response) => boolean | void): this;
     send(data?: string | { ... }): this;
     serialize(serializer: (any) => string): this;
     set(field: { ... }): this;

--- a/definitions/npm/supertest_v4.x.x/test_basic-functionality.js
+++ b/definitions/npm/supertest_v4.x.x/test_basic-functionality.js
@@ -136,9 +136,9 @@ describe('expectations', () => {
     await app.unsubscribe('/').expect(200);
 
     // check we're actually type checking using typos
-    // $FlowExpectedError
+    // $FlowExpectedError[prop-missing]
     await app.psot('/').expect(200);
-    // $FlowExpectedError
+    // $FlowExpectedError[prop-missing]
     await app.post('/').expct(200);
   });
 
@@ -169,21 +169,27 @@ describe('expectations', () => {
     (response.notFound: boolean);
     (response.notAcceptable: boolean);
     (response.unprocessableEntity: boolean);
+  });
 
+  it('actually checks types of response', async () => {
     // check we're actually type checking using typos
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
+    const response = await request(serverFunction)
+      .get('/user')
+      .expect(200);
+
     (response.tpye: string);
-  })
+  });
 
   it('there is a called boolean in the request', () => {
     let req = request(serverFunction).get('/user');
     (req.called: boolean);
-    // $FlowExpectedError
+    // $FlowExpectedError[prop-missing]
     req.foo;
 
     req = req.expect(200);
     (req.called: boolean);
-    // $FlowExpectedError
+    // $FlowExpectedError[prop-missing]
     req.foo;
   })
 });

--- a/definitions/npm/supertest_v4.x.x/test_basic-functionality.js
+++ b/definitions/npm/supertest_v4.x.x/test_basic-functionality.js
@@ -191,5 +191,33 @@ describe('expectations', () => {
     (req.called: boolean);
     // $FlowExpectedError[prop-missing]
     req.foo;
-  })
+  });
+
+  it('supports retrying requests', async () => {
+    await request(serverFunction)
+      .post('/')
+      .retry()
+      .expect(200);
+
+    await request(serverFunction)
+      .post('/')
+      .retry(2)
+      .expect(200);
+
+    await request(serverFunction)
+      .post('/')
+      .retry(2, (err, res) => {
+        if (res.statusCode === 404) {
+          return true;
+        }
+        return false;
+      })
+      .expect(200);
+
+    await request(serverFunction)
+      .post('/')
+      // $FlowExpectedError[incompatible-call]
+      .retry(1, (err, res) => "foo")
+      .expect(200);
+  });
 });

--- a/definitions/npm/supertest_v5.x.x/flow_v0.94.x-/supertest_v5.x.x.js
+++ b/definitions/npm/supertest_v5.x.x/flow_v0.94.x-/supertest_v5.x.x.js
@@ -1,0 +1,283 @@
+declare module 'supertest' {
+  import type { IncomingMessage, ServerResponse } from 'http';
+  import type { ReadStream as fs$ReadStream } from 'fs';
+
+  // ----- Types from superagent -----
+  declare type superagent$ResponseError = {|
+    status: number,
+    text: string,
+    method: string,
+    path: string,
+  |} & Error;
+
+  declare type superagent$Response = {|
+    text?: string, // Present for text/json/urlencoded answers.
+    body: any,
+    type: string,
+    xhr: XMLHttpRequest,
+    redirects: string[],
+
+    charset?: string, // This is decoded from the content-type
+    error: superagent$ResponseError | false,
+    files: any,
+    get(header: string): string,
+    get(header: 'Set-Cookie'): string[],
+    headers: {| [key: string]: string |},
+    header: {| [key: string]: string |},
+
+    links: {| [key: string]: string |},
+
+    // status numbers
+    status: number,
+    statusCode: number,
+    statusType: 1 | 2 | 3 | 4 | 5,
+
+    // Status boolean
+    info: boolean, // 1xx
+    ok: boolean, // 2xx
+    redirect: boolean, // 3xx
+    clientError: boolean, // 4xx
+    serverError: boolean, // 5xx
+
+    created: boolean, // 201
+    accepted: boolean, // 202
+    noContent: boolean, // 204
+    badRequest: boolean, // 400
+    unauthorized: boolean, // 401
+    forbidden: boolean, // 403
+    notFound: boolean, // 404
+    notAcceptable: boolean, // 406
+    unprocessableEntity: boolean, // 422
+  |} & stream$Readable;
+
+  declare type MultipartValueSingle =
+    | Blob
+    | Buffer
+    | fs$ReadStream
+    | string
+    | boolean
+    | number;
+
+  declare type MultipartValue = MultipartValueSingle | MultipartValueSingle[];
+
+  declare type superagent$CallbackHandler = (
+    err: any,
+    res: superagent$Response
+  ) => mixed;
+
+  declare type superagent$BrowserParser = (str: string) => mixed;
+  declare type superagent$NodeParser = (
+    res: superagent$Response,
+    callback: (err: Error | null, body: any) => void
+  ) => void;
+  declare type superagent$Parser =
+    | superagent$BrowserParser
+    | superagent$NodeParser;
+
+  // We declare only the event emitted from node. The one in the browser is
+  // quite different.
+  declare type superagent$ProgressEvent = {|
+    direction: 'upload',
+    loaded: number,
+    lengthComputable: true,
+    total: number,
+  |};
+
+  // Note: superagent$Request should inherit from both a Promise and a node
+  // Stream, but I don't know how to do it with Flow... I decided to use the
+  // Promise because it's likely more useful.
+  declare class superagent$Request extends Promise<superagent$Response> {
+    called: boolean;
+
+    abort(): void;
+    accept(type: string): this;
+    attach(
+      field: string,
+      file: MultipartValueSingle,
+      options?:
+        | string
+        | {|
+            filename: string,
+            contentType?: string,
+          |}
+    ): this;
+    auth(
+      user: string,
+      pass: string,
+      options?: {|
+        type: 'basic' | 'auto', // "auto" isn't available in node
+      |}
+    ): this;
+    auth(
+      token: string,
+      options: {|
+        type: 'bearer',
+      |}
+    ): this;
+    buffer(val?: boolean): this;
+    ca(cert: string | string[] | Buffer | Buffer[]): this;
+    cert(cert: string | string[] | Buffer | Buffer[]): this;
+    clearTimeout(): this;
+    // Removing it here because it's overriden below in supertest, and Flow
+    // doesn't let the override work because the return value is different.
+    // end(callback?: superagent$CallbackHandler): void;
+    field(name: string, val: MultipartValue): this;
+    field(fields: {|
+      [fieldName: string]: MultipartValue,
+    |}): this;
+    get(field: string): string;
+    key(cert: string | string[] | Buffer | Buffer[]): this;
+    ok(callback: (res: superagent$Response) => boolean): this;
+    on(name: 'error', handler: (err: any) => void): this;
+    on(
+      name: 'progress',
+      handler: (event: superagent$ProgressEvent) => void
+    ): this;
+    on(
+      name: 'response',
+      handler: (response: superagent$Response) => void
+    ): this;
+    on(name: string, handler: (event: any) => void): this;
+    parse(parser: superagent$Parser): this;
+    part(): this;
+    pfx(
+      cert:
+        | string
+        | string[]
+        | Buffer
+        | Buffer[]
+        | {|
+            pfx: string | Buffer,
+            passphrase: string,
+          |}
+    ): this;
+    pipe(
+      stream: stream$Writable,
+      options?: {| end: boolean |}
+    ): stream$Writable;
+    query(val: { ... } | string): this;
+    redirects(n: number): this;
+    responseType(type: string): this;
+    retry(count?: number, callback?: (err: any, res: superagent$Response) => boolean | void): this;
+    send(data?: string | { ... }): this;
+    serialize(serializer: (any) => string): this;
+    set(field: { ... }): this;
+    set(field: string, val: string): this;
+    set(field: 'Cookie', val: string[]): this;
+    timeout(
+      ms:
+        | number
+        | {|
+            deadline?: number,
+            response?: number,
+          |}
+    ): this;
+    type(val: string): this;
+    unset(field: string): this;
+    // use(fn: request$Plugin): this; TODO No support for plugins
+    withCredentials(): this;
+    write(data: string | Buffer, encoding?: string): this;
+    maxResponseSize(size: number): this;
+  }
+
+  // ----- Types from supertest -----
+  declare type supertest$RequestFunction = (url: string) => supertest$Test;
+
+  // Possible HTTP requests.
+  declare type supertest$Request = {|
+    acl: supertest$RequestFunction,
+    bind: supertest$RequestFunction,
+    checkout: supertest$RequestFunction,
+    connect: supertest$RequestFunction,
+    copy: supertest$RequestFunction,
+    delete: supertest$RequestFunction,
+    del: supertest$RequestFunction,
+    get: supertest$RequestFunction,
+    head: supertest$RequestFunction,
+    link: supertest$RequestFunction,
+    lock: supertest$RequestFunction,
+    'm-search': supertest$RequestFunction,
+    merge: supertest$RequestFunction,
+    mkactivity: supertest$RequestFunction,
+    mkcalendar: supertest$RequestFunction,
+    mkcol: supertest$RequestFunction,
+    move: supertest$RequestFunction,
+    notify: supertest$RequestFunction,
+    options: supertest$RequestFunction,
+    patch: supertest$RequestFunction,
+    post: supertest$RequestFunction,
+    propfind: supertest$RequestFunction,
+    proppatch: supertest$RequestFunction,
+    purge: supertest$RequestFunction,
+    put: supertest$RequestFunction,
+    rebind: supertest$RequestFunction,
+    report: supertest$RequestFunction,
+    search: supertest$RequestFunction,
+    source: supertest$RequestFunction,
+    subscribe: supertest$RequestFunction,
+    trace: supertest$RequestFunction,
+    unbind: supertest$RequestFunction,
+    unlink: supertest$RequestFunction,
+    unlock: supertest$RequestFunction,
+    unsubscribe: supertest$RequestFunction,
+  |};
+
+  declare type supertest$BodyAssertion = RegExp | string | { ... };
+
+  declare class supertest$Test extends superagent$Request {
+    constructor(
+      app: http$Server | string,
+      method: string,
+      path: string,
+      host?: string
+    ): this;
+    app: http$Server | string;
+    url: string;
+
+    // ASSERTIONS
+
+    // Queue a status assertion
+    expect(status: number, callback?: superagent$CallbackHandler): this;
+
+    // Queue a status and body assertion
+    expect(
+      status: number,
+      body: supertest$BodyAssertion,
+      callback?: superagent$CallbackHandler
+    ): this;
+
+    // Queue a body assertion
+    expect(
+      body: supertest$BodyAssertion,
+      callback?: superagent$CallbackHandler
+    ): this;
+
+    // Queue a header assertion
+    expect(
+      field: string,
+      val: string | number | RegExp,
+      callback?: superagent$CallbackHandler
+    ): this;
+
+    // Queue a generic assertion
+    // Note: it should appear after all other `expect` shapes because otherwise
+    // Flow has problems selecting the right form.
+    expect(checker: (res: superagent$Response) => mixed): this;
+
+    // Run the queued assertions
+    end(callback?: superagent$CallbackHandler): this;
+  }
+
+  // Accepted arguments to the supertest function.
+  declare type supertest$Server =
+    | string
+    | http$Server
+    | (<I: IncomingMessage, R: ServerResponse>(I, R) => void);
+
+  declare module.exports: {|
+    (server: supertest$Server): supertest$Request,
+    Test: supertest$Test,
+    // TODO implement a proper supertest$agent
+    agent: any,
+  |};
+}

--- a/definitions/npm/supertest_v5.x.x/test_basic-functionality.js
+++ b/definitions/npm/supertest_v5.x.x/test_basic-functionality.js
@@ -1,0 +1,223 @@
+import { describe, it } from 'flow-typed-test';
+import { createServer } from 'http';
+import assert from 'assert';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+import request from 'supertest';
+
+describe('expectations', () => {
+  declare function serverFunction(req: IncomingMessage, res: ServerResponse): void;
+
+  it('works with get method', async () => {
+    await request(serverFunction).get('/').expect(200);
+    await request(createServer(serverFunction)).get('/').expect(200);
+
+    request(serverFunction)
+      .get('/user')
+      .auth('username', 'password')
+      .expect('Content-Type', /json/)
+      .expect('Content-Length', '15')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) throw err;
+      });
+  });
+
+  it('accepts various authentication styles', async () => {
+    await request(serverFunction)
+      .get('/user')
+      .auth('username', 'password')
+      .expect(200);
+    await request(serverFunction)
+      .get('/user')
+      .auth('token', { type: 'bearer' })
+      .expect(200, 'body string');
+  });
+
+  it('works with callback-style test runners', (done) => {
+    request(serverFunction)
+      .get('/user')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200, done);
+    request(serverFunction)
+      .get('/user')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200, /some body/, done);
+  });
+
+  it('works with the post method', async () => {
+    await request(serverFunction)
+      .post('/users')
+      .send({name: 'john'})
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200);
+  });
+
+  it('works with promises-style test runner', (): Promise<any> => {
+    return request(serverFunction)
+      .get('/users')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then(response => {
+        assert(response.body.email, 'foo@bar.com');
+        (response.type: string);
+      })
+  });
+
+  it('works with a function expectation', async () => {
+    await request(serverFunction)
+      .post('/user')
+      .send('name=john') // x-www-form-urlencoded upload
+      .set('Accept', 'application/json')
+      .expect(function(res) {
+        res.body.id = 'some fixed id';
+        res.body.name = res.body.name.toLowerCase();
+      })
+      .expect(200, {
+        id: 'some fixed id',
+        name: 'john'
+      });
+  });
+
+  it('supports testing multipart upload', async () => {
+    await request(serverFunction)
+      .post('/')
+      .field('name', 'my awesome avatar')
+      .attach('avatar', 'test/fixtures/avatar.jpg')
+      .expect(200);
+  });
+
+  it('supports query strings', async () => {
+    await request(serverFunction)
+      .get('/')
+      .query({ foo: 'bar' });
+  });
+
+  it('supports more methods', async () => {
+    const app = request(serverFunction);
+    await app.acl('/').expect(200);
+    await app.bind('/').expect(200);
+    await app.checkout('/').expect(200);
+    await app.connect('/').expect(200);
+    await app.copy('/').expect(200);
+    await app.delete('/').expect(200);
+    await app.del('/').expect(200);
+    await app.get('/').expect(200);
+    await app.head('/').expect(200);
+    await app.link('/').expect(200);
+    await app.lock('/').expect(200);
+    await app['m-search']('/').expect(200);
+    await app.merge('/').expect(200);
+    await app.mkactivity('/').expect(200);
+    await app.mkcalendar('/').expect(200);
+    await app.mkcol('/').expect(200);
+    await app.move('/').expect(200);
+    await app.notify('/').expect(200);
+    await app.options('/').expect(200);
+    await app.patch('/').expect(200);
+    await app.post('/').expect(200);
+    await app.propfind('/').expect(200);
+    await app.proppatch('/').expect(200);
+    await app.purge('/').expect(200);
+    await app.put('/').expect(200);
+    await app.rebind('/').expect(200);
+    await app.report('/').expect(200);
+    await app.search('/').expect(200);
+    await app.source('/').expect(200);
+    await app.subscribe('/').expect(200);
+    await app.trace('/').expect(200);
+    await app.unbind('/').expect(200);
+    await app.unlink('/').expect(200);
+    await app.unlock('/').expect(200);
+    await app.unsubscribe('/').expect(200);
+
+    // check we're actually type checking using typos
+    // $FlowExpectedError[prop-missing]
+    await app.psot('/').expect(200);
+    // $FlowExpectedError[prop-missing]
+    await app.post('/').expct(200);
+  });
+
+  it('returns a proper response', async () => {
+    const response = await request(serverFunction)
+      .get('/user')
+      .expect(200);
+
+    (response.text: string | void);
+    (response.type: string);
+    (response.charset: string | void);
+    (response.status: number);
+    (response.statusCode: number);
+    (response.headers['Content-Length']: string);
+
+    // errors
+    (response.ok: boolean);
+    (response.redirect: boolean);
+    (response.info: boolean);
+    (response.clientError: boolean);
+    (response.serverError: boolean);
+    (response.created: boolean);
+    (response.accepted: boolean);
+    (response.noContent: boolean);
+    (response.badRequest: boolean);
+    (response.unauthorized: boolean);
+    (response.forbidden: boolean);
+    (response.notFound: boolean);
+    (response.notAcceptable: boolean);
+    (response.unprocessableEntity: boolean);
+  });
+
+  it('actually checks types of response', async () => {
+    // check we're actually type checking using typos
+    // $FlowExpectedError[incompatible-call]
+    const response = await request(serverFunction)
+      .get('/user')
+      .expect(200);
+
+    (response.tpye: string);
+  });
+
+  it('there is a called boolean in the request', () => {
+    let req = request(serverFunction).get('/user');
+    (req.called: boolean);
+    // $FlowExpectedError[prop-missing]
+    req.foo;
+
+    req = req.expect(200);
+    (req.called: boolean);
+    // $FlowExpectedError[prop-missing]
+    req.foo;
+  });
+
+  it('supports retrying requests', async () => {
+    await request(serverFunction)
+      .post('/')
+      .retry()
+      .expect(200);
+
+    await request(serverFunction)
+      .post('/')
+      .retry(2)
+      .expect(200);
+
+    await request(serverFunction)
+      .post('/')
+      .retry(2, (err, res) => {
+        if (res.statusCode === 404) {
+          return true;
+        }
+        return false;
+      })
+      .expect(200);
+
+    await request(serverFunction)
+      .post('/')
+      // $FlowExpectedError[incompatible-call]
+      .retry(1, (err, res) => "foo")
+      .expect(200);
+  });
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/visionmedia/supertest and https://visionmedia.github.io/superagent/#retrying-requests
- Link to GitHub or NPM: https://github.com/visionmedia/supertest and https://github.com/visionmedia/superagent
- Type of contribution: new definition and fix

Other notes:
There's no API change between v4 and v5, so I first fixed the issue in v4, and then copied everything over to a new v5 libdef.
