### PR TITLE
Feature/@ginkgo bioworks/react json schema form builder

### DIFF
--- a/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x/flow_v0.30.x-v0.103.x/react-json-schema-form-builder_v1.x.x.js
+++ b/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x/flow_v0.30.x-v0.103.x/react-json-schema-form-builder_v1.x.x.js
@@ -1,0 +1,120 @@
+declare module '@ginkgo-bioworks/react-json-schema-form-builder' {
+  declare type CardProps = {
+    name: string,
+    required: boolean,
+    dataOptions: { [string]: any },
+    uiOptions: { [string]: any },
+    $ref?: string,
+    dependents?: Array<{
+      children: Array<string>,
+      value?: any,
+    }>,
+    dependent?: boolean,
+    parent?: string,
+    propType: string,
+    neighborNames: Array<string>,
+  };
+
+  declare type SectionProps = {
+    name: string,
+    required: boolean,
+    schema: { [string]: any },
+    uischema: { [string]: any },
+    $ref?: string,
+    dependents?: Array<{
+      children: Array<string>,
+      value?: any,
+    }>,
+    dependent?: boolean,
+    propType: string,
+    neighborNames: Array<string>,
+  };
+
+  declare type ElementProps = CardProps & SectionProps;
+
+  declare type Parameters = {
+    [string]: string | number | boolean | Array<string | number>,
+    name: string,
+    path: string,
+    definitionData: { [string]: any },
+    definitionUi: { [string]: any },
+    category: string,
+    'ui:option': { [string]: any },
+  };
+
+  declare type DataType =
+    | 'string'
+    | 'number'
+    | 'boolean'
+    | 'integer'
+    | 'array'
+    | '*'
+    | null;
+
+  declare type MatchType = {
+    types: Array<DataType>,
+    widget?: string,
+    field?: string,
+    format?: string,
+    $ref?: boolean,
+    enum?: boolean,
+  };
+
+  declare type FormInput = {
+    displayName: string,
+    // given a data and ui schema, determine if the object is of this input type
+    matchIf: Array<MatchType>,
+    // allowed keys for ui:options
+    possibleOptions?: Array<string>,
+    defaultDataSchema: {
+      [string]: any,
+    },
+    defaultUiSchema: {
+      [string]: any,
+    },
+    // the data schema type
+    type: DataType,
+    // inputs on the preview card
+    cardBody: React.AbstractComponent<{
+      parameters: Parameters,
+      onChange: (newParams: Parameters) => void,
+      mods: { [string]: any },
+    }>,
+    // inputs for the modal
+    modalBody?: React.AbstractComponent<{
+      parameters: Parameters,
+      onChange: (newParams: Parameters) => void,
+    }>,
+  };
+
+  // optional properties that can add custom features to the form builder
+  declare type Mods = {
+    customFormInputs?: {
+      [string]: FormInput,
+    },
+    tooltipDescriptions?: {
+      add?: string,
+      cardObjectName?: string,
+      cardDisplayName?: string,
+      cardDescription?: string,
+      cardInputType?: string,
+    },
+  };
+
+  declare type FormBuilderProps = {
+    schema: string,
+    uischema: string,
+    onChange: (string, string) => any,
+    mods?: Mods,
+    className?: string,
+  };
+
+  declare export class FormBuilder extends React$Component<FormBuilderProps> {
+    static defaultProps: FormBuilderProps;
+  }
+
+  declare export class PredefinedGallery
+    extends React$Component<FormBuilderProps> {
+    static defaultProps: FormBuilderProps;
+  }
+}

