### PR TITLE
Add definitions

### DIFF
--- a/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder/flow_v0.92.x-/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x.js
+++ b/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder/flow_v0.92.x-/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x.js
@@ -1,0 +1,120 @@
+declare module '@ginkgo-bioworks/react-json-schema-form-builder' {
+  declare type CardProps = {
+    name: string,
+    required: boolean,
+    dataOptions: { [string]: any },
+    uiOptions: { [string]: any },
+    $ref?: string,
+    dependents?: Array<{
+      children: Array<string>,
+      value?: any,
+    }>,
+    dependent?: boolean,
+    parent?: string,
+    propType: string,
+    neighborNames: Array<string>,
+  };
+
+  declare type SectionProps = {
+    name: string,
+    required: boolean,
+    schema: { [string]: any },
+    uischema: { [string]: any },
+    $ref?: string,
+    dependents?: Array<{
+      children: Array<string>,
+      value?: any,
+    }>,
+    dependent?: boolean,
+    propType: string,
+    neighborNames: Array<string>,
+  };
+
+  declare type ElementProps = CardProps & SectionProps;
+
+  declare type Parameters = {
+    [string]: string | number | boolean | Array<string | number>,
+    name: string,
+    path: string,
+    definitionData: { [string]: any },
+    definitionUi: { [string]: any },
+    category: string,
+    'ui:option': { [string]: any },
+  };
+
+  declare type DataType =
+    | 'string'
+    | 'number'
+    | 'boolean'
+    | 'integer'
+    | 'array'
+    | '*'
+    | null;
+
+  declare type MatchType = {
+    types: Array<DataType>,
+    widget?: string,
+    field?: string,
+    format?: string,
+    $ref?: boolean,
+    enum?: boolean,
+  };
+
+  declare type FormInput = {
+    displayName: string,
+    // given a data and ui schema, determine if the object is of this input type
+    matchIf: Array<MatchType>,
+    // allowed keys for ui:options
+    possibleOptions?: Array<string>,
+    defaultDataSchema: {
+      [string]: any,
+    },
+    defaultUiSchema: {
+      [string]: any,
+    },
+    // the data schema type
+    type: DataType,
+    // inputs on the preview card
+    cardBody: React.AbstractComponent<{
+      parameters: Parameters,
+      onChange: (newParams: Parameters) => void,
+      mods: { [string]: any },
+    }>,
+    // inputs for the modal
+    modalBody?: React.AbstractComponent<{
+      parameters: Parameters,
+      onChange: (newParams: Parameters) => void,
+    }>,
+  };
+
+  // optional properties that can add custom features to the form builder
+  declare type Mods = {
+    customFormInputs?: {
+      [string]: FormInput,
+    },
+    tooltipDescriptions?: {
+      add?: string,
+      cardObjectName?: string,
+      cardDisplayName?: string,
+      cardDescription?: string,
+      cardInputType?: string,
+    },
+  };
+
+  declare type FormBuilderProps = {
+    schema: string,
+    uischema: string,
+    onChange: (string, string) => any,
+    mods?: Mods,
+    className?: string,
+  };
+
+  declare export class FormBuilder extends React$Component<FormBuilderProps> {
+    static defaultProps: FormBuilderProps;
+  }
+
+  declare export class PredefinedGallery
+    extends React$Component<FormBuilderProps> {
+    static defaultProps: FormBuilderProps;
+  }
+}

--- a/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder/test_@ginkgo-bioworks/react-json-schema-form-builder.js
+++ b/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder/test_@ginkgo-bioworks/react-json-schema-form-builder.js
@@ -1,0 +1,26 @@
+// @flow
+
+import React from 'react';
+import {
+  FormBuilder,
+  PredefinedGallery,
+} from '@ginkgo-bioworks/react-json-schema-form-builder';
+import { it, describe, expect } from 'flow-typed-test';
+import { mount } from 'enzyme';
+
+describe('react-json-schema-form-builder', () => {
+  const props = {
+    schema: '',
+    uischema: '',
+    onChange: (newSchema, newUiSchema) => {},
+  };
+  it('render form builder', () => {
+    const wrapper = mount(<FormBuilder {...props} />);
+    expect(wrapper.exists('.form-body')).toBeTruthy();
+  });
+
+  it('render predefined gallery', () => {
+    const wrapper = mount(<PredefinedGallery {...props} />);
+    expect(wrapper.exists('.form_gallery_container')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://react-json-schema-form-builder.readthedocs.io/en/main/Home/
- Link to GitHub or NPM: https://github.com/ginkgobioworks/react-json-schema-form-builder
- Type of contribution: new definition

Other notes:
First flow type definition contribution for this scoped React component. Mainly would like for users that install the libdef to have flow typed access to some of the props that create the element.

