### PR TITLE
[webpack_v4.x.x] Add infrastructure logging options

### DIFF
--- a/definitions/npm/webpack_v4.x.x/flow_v0.104.x-/test_webpack_v4.x.x.js
+++ b/definitions/npm/webpack_v4.x.x/flow_v0.104.x-/test_webpack_v4.x.x.js
@@ -6,6 +6,10 @@ const options: WebpackOptions = {
   devServer: {
     compress: true
   },
+  infrastructureLogging: {
+    level: 'info',
+    debug: ['MyPlugin', /MyPlugin/, (name) => name.includes('MyPlugin')],
+  },
   output: {
     filename: '[name].bundle.js',
   },

--- a/definitions/npm/webpack_v4.x.x/flow_v0.104.x-/webpack_v4.x.x.js
+++ b/definitions/npm/webpack_v4.x.x/flow_v0.104.x-/webpack_v4.x.x.js
@@ -569,6 +569,14 @@ declare module 'webpack' {
       | false,
     entry?: Entry,
     externals?: Externals,
+    infrastructureLogging?: {|
+      level?: 'none' | 'error' | 'warn' | 'info' | 'log' | 'verbose',
+      debug?:
+        | string
+        | RegExp
+        | ((string) => boolean)
+        | Array<string | RegExp | ((string) => boolean)>,
+    |},
     loader?: { [k: string]: any, ... },
     mode?: 'development' | 'production' | 'none',
     module?: ModuleOptions,


### PR DESCRIPTION
Adds missing infrastructure-level logging options.

- Links to documentation: https://v4.webpack.js.org/configuration/other-options/#infrastructurelogging
- Link to GitHub or NPM: https://github.com/webpack/webpack
- Type of contribution: addition
