### PR TITLE
[react-navigation] Update all suppressions to use error codes

### DIFF
--- a/definitions/npm/@react-navigation/bottom-tabs_v5.x.x/test_bottom-tabs.js
+++ b/definitions/npm/@react-navigation/bottom-tabs_v5.x.x/test_bottom-tabs.js
@@ -51,9 +51,9 @@ function ValidScreen(props: {|
   route: NavRoute<'One'>,
 |}) {
   props.navigation.navigate('Another');
-  // $FlowExpectedError invalid params
+  // $FlowFixMe[incompatible-call] invalid params
   props.navigation.navigate('Another', {});
-  // $FlowExpectedError invalid route
+  // $FlowFixMe[incompatible-call] invalid route
   props.navigation.navigate('test', { sup: true, yo: null });
   props.navigation.jumpTo('Three');
   (props.navigation: NavigationProp<
@@ -75,7 +75,7 @@ function InvalidScreen(props: {|
     tabBarLabel: 'SUP',
     unmountOnBlur: true,
   });
-  // $FlowExpectedError invalid navigator props
+  // $FlowFixMe[prop-missing] invalid navigator props
   props.navigation.setOptions({ fake: 12 });
   React.useEffect(() => {
     return props.navigation.addListener(
@@ -90,15 +90,15 @@ function InvalidScreen(props: {|
 }
 
 <Tab.Screen name="One" component={ValidScreen} />;
-// $FlowExpectedError non-matching component
+// $FlowFixMe[incompatible-type] non-matching component
 <Tab.Screen name="Two" component={ValidScreen} />;
-// $FlowExpectedError invalid route name
+// $FlowFixMe[incompatible-type] invalid route name
 <Tab.Screen name="Four" component={ValidScreen} />;
-// $FlowExpectedError invalid params
+// $FlowFixMe[incompatible-type] invalid params
 <Tab.Screen name="One" component={ValidScreen} initialParams={{ hey: 5 }} />;
-// $FlowExpectedError non-local route
+// $FlowFixMe[incompatible-type] non-local route
 <Tab.Screen name="Another" component={ValidScreen} />;
-// $FlowExpectedError invalid screen props
+// $FlowFixMe[incompatible-type] invalid screen props
 <Tab.Screen name="One" component={InvalidScreen} />;
 
 /**
@@ -106,9 +106,9 @@ function InvalidScreen(props: {|
  */
 
 <Tab.Navigator lazy={true} />;
-// $FlowExpectedError invalid navigator props
+// $FlowFixMe[prop-missing] invalid navigator props
 <Tab.Navigator
-  // $FlowExpectedError invalid navigator props
+  // $FlowFixMe[incompatible-type] invalid navigator props
   lazy={5}
   someOtherProp="fake"
 />;

--- a/definitions/npm/@react-navigation/core_v3.x.x/test_core.js
+++ b/definitions/npm/@react-navigation/core_v3.x.x/test_core.js
@@ -45,5 +45,5 @@ const fakeNavigateAction = {
   fake: "Navigation/NAVIGATE",
   blah: "Test1",
 };
-// $FlowExpectedError not a valid action!
+// $FlowFixMe[incompatible-call] not a valid action!
 tabRouter.getStateForAction(fakeNavigateAction, null);

--- a/definitions/npm/@react-navigation/core_v5.x.x/test_core.js
+++ b/definitions/npm/@react-navigation/core_v5.x.x/test_core.js
@@ -59,27 +59,27 @@ removeListener();
 navProp.addListener('another', e => {
   (e.type: 'another');
   (e.data: string);
-  // $FlowExpectedError canPreventDefault set to false
+  // $FlowFixMe[prop-missing] canPreventDefault set to false
   e.preventDefault();
 });
 navProp.addListener('third', e => {
   (e.type: 'third');
   (e.target: ?string);
-  // $FlowExpectedError there's no data field on this event
+  // $FlowFixMe[prop-missing] there's no data field on this event
   e.data;
   e.preventDefault();
 });
 navProp.setParams({ sup: false });
 
 navProp.navigate('CoolScreen', { sup: true, yo: null });
-// $FlowExpectedError CoolScreen route needs params
+// $FlowFixMe[incompatible-call] CoolScreen route needs params
 navProp.navigate('CoolScreen');
 navProp.navigate({ name: 'CoolScreen', params: { sup: true, yo: null } });
 navProp.navigate('another');
 navProp.navigate('another', { eh: 'hello' });
-// $FlowExpectedError wrong params
+// $FlowFixMe[incompatible-call] wrong params
 navProp.navigate('another', { eh: 'yo', fake: 'hello' });
-// $FlowExpectedError not a valid route name
+// $FlowFixMe[incompatible-call] not a valid route name
 navProp.navigate('another2');
 
 navProp.dispatch(CommonActions.goBack());
@@ -104,7 +104,7 @@ declare var inexactNavProp: NavigationProp<
   {||},
 >;
 inexactNavProp.navigate('another2');
-// $FlowExpectedError CoolScreen route needs params
+// $FlowFixMe[incompatible-call] CoolScreen route needs params
 inexactNavProp.navigate('CoolScreen');
 inexactNavProp.navigate('another', { eh: 'yo', fake: 'hello' });
 
@@ -199,9 +199,9 @@ function BadlyTypedCoolScreen(props: {|
 }
 
 <Example.Screen name="CoolScreen" component={CoolScreen} />;
-// $FlowExpectedError invalid route name
+// $FlowFixMe[incompatible-type] invalid route name
 <Example.Screen name="Fake" component={CoolScreen} />;
-// $FlowExpectedError invalid screen props
+// $FlowFixMe[incompatible-type] invalid screen props
 <Example.Screen name="CoolScreen" component={BadlyTypedCoolScreen} />;
 
 /**
@@ -248,7 +248,7 @@ tabRouter.getStateForAction(
 );
 tabRouter.getStateForAction(
   tabState,
-  // $FlowExpectedError not a valid action!
+  // $FlowFixMe[incompatible-call] not a valid action!
   { fake: 'NAVIGATE', blah: 'Test1' },
   routerConfigOptions,
 );

--- a/definitions/npm/@react-navigation/drawer_v5.x.x/test_drawer.js
+++ b/definitions/npm/@react-navigation/drawer_v5.x.x/test_drawer.js
@@ -51,9 +51,9 @@ function ValidScreen(props: {|
   route: NavRoute<'One'>,
 |}) {
   props.navigation.navigate('Another');
-  // $FlowExpectedError invalid params
+  // $FlowFixMe[incompatible-call] invalid params
   props.navigation.navigate('Another', {});
-  // $FlowExpectedError invalid route
+  // $FlowFixMe[incompatible-call] invalid route
   props.navigation.navigate('test', { sup: true, yo: null });
   props.navigation.jumpTo('Three');
   props.navigation.openDrawer();
@@ -79,14 +79,14 @@ function InvalidScreen(props: {|
     gestureEnabled: false,
     swipeEnabled: false,
   });
-  // $FlowExpectedError invalid navigator props
+  // $FlowFixMe[prop-missing] invalid navigator props
   props.navigation.setOptions({ fake: 12 });
   React.useEffect(() => {
     return props.navigation.addListener(
       'drawerOpen',
       e => {
         (e.type: 'drawerOpen');
-        // $FlowExpectedError swipeStart doesn't support preventDefault
+        // $FlowFixMe[prop-missing] swipeStart doesn't support preventDefault
         e.preventDefault();
       },
     );
@@ -95,15 +95,15 @@ function InvalidScreen(props: {|
 }
 
 <Drawer.Screen name="One" component={ValidScreen} />;
-// $FlowExpectedError non-matching component
+// $FlowFixMe[incompatible-type] non-matching component
 <Drawer.Screen name="Two" component={ValidScreen} />;
-// $FlowExpectedError invalid route name
+// $FlowFixMe[incompatible-type] invalid route name
 <Drawer.Screen name="Four" component={ValidScreen} />;
-// $FlowExpectedError invalid params
+// $FlowFixMe[incompatible-type] invalid params
 <Drawer.Screen name="One" component={ValidScreen} initialParams={{ hey: 5 }} />;
-// $FlowExpectedError non-local route
+// $FlowFixMe[incompatible-type] non-local route
 <Drawer.Screen name="Another" component={ValidScreen} />;
-// $FlowExpectedError invalid screen props
+// $FlowFixMe[incompatible-type] invalid screen props
 <Drawer.Screen name="One" component={InvalidScreen} />;
 
 /**
@@ -112,9 +112,9 @@ function InvalidScreen(props: {|
 
 <Drawer.Navigator drawerPosition="left" hideStatusBar={true} />;
 <Drawer.Navigator drawerType="front" edgeWidth={5} />;
-// $FlowExpectedError invalid navigator props
+// $FlowFixMe[prop-missing] invalid navigator props
 <Drawer.Navigator
-  // $FlowExpectedError invalid navigator props
+  // $FlowFixMe[incompatible-type] invalid navigator props
   edgeWidth="string"
   someOtherProp="fake"
 />;

--- a/definitions/npm/@react-navigation/material-bottom-tabs_v5.x.x/test_material-bottom-tabs.js
+++ b/definitions/npm/@react-navigation/material-bottom-tabs_v5.x.x/test_material-bottom-tabs.js
@@ -51,9 +51,9 @@ function ValidScreen(props: {|
   route: NavRoute<'One'>,
 |}) {
   props.navigation.navigate('Another');
-  // $FlowExpectedError invalid params
+  // $FlowFixMe[incompatible-call] invalid params
   props.navigation.navigate('Another', {});
-  // $FlowExpectedError invalid route
+  // $FlowFixMe[incompatible-call] invalid route
   props.navigation.navigate('test', { sup: true, yo: null });
   props.navigation.jumpTo('Three');
   (props.navigation: NavigationProp<
@@ -75,7 +75,7 @@ function InvalidScreen(props: {|
     tabBarLabel: 'SUP',
     tabBarBadge: true,
   });
-  // $FlowExpectedError invalid navigator props
+  // $FlowFixMe[prop-missing] invalid navigator props
   props.navigation.setOptions({ fake: 12 });
   React.useEffect(() => {
     return props.navigation.addListener(
@@ -90,15 +90,15 @@ function InvalidScreen(props: {|
 }
 
 <Tab.Screen name="One" component={ValidScreen} />;
-// $FlowExpectedError non-matching component
+// $FlowFixMe[incompatible-type] non-matching component
 <Tab.Screen name="Two" component={ValidScreen} />;
-// $FlowExpectedError invalid route name
+// $FlowFixMe[incompatible-type] invalid route name
 <Tab.Screen name="Four" component={ValidScreen} />;
-// $FlowExpectedError invalid params
+// $FlowFixMe[incompatible-type] invalid params
 <Tab.Screen name="One" component={ValidScreen} initialParams={{ hey: 5 }} />;
-// $FlowExpectedError non-local route
+// $FlowFixMe[incompatible-type] non-local route
 <Tab.Screen name="Another" component={ValidScreen} />;
-// $FlowExpectedError invalid screen props
+// $FlowFixMe[incompatible-type] invalid screen props
 <Tab.Screen name="One" component={InvalidScreen} />;
 
 /**
@@ -107,9 +107,9 @@ function InvalidScreen(props: {|
 
 <Tab.Navigator shifting={true} />;
 <Tab.Navigator activeColor="blah" />;
-// $FlowExpectedError invalid navigator props
+// $FlowFixMe[prop-missing] invalid navigator props
 <Tab.Navigator
-  // $FlowExpectedError invalid navigator props
+  // $FlowFixMe[incompatible-type] invalid navigator props
   shifting={5}
   someOtherProp="fake"
 />;

--- a/definitions/npm/@react-navigation/material-top-tabs_v5.x.x/test_material-top-tabs.js
+++ b/definitions/npm/@react-navigation/material-top-tabs_v5.x.x/test_material-top-tabs.js
@@ -51,9 +51,9 @@ function ValidScreen(props: {|
   route: NavRoute<'One'>,
 |}) {
   props.navigation.navigate('Another');
-  // $FlowExpectedError invalid params
+  // $FlowFixMe[incompatible-call] invalid params
   props.navigation.navigate('Another', {});
-  // $FlowExpectedError invalid route
+  // $FlowFixMe[incompatible-call] invalid route
   props.navigation.navigate('test', { sup: true, yo: null });
   props.navigation.jumpTo('Three');
   (props.navigation: NavigationProp<
@@ -75,7 +75,7 @@ function InvalidScreen(props: {|
     tabBarLabel: 'SUP',
     tabBarTestID: '5',
   });
-  // $FlowExpectedError invalid navigator props
+  // $FlowFixMe[prop-missing] invalid navigator props
   props.navigation.setOptions({ fake: 12 });
   React.useEffect(() => {
     return props.navigation.addListener(
@@ -91,7 +91,7 @@ function InvalidScreen(props: {|
       'swipeStart',
       e => {
         (e.type: 'swipeStart');
-        // $FlowExpectedError swipeStart doesn't support preventDefault
+        // $FlowFixMe[prop-missing] swipeStart doesn't support preventDefault
         e.preventDefault();
       },
     );
@@ -100,15 +100,15 @@ function InvalidScreen(props: {|
 }
 
 <Tab.Screen name="One" component={ValidScreen} />;
-// $FlowExpectedError non-matching component
+// $FlowFixMe[incompatible-type] non-matching component
 <Tab.Screen name="Two" component={ValidScreen} />;
-// $FlowExpectedError invalid route name
+// $FlowFixMe[incompatible-type] invalid route name
 <Tab.Screen name="Four" component={ValidScreen} />;
-// $FlowExpectedError invalid params
+// $FlowFixMe[incompatible-type] invalid params
 <Tab.Screen name="One" component={ValidScreen} initialParams={{ hey: 5 }} />;
-// $FlowExpectedError non-local route
+// $FlowFixMe[incompatible-type] non-local route
 <Tab.Screen name="Another" component={ValidScreen} />;
-// $FlowExpectedError invalid screen props
+// $FlowFixMe[incompatible-type] invalid screen props
 <Tab.Screen name="One" component={InvalidScreen} />;
 
 /**
@@ -118,9 +118,9 @@ function InvalidScreen(props: {|
 <Tab.Navigator tabBarPosition="top" />;
 <Tab.Navigator lazy={false} />;
 <Tab.Navigator timingConfig={{ duration: 5 }} />;
-// $FlowExpectedError invalid navigator props
+// $FlowFixMe[prop-missing] invalid navigator props
 <Tab.Navigator
-  // $FlowExpectedError invalid navigator props
+  // $FlowFixMe[incompatible-type] invalid navigator props
   lazy={5}
   someOtherProp="fake"
 />;

--- a/definitions/npm/@react-navigation/stack_v5.x.x/test_stack.js
+++ b/definitions/npm/@react-navigation/stack_v5.x.x/test_stack.js
@@ -51,9 +51,9 @@ function ValidScreen(props: {|
   route: NavRoute<'One'>,
 |}) {
   props.navigation.navigate('Another');
-  // $FlowExpectedError invalid params
+  // $FlowFixMe[incompatible-call] invalid params
   props.navigation.navigate('Another', {});
-  // $FlowExpectedError invalid route
+  // $FlowFixMe[incompatible-call] invalid route
   props.navigation.navigate('test', { sup: true, yo: null });
   props.navigation.push('One', { hey: 'sup' });
   props.navigation.pop(5);
@@ -77,14 +77,14 @@ function InvalidScreen(props: {|
     headerTitle: 'ayyyy',
     headerStatusBarHeight: 5,
   });
-  // $FlowExpectedError invalid navigator props
+  // $FlowFixMe[prop-missing] invalid navigator props
   props.navigation.setOptions({ fake: 12 });
   React.useEffect(() => {
     return props.navigation.addListener(
       'transitionStart',
       e => {
         (e.type: 'transitionStart');
-        // $FlowExpectedError swipeStart doesn't support preventDefault
+        // $FlowFixMe[prop-missing] swipeStart doesn't support preventDefault
         e.preventDefault();
       },
     );
@@ -93,15 +93,15 @@ function InvalidScreen(props: {|
 }
 
 <Stack.Screen name="One" component={ValidScreen} />;
-// $FlowExpectedError non-matching component
+// $FlowFixMe[incompatible-type] non-matching component
 <Stack.Screen name="Two" component={ValidScreen} />;
-// $FlowExpectedError invalid route name
+// $FlowFixMe[incompatible-type] invalid route name
 <Stack.Screen name="Four" component={ValidScreen} />;
-// $FlowExpectedError invalid params
+// $FlowFixMe[incompatible-type] invalid params
 <Stack.Screen name="One" component={ValidScreen} initialParams={{ hey: 5 }} />;
-// $FlowExpectedError non-local route
+// $FlowFixMe[incompatible-type] non-local route
 <Stack.Screen name="Another" component={ValidScreen} />;
-// $FlowExpectedError invalid screen props
+// $FlowFixMe[incompatible-type] invalid screen props
 <Stack.Screen name="One" component={InvalidScreen} />;
 
 /**
@@ -113,9 +113,9 @@ function InvalidScreen(props: {|
   headerMode="float"
   keyboardHandlingEnabled={true}
 />;
-// $FlowExpectedError invalid navigator props
+// $FlowFixMe[prop-missing] invalid navigator props
 <Stack.Navigator
-  // $FlowExpectedError invalid navigator props
+  // $FlowFixMe[incompatible-type] invalid navigator props
   mode="FAKE"
   headerMode="float"
   keyboardHandlingEnabled={true}


### PR DESCRIPTION
Fixing the warnings in tests that started popping of as of Flow 0.132