### PR TITLE
Make the new preventScroll prop of react-modal_v3.12.x optional

### DIFF
--- a/definitions/npm/react-modal_v3.12.x/flow_v0.104.x-/react-modal_v3.12.x.js
+++ b/definitions/npm/react-modal_v3.12.x/flow_v0.104.x-/react-modal_v3.12.x.js
@@ -55,7 +55,7 @@ declare module 'react-modal' {
       props: ModalElementProps,
       contentElement: HTMLElement
     ) => HTMLElement,
-    preventScroll: boolean,
+    preventScroll?: boolean,
     ...
   };
 


### PR DESCRIPTION
It has a default value in defaultProps.
https://github.com/reactjs/react-modal/blob/master/src/components/Modal.js#L89

- https://github.com/flow-typed/flow-typed/pull/3957
- Type of contribution: fix
