### PR TITLE
Add last arg to spy call -[FIX]

### DIFF
--- a/definitions/npm/sinon_v7.x.x/flow_v0.80.x-/sinon_v7.x.x.js
+++ b/definitions/npm/sinon_v7.x.x/flow_v0.80.x-/sinon_v7.x.x.js
@@ -98,7 +98,7 @@ declare module 'sinon' {
     calledBefore(call: SinonSpyCall): boolean;
     calledAfter(call: SinonSpyCall): boolean;
     calledWithNew(call: SinonSpyCall): boolean;
-    lastArg(): SinonSpyCall;
+    lastArg: SinonSpyCall;
   }
 
   declare interface SinonSpy extends SinonSpyCallApi, SinonFake {

--- a/definitions/npm/sinon_v7.x.x/flow_v0.80.x-/sinon_v7.x.x.js
+++ b/definitions/npm/sinon_v7.x.x/flow_v0.80.x-/sinon_v7.x.x.js
@@ -98,6 +98,7 @@ declare module 'sinon' {
     calledBefore(call: SinonSpyCall): boolean;
     calledAfter(call: SinonSpyCall): boolean;
     calledWithNew(call: SinonSpyCall): boolean;
+    lastArg(): SinonSpyCall;
   }
 
   declare interface SinonSpy extends SinonSpyCallApi, SinonFake {

--- a/definitions/npm/sinon_v7.x.x/flow_v0.80.x-/sinon_v7.x.x.js
+++ b/definitions/npm/sinon_v7.x.x/flow_v0.80.x-/sinon_v7.x.x.js
@@ -98,7 +98,7 @@ declare module 'sinon' {
     calledBefore(call: SinonSpyCall): boolean;
     calledAfter(call: SinonSpyCall): boolean;
     calledWithNew(call: SinonSpyCall): boolean;
-    lastArg: SinonSpyCall;
+    lastArg: mixed;
   }
 
   declare interface SinonSpy extends SinonSpyCallApi, SinonFake {
@@ -245,12 +245,12 @@ declare module 'sinon' {
   }
 
   declare interface SinonFakeUploadProgress {
-    eventListeners: {
+    eventListeners: {|
       progress: Array<any>;
       load: Array<any>;
       abort: Array<any>;
       error: Array<any>;
-    };
+    |};
 
     addEventListener(event: string, listener: (e: Event) => any): void;
     removeEventListener(event: string, listener: (e: Event) => any): void;
@@ -478,7 +478,7 @@ declare module 'sinon' {
     XMLHttpRequest: XMLHttpRequest;
   }
 
-  declare module.exports: {
+  declare module.exports: {|
     createFakeServer(config?: SinonFakeServerConfig): SinonFakeServer;
     createFakeServerWithClock(): SinonFakeServer;
     createSandbox(config?: SinonSandboxConfig): SinonSandbox;
@@ -509,5 +509,5 @@ declare module 'sinon' {
       exception: any,
       id: number,
       errorWithCallStack: any): SinonSpyCall;
-  };
+  |};
 }

--- a/definitions/npm/sinon_v7.x.x/test_sinon_v7.x.x.js
+++ b/definitions/npm/sinon_v7.x.x/test_sinon_v7.x.x.js
@@ -247,6 +247,13 @@ function testGetCalls() {
   }
 }
 
+function testLastArg() {
+  let spy = sinon.spy();
+  let date = new Date();
+  spy(1, 2, date);
+  return spy.lastCall.lastArg === date;
+}
+
 function testFake(): boolean {
   const callback = sinon.fake();
   callback();


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: [sinon docs](https://sinonjs.org/releases/latest/spy-call/)
- Type of contribution: new definition | addition | **fix** | refactor

Other notes: LastArg should actually be mixed since it's based on the object it's called on 😥  Fix for parcel