### PR TITLE
refactor: clean up fs.readFile usage

### DIFF
--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -42,7 +42,7 @@ async function touchFile(filePath) {
 }
 
 async function writePkgJson(filePath, pkgJson) {
-  await fs.writeFile(filePath, JSON.stringify(pkgJson));
+  await fs.writeJson(filePath, pkgJson);
 }
 
 describe('install (command)', () => {
@@ -344,10 +344,10 @@ describe('install (command)', () => {
         ).toEqual([true, true]);
 
         // Signs installed libdefs
-        const fooLibDefRawContents = await fs.readFile(
+        const fooLibDefContents = await fs.readFile(
           path.join(FLOWPROJ_DIR, 'flow-typed', 'npm', 'foo_v1.x.x.js'),
+          'utf8',
         );
-        const fooLibDefContents = fooLibDefRawContents.toString();
         expect(fooLibDefContents).toContain('// flow-typed signature: ');
         expect(fooLibDefContents).toContain('// flow-typed version: ');
       });
@@ -565,7 +565,7 @@ describe('install (command)', () => {
 
         // Tweak the libdef for foo
         const libdefFileContent =
-          (await fs.readFile(libdefFilePath)).toString() + '\n// TWEAKED!';
+          (await fs.readFile(libdefFilePath, 'utf8')) + '\n// TWEAKED!';
         await fs.writeFile(libdefFilePath, libdefFileContent);
 
         // Run install command again
@@ -577,7 +577,7 @@ describe('install (command)', () => {
         });
 
         // Verify that the tweaked libdef file wasn't overwritten
-        expect(await (await fs.readFile(libdefFilePath)).toString()).toBe(
+        expect(await fs.readFile(libdefFilePath, 'utf8')).toBe(
           libdefFileContent,
         );
       });
@@ -617,8 +617,7 @@ describe('install (command)', () => {
         );
 
         // Tweak the libdef for foo
-        const libdefFileRawContent = await fs.readFile(libdefFilePath);
-        const libdefFileContent = libdefFileRawContent.toString();
+        const libdefFileContent = await fs.readFile(libdefFilePath, 'utf8');
         await fs.writeFile(libdefFilePath, libdefFileContent + '\n// TWEAKED!');
 
         // Run install command again
@@ -630,7 +629,7 @@ describe('install (command)', () => {
         });
 
         // Verify that the tweaked libdef file wasn't overwritten
-        expect(await (await fs.readFile(libdefFilePath)).toString()).toBe(
+        expect(await fs.readFile(libdefFilePath, 'utf8')).toBe(
           libdefFileContent,
         );
       });

--- a/cli/src/lib/__mocks__/node.js
+++ b/cli/src/lib/__mocks__/node.js
@@ -32,27 +32,38 @@ export const fs = {
   mkdir: node_fs.mkdir,
   readdir: node_fs.readdir,
   // $FlowFixMe
-  readFile: jest.fn((filePath: string, encoding?: any): Promise<
-    string | Buffer,
-  > => {
-    return new Promise((resolve, reject) => {
-      process.nextTick(() => {
-        if (fs.mockFiles[filePath]) {
-          resolve(
-            typeof encoding === 'string'
-              ? fs.mockFiles[filePath].toString(encoding)
-              : fs.mockFiles[filePath],
-          );
-        } else {
-          reject(
-            new Error(`ENOENT: no such file or directory, open '${filePath}'`),
-          );
-        }
+  readFile: jest.fn(
+    (
+      filePath: string,
+      options?: string | {encoding?: string, ...},
+    ): Promise<string | Buffer> => {
+      const encoding = options instanceof Object ? options.encoding : options;
+      return new Promise((resolve, reject) => {
+        process.nextTick(() => {
+          if (fs.mockFiles[filePath]) {
+            resolve(
+              typeof encoding === 'string'
+                ? fs.mockFiles[filePath].toString(encoding)
+                : fs.mockFiles[filePath],
+            );
+          } else {
+            reject(
+              new Error(
+                `ENOENT: no such file or directory, open '${filePath}'`,
+              ),
+            );
+          }
+        });
       });
-    });
-  }),
-  readJson: (filePath: string): Promise<any> =>
-    fs.readFile(filePath, 'utf8').then(data => JSON.parse(String(data))),
+    },
+  ),
+  readJson: (
+    filePath: string,
+    options?: string | {encoding?: string},
+  ): Promise<any> =>
+    fs
+      .readFile(filePath, options || 'utf8')
+      .then(data => JSON.parse(String(data))),
   rename: node_fs.rename,
   rmdir: node_fs.rmdir,
   stat: node_fs.stat,

--- a/cli/src/lib/__mocks__/node.js
+++ b/cli/src/lib/__mocks__/node.js
@@ -32,11 +32,17 @@ export const fs = {
   mkdir: node_fs.mkdir,
   readdir: node_fs.readdir,
   // $FlowFixMe
-  readFile: jest.fn((filePath: string): Promise<Buffer> => {
+  readFile: jest.fn((filePath: string, encoding?: any): Promise<
+    string | Buffer,
+  > => {
     return new Promise((resolve, reject) => {
       process.nextTick(() => {
         if (fs.mockFiles[filePath]) {
-          resolve(fs.mockFiles[filePath]);
+          resolve(
+            typeof encoding === 'string'
+              ? fs.mockFiles[filePath].toString(encoding)
+              : fs.mockFiles[filePath],
+          );
         } else {
           reject(
             new Error(`ENOENT: no such file or directory, open '${filePath}'`),
@@ -45,6 +51,8 @@ export const fs = {
       });
     });
   }),
+  readJson: (filePath: string): Promise<any> =>
+    fs.readFile(filePath, 'utf8').then(data => JSON.parse(data)),
   rename: node_fs.rename,
   rmdir: node_fs.rmdir,
   stat: node_fs.stat,
@@ -52,6 +60,7 @@ export const fs = {
   Stats: node_fs.Stats,
   unlink: node_fs.unlink,
   writeFile: node_fs.writeFile,
+  writeJson: node_fs.writeJson,
 };
 
 export const https = node_https;

--- a/cli/src/lib/__mocks__/node.js
+++ b/cli/src/lib/__mocks__/node.js
@@ -52,7 +52,7 @@ export const fs = {
     });
   }),
   readJson: (filePath: string): Promise<any> =>
-    fs.readFile(filePath, 'utf8').then(data => JSON.parse(data)),
+    fs.readFile(filePath, 'utf8').then(data => JSON.parse(String(data))),
   rename: node_fs.rename,
   rmdir: node_fs.rmdir,
   stat: node_fs.stat,

--- a/cli/src/lib/cacheRepoUtils.js
+++ b/cli/src/lib/cacheRepoUtils.js
@@ -130,7 +130,7 @@ export async function verifyCLIVersion(): Promise<void> {
     'definitions',
     '.cli-metadata.json',
   );
-  const metadata = JSON.parse(String(await fs.readFile(metadataPath)));
+  const metadata = await fs.readJson(metadataPath);
   const compatibleCLIRange = metadata.compatibleCLIRange;
   if (!compatibleCLIRange) {
     throw new Error(
@@ -139,9 +139,7 @@ export async function verifyCLIVersion(): Promise<void> {
     );
   }
   const thisCLIPkgJsonPath = path.join(__dirname, '..', '..', 'package.json');
-  const thisCLIPkgJson = JSON.parse(
-    String(await fs.readFile(thisCLIPkgJsonPath)),
-  );
+  const thisCLIPkgJson = await fs.readJson(thisCLIPkgJsonPath);
   const thisCLIVersion = thisCLIPkgJson.version;
   if (!semver.satisfies(thisCLIVersion, compatibleCLIRange)) {
     throw new Error(

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -381,7 +381,7 @@ function validateVersionPart(part, partName, context) {
  */
 async function verifyCLIVersion(defsDirPath) {
   const metadataFilePath = path.join(defsDirPath, '.cli-metadata.json');
-  const metadata = JSON.parse(String(await fs.readFile(metadataFilePath)));
+  const metadata = await fs.readJson(metadataFilePath);
   if (!metadata.compatibleCLIRange) {
     throw new Error(
       `Unable to find the 'compatibleCLIRange' property in ` +

--- a/cli/src/lib/node.js
+++ b/cli/src/lib/node.js
@@ -93,6 +93,7 @@ export const fs = {
   open: fsExtra.open,
   readdir: fsExtra.readdir,
   readFile: fsExtra.readFile,
+  readJson: fsExtra.readJson,
   rename: fsExtra.rename,
   rmdir: fsExtra.rmdir,
   stat: fsExtra.stat,
@@ -100,6 +101,7 @@ export const fs = {
   Stats: fsExtra.Stats,
   unlink: fsExtra.unlink,
   writeFile: fsExtra.writeFile,
+  writeJson: fsExtra.writeJson,
 };
 export const https = node_https;
 export const os = node_os;

--- a/cli/src/lib/npm/npmLibDefs.js
+++ b/cli/src/lib/npm/npmLibDefs.js
@@ -434,7 +434,7 @@ export async function getInstalledNpmLibDef(
   const terseFilePath = path.relative(flowProjectRootDir, fullFilePath);
   const fileStat = await fs.stat(fullFilePath);
   if (fileStat.isFile()) {
-    const fileContent = (await fs.readFile(fullFilePath)).toString();
+    const fileContent = await fs.readFile(fullFilePath, 'utf8');
     if (verifySignedCode(fileContent)) {
       const signedCodeVer = getSignedCodeVersion(fileContent);
       if (signedCodeVer === null) {

--- a/cli/src/lib/npm/npmProjectUtils.js
+++ b/cli/src/lib/npm/npmProjectUtils.js
@@ -93,10 +93,10 @@ export function getPackageJsonDependencies(
 
 export async function getPackageJsonData(pathStr: string): Promise<PkgJson> {
   const pkgJsonPath = await findPackageJsonPath(pathStr);
-  const pkgJsonContent = await fs.readFile(pkgJsonPath);
+  const pkgJsonContent = await fs.readJson(pkgJsonPath);
   return {
     pathStr: pkgJsonPath,
-    content: JSON.parse(pkgJsonContent.toString()),
+    content: pkgJsonContent,
   };
 }
 

--- a/cli/src/lib/stubUtils.js
+++ b/cli/src/lib/stubUtils.js
@@ -331,8 +331,8 @@ declare module '%s' {
   if (!overwrite) {
     const exists = await fs.exists(filename);
     if (exists) {
-      const existingStub = await fs.readFile(filename);
-      if (!verifySignedCode(existingStub.toString())) {
+      const existingStub = await fs.readFile(filename, 'utf8');
+      if (!verifySignedCode(existingStub)) {
         throw new Error(
           'Stub already exists and has been modified. ' +
             'Use --overwrite to overwrite',


### PR DESCRIPTION
The way `fs.readFile` was being used looked like a code smell, and sure enough, the way it was being mocked would cause surprise errors for anyone who adds idiomatic `fs-extra` calls in new or updated tests.  Pass encoding (`'utf8'`, the default) to get `readFile` to resolve to a string instead of a buffer, and use `readJson` where applicable.  Update fs mocks to behave a bit more like `fs-extra` in this regard (though I'm not sure it would be possible to support all options, but we can at least support encoding string as second argument).