### PR TITLE
Adding calledOnceWithExactly to definition

### DIFF
--- a/definitions/npm/sinon_v7.x.x/flow_v0.80.x-/sinon_v7.x.x.js
+++ b/definitions/npm/sinon_v7.x.x/flow_v0.80.x-/sinon_v7.x.x.js
@@ -105,6 +105,7 @@ declare module 'sinon' {
     (...args: Array<any>): any;
     withArgs(...args: Array<any>): SinonSpy;
     invokeCallback(...args: Array<any>): void;
+    calledOnceWithExactly(...args: Array<any>): boolean;
   }
 
   declare interface SinonSpyStatic {

--- a/definitions/npm/sinon_v7.x.x/test_sinon_v7.x.x.js
+++ b/definitions/npm/sinon_v7.x.x/test_sinon_v7.x.x.js
@@ -203,6 +203,7 @@ function testSpy() {
   sinon.spy().calledBefore(otherSpy);
   sinon.spy().calledImmediatelyAfter(otherSpy);
   sinon.spy().calledImmediatelyBefore(otherSpy);
+  sinon.spy().calledOnceWithExactly('foo');
 }
 
 testOne();


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: See calledOnceWithExactly at [sinon docs](https://sinonjs.org/releases/latest/spies/)
- Link to GitHub or NPM: [Parcel](https://github.com/parcel-bundler/parcel)
- Type of contribution: new definition | __addition__ | fix | refactor


Other notes:  added test in `test_sinon_v7.x.x.js`

Need this change in order to use definition within Parcel