--- a/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x/flow_v0.92.x-/react-json-schema-form-builder_v1.x.x.js
+++ b/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x/flow_v0.92.x-/react-json-schema-form-builder_v1.x.x.js
@@ -1,46 +1,46 @@
 declare module '@ginkgo-bioworks/react-json-schema-form-builder' {
-  declare type CardProps = {
+  declare type CardProps = {|
     name: string,
     required: boolean,
-    dataOptions: { [string]: any },
-    uiOptions: { [string]: any },
+    dataOptions: {| [string]: any |},
+    uiOptions: {| [string]: any |},
     $ref?: string,
-    dependents?: Array<{
+    dependents?: Array<{|
       children: Array<string>,
       value?: any,
-    }>,
+    |}>,
     dependent?: boolean,
     parent?: string,
     propType: string,
     neighborNames: Array<string>,
-  };
+  |};
 
-  declare type SectionProps = {
+  declare type SectionProps = {|
     name: string,
     required: boolean,
-    schema: { [string]: any },
-    uischema: { [string]: any },
+    schema: {| [string]: any |},
+    uischema: {| [string]: any |},
     $ref?: string,
-    dependents?: Array<{
+    dependents?: Array<{|
       children: Array<string>,
       value?: any,
-    }>,
+    |}>,
     dependent?: boolean,
     propType: string,
     neighborNames: Array<string>,
-  };
+  |};
 
   declare type ElementProps = CardProps & SectionProps;
 
-  declare type Parameters = {
+  declare type Parameters = {|
     [string]: string | number | boolean | Array<string | number>,
     name: string,
     path: string,
-    definitionData: { [string]: any },
-    definitionUi: { [string]: any },
+    definitionData: {| [string]: any |},
+    definitionUi: {| [string]: any |},
     category: string,
-    'ui:option': { [string]: any },
-  };
+    'ui:option': {| [string]: any |},
+  |};
 
   declare type DataType =
     | 'string'
@@ -51,63 +51,63 @@ declare module '@ginkgo-bioworks/react-json-schema-form-builder' {
     | '*'
     | null;
 
-  declare type MatchType = {
+  declare type MatchType = {|
     types: Array<DataType>,
     widget?: string,
     field?: string,
     format?: string,
     $ref?: boolean,
     enum?: boolean,
-  };
+  |};
 
-  declare type FormInput = {
+  declare type FormInput = {|
     displayName: string,
     // given a data and ui schema, determine if the object is of this input type
     matchIf: Array<MatchType>,
     // allowed keys for ui:options
     possibleOptions?: Array<string>,
-    defaultDataSchema: {
+    defaultDataSchema: {|
       [string]: any,
-    },
-    defaultUiSchema: {
+    |},
+    defaultUiSchema: {|
       [string]: any,
-    },
+    |},
     // the data schema type
     type: DataType,
     // inputs on the preview card
-    cardBody: React.AbstractComponent<{
+    cardBody: React$AbstractComponent<{|
       parameters: Parameters,
       onChange: (newParams: Parameters) => void,
-      mods: { [string]: any },
-    }>,
+      mods: {| [string]: any |},
+    |}>,
     // inputs for the modal
-    modalBody?: React.AbstractComponent<{
+    modalBody?: React$AbstractComponent<{|
       parameters: Parameters,
       onChange: (newParams: Parameters) => void,
-    }>,
-  };
+    |}>,
+  |};
 
   // optional properties that can add custom features to the form builder
-  declare type Mods = {
-    customFormInputs?: {
+  declare type Mods = {|
+    customFormInputs?: {|
       [string]: FormInput,
-    },
-    tooltipDescriptions?: {
+    |},
+    tooltipDescriptions?: {|
       add?: string,
       cardObjectName?: string,
       cardDisplayName?: string,
       cardDescription?: string,
       cardInputType?: string,
-    },
-  };
+    |},
+  |};
 
-  declare type FormBuilderProps = {
+  declare type FormBuilderProps = {|
     schema: string,
     uischema: string,
     onChange: (string, string) => any,
     mods?: Mods,
     className?: string,
-  };
+  |};
 
   declare export class FormBuilder extends React$Component<FormBuilderProps> {
     static defaultProps: FormBuilderProps;

--- a/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x/test_react-json-schema-form-builder_v1.x.x.js
+++ b/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x/test_react-json-schema-form-builder_v1.x.x.js
@@ -1,0 +1,26 @@
+// @flow
+
+import React from 'react';
+import {
+  FormBuilder,
+  PredefinedGallery,
+} from '@ginkgo-bioworks/react-json-schema-form-builder';
+import { it, describe, expect } from 'flow-typed-test';
+import { mount } from 'enzyme';
+
+describe('@ginkgo-bioworks/react-json-schema-form-builder', () => {
+  const props = {
+    schema: '',
+    uischema: '',
+    onChange: (newSchema, newUiSchema) => {},
+  };
+  it('render form builder', () => {
+    const wrapper = mount(<FormBuilder {...props} />);
+    expect(wrapper.exists('.form-body')).toBeTruthy();
+  });
+
+  it('render predefined gallery', () => {
+    const wrapper = mount(<PredefinedGallery {...props} />);
+    expect(wrapper.exists('.form_gallery_container')).toBeTruthy();
+  });
+});

--- a/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x/test_react-json-schema-form-builder_v1.x.x.js
+++ b/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x/test_react-json-schema-form-builder_v1.x.x.js
@@ -1,12 +1,11 @@
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {
   FormBuilder,
   PredefinedGallery,
 } from '@ginkgo-bioworks/react-json-schema-form-builder';
-import { it, describe, expect } from 'flow-typed-test';
-import { mount } from 'enzyme';
+import { it, describe } from 'flow-typed-test';
 
 describe('@ginkgo-bioworks/react-json-schema-form-builder', () => {
   const props = {
@@ -14,13 +13,64 @@ describe('@ginkgo-bioworks/react-json-schema-form-builder', () => {
     uischema: '',
     onChange: (newSchema, newUiSchema) => {},
   };
+  const optionalProps = {
+    schema: '',
+    uischema: '',
+    onChange: (newSchema, newUiSchema) => {},
+    mods: {},
+    className: 'foo'
+  };
+
+  const extraneousProps = {
+    schema: '',
+    uischema: '',
+    onChange: (newSchema, newUiSchema) => {},
+    extraneousProp: 'extraneous'
+  }
+
+  const malformedMods = {
+    schema: '',
+    uischema: '',
+    onChange: (newSchema, newUiSchema) => {},
+    mods: {
+      extraneousProp: 'extraneous'
+    },
+    className: 'foo'
+  }
+
   it('render form builder', () => {
-    const wrapper = mount(<FormBuilder {...props} />);
-    expect(wrapper.exists('.form-body')).toBeTruthy();
+    <FormBuilder {...props} />
+  });
+
+  it('render form builder with optional props', () => {
+    <FormBuilder {...optionalProps} />
+  });
+
+  it('form builder errors on extraneous properties passed in', () => {
+    // $FlowExpectedError
+    <FormBuilder {...extraneousProps} />
+  });
+
+  it('form builder errors on improper mods passed in', () => {
+    // $FlowExpectedError
+    <FormBuilder {...malformedMods} />
   });
 
   it('render predefined gallery', () => {
-    const wrapper = mount(<PredefinedGallery {...props} />);
-    expect(wrapper.exists('.form_gallery_container')).toBeTruthy();
+    <PredefinedGallery {...props} />
+  });
+
+  it('render predefined with optional props', () => {
+    <PredefinedGallery {...optionalProps} />
+  });
+
+  it('predefined gallery errors on extraneous properties passed in', () => {
+    // $FlowExpectedError
+    <PredefinedGallery {...extraneousProps} />
+  });
+
+  it('predefined gallery errors on improper mods passed in', () => {
+    // $FlowExpectedError
+    <PredefinedGallery {...malformedMods} />
   });
 });


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://react-json-schema-form-builder.readthedocs.io/en/main/Home/
- Link to GitHub or NPM: https://github.com/ginkgobioworks/react-json-schema-form-builder
- Type of contribution: new definition

Other notes:
First flow type definition contribution for this scoped React component. Mainly would like for users that install the libdef to have flow typed access to some of the props that create the element.

