### PR TITLE
[luxon_v1.9.x] add toRelative and toRelativeCalendar

### DIFF
--- a/definitions/npm/luxon_v0.2.x/flow_v0.104.x-/test_luxon.js
+++ b/definitions/npm/luxon_v0.2.x/flow_v0.104.x-/test_luxon.js
@@ -33,7 +33,7 @@ Settings.defaultZone = new CustomZone();
 
 (Info.eras("long"): Array<string>);
 (Info.eras("long", { locale: "de-DE" }): Array<string>);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Info.eras("long", { foo: "bar" }): Array<string>);
 
 (Info.features().intl: boolean);
@@ -53,7 +53,7 @@ Settings.defaultZone = new CustomZone();
   numberingSystem: "latn",
   outputCalendar: "buddhist"
 }): Array<string>);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Info.months("long", { foo: "bar" }): Array<string>);
 
 (Info.monthsFormat("long"): Array<string>);
@@ -63,7 +63,7 @@ Settings.defaultZone = new CustomZone();
   numberingSystem: "latn",
   outputCalendar: "buddhist"
 }): Array<string>);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Info.monthsFormat("long", { foo: "bar" }): Array<string>);
 
 (Info.weekdays("long"): Array<string>);
@@ -73,7 +73,7 @@ Settings.defaultZone = new CustomZone();
   numberingSystem: "latn",
   outputCalendar: "buddhist"
 }): Array<string>);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Info.weekdays("long", { foo: "bar" }): Array<string>);
 
 (Info.weekdaysFormat("long"): Array<string>);
@@ -83,7 +83,7 @@ Settings.defaultZone = new CustomZone();
   numberingSystem: "latn",
   outputCalendar: "buddhist"
 }): Array<string>);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Info.weekdaysFormat("long", { foo: "bar" }): Array<string>);
 
 (DateTime.local().toJSDate(): Date);
