### PR TITLE
[@ungap/promise-all-settled_v1.1.x] Add definitions

### DIFF
--- a/definitions/npm/@ungap/promise-all-settled_v1.1.x/flow_v0.104.x-/promise-all-settled_v1.1.x.js
+++ b/definitions/npm/@ungap/promise-all-settled_v1.1.x/flow_v0.104.x-/promise-all-settled_v1.1.x.js
@@ -1,0 +1,22 @@
+declare module '@ungap/promise-all-settled' {
+  declare type SettledPromiseResult<+T> =
+    | {|
+        +status: 'fulfilled',
+        +value: T,
+      |}
+    | {|
+        +status: 'rejected',
+        +reason: any,
+      |};
+
+  /**
+   * Creates a Promise that is resolved with an array of results when all
+   * of the provided Promises resolve or reject.
+   * @param promises  An array of Promises.
+   * @returns A new Promise.
+   * @see https://github.com/facebook/flow/blob/92dad73bbc64540dcedecf6ad4589634544b62ea/lib/core.js#L1880
+   */
+  declare export default function allSettled<T: Iterable<mixed>>(
+    promises: T
+  ): Promise<$TupleMap<T, <T>(p: Promise<T> | T) => SettledPromiseResult<T>>>;
+}

--- a/definitions/npm/@ungap/promise-all-settled_v1.1.x/flow_v0.104.x-/test_promise-all-settled_v1.1.x.js
+++ b/definitions/npm/@ungap/promise-all-settled_v1.1.x/flow_v0.104.x-/test_promise-all-settled_v1.1.x.js
@@ -1,0 +1,33 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import allSettled from '@ungap/promise-all-settled';
+
+describe('The `allSettled` function', () => {
+  it('usage with call', () => {
+    allSettled.call(Promise, []);
+
+    allSettled.call(Promise, [Promise.resolve(), Promise.resolve()]);
+
+    allSettled.call(Promise, [123]);
+
+    // $FlowExpectedError[incompatible-call]
+    allSettled.call(Promise.resolve());
+    // $FlowExpectedError[prop-missing]
+    allSettled.call(Promise, Promise.resolve());
+    // $FlowExpectedError[prop-missing]
+    allSettled.call(Promise, 123);
+  });
+
+  it('usage with bind', () => {
+    const $settled = allSettled.bind(Promise);
+
+    $settled([]);
+    $settled([Promise.resolve(), Promise.resolve()]);
+
+    // $FlowExpectedError[prop-missing]
+    $settled(Promise.resolve());
+    // $FlowExpectedError[prop-missing]
+    $settled(123);
+  });
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/ungap/promise-all-settled
- Link to GitHub or NPM:  https://github.com/ungap/promise-all-settled
- Type of contribution: new definition

Other notes:
Couldn't make `typeof Promise.allSettled` (added in Flow > 0.120) with `call, bind`... So copy/pasta.