@@ -106,21 +106,21 @@ DateTime.fromHTTP("Sun, 06 Nov 1994 08:49:37 GMT", {
   outputCalendar: "gregory",
   numberingSystem: "buddhist"
 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromHTTP();
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromHTTP({});
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 DateTime.fromHTTP("Sun, 06 Nov 1994 08:49:37 GMT", { foo: "bar" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromHTTP("Sun, 06 Nov 1994 08:49:37 GMT", { zone: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromHTTP("Sun, 06 Nov 1994 08:49:37 GMT", { locale: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromHTTP("Sun, 06 Nov 1994 08:49:37 GMT", { setZone: "yes" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromHTTP("Sun, 06 Nov 1994 08:49:37 GMT", { outputCalendar: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromHTTP("Sun, 06 Nov 1994 08:49:37 GMT", { numberingSystem: 2 });
 
 var date: DateTime = DateTime.fromObject({ year: 2017, month: 1, day: 23 });
@@ -138,25 +138,25 @@ DateTime.fromObject({
   outputCalendar: "gregory",
   numberingSystem: "buddhist"
 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject();
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject("blah");
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 DateTime.fromObject({ year: 2017, month: 1, day: 23, foo: "bar" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject({ year: 2017, month: "January", day: 23 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject({ year: 2017, month: 1, day: "Monday" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject({ year: 2017, month: 1, day: 23, zone: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject({ year: 2017, month: 1, day: 23, locale: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject({ year: 2017, month: 1, day: 23, setZone: "yes" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject({ year: 2017, month: 1, day: 23, outputCalendar: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject({ year: 2017, month: 1, day: 23, numberingSystem: 2 });
 
 var date: DateTime = DateTime.fromISO("2017-01-28T23:00:01");
@@ -171,19 +171,19 @@ DateTime.fromISO("2017-01-28T23:00:01", {
   outputCalendar: "gregory",
   numberingSystem: "buddhist"
 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromISO();
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 DateTime.fromISO("2017-01-28T23:00:01", { foo: "bar" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromISO("2017-01-28T23:00:01", { zone: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromISO("2017-01-28T23:00:01", { locale: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromISO("2017-01-28T23:00:01", { setZone: "yes" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromISO("2017-01-28T23:00:01", { outputCalendar: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromISO("2017-01-28T23:00:01", { numberingSystem: 2 });
 
 var date: DateTime = DateTime.fromJSDate(new Date());
@@ -198,21 +198,21 @@ DateTime.fromJSDate(new Date(), {
   outputCalendar: "gregory",
   numberingSystem: "buddhist"
 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromJSDate();
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromJSDate(1234234123);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 DateTime.fromJSDate(new Date(), { foo: "bar" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromJSDate(new Date(), { zone: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromJSDate(new Date(), { locale: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromJSDate(new Date(), { setZone: "yes" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromJSDate(new Date(), { outputCalendar: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromJSDate(new Date(), { numberingSystem: 2 });
 
 var date: DateTime = DateTime.fromMillis(123412323);
@@ -227,21 +227,21 @@ DateTime.fromMillis(123412323, {
   outputCalendar: "gregory",
   numberingSystem: "buddhist"
 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromMillis();
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromMillis("1234234123");
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 DateTime.fromMillis(123412323, { foo: "bar" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromMillis(123412323, { zone: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromMillis(123412323, { locale: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromMillis(123412323, { setZone: "yes" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromMillis(123412323, { outputCalendar: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromMillis(123412323, { numberingSystem: 2 });
 
 var date: DateTime = DateTime.fromRFC2822("12/15/2017, 12:47:25 PM");
@@ -256,19 +256,19 @@ DateTime.fromRFC2822("12/15/2017, 12:47:25 PM", {
   outputCalendar: "gregory",
   numberingSystem: "buddhist"
 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromRFC2822();
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 DateTime.fromRFC2822("12/15/2017, 12:47:25 PM", { foo: "bar" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromRFC2822("12/15/2017, 12:47:25 PM", { zone: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromRFC2822("12/15/2017, 12:47:25 PM", { locale: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromRFC2822("12/15/2017, 12:47:25 PM", { setZone: "yes" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromRFC2822("12/15/2017, 12:47:25 PM", { outputCalendar: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromRFC2822("12/15/2017, 12:47:25 PM", { numberingSystem: 2 });
 
 var date: DateTime = DateTime.fromSQL("12/15/2017, 12:47:25 PM");
@@ -283,19 +283,19 @@ DateTime.fromSQL("12/15/2017, 12:47:25 PM", {
   outputCalendar: "gregory",
   numberingSystem: "buddhist"
 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromSQL();
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 DateTime.fromSQL("12/15/2017, 12:47:25 PM", { foo: "bar" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromSQL("12/15/2017, 12:47:25 PM", { zone: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromSQL("12/15/2017, 12:47:25 PM", { locale: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromSQL("12/15/2017, 12:47:25 PM", { setZone: "yes" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromSQL("12/15/2017, 12:47:25 PM", { outputCalendar: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromSQL("12/15/2017, 12:47:25 PM", { numberingSystem: 2 });
 
 var date: DateTime = DateTime.fromString(
@@ -304,56 +304,56 @@ var date: DateTime = DateTime.fromString(
 );
 DateTime.fromString("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {});
 DateTime.fromString("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
-  zone: "America/Chicago"
+  zone: "America/Chicago",
 });
 DateTime.fromString("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
-  zone: new CustomZone()
+  zone: new CustomZone(),
 });
 DateTime.fromString("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
-  locale: "en-US"
+  locale: "en-US",
 });
 DateTime.fromString("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
   zone: "America/Chicago",
   setZone: true,
   locale: "en-US",
   outputCalendar: "gregory",
-  numberingSystem: "buddhist"
+  numberingSystem: "buddhist",
 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromString();
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromString("12/15/2017, 12:47:25 PM");
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromString("12/15/2017, 12:47:25 PM", 2);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromString("12/15/2017, 12:47:25 PM", { zone: "America/Chicago" });
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 DateTime.fromString("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
-  foo: "bar"
+  foo: "bar",
 });
-// $FlowExpectedError
 DateTime.fromString("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
-  zone: 2
+// $FlowExpectedError[incompatible-call]
+  zone: 2,
 });
-// $FlowExpectedError
 DateTime.fromString("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
-  locale: 2
+// $FlowExpectedError[incompatible-call]
+  locale: 2,
 });
-// $FlowExpectedError
 DateTime.fromString("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
-  setZone: "yes"
+// $FlowExpectedError[incompatible-call]
+  setZone: "yes",
 });
-// $FlowExpectedError
 DateTime.fromString("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
-  outputCalendar: 2
+// $FlowExpectedError[incompatible-call]
+  outputCalendar: 2,
 });
-// $FlowExpectedError
 DateTime.fromString("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
-  numberingSystem: 2
+// $FlowExpectedError[incompatible-call]
+  numberingSystem: 2,
 });
 
 var date: DateTime = DateTime.invalid("test");
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.invalid();
 
 // Flow 0.40 - 0.45 allows these but they're incorrect...bug!
@@ -362,9 +362,9 @@ DateTime.invalid();
 
 var date = DateTime.max(DateTime.local(), DateTime.utc(), DateTime.utc());
 var date = DateTime.min(DateTime.local(), DateTime.utc(), DateTime.utc());
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 var date = DateTime.max(DateTime.local(), null, DateTime.utc());
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 var date = DateTime.min(DateTime.local(), null, DateTime.utc());
 
 (date.day: number);
@@ -403,14 +403,14 @@ var date = DateTime.min(DateTime.local(), null, DateTime.utc());
 (date.diff(DateTime.utc(), ["year", "month"], {
   conversionAccuracy: "longterm"
 }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.diff(new Date()): Duration);
 (date.diff(DateTime.utc()): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.diff(DateTime.utc(), "glom"): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.diff(DateTime.utc(), ["year", "glom"]): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (date.diff(DateTime.utc(), ["year", "month"], { foo: "bar" }): Duration);
 
 (date.diffNow(): Duration);
@@ -418,46 +418,46 @@ var date = DateTime.min(DateTime.local(), null, DateTime.utc());
 (date.diffNow(["year", "month"]): Duration);
 (date.diffNow(["year", "month"], {}): Duration);
 (date.diffNow(["year", "month"], { conversionAccuracy: "longterm" }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.diff(new Date()): Duration);
 (date.diff(DateTime.utc()): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.diffNow("glom"): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.diffNow(["year", "glom"]): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (date.diffNow(["year", "month"], { foo: "bar" }): Duration);
 
 (date.startOf("year"): DateTime);
 (date.startOf("month"): DateTime);
 (date.startOf("day"): DateTime);
 (date.startOf("seconds"): DateTime);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.startOf("secs"): DateTime);
 
 (date.endOf("year"): DateTime);
 (date.endOf("month"): DateTime);
 (date.endOf("day"): DateTime);
 (date.endOf("seconds"): DateTime);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.endOf("secs"): DateTime);
 
 if (date.equals(DateTime.utc())) {
 }
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 if (date.equals(new Date())) {
 }
 
 (date.get("year"): number);
 (date.get("month"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.get("secs"): number);
 
 (date.hasSame(DateTime.utc(), "year"): boolean);
 (date.hasSame(DateTime.utc(), "month"): boolean);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.hasSame(DateTime.utc(), "secs"): boolean);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.hasSame(new Date(), "month"): boolean);
 
 (date.inspect(): string);
@@ -465,13 +465,13 @@ if (date.equals(new Date())) {
 (date.minus({ day: 1 }): DateTime);
 (date.minus(232): DateTime);
 (date.minus(Duration.fromObject({ day: 1 })): DateTime);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.minus({ glab: 1 }): DateTime);
 
 (date.plus({ day: 1 }): DateTime);
 (date.plus(232): DateTime);
 (date.plus(Duration.fromObject({ day: 1 })): DateTime);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.plus({ glab: 1 }): DateTime);
 
 (date.reconfigure({ zone: "America/Detroit" }): DateTime);
@@ -483,7 +483,7 @@ if (date.equals(new Date())) {
 (date.set({ year: 1, month: 2 }): DateTime);
 (date.set({ minutes: 1, seconds: 2 }): DateTime);
 (date.set({ minutes: 1, seconds: 2, ordinal: 255 }): DateTime);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.set({ minutes: 1, seconds: 2, simpsons: 3 }): DateTime);
 
 (date.setLocale("de-DE"): DateTime);
@@ -503,7 +503,7 @@ if (date.equals(new Date())) {
   suppressSeconds: true,
   includeOffset: true
 }): string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (date.toISO({ blah: true }): string);
 
 (date.toISOTime(): string);
@@ -513,7 +513,7 @@ if (date.equals(new Date())) {
   suppressSeconds: true,
   includeOffset: true
 }): string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (date.toISOTime({ blah: true }): string);
 
 (date.toISOWeekDate(): string);
@@ -531,13 +531,13 @@ if (date.equals(new Date())) {
   value: number,
   ...
 }>);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (date.toLocaleParts({ foo: "bar" }): Array<{ type: string, value: number, ... }>);
 
 (date.toLocaleString(): string);
 (date.toLocaleString({ month: "numeric" }): string);
 (date.toLocaleString({ year: "numeric" }): string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (date.toLocaleString({ foo: "bar" }): string);
 
 (date.toObject().year: number);
@@ -550,11 +550,11 @@ if (date.equals(new Date())) {
 (date.toObject({ includeConfig: true }).locale: string);
 (date.toObject({ includeConfig: true }).outputCalendar: ?string);
 (date.toObject({ includeConfig: true }).numberingSystem: ?string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 date.toObject({ includeConfig: false }).locale;
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 date.toObject({ includeConfig: false }).outputCalendar;
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 date.toObject({ includeConfig: false }).numberingSystem;
 
 (date.toRFC2822(): string);
@@ -562,7 +562,7 @@ date.toObject({ includeConfig: false }).numberingSystem;
 (date.toSQL(): string);
 (date.toSQL({}): string);
 (date.toSQL({ includeZone: true, includeOffset: true }): string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (date.toSQL({ blah: true }): string);
 
 (date.toSQLDate(): string);
@@ -570,7 +570,7 @@ date.toObject({ includeConfig: false }).numberingSystem;
 (date.toSQLTime(): string);
 (date.toSQLTime({}): string);
 (date.toSQLTime({ includeZone: true, includeOffset: true }): string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (date.toSQLTime({ blah: true }): string);
 
 (date.toString(): string);
@@ -589,9 +589,9 @@ date.toObject({ includeConfig: false }).numberingSystem;
   numberingSystem: "gujr",
   conversionAccuracy: "casual"
 }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Duration.fromISO(): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Duration.fromISO("lkasdfa", { foo: "bar" }): Duration);
 
 (Duration.fromObject({ year: 1 }): Duration);
@@ -604,9 +604,9 @@ date.toObject({ includeConfig: false }).numberingSystem;
   numberingSystem: "gujr",
   conversionAccuracy: "casual"
 }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Duration.fromObject(): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Duration.fromObject({ year: 1, months: 1, foo: "bar" }): Duration);
 
 (Duration.fromMillis(23123412): Duration);
@@ -615,13 +615,13 @@ date.toObject({ includeConfig: false }).numberingSystem;
   numberingSystem: "gujr",
   conversionAccuracy: "casual"
 }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Duration.fromMillis(): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Duration.fromMillis(23123412, { foo: "bar" }): Duration);
 
 (Duration.invalid("test"): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Duration.invalid(): Duration);
 
 var dur: Duration = Duration.invalid("test");
@@ -655,11 +655,11 @@ var dur: Duration = Duration.invalid("test");
 (dur.as("seconds"): number);
 (dur.as("millisecond"): number);
 (dur.as("milliseconds"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (dur.as("date"): number);
 
 (dur.equals(Duration.invalid("test")): boolean);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (dur.equals(new Date()): boolean);
 
 (dur.get("year"): number);
@@ -678,7 +678,7 @@ var dur: Duration = Duration.invalid("test");
 (dur.get("seconds"): number);
 (dur.get("millisecond"): number);
 (dur.get("milliseconds"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (dur.get("date"): number);
 
 (dur.inspect(): string);
@@ -689,37 +689,37 @@ var dur: Duration = Duration.invalid("test");
 (dur.minus({ day: 1 }): Duration);
 (dur.minus(232): Duration);
 (dur.minus(Duration.fromObject({ day: 1 })): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (dur.minus({ glab: 1 }): Duration);
 
 (dur.plus({ day: 1 }): Duration);
 (dur.plus(232): Duration);
 (dur.plus(Duration.fromObject({ day: 1 })): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (dur.plus({ glab: 1 }): Duration);
 
 (dur.reconfigure({ locale: "de-DE" }): Duration);
 (dur.reconfigure({ numberingSystem: "latn" }): Duration);
 (dur.reconfigure({ conversionAccuracy: "longterm" }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (dur.reconfigure({ foo: "bar" }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (dur.reconfigure({ conversionAccuracy: "date" }): Duration);
 
 (dur.set({ year: 1 }): Duration);
 (dur.set({ months: 1 }): Duration);
 (dur.set({ months: 1, locale: "de-DE" }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (dur.set({ foos: 1 }): Duration);
 
 (dur.shiftTo("years"): Duration);
 (dur.shiftTo("years", "days"): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (dur.shiftTo("years", "mnths", "days"): Duration);
 
 (dur.toFormat("yyyy/MM/dd"): string);
 (dur.toFormat("yyyy/MM/dd", { round: true }): string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (dur.toFormat("yyyy/MM/dd", { rnd: true }): string);
 
 (dur.toISO(): string);
@@ -735,11 +735,11 @@ var dur: Duration = Duration.invalid("test");
 (dur.toObject({ includeConfig: true }).locale: string);
 (dur.toObject({ includeConfig: true }).numberingSystem: ?string);
 (dur.toObject({ includeConfig: true }).conversionAccuracy: ?string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 dur.toObject({ includeConfig: false }).locale;
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 dur.toObject({ includeConfig: false }).numberingSystem;
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 dur.toObject({ includeConfig: false }).conversionAccuracy;
 
 (dur.toString(): string);
@@ -753,9 +753,9 @@ dur.toObject({ includeConfig: false }).conversionAccuracy;
 ): Interval);
 (Interval.after({ year: 2017, month: 1 }, { year: 1 }): Interval);
 (Interval.after({ year: 2017, month: 1 }, 123123): Interval);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Interval.after({ year: 2017, month: 1, foo: "bar" }, { year: 1 }): Interval);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Interval.after({ year: 2017, month: 1 }, { year: 1, foo: "bar" }): Interval);
 
 (Interval.before(DateTime.utc(), Duration.fromObject({ year: 1 })): Interval);
@@ -767,9 +767,9 @@ dur.toObject({ includeConfig: false }).conversionAccuracy;
 ): Interval);
 (Interval.before({ year: 2017, month: 1 }, { year: 1 }): Interval);
 (Interval.before({ year: 2017, month: 1 }, 123123): Interval);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Interval.before({ year: 2017, month: 1, foo: "bar" }, { year: 1 }): Interval);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Interval.before({ year: 2017, month: 1 }, { year: 1, foo: "bar" }): Interval);
 
 (Interval.fromDateTimes(DateTime.utc(), DateTime.utc()): Interval);
@@ -780,13 +780,13 @@ dur.toObject({ includeConfig: false }).conversionAccuracy;
   { year: 2017, month: 1 }
 ): Interval);
 (Interval.fromDateTimes(
-  // $FlowExpectedError
+  // $FlowExpectedError[incompatible-call]
   { year: 2016, month: 1, foo: 'bar' },
   { year: 2017, month: 1 }
 ): Interval);
 (Interval.fromDateTimes(
   { year: 2016, month: 1 },
-  // $FlowExpectedError
+  // $FlowExpectedError[incompatible-call]
   { year: 2017, month: 1, foo: 'bar' }
 ): Interval);
 
@@ -795,24 +795,28 @@ dur.toObject({ includeConfig: false }).conversionAccuracy;
   zone: "America/Chicago",
   locale: "de-DE"
 }): Interval);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Interval.fromISO("23;lkj1", { foo: "bar" }): Interval);
 
 (Interval.invalid("test"): Interval);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Interval.invalid(): Interval);
 
 var int: Interval = Interval.invalid("test");
 
 (Interval.merge([int]): Array<Interval>);
 (Interval.merge([int, int, int]): Array<Interval>);
-// $FlowExpectedError
-(Interval.merge(int, int, int): Array<Interval>);
+// $FlowExpectedError[extra-arg]
+(Interval.merge([int], int): Array<Interval>);
+// $FlowExpectedError[incompatible-call]
+(Interval.merge(int): Array<Interval>);
 
 (Interval.xor([int]): Array<Interval>);
 (Interval.xor([int, int, int]): Array<Interval>);
-// $FlowExpectedError
-(Interval.xor(int, int, int): Array<Interval>);
+// $FlowExpectedError[extra-arg]
+(Interval.xor([int], int): Array<Interval>);
+// $FlowExpectedError[incompatible-call]
+(Interval.xor(int): Array<Interval>);
 
 (int.end: DateTime);
 (int.invalidReason: ?string);
@@ -839,21 +843,21 @@ var int: Interval = Interval.invalid("test");
 (int.count("milliseconds"): number);
 (int.count("week"): number);
 (int.count("weeks"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.count("wks"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.count("weekNumber"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.count("weekNumbers"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.count("weekYear"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.count("weekYears"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.count("weekday"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.count("weekdays"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.count("ordinal"): number);
 
 (int.difference(): Interval);
@@ -880,22 +884,22 @@ var int: Interval = Interval.invalid("test");
 (int.hasSame("milliseconds"): boolean);
 (int.hasSame("week"): boolean);
 (int.hasSame("weeks"): boolean);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.hasSame("wks"): boolean);
-// $FlowExpectedError
-(int.hasSame("weekNumber"): number);
-// $FlowExpectedError
-(int.hasSame("weekNumbers"): number);
-// $FlowExpectedError
-(int.hasSame("weekYear"): number);
-// $FlowExpectedError
-(int.hasSame("weekYears"): number);
-// $FlowExpectedError
-(int.hasSame("weekday"): number);
-// $FlowExpectedError
-(int.hasSame("weekdays"): number);
-// $FlowExpectedError
-(int.hasSame("ordinal"): number);
+// $FlowExpectedError[incompatible-call]
+(int.hasSame("weekNumber"): boolean);
+// $FlowExpectedError[incompatible-call]
+(int.hasSame("weekNumbers"): boolean);
+// $FlowExpectedError[incompatible-call]
+(int.hasSame("weekYear"): boolean);
+// $FlowExpectedError[incompatible-call]
+(int.hasSame("weekYears"): boolean);
+// $FlowExpectedError[incompatible-call]
+(int.hasSame("weekday"): boolean);
+// $FlowExpectedError[incompatible-call]
+(int.hasSame("weekdays"): boolean);
+// $FlowExpectedError[incompatible-call]
+(int.hasSame("ordinal"): boolean);
 
 (int.inspect(): string);
 
@@ -921,21 +925,21 @@ var int: Interval = Interval.invalid("test");
 (int.length("milliseconds"): number);
 (int.length("week"): number);
 (int.length("weeks"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.length("wks"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.length("weekNumber"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.length("weekNumbers"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.length("weekYear"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.length("weekYears"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.length("weekday"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.length("weekdays"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.length("ordinal"): number);
 
 (int.overlaps(int): boolean);
@@ -943,7 +947,7 @@ var int: Interval = Interval.invalid("test");
 (int.set({ start: date }): Interval);
 (int.set({ end: date }): Interval);
 (int.set({ start: date, end: date }): Interval);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (int.set({ foo: "bar" }): Interval);
 
 (int.splitAt(): Array<Interval>);
@@ -955,9 +959,9 @@ var int: Interval = Interval.invalid("test");
   conversionAccuracy: "longterm"
 }): Duration);
 (int.toDuration("year", { conversionAccuracy: "longterm" }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.toDuration("year", { conversionAccuracy: "blah" }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (int.toDuration("year", { foo: "bar" }): Duration);
 
 (int.toISO(): string);
@@ -966,7 +970,7 @@ var int: Interval = Interval.invalid("test");
   suppressSeconds: true,
   includeOffset: true
 }): string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (int.toISO({
   suressMilliseconds: true,
   suppressSeconds: true,

--- a/definitions/npm/luxon_v0.4.x/flow_v0.104.x-/test_luxon.js
+++ b/definitions/npm/luxon_v0.4.x/flow_v0.104.x-/test_luxon.js
@@ -33,7 +33,7 @@ Settings.defaultZone = new CustomZone();
 
 (Info.eras("long"): Array<string>);
 (Info.eras("long", { locale: "de-DE" }): Array<string>);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Info.eras("long", { foo: "bar" }): Array<string>);
 
 (Info.features().intl: boolean);
@@ -53,7 +53,7 @@ Settings.defaultZone = new CustomZone();
   numberingSystem: "latn",
   outputCalendar: "buddhist"
 }): Array<string>);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Info.months("long", { foo: "bar" }): Array<string>);
 
 (Info.monthsFormat("long"): Array<string>);
@@ -63,7 +63,7 @@ Settings.defaultZone = new CustomZone();
   numberingSystem: "latn",
   outputCalendar: "buddhist"
 }): Array<string>);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Info.monthsFormat("long", { foo: "bar" }): Array<string>);
 
 (Info.weekdays("long"): Array<string>);
@@ -73,7 +73,7 @@ Settings.defaultZone = new CustomZone();
   numberingSystem: "latn",
   outputCalendar: "buddhist"
 }): Array<string>);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Info.weekdays("long", { foo: "bar" }): Array<string>);
 
 (Info.weekdaysFormat("long"): Array<string>);
@@ -83,7 +83,7 @@ Settings.defaultZone = new CustomZone();
   numberingSystem: "latn",
   outputCalendar: "buddhist"
 }): Array<string>);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Info.weekdaysFormat("long", { foo: "bar" }): Array<string>);
 
 (DateTime.local().toJSDate(): Date);
@@ -106,21 +106,21 @@ DateTime.fromHTTP("Sun, 06 Nov 1994 08:49:37 GMT", {
   outputCalendar: "gregory",
   numberingSystem: "buddhist"
 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromHTTP();
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromHTTP({});
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 DateTime.fromHTTP("Sun, 06 Nov 1994 08:49:37 GMT", { foo: "bar" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromHTTP("Sun, 06 Nov 1994 08:49:37 GMT", { zone: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromHTTP("Sun, 06 Nov 1994 08:49:37 GMT", { locale: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromHTTP("Sun, 06 Nov 1994 08:49:37 GMT", { setZone: "yes" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromHTTP("Sun, 06 Nov 1994 08:49:37 GMT", { outputCalendar: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromHTTP("Sun, 06 Nov 1994 08:49:37 GMT", { numberingSystem: 2 });
 
 var date: DateTime = DateTime.fromObject({ year: 2017, month: 1, day: 23 });
@@ -138,25 +138,25 @@ DateTime.fromObject({
   outputCalendar: "gregory",
   numberingSystem: "buddhist"
 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject();
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject("blah");
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 DateTime.fromObject({ year: 2017, month: 1, day: 23, foo: "bar" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject({ year: 2017, month: "January", day: 23 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject({ year: 2017, month: 1, day: "Monday" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject({ year: 2017, month: 1, day: 23, zone: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject({ year: 2017, month: 1, day: 23, locale: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject({ year: 2017, month: 1, day: 23, setZone: "yes" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject({ year: 2017, month: 1, day: 23, outputCalendar: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromObject({ year: 2017, month: 1, day: 23, numberingSystem: 2 });
 
 var date: DateTime = DateTime.fromISO("2017-01-28T23:00:01");
@@ -171,19 +171,19 @@ DateTime.fromISO("2017-01-28T23:00:01", {
   outputCalendar: "gregory",
   numberingSystem: "buddhist"
 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromISO();
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 DateTime.fromISO("2017-01-28T23:00:01", { foo: "bar" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromISO("2017-01-28T23:00:01", { zone: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromISO("2017-01-28T23:00:01", { locale: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromISO("2017-01-28T23:00:01", { setZone: "yes" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromISO("2017-01-28T23:00:01", { outputCalendar: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromISO("2017-01-28T23:00:01", { numberingSystem: 2 });
 
 var date: DateTime = DateTime.fromJSDate(new Date());
@@ -198,21 +198,21 @@ DateTime.fromJSDate(new Date(), {
   outputCalendar: "gregory",
   numberingSystem: "buddhist"
 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromJSDate();
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromJSDate(1234234123);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 DateTime.fromJSDate(new Date(), { foo: "bar" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromJSDate(new Date(), { zone: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromJSDate(new Date(), { locale: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromJSDate(new Date(), { setZone: "yes" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromJSDate(new Date(), { outputCalendar: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromJSDate(new Date(), { numberingSystem: 2 });
 
 var date: DateTime = DateTime.fromMillis(123412323);
@@ -227,21 +227,21 @@ DateTime.fromMillis(123412323, {
   outputCalendar: "gregory",
   numberingSystem: "buddhist"
 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromMillis();
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromMillis("1234234123");
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 DateTime.fromMillis(123412323, { foo: "bar" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromMillis(123412323, { zone: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromMillis(123412323, { locale: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromMillis(123412323, { setZone: "yes" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromMillis(123412323, { outputCalendar: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromMillis(123412323, { numberingSystem: 2 });
 
 var date: DateTime = DateTime.fromRFC2822("12/15/2017, 12:47:25 PM");
@@ -256,19 +256,19 @@ DateTime.fromRFC2822("12/15/2017, 12:47:25 PM", {
   outputCalendar: "gregory",
   numberingSystem: "buddhist"
 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromRFC2822();
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 DateTime.fromRFC2822("12/15/2017, 12:47:25 PM", { foo: "bar" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromRFC2822("12/15/2017, 12:47:25 PM", { zone: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromRFC2822("12/15/2017, 12:47:25 PM", { locale: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromRFC2822("12/15/2017, 12:47:25 PM", { setZone: "yes" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromRFC2822("12/15/2017, 12:47:25 PM", { outputCalendar: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromRFC2822("12/15/2017, 12:47:25 PM", { numberingSystem: 2 });
 
 var date: DateTime = DateTime.fromSQL("12/15/2017, 12:47:25 PM");
@@ -283,77 +283,77 @@ DateTime.fromSQL("12/15/2017, 12:47:25 PM", {
   outputCalendar: "gregory",
   numberingSystem: "buddhist"
 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromSQL();
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 DateTime.fromSQL("12/15/2017, 12:47:25 PM", { foo: "bar" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromSQL("12/15/2017, 12:47:25 PM", { zone: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromSQL("12/15/2017, 12:47:25 PM", { locale: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromSQL("12/15/2017, 12:47:25 PM", { setZone: "yes" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromSQL("12/15/2017, 12:47:25 PM", { outputCalendar: 2 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromSQL("12/15/2017, 12:47:25 PM", { numberingSystem: 2 });
 
 var date: DateTime = DateTime.fromFormat(
-  '12/15/2017, 12:47:25 PM',
-  'dd/MM/yyyy h:mm:ss a'
+  "12/15/2017, 12:47:25 PM",
+  "dd/MM/yyyy h:mm:ss a"
 );
-DateTime.fromFormat('12/15/2017, 12:47:25 PM', 'dd/MM/yyyy h:mm:ss a', {});
-DateTime.fromFormat('12/15/2017, 12:47:25 PM', 'dd/MM/yyyy h:mm:ss a', {
-  zone: 'America/Chicago',
+DateTime.fromFormat("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {});
+DateTime.fromFormat("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
+  zone: "America/Chicago",
 });
-DateTime.fromFormat('12/15/2017, 12:47:25 PM', 'dd/MM/yyyy h:mm:ss a', {
+DateTime.fromFormat("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
   zone: new CustomZone(),
 });
-DateTime.fromFormat('12/15/2017, 12:47:25 PM', 'dd/MM/yyyy h:mm:ss a', {
-  locale: 'en-US',
+DateTime.fromFormat("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
+  locale: "en-US",
 });
-DateTime.fromFormat('12/15/2017, 12:47:25 PM', 'dd/MM/yyyy h:mm:ss a', {
-  zone: 'America/Chicago',
+DateTime.fromFormat("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
+  zone: "America/Chicago",
   setZone: true,
-  locale: 'en-US',
-  outputCalendar: 'gregory',
-  numberingSystem: 'buddhist',
+  locale: "en-US",
+  outputCalendar: "gregory",
+  numberingSystem: "buddhist",
 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.fromFormat();
-// $FlowExpectedError
-DateTime.fromFormat('12/15/2017, 12:47:25 PM');
-// $FlowExpectedError
-DateTime.fromFormat('12/15/2017, 12:47:25 PM', 2);
-// $FlowExpectedError
-DateTime.fromFormat('12/15/2017, 12:47:25 PM', { zone: 'America/Chicago' });
-// $FlowExpectedError
-DateTime.fromFormat('12/15/2017, 12:47:25 PM', 'dd/MM/yyyy h:mm:ss a', {
-  foo: 'bar',
+// $FlowExpectedError[incompatible-call]
+DateTime.fromFormat("12/15/2017, 12:47:25 PM");
+// $FlowExpectedError[incompatible-call]
+DateTime.fromFormat("12/15/2017, 12:47:25 PM", 2);
+// $FlowExpectedError[incompatible-call]
+DateTime.fromFormat("12/15/2017, 12:47:25 PM", { zone: "America/Chicago" });
+// $FlowExpectedError[prop-missing]
+DateTime.fromFormat("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
+  foo: "bar",
 });
-// $FlowExpectedError
-DateTime.fromFormat('12/15/2017, 12:47:25 PM', 'dd/MM/yyyy h:mm:ss a', {
+DateTime.fromFormat("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
+// $FlowExpectedError[incompatible-call]
   zone: 2,
 });
-// $FlowExpectedError
-DateTime.fromFormat('12/15/2017, 12:47:25 PM', 'dd/MM/yyyy h:mm:ss a', {
+DateTime.fromFormat("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
+// $FlowExpectedError[incompatible-call]
   locale: 2,
 });
-// $FlowExpectedError
-DateTime.fromFormat('12/15/2017, 12:47:25 PM', 'dd/MM/yyyy h:mm:ss a', {
-  setZone: 'yes',
+DateTime.fromFormat("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
+// $FlowExpectedError[incompatible-call]
+  setZone: "yes",
 });
-// $FlowExpectedError
-DateTime.fromFormat('12/15/2017, 12:47:25 PM', 'dd/MM/yyyy h:mm:ss a', {
+DateTime.fromFormat("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
+// $FlowExpectedError[incompatible-call]
   outputCalendar: 2,
 });
-// $FlowExpectedError
-DateTime.fromFormat('12/15/2017, 12:47:25 PM', 'dd/MM/yyyy h:mm:ss a', {
+DateTime.fromFormat("12/15/2017, 12:47:25 PM", "dd/MM/yyyy h:mm:ss a", {
+// $FlowExpectedError[incompatible-call]
   numberingSystem: 2,
 });
 
 var date: DateTime = DateTime.invalid("test");
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 DateTime.invalid();
 
 // Flow 0.40 - 0.45 allows these but they're incorrect...bug!
@@ -362,9 +362,9 @@ DateTime.invalid();
 
 var date = DateTime.max(DateTime.local(), DateTime.utc(), DateTime.utc());
 var date = DateTime.min(DateTime.local(), DateTime.utc(), DateTime.utc());
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 var date = DateTime.max(DateTime.local(), null, DateTime.utc());
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 var date = DateTime.min(DateTime.local(), null, DateTime.utc());
 
 (date.day: number);
@@ -403,14 +403,14 @@ var date = DateTime.min(DateTime.local(), null, DateTime.utc());
 (date.diff(DateTime.utc(), ["year", "month"], {
   conversionAccuracy: "longterm"
 }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.diff(new Date()): Duration);
 (date.diff(DateTime.utc()): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.diff(DateTime.utc(), "glom"): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.diff(DateTime.utc(), ["year", "glom"]): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (date.diff(DateTime.utc(), ["year", "month"], { foo: "bar" }): Duration);
 
 (date.diffNow(): Duration);
@@ -423,32 +423,32 @@ var date = DateTime.min(DateTime.local(), null, DateTime.utc());
 (date.startOf("month"): DateTime);
 (date.startOf("day"): DateTime);
 (date.startOf("seconds"): DateTime);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.startOf("secs"): DateTime);
 
 (date.endOf("year"): DateTime);
 (date.endOf("month"): DateTime);
 (date.endOf("day"): DateTime);
 (date.endOf("seconds"): DateTime);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.endOf("secs"): DateTime);
 
 if (date.equals(DateTime.utc())) {
 }
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 if (date.equals(new Date())) {
 }
 
 (date.get("year"): number);
 (date.get("month"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.get("secs"): number);
 
 (date.hasSame(DateTime.utc(), "year"): boolean);
 (date.hasSame(DateTime.utc(), "month"): boolean);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.hasSame(DateTime.utc(), "secs"): boolean);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.hasSame(new Date(), "month"): boolean);
 
 (date.inspect(): string);
@@ -456,13 +456,13 @@ if (date.equals(new Date())) {
 (date.minus({ day: 1 }): DateTime);
 (date.minus(232): DateTime);
 (date.minus(Duration.fromObject({ day: 1 })): DateTime);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.minus({ glab: 1 }): DateTime);
 
 (date.plus({ day: 1 }): DateTime);
 (date.plus(232): DateTime);
 (date.plus(Duration.fromObject({ day: 1 })): DateTime);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.plus({ glab: 1 }): DateTime);
 
 (date.reconfigure({ zone: "America/Detroit" }): DateTime);
@@ -474,7 +474,7 @@ if (date.equals(new Date())) {
 (date.set({ year: 1, month: 2 }): DateTime);
 (date.set({ minutes: 1, seconds: 2 }): DateTime);
 (date.set({ minutes: 1, seconds: 2, ordinal: 255 }): DateTime);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (date.set({ minutes: 1, seconds: 2, simpsons: 3 }): DateTime);
 
 (date.setLocale("de-DE"): DateTime);
@@ -494,7 +494,7 @@ if (date.equals(new Date())) {
   suppressSeconds: true,
   includeOffset: true
 }): string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (date.toISO({ blah: true }): string);
 
 (date.toISOTime(): string);
@@ -504,7 +504,7 @@ if (date.equals(new Date())) {
   suppressSeconds: true,
   includeOffset: true
 }): string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (date.toISOTime({ blah: true }): string);
 
 (date.toISOWeekDate(): string);
@@ -522,13 +522,13 @@ if (date.equals(new Date())) {
   value: number,
   ...
 }>);
-// $FlowExpectedError
-(date.toLocaleParts({ foo: "bar" }): Array<{ type: string, value: number }>);
+// $FlowExpectedError[prop-missing]
+(date.toLocaleParts({ foo: "bar" }): Array<{ type: string, value: number, ... }>);
 
 (date.toLocaleString(): string);
 (date.toLocaleString({ month: "numeric" }): string);
 (date.toLocaleString({ year: "numeric" }): string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (date.toLocaleString({ foo: "bar" }): string);
 
 (date.toObject().year: number);
@@ -541,11 +541,11 @@ if (date.equals(new Date())) {
 (date.toObject({ includeConfig: true }).locale: string);
 (date.toObject({ includeConfig: true }).outputCalendar: ?string);
 (date.toObject({ includeConfig: true }).numberingSystem: ?string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 date.toObject({ includeConfig: false }).locale;
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 date.toObject({ includeConfig: false }).outputCalendar;
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 date.toObject({ includeConfig: false }).numberingSystem;
 
 (date.toRFC2822(): string);
@@ -553,7 +553,7 @@ date.toObject({ includeConfig: false }).numberingSystem;
 (date.toSQL(): string);
 (date.toSQL({}): string);
 (date.toSQL({ includeZone: true, includeOffset: true }): string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (date.toSQL({ blah: true }): string);
 
 (date.toSQLDate(): string);
@@ -561,7 +561,7 @@ date.toObject({ includeConfig: false }).numberingSystem;
 (date.toSQLTime(): string);
 (date.toSQLTime({}): string);
 (date.toSQLTime({ includeZone: true, includeOffset: true }): string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (date.toSQLTime({ blah: true }): string);
 
 (date.toString(): string);
@@ -580,9 +580,9 @@ date.toObject({ includeConfig: false }).numberingSystem;
   numberingSystem: "gujr",
   conversionAccuracy: "casual"
 }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Duration.fromISO(): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Duration.fromISO("lkasdfa", { foo: "bar" }): Duration);
 
 (Duration.fromObject({ year: 1 }): Duration);
@@ -595,9 +595,9 @@ date.toObject({ includeConfig: false }).numberingSystem;
   numberingSystem: "gujr",
   conversionAccuracy: "casual"
 }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Duration.fromObject(): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Duration.fromObject({ year: 1, months: 1, foo: "bar" }): Duration);
 
 (Duration.fromMillis(23123412): Duration);
@@ -606,13 +606,13 @@ date.toObject({ includeConfig: false }).numberingSystem;
   numberingSystem: "gujr",
   conversionAccuracy: "casual"
 }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Duration.fromMillis(): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Duration.fromMillis(23123412, { foo: "bar" }): Duration);
 
 (Duration.invalid("test"): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Duration.invalid(): Duration);
 
 var dur: Duration = Duration.invalid("test");
@@ -646,11 +646,11 @@ var dur: Duration = Duration.invalid("test");
 (dur.as("seconds"): number);
 (dur.as("millisecond"): number);
 (dur.as("milliseconds"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (dur.as("date"): number);
 
 (dur.equals(Duration.invalid("test")): boolean);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (dur.equals(new Date()): boolean);
 
 (dur.get("year"): number);
@@ -669,7 +669,7 @@ var dur: Duration = Duration.invalid("test");
 (dur.get("seconds"): number);
 (dur.get("millisecond"): number);
 (dur.get("milliseconds"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (dur.get("date"): number);
 
 (dur.inspect(): string);
@@ -680,37 +680,37 @@ var dur: Duration = Duration.invalid("test");
 (dur.minus({ day: 1 }): Duration);
 (dur.minus(232): Duration);
 (dur.minus(Duration.fromObject({ day: 1 })): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (dur.minus({ glab: 1 }): Duration);
 
 (dur.plus({ day: 1 }): Duration);
 (dur.plus(232): Duration);
 (dur.plus(Duration.fromObject({ day: 1 })): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (dur.plus({ glab: 1 }): Duration);
 
 (dur.reconfigure({ locale: "de-DE" }): Duration);
 (dur.reconfigure({ numberingSystem: "latn" }): Duration);
 (dur.reconfigure({ conversionAccuracy: "longterm" }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (dur.reconfigure({ foo: "bar" }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (dur.reconfigure({ conversionAccuracy: "date" }): Duration);
 
 (dur.set({ year: 1 }): Duration);
 (dur.set({ months: 1 }): Duration);
 (dur.set({ months: 1, locale: "de-DE" }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (dur.set({ foos: 1 }): Duration);
 
 (dur.shiftTo("years"): Duration);
 (dur.shiftTo("years", "days"): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (dur.shiftTo("years", "mnths", "days"): Duration);
 
 (dur.toFormat("yyyy/MM/dd"): string);
 (dur.toFormat("yyyy/MM/dd", { round: true }): string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (dur.toFormat("yyyy/MM/dd", { rnd: true }): string);
 
 (dur.toISO(): string);
@@ -726,11 +726,11 @@ var dur: Duration = Duration.invalid("test");
 (dur.toObject({ includeConfig: true }).locale: string);
 (dur.toObject({ includeConfig: true }).numberingSystem: ?string);
 (dur.toObject({ includeConfig: true }).conversionAccuracy: ?string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 dur.toObject({ includeConfig: false }).locale;
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 dur.toObject({ includeConfig: false }).numberingSystem;
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 dur.toObject({ includeConfig: false }).conversionAccuracy;
 
 (dur.toString(): string);
@@ -744,9 +744,9 @@ dur.toObject({ includeConfig: false }).conversionAccuracy;
 ): Interval);
 (Interval.after({ year: 2017, month: 1 }, { year: 1 }): Interval);
 (Interval.after({ year: 2017, month: 1 }, 123123): Interval);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Interval.after({ year: 2017, month: 1, foo: "bar" }, { year: 1 }): Interval);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Interval.after({ year: 2017, month: 1 }, { year: 1, foo: "bar" }): Interval);
 
 (Interval.before(DateTime.utc(), Duration.fromObject({ year: 1 })): Interval);
@@ -758,9 +758,9 @@ dur.toObject({ includeConfig: false }).conversionAccuracy;
 ): Interval);
 (Interval.before({ year: 2017, month: 1 }, { year: 1 }): Interval);
 (Interval.before({ year: 2017, month: 1 }, 123123): Interval);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Interval.before({ year: 2017, month: 1, foo: "bar" }, { year: 1 }): Interval);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Interval.before({ year: 2017, month: 1 }, { year: 1, foo: "bar" }): Interval);
 
 (Interval.fromDateTimes(DateTime.utc(), DateTime.utc()): Interval);
@@ -771,13 +771,13 @@ dur.toObject({ includeConfig: false }).conversionAccuracy;
   { year: 2017, month: 1 }
 ): Interval);
 (Interval.fromDateTimes(
-  // $FlowExpectedError
+  // $FlowExpectedError[incompatible-call]
   { year: 2016, month: 1, foo: 'bar' },
   { year: 2017, month: 1 }
 ): Interval);
 (Interval.fromDateTimes(
   { year: 2016, month: 1 },
-  // $FlowExpectedError
+  // $FlowExpectedError[incompatible-call]
   { year: 2017, month: 1, foo: 'bar' }
 ): Interval);
 
@@ -786,24 +786,28 @@ dur.toObject({ includeConfig: false }).conversionAccuracy;
   zone: "America/Chicago",
   locale: "de-DE"
 }): Interval);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (Interval.fromISO("23;lkj1", { foo: "bar" }): Interval);
 
 (Interval.invalid("test"): Interval);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (Interval.invalid(): Interval);
 
 var int: Interval = Interval.invalid("test");
 
 (Interval.merge([int]): Array<Interval>);
 (Interval.merge([int, int, int]): Array<Interval>);
-// $FlowExpectedError
-(Interval.merge(int, int, int): Array<Interval>);
+// $FlowExpectedError[extra-arg]
+(Interval.merge([int], int): Array<Interval>);
+// $FlowExpectedError[incompatible-call]
+(Interval.merge(int): Array<Interval>);
 
 (Interval.xor([int]): Array<Interval>);
 (Interval.xor([int, int, int]): Array<Interval>);
-// $FlowExpectedError
-(Interval.xor(int, int, int): Array<Interval>);
+// $FlowExpectedError[extra-arg]
+(Interval.xor([int], int): Array<Interval>);
+// $FlowExpectedError[incompatible-call]
+(Interval.xor(int): Array<Interval>);
 
 (int.end: DateTime);
 (int.invalidReason: ?string);
@@ -830,21 +834,21 @@ var int: Interval = Interval.invalid("test");
 (int.count("milliseconds"): number);
 (int.count("week"): number);
 (int.count("weeks"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.count("wks"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.count("weekNumber"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.count("weekNumbers"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.count("weekYear"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.count("weekYears"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.count("weekday"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.count("weekdays"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.count("ordinal"): number);
 
 (int.difference(): Interval);
@@ -871,22 +875,22 @@ var int: Interval = Interval.invalid("test");
 (int.hasSame("milliseconds"): boolean);
 (int.hasSame("week"): boolean);
 (int.hasSame("weeks"): boolean);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.hasSame("wks"): boolean);
-// $FlowExpectedError
-(int.hasSame("weekNumber"): number);
-// $FlowExpectedError
-(int.hasSame("weekNumbers"): number);
-// $FlowExpectedError
-(int.hasSame("weekYear"): number);
-// $FlowExpectedError
-(int.hasSame("weekYears"): number);
-// $FlowExpectedError
-(int.hasSame("weekday"): number);
-// $FlowExpectedError
-(int.hasSame("weekdays"): number);
-// $FlowExpectedError
-(int.hasSame("ordinal"): number);
+// $FlowExpectedError[incompatible-call]
+(int.hasSame("weekNumber"): boolean);
+// $FlowExpectedError[incompatible-call]
+(int.hasSame("weekNumbers"): boolean);
+// $FlowExpectedError[incompatible-call]
+(int.hasSame("weekYear"): boolean);
+// $FlowExpectedError[incompatible-call]
+(int.hasSame("weekYears"): boolean);
+// $FlowExpectedError[incompatible-call]
+(int.hasSame("weekday"): boolean);
+// $FlowExpectedError[incompatible-call]
+(int.hasSame("weekdays"): boolean);
+// $FlowExpectedError[incompatible-call]
+(int.hasSame("ordinal"): boolean);
 
 (int.inspect(): string);
 
@@ -912,21 +916,21 @@ var int: Interval = Interval.invalid("test");
 (int.length("milliseconds"): number);
 (int.length("week"): number);
 (int.length("weeks"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.length("wks"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.length("weekNumber"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.length("weekNumbers"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.length("weekYear"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.length("weekYears"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.length("weekday"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.length("weekdays"): number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.length("ordinal"): number);
 
 (int.overlaps(int): boolean);
@@ -934,7 +938,7 @@ var int: Interval = Interval.invalid("test");
 (int.set({ start: date }): Interval);
 (int.set({ end: date }): Interval);
 (int.set({ start: date, end: date }): Interval);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (int.set({ foo: "bar" }): Interval);
 
 (int.splitAt(): Array<Interval>);
@@ -946,9 +950,9 @@ var int: Interval = Interval.invalid("test");
   conversionAccuracy: "longterm"
 }): Duration);
 (int.toDuration("year", { conversionAccuracy: "longterm" }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 (int.toDuration("year", { conversionAccuracy: "blah" }): Duration);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (int.toDuration("year", { foo: "bar" }): Duration);
 
 (int.toISO(): string);
@@ -957,7 +961,7 @@ var int: Interval = Interval.invalid("test");
   suppressSeconds: true,
   includeOffset: true
 }): string);
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 (int.toISO({
   suressMilliseconds: true,
   suppressSeconds: true,

--- a/definitions/npm/luxon_v1.9.x/flow_v0.104.x-/luxon_v1.9.x.js
+++ b/definitions/npm/luxon_v1.9.x/flow_v0.104.x-/luxon_v1.9.x.js
@@ -1,0 +1,587 @@
+// @flow
+
+declare module "luxon" {
+  declare type UnitLength = "narrow" | "short" | "long";
+  declare type WeekdayLength = UnitLength;
+  declare type EraLength = UnitLength;
+  declare type MonthLength =
+    | "numeric"
+    | "2-digit"
+    | "narrow"
+    | "short"
+    | "long";
+  declare type NumericLength = "numeric" | "2-digit";
+
+  declare type HourCycle = "h11" | "h12" | "h23" | "h24";
+
+  declare type IntlDateTimeFormatOptions = {|
+    localeMatcher?: "lookup" | "best fit",
+    timeZone?: string,
+    hour12?: boolean,
+    hourCycle?: HourCycle,
+    formatMatcher?: "basic" | "best fit",
+    weekday?: WeekdayLength,
+    era?: EraLength,
+    year?: NumericLength,
+    month?: MonthLength,
+    day?: NumericLength,
+    hour?: NumericLength,
+    minute?: NumericLength,
+    second?: NumericLength,
+    timeZoneName?: "short" | "long"
+  |};
+
+  declare export class Zone {
+    static offsetName(
+      ts: number,
+      opts?: {
+        format?: ?string,
+        localeCode?: ?string,
+        ...
+      }
+    ): string;
+    +isValid: boolean;
+    +name: string;
+    +type: string;
+    +universal: boolean;
+    equals(otherZone: Zone): boolean;
+    offset(ts: number): number;
+  }
+
+  declare export class Settings {
+    static defaultLocale: string;
+    static defaultNumberingSystem: ?string;
+    static defaultOutputCalendar: ?string;
+    static defaultZone: Zone;
+    static defaultZoneName: string;
+    static now: () => number;
+    static throwOnInvalid: boolean;
+    static resetCaches(): void;
+  }
+
+  declare type MonthWeekdayOptions = {|
+    locale?: ?string,
+    numberingSystem?: ?string,
+    outputCalendar?: ?string
+  |};
+
+  declare export class Info {
+    static eras(
+      length: EraLength,
+      options?: {| locale?: ?string |}
+    ): Array<string>;
+    static features(): {
+      intl: boolean,
+      intlTokens: boolean,
+      timezones: boolean,
+      ...
+    };
+    static hasDST(zone: string | Zone): boolean;
+    static isValidIANAZone(zone: string): boolean;
+    static meridiems(options?: {| locale?: ?string |}): Array<string>;
+    static months(
+      length: MonthLength,
+      options?: MonthWeekdayOptions
+    ): Array<string>;
+    static monthsFormat(
+      length: MonthLength,
+      options?: MonthWeekdayOptions
+    ): Array<string>;
+    static weekdays(
+      length: WeekdayLength,
+      options?: MonthWeekdayOptions
+    ): Array<string>;
+    static weekdaysFormat(
+      length: WeekdayLength,
+      options?: MonthWeekdayOptions
+    ): Array<string>;
+  }
+
+  declare export type ConversionAccuracy = "longterm" | "casual";
+
+  declare export type DateTimeUnit =
+    | "year"
+    | "years"
+    | "month"
+    | "months"
+    | "day"
+    | "days"
+    | "hour"
+    | "hours"
+    | "minute"
+    | "minutes"
+    | "second"
+    | "seconds"
+    | "millisecond"
+    | "milliseconds"
+    | "weekNumber"
+    | "weekNumbers"
+    | "weekYear"
+    | "weekYears"
+    | "weekday"
+    | "weekdays"
+    | "week"
+    | "weeks"
+    | "ordinal";
+
+  declare export type DurationUnit =
+    | "year"
+    | "years"
+    | "month"
+    | "months"
+    | "week"
+    | "weeks"
+    | "day"
+    | "days"
+    | "hour"
+    | "hours"
+    | "minute"
+    | "minutes"
+    | "second"
+    | "seconds"
+    | "millisecond"
+    | "milliseconds";
+
+  declare export type ToRelativeUnit =
+    | "years"
+    | "quarters"
+    | "months"
+    | "weeks"
+    | "days"
+    | "hours"
+    | "minutes"
+    | "seconds";
+
+  declare export type ToRelativeCalendarUnit =
+    | "years"
+    | "quarters"
+    | "months"
+    | "weeks"
+    | "days";
+
+  declare export class Interval {
+    static after(
+      start: DateTime | DateTimeFromObjectOptions | Date,
+      duration: Duration | number | DurationFromObjectOptions
+    ): Interval;
+    static before(
+      end: DateTime | DateTimeFromObjectOptions | Date,
+      duration: Duration | number | DurationFromObjectOptions
+    ): Interval;
+    static fromDateTimes(
+      start: DateTime | DateTimeFromObjectOptions | Date,
+      end: DateTime | DateTimeFromObjectOptions | Date
+    ): Interval;
+    static fromISO(string: string, options?: DateTimeFromOptions): Interval;
+    static invalid(reason: string): Interval;
+    static merge(intervals: Array<Interval>): Array<Interval>;
+    static xor(intervals: Array<Interval>): Array<Interval>;
+    end: DateTime;
+    invalidReason: ?string;
+    isValid: boolean;
+    start: DateTime;
+    abutsEnd(other: Interval): boolean;
+    abutsStart(other: Interval): boolean;
+    contains(dateTime: DateTime): boolean;
+    count(unit: DurationUnit): number;
+    difference(...intervals: Array<Interval>): Interval;
+    divideEqually(numberOfParts: number): Array<Interval>;
+    engulfs(other: Interval): boolean;
+    equals(other: Interval): boolean;
+    hasSame(unit: DurationUnit): boolean;
+    inspect(): string;
+    intersection(other: Interval): Interval;
+    isAfter(dateTime: DateTime): boolean;
+    isBefore(dateTime: DateTime): boolean;
+    isEmpty(): boolean;
+    length(unit: DurationUnit): number;
+    overlaps(other: Interval): boolean;
+    set(values: {| start?: DateTime, end?: DateTime |}): Interval;
+    splitAt(...dateTimes: Array<DateTime>): Array<Interval>;
+    splitBy(duration: number | Duration | DurationFromObjectOptions): Array<Interval>;
+    toDuration(
+      unit: DurationUnit | Array<DurationUnit>,
+      options?: {| conversionAccuracy?: ?ConversionAccuracy |}
+    ): Duration;
+    toFormat(dateFormat: string, options?: {| separator?: string |}): string;
+    toISO(options?: ToISOOptions): string;
+    toString(): string;
+    union(other: Interval): Interval;
+  }
+
+  declare type DurationFromOptions = {|
+    locale?: ?string,
+    numberingSystem?: ?string,
+    conversionAccuracy?: ?ConversionAccuracy
+  |};
+
+  declare type DurationFromObjectOptions = {|
+    year?: number,
+    years?: number,
+    month?: number,
+    months?: number,
+    week?: number,
+    weeks?: number,
+    day?: number,
+    days?: number,
+    hour?: number,
+    hours?: number,
+    minute?: number,
+    minutes?: number,
+    second?: number,
+    seconds?: number,
+    millsecond?: number,
+    milliseconds?: number,
+    locale?: ?string,
+    numberingSystem?: ?string,
+    conversionAccuracy?: ?ConversionAccuracy
+  |};
+
+  declare export type DurationObject = {
+    years?: number,
+    months?: number,
+    days?: number,
+    hours?: number,
+    minutes?: number,
+    seconds?: number,
+    milliseconds?: number,
+    ...
+  };
+
+  declare export type DurationConfig = {
+    locale: string,
+    numberingSystem: ?string,
+    conversionAccuracy: ConversionAccuracy,
+    ...
+  };
+
+  declare export class Duration {
+    static fromISO(text: string, options?: DurationFromOptions): Duration;
+    static fromObject(obj: DurationFromObjectOptions): Duration;
+    static fromMillis(count: number, options?: DurationFromOptions): Duration;
+    static invalid(reason: string): Duration;
+    days: number;
+    hours: number;
+    invalidReason: ?string;
+    isValid: boolean;
+    locale: string;
+    milliseconds: number;
+    minutes: number;
+    months: number;
+    numberingSystem: string;
+    seconds: number;
+    weeks: number;
+    years: number;
+    as(unit: DurationUnit): number;
+    equals(other: Duration): boolean;
+    get(unit: DurationUnit): number;
+    inspect(): string;
+    minus(duration: Duration | number | DurationFromObjectOptions): Duration;
+    negate(): Duration;
+    normalize(): Duration;
+    plus(duration: Duration | number | DurationFromObjectOptions): Duration;
+    reconfigure(options: DurationFromOptions): Duration;
+    set(values: DurationFromObjectOptions): Duration;
+    shiftTo(first: DurationUnit, ...rest: Array<DurationUnit>): Duration;
+    toFormat(fmt: string, options?: {| round?: boolean |}): string;
+    toISO(): string;
+    toJSON(): string;
+    toObject(options: {| includeConfig: true |}): DurationObject &
+      DurationConfig;
+    toObject(options?: {| includeConfig?: boolean |}): DurationObject;
+    toString(): string;
+    valueOf(): number;
+  }
+
+  declare type DateTimeFromOptions = {|
+    zone?: ?(string | Zone),
+    setZone?: ?boolean,
+    locale?: ?string,
+    outputCalendar?: ?string,
+    numberingSystem?: ?string
+  |};
+
+  declare type ToISOOptions = {|
+    suppressMilliseconds?: ?boolean,
+    suppressSeconds?: ?boolean,
+    includeOffset?: ?boolean
+  |};
+
+  declare type SetZoneOptions = {|
+    keepCalendarTime?: ?boolean, // Support deprecated name for keepLocalTime
+    keepLocalTime?: ?boolean,
+  |};
+
+  declare type DateTimeFieldsOptions = {|
+    year?: number,
+    years?: number,
+    month?: number,
+    months?: number,
+    day?: number,
+    days?: number,
+    hour?: number,
+    hours?: number,
+    minute?: number,
+    minutes?: number,
+    second?: number,
+    seconds?: number,
+    millisecond?: number,
+    milliseconds?: number,
+    weekNumber?: number,
+    weekNumbers?: number,
+    weekYear?: number,
+    weekYears?: number,
+    weekday?: number,
+    weekdays?: number,
+    week?: number,
+    weeks?: number
+  |};
+
+  declare type DateTimeFromObjectOptions = {|
+    year?: number,
+    years?: number,
+    month?: number,
+    months?: number,
+    day?: number,
+    days?: number,
+    hour?: number,
+    hours?: number,
+    minute?: number,
+    minutes?: number,
+    second?: number,
+    seconds?: number,
+    millisecond?: number,
+    milliseconds?: number,
+    weekNumber?: number,
+    weekNumbers?: number,
+    weekYear?: number,
+    weekYears?: number,
+    weekday?: number,
+    weekdays?: number,
+    week?: number,
+    weeks?: number,
+    zone?: ?(string | Zone),
+    setZone?: ?boolean,
+    locale?: ?string,
+    outputCalendar?: ?string,
+    numberingSystem?: ?string
+  |};
+
+  declare type DateTimeDiffOptions = {|
+    conversionAccuracy?: ?ConversionAccuracy
+  |};
+
+  declare export type DateTimeObject = {
+    year: number,
+    month: number,
+    day: number,
+    hour: number,
+    minute: number,
+    second: number,
+    millisecond: number,
+    ...
+  };
+
+  declare export type DateTimeConfig = {
+    locale: string,
+    outputCalendar: ?string,
+    numberingSystem: ?string,
+    ...
+  };
+
+  declare export type ResolvedLocaleOptions = {
+    locale: string,
+    outputCalendar: string,
+    numberingSystem: string,
+    ...
+  };
+
+  declare export type ToRelativeOptions = {|
+    base?: DateTime,
+    locale?: string,
+    style?: UnitLength,
+    unit?: ToRelativeUnit,
+    round?: boolean,
+    padding?: number,
+    numberingSystem?: ?string,
+  |};
+
+  declare export type ToRelativeCalendarOptions = {|
+    base?: DateTime,
+    locale?: string,
+    unit?: ToRelativeCalendarUnit,
+    numberingSystem?: ?string,
+  |};
+
+  declare export class DateTime {
+    static DATETIME_FULL: IntlDateTimeFormatOptions;
+    static DATETIME_FULL_WITH_SECONDS: IntlDateTimeFormatOptions;
+    static DATETIME_HUGE: IntlDateTimeFormatOptions;
+    static DATETIME_HUGE_WITH_SECONDS: IntlDateTimeFormatOptions;
+    static DATETIME_MED: IntlDateTimeFormatOptions;
+    static DATETIME_MED_WITH_SECONDS: IntlDateTimeFormatOptions;
+    static DATETIME_SHORT: IntlDateTimeFormatOptions;
+    static DATETIME_SHORT_WITH_SECONDS: IntlDateTimeFormatOptions;
+    static DATE_FULL: IntlDateTimeFormatOptions;
+    static DATE_HUGE: IntlDateTimeFormatOptions;
+    static DATE_MED: IntlDateTimeFormatOptions;
+    static DATE_SHORT: IntlDateTimeFormatOptions;
+    static TIME_24_SIMPLE: IntlDateTimeFormatOptions;
+    static TIME_24_WITH_LONG_OFFSET: IntlDateTimeFormatOptions;
+    static TIME_24_WITH_SECONDS: IntlDateTimeFormatOptions;
+    static TIME_24_WITH_SHORT_OFFSET: IntlDateTimeFormatOptions;
+    static TIME_SIMPLE: IntlDateTimeFormatOptions;
+    static TIME_WITH_LONG_OFFSET: IntlDateTimeFormatOptions;
+    static TIME_WITH_SECONDS: IntlDateTimeFormatOptions;
+    static TIME_WITH_SHORT_OFFSET: IntlDateTimeFormatOptions;
+    static local(
+      year?: number,
+      month?: number,
+      day?: number,
+      hour?: number,
+      minute?: number,
+      second?: number,
+      millisecond?: number
+    ): DateTime;
+    static utc(
+      year?: number,
+      month?: number,
+      day?: number,
+      hour?: number,
+      minute?: number,
+      second?: number,
+      millisecond?: number
+    ): DateTime;
+    static fromHTTP(text: string, options?: DateTimeFromOptions): DateTime;
+    static fromObject(obj: DateTimeFromObjectOptions): DateTime;
+    static fromISO(text: string, options?: DateTimeFromOptions): DateTime;
+    static fromJSDate(date: Date, options?: DateTimeFromOptions): DateTime;
+    static fromMillis(
+      millseconds: number,
+      options?: DateTimeFromOptions
+    ): DateTime;
+    static fromSeconds(
+      seconds: number,
+      options?: DateTimeFromOptions
+    ): DateTime;
+    static fromRFC2822(text: string, options?: DateTimeFromOptions): DateTime;
+    static fromSQL(text: string, options?: DateTimeFromOptions): DateTime;
+    static fromFormat(
+      text: string,
+      fmt: string,
+      options?: DateTimeFromOptions
+    ): DateTime;
+    static fromFormatExplain(
+      text: string,
+      fmt: string,
+      options?: DateTimeFromOptions
+    ): {
+      input: string,
+      tokens: Array<{
+        literal: boolean,
+        val: string,
+        ...
+      }>,
+      regex: RegExp,
+      rawMatches: ?Array<string>,
+      matches: Object,
+      result: { [unit: DateTimeUnit]: number, ... },
+      zone: ?Zone,
+      ...
+    };
+    static invalid(reason: string): DateTime;
+    static max(first: DateTime, ...rest: Array<DateTime>): DateTime;
+    static min(first: DateTime, ...rest: Array<DateTime>): DateTime;
+    day: number;
+    daysInMonth: number;
+    daysInYear: number;
+    hour: number;
+    invalidReason: ?string;
+    isInDST: boolean;
+    isInLeapYear: boolean;
+    isOffsetFixed: boolean;
+    isValid: boolean;
+    locale: string;
+    millisecond: number;
+    minute: number;
+    month: number;
+    monthLong: string;
+    monthShort: string;
+    numberingSystem: ?string;
+    offset: number;
+    offsetNameLong: string;
+    offsetNameShort: string;
+    ordinal: number;
+    outputCalendar: ?string;
+    second: number;
+    weekNumber: number;
+    weekYear: number;
+    weekday: number;
+    weekdayLong: string;
+    weekdayShort: string;
+    weeksInWeekYear: number;
+    year: number;
+    zoneName: string;
+    diff(
+      otherDateTime: DateTime,
+      unit?: DateTimeUnit | Array<DateTimeUnit>,
+      options?: DateTimeDiffOptions
+    ): Duration;
+    diffNow(
+      unit?: DateTimeUnit | Array<DateTimeUnit>,
+      options?: DateTimeDiffOptions
+    ): Duration;
+    endOf(unit: DateTimeUnit): DateTime;
+    equals(other: DateTime): boolean;
+    get(unit: DateTimeUnit): number;
+    hasSame(other: DateTime, unit: DateTimeUnit): boolean;
+    inspect(): string;
+    minus(duration: Duration | number | DurationFromObjectOptions): DateTime;
+    plus(duration: Duration | number | DurationFromObjectOptions): DateTime;
+    reconfigure(options: DateTimeFromOptions): DateTime;
+    resolvedLocaleOpts(
+      options?: IntlDateTimeFormatOptions
+    ): ResolvedLocaleOptions;
+    set(values: { [unit: DateTimeUnit]: number, ... }): DateTime;
+    setLocale(locale: string): DateTime;
+    setZone(zone: string | Zone, options?: SetZoneOptions): DateTime;
+    startOf(unit: DateTimeUnit): DateTime;
+    toBSON(): Date;
+    toFormat(fmt: string, options?: {| round?: ?boolean |}): string;
+    toHTTP(): string;
+    toISO(options?: ToISOOptions): string;
+    toISODate(): string;
+    toISOTime(options?: ToISOOptions): string;
+    toISOWeekDate(): string;
+    toJSDate(): Date;
+    toLocal(): DateTime;
+    toLocaleParts(
+      options?: IntlDateTimeFormatOptions
+    ): Array<{
+      type: string,
+      value: number,
+      ...
+    }>;
+    toLocaleString(options?: IntlDateTimeFormatOptions): string;
+    toRelative(options?: ToRelativeOptions): string;
+    toRelativeCalendar(options?: ToRelativeCalendarOptions): string;
+    toMillis(): number;
+    toObject(options: {| includeConfig: true |}): DateTimeObject &
+      DateTimeConfig;
+    toObject(options?: {| includeConfig?: ?boolean |}): DateTimeObject;
+    toRFC2822(): string;
+    toSQL(opts?: {|
+      includeZone?: ?boolean,
+      includeOffset?: ?boolean
+    |}): string;
+    toSQLDate(): string;
+    toSQLTime(opts?: {|
+      includeZone?: ?boolean,
+      includeOffset?: ?boolean
+    |}): string;
+    toString(): string;
+    toUTC(offset?: number, options?: SetZoneOptions): DateTime;
+    until(other: DateTime): Interval;
+    valueOf(): number;
+  }
+}

--- a/definitions/npm/luxon_v1.9.x/flow_v0.104.x-/test_luxon.js
+++ b/definitions/npm/luxon_v1.9.x/flow_v0.104.x-/test_luxon.js
@@ -573,6 +573,25 @@ if (date.equals(new Date())) {
 // $FlowExpectedError[prop-missing]
 (date.toLocaleString({ foo: "bar" }): string);
 
+(date.toRelative(): string);
+(date.toRelative({ base: date }): string);
+// $FlowExpectedError[incompatible-call]
+(date.toRelative({ base: '2020-09-01' }): string);
+(date.toRelative({ locale: "fr" }): string);
+// $FlowExpectedError[prop-missing]
+(date.toRelative({foo: 'bar'}): string);
+
+(date.toRelativeCalendar(): string);
+(date.toRelativeCalendar({ base: date }): string);
+// $FlowExpectedError[incompatible-call]
+(date.toRelativeCalendar({ base: '2020-09-01' }): string);
+(date.toRelativeCalendar({ locale: "fr" }): string);
+// $FlowExpectedError[incompatible-call]
+(date.toRelativeCalendar({ unit: "seconds" }): string);
+(date.toRelativeCalendar({ unit: "quarters" }): string);
+// $FlowExpectedError[prop-missing]
+(date.toRelativeCalendar({foo: 'bar'}): string);
+
 (date.toMillis(): number);
 
 (date.toObject().year: number);


### PR DESCRIPTION
- Links to documentation:
      toRelative: https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#instance-method-toRelative
      toRelativeCalendar: https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#instance-method-toRelativeCalendar
- Link to GitHub or NPM: https://github.com/moment/luxon
- Type of contribution: addition

Other notes:
The methods I'm adding were not added to the library until [v1.9.0](https://github.com/moment/luxon/blob/master/CHANGELOG.md#190) . I wasn't sure whether there's a remedy for that.

