### PR TITLE
[react-navigation] Replace $Shape with $Rest<T, {...}>

### DIFF
--- a/definitions/npm/@react-navigation/bottom-tabs_v5.x.x/flow_v0.104.x-/bottom-tabs_v5.x.x.js
+++ b/definitions/npm/@react-navigation/bottom-tabs_v5.x.x/flow_v0.104.x-/bottom-tabs_v5.x.x.js
@@ -416,7 +416,7 @@ declare module '@react-navigation/bottom-tabs' {
   >;
   declare type $IsUndefined<X> = $IsA<X, void>;
 
-  declare type $Partial<T> = $Rest<T, {...}>;
+  declare type $Partial<T> = $ReadOnly<$Rest<T, {...}>>;
 
   /**
    * Actions, state, etc.

--- a/definitions/npm/@react-navigation/bottom-tabs_v5.x.x/flow_v0.104.x-/bottom-tabs_v5.x.x.js
+++ b/definitions/npm/@react-navigation/bottom-tabs_v5.x.x/flow_v0.104.x-/bottom-tabs_v5.x.x.js
@@ -263,7 +263,7 @@ declare module '@react-navigation/bottom-tabs' {
   // Copied from
   // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
   declare type Stringish = string;
-  declare type EdgeInsetsProp = $ReadOnly<$Shape<EdgeInsets>>;
+  declare type EdgeInsetsProp = $ReadOnly<$Partial<EdgeInsets>>;
   declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
     accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
     accessibilityElementsHidden?: ?boolean,
@@ -841,12 +841,12 @@ declare module '@react-navigation/bottom-tabs' {
       State,
       EventMap,
     >>,
-    +setOptions: (options: $Shape<ScreenOptions>) => void,
+    +setOptions: (options: $Partial<ScreenOptions>) => void,
     +setParams: (
       params: $If<
         $IsUndefined<$ElementType<ParamList, RouteName>>,
         empty,
-        $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+        $Partial<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
       >,
     ) => void,
     ...
@@ -893,7 +893,7 @@ declare module '@react-navigation/bottom-tabs' {
           route: RouteProp<ParamList, RouteName>,
           navigation: NavProp,
         |}) => ScreenListeners<EventMap, State>,
-    +initialParams?: $Shape<$ElementType<ParamList, RouteName>>,
+    +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
   |};
 
   declare export type ScreenProps<
@@ -1176,7 +1176,7 @@ declare module '@react-navigation/bottom-tabs' {
     +styleInterpolator: StackHeaderStyleInterpolator,
   |};
 
-  declare export type StackHeaderLeftButtonProps = $Shape<{|
+  declare export type StackHeaderLeftButtonProps = $Partial<{|
     +onPress: (() => void),
     +pressColorAndroid: string;
     +backImage: (props: {| tintColor: string |}) => React$Node,
@@ -1204,7 +1204,7 @@ declare module '@react-navigation/bottom-tabs' {
   declare export type StackHeaderTitleInputProps =
     $Exact<StackHeaderTitleInputBase>;
 
-  declare export type StackOptions = $Shape<{|
+  declare export type StackOptions = $Partial<{|
     +title: string,
     +header: StackHeaderProps => React$Node,
     +headerShown: boolean,
@@ -1217,7 +1217,7 @@ declare module '@react-navigation/bottom-tabs' {
     +gestureEnabled: boolean,
     +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
     +gestureVelocityImpact: number,
-    +safeAreaInsets: $Shape<EdgeInsets>,
+    +safeAreaInsets: $Partial<EdgeInsets>,
     // Transition
     ...TransitionPreset,
     // Header
@@ -1349,7 +1349,7 @@ declare module '@react-navigation/bottom-tabs' {
         >,
       |};
 
-  declare export type BottomTabOptions = $Shape<{|
+  declare export type BottomTabOptions = $Partial<{|
     +title: string,
     +tabBarLabel:
       | string
@@ -1364,7 +1364,7 @@ declare module '@react-navigation/bottom-tabs' {
     +tabBarAccessibilityLabel: string,
     +tabBarTestID: string,
     +tabBarVisible: boolean,
-    +tabBarVisibilityAnimationConfig: $Shape<{|
+    +tabBarVisibilityAnimationConfig: $Partial<{|
       +show: TabBarVisibilityAnimationConfig,
       +hide: TabBarVisibilityAnimationConfig,
     |}>,
@@ -1432,7 +1432,7 @@ declare module '@react-navigation/bottom-tabs' {
     BottomTabOptions,
   >;
 
-  declare export type BottomTabBarOptions = $Shape<{|
+  declare export type BottomTabBarOptions = $Partial<{|
     +keyboardHidesTabBar: boolean,
     +activeTintColor: string,
     +inactiveTintColor: string,
@@ -1446,7 +1446,7 @@ declare module '@react-navigation/bottom-tabs' {
     +tabStyle: ViewStyleProp,
     +labelPosition: 'beside-icon' | 'below-icon',
     +adaptive: boolean,
-    +safeAreaInsets: $Shape<EdgeInsets>,
+    +safeAreaInsets: $Partial<EdgeInsets>,
     +style: ViewStyleProp,
   |}>;
 
@@ -1485,7 +1485,7 @@ declare module '@react-navigation/bottom-tabs' {
    * Material bottom tab options
    */
 
-  declare export type MaterialBottomTabOptions = $Shape<{|
+  declare export type MaterialBottomTabOptions = $Partial<{|
     +title: string,
     +tabBarColor: string,
     +tabBarLabel: string,
@@ -1632,7 +1632,7 @@ declare module '@react-navigation/bottom-tabs' {
    * Material top tab options
    */
 
-  declare export type MaterialTopTabOptions = $Shape<{|
+  declare export type MaterialTopTabOptions = $Partial<{|
     +title: string,
     +tabBarLabel:
       | string
@@ -1687,14 +1687,14 @@ declare module '@react-navigation/bottom-tabs' {
     +swipeEnabled: boolean,
     +swipeVelocityImpact?: number,
     +springVelocityScale?: number,
-    +springConfig: $Shape<{|
+    +springConfig: $Partial<{|
       +damping: number,
       +mass: number,
       +stiffness: number,
       +restSpeedThreshold: number,
       +restDisplacementThreshold: number,
     |}>,
-    +timingConfig: $Shape<{|
+    +timingConfig: $Partial<{|
       +duration: number,
     |}>,
   |};
@@ -1724,7 +1724,7 @@ declare module '@react-navigation/bottom-tabs' {
     +getTabWidth: number => number,
   |};
 
-  declare export type MaterialTopTabBarOptions = $Shape<{|
+  declare export type MaterialTopTabBarOptions = $Partial<{|
     +scrollEnabled: boolean,
     +bounces: boolean,
     +pressColor: string,
@@ -1770,7 +1770,7 @@ declare module '@react-navigation/bottom-tabs' {
     ...$Partial<MaterialTopTabPagerCommonProps>,
     +position?: any, // Reanimated.Value<number>
     +tabBarPosition?: 'top' | 'bottom',
-    +initialLayout?: $Shape<{| +width: number, +height: number |}>,
+    +initialLayout?: $Partial<{| +width: number, +height: number |}>,
     +lazy?: boolean,
     +lazyPreloadDistance?: number,
     +removeClippedSubviews?: boolean,
@@ -1801,7 +1801,7 @@ declare module '@react-navigation/bottom-tabs' {
    * Drawer options
    */
 
-  declare export type DrawerOptions = $Shape<{|
+  declare export type DrawerOptions = $Partial<{|
     title: string,
     drawerLabel:
       | string
@@ -1867,7 +1867,7 @@ declare module '@react-navigation/bottom-tabs' {
     DrawerOptions,
   >;
 
-  declare export type DrawerItemListBaseOptions = $Shape<{|
+  declare export type DrawerItemListBaseOptions = $Partial<{|
     +activeTintColor: string,
     +activeBackgroundColor: string,
     +inactiveTintColor: string,
@@ -1876,7 +1876,7 @@ declare module '@react-navigation/bottom-tabs' {
     +labelStyle: TextStyleProp,
   |}>;
 
-  declare export type DrawerContentOptions = $Shape<{|
+  declare export type DrawerContentOptions = $Partial<{|
     ...DrawerItemListBaseOptions,
     +contentContainerStyle: ViewStyleProp,
     +style: ViewStyleProp,

--- a/definitions/npm/@react-navigation/core_v5.x.x/flow_v0.104.x-/core_v5.x.x.js
+++ b/definitions/npm/@react-navigation/core_v5.x.x/flow_v0.104.x-/core_v5.x.x.js
@@ -416,7 +416,7 @@ declare module '@react-navigation/core' {
   >;
   declare type $IsUndefined<X> = $IsA<X, void>;
 
-  declare type $Partial<T> = $Rest<T, {...}>;
+  declare type $Partial<T> = $ReadOnly<$Rest<T, {...}>>;
 
   /**
    * Actions, state, etc.

--- a/definitions/npm/@react-navigation/core_v5.x.x/flow_v0.104.x-/core_v5.x.x.js
+++ b/definitions/npm/@react-navigation/core_v5.x.x/flow_v0.104.x-/core_v5.x.x.js
@@ -263,7 +263,7 @@ declare module '@react-navigation/core' {
   // Copied from
   // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
   declare type Stringish = string;
-  declare type EdgeInsetsProp = $ReadOnly<$Shape<EdgeInsets>>;
+  declare type EdgeInsetsProp = $ReadOnly<$Partial<EdgeInsets>>;
   declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
     accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
     accessibilityElementsHidden?: ?boolean,
@@ -841,12 +841,12 @@ declare module '@react-navigation/core' {
       State,
       EventMap,
     >>,
-    +setOptions: (options: $Shape<ScreenOptions>) => void,
+    +setOptions: (options: $Partial<ScreenOptions>) => void,
     +setParams: (
       params: $If<
         $IsUndefined<$ElementType<ParamList, RouteName>>,
         empty,
-        $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+        $Partial<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
       >,
     ) => void,
     ...
@@ -893,7 +893,7 @@ declare module '@react-navigation/core' {
           route: RouteProp<ParamList, RouteName>,
           navigation: NavProp,
         |}) => ScreenListeners<EventMap, State>,
-    +initialParams?: $Shape<$ElementType<ParamList, RouteName>>,
+    +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
   |};
 
   declare export type ScreenProps<
@@ -1176,7 +1176,7 @@ declare module '@react-navigation/core' {
     +styleInterpolator: StackHeaderStyleInterpolator,
   |};
 
-  declare export type StackHeaderLeftButtonProps = $Shape<{|
+  declare export type StackHeaderLeftButtonProps = $Partial<{|
     +onPress: (() => void),
     +pressColorAndroid: string;
     +backImage: (props: {| tintColor: string |}) => React$Node,
@@ -1204,7 +1204,7 @@ declare module '@react-navigation/core' {
   declare export type StackHeaderTitleInputProps =
     $Exact<StackHeaderTitleInputBase>;
 
-  declare export type StackOptions = $Shape<{|
+  declare export type StackOptions = $Partial<{|
     +title: string,
     +header: StackHeaderProps => React$Node,
     +headerShown: boolean,
@@ -1217,7 +1217,7 @@ declare module '@react-navigation/core' {
     +gestureEnabled: boolean,
     +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
     +gestureVelocityImpact: number,
-    +safeAreaInsets: $Shape<EdgeInsets>,
+    +safeAreaInsets: $Partial<EdgeInsets>,
     // Transition
     ...TransitionPreset,
     // Header
@@ -1349,7 +1349,7 @@ declare module '@react-navigation/core' {
         >,
       |};
 
-  declare export type BottomTabOptions = $Shape<{|
+  declare export type BottomTabOptions = $Partial<{|
     +title: string,
     +tabBarLabel:
       | string
@@ -1364,7 +1364,7 @@ declare module '@react-navigation/core' {
     +tabBarAccessibilityLabel: string,
     +tabBarTestID: string,
     +tabBarVisible: boolean,
-    +tabBarVisibilityAnimationConfig: $Shape<{|
+    +tabBarVisibilityAnimationConfig: $Partial<{|
       +show: TabBarVisibilityAnimationConfig,
       +hide: TabBarVisibilityAnimationConfig,
     |}>,
@@ -1432,7 +1432,7 @@ declare module '@react-navigation/core' {
     BottomTabOptions,
   >;
 
-  declare export type BottomTabBarOptions = $Shape<{|
+  declare export type BottomTabBarOptions = $Partial<{|
     +keyboardHidesTabBar: boolean,
     +activeTintColor: string,
     +inactiveTintColor: string,
@@ -1446,7 +1446,7 @@ declare module '@react-navigation/core' {
     +tabStyle: ViewStyleProp,
     +labelPosition: 'beside-icon' | 'below-icon',
     +adaptive: boolean,
-    +safeAreaInsets: $Shape<EdgeInsets>,
+    +safeAreaInsets: $Partial<EdgeInsets>,
     +style: ViewStyleProp,
   |}>;
 
@@ -1485,7 +1485,7 @@ declare module '@react-navigation/core' {
    * Material bottom tab options
    */
 
-  declare export type MaterialBottomTabOptions = $Shape<{|
+  declare export type MaterialBottomTabOptions = $Partial<{|
     +title: string,
     +tabBarColor: string,
     +tabBarLabel: string,
@@ -1632,7 +1632,7 @@ declare module '@react-navigation/core' {
    * Material top tab options
    */
 
-  declare export type MaterialTopTabOptions = $Shape<{|
+  declare export type MaterialTopTabOptions = $Partial<{|
     +title: string,
     +tabBarLabel:
       | string
@@ -1687,14 +1687,14 @@ declare module '@react-navigation/core' {
     +swipeEnabled: boolean,
     +swipeVelocityImpact?: number,
     +springVelocityScale?: number,
-    +springConfig: $Shape<{|
+    +springConfig: $Partial<{|
       +damping: number,
       +mass: number,
       +stiffness: number,
       +restSpeedThreshold: number,
       +restDisplacementThreshold: number,
     |}>,
-    +timingConfig: $Shape<{|
+    +timingConfig: $Partial<{|
       +duration: number,
     |}>,
   |};
@@ -1724,7 +1724,7 @@ declare module '@react-navigation/core' {
     +getTabWidth: number => number,
   |};
 
-  declare export type MaterialTopTabBarOptions = $Shape<{|
+  declare export type MaterialTopTabBarOptions = $Partial<{|
     +scrollEnabled: boolean,
     +bounces: boolean,
     +pressColor: string,
@@ -1770,7 +1770,7 @@ declare module '@react-navigation/core' {
     ...$Partial<MaterialTopTabPagerCommonProps>,
     +position?: any, // Reanimated.Value<number>
     +tabBarPosition?: 'top' | 'bottom',
-    +initialLayout?: $Shape<{| +width: number, +height: number |}>,
+    +initialLayout?: $Partial<{| +width: number, +height: number |}>,
     +lazy?: boolean,
     +lazyPreloadDistance?: number,
     +removeClippedSubviews?: boolean,
@@ -1801,7 +1801,7 @@ declare module '@react-navigation/core' {
    * Drawer options
    */
 
-  declare export type DrawerOptions = $Shape<{|
+  declare export type DrawerOptions = $Partial<{|
     title: string,
     drawerLabel:
       | string
@@ -1867,7 +1867,7 @@ declare module '@react-navigation/core' {
     DrawerOptions,
   >;
 
-  declare export type DrawerItemListBaseOptions = $Shape<{|
+  declare export type DrawerItemListBaseOptions = $Partial<{|
     +activeTintColor: string,
     +activeBackgroundColor: string,
     +inactiveTintColor: string,
@@ -1876,7 +1876,7 @@ declare module '@react-navigation/core' {
     +labelStyle: TextStyleProp,
   |}>;
 
-  declare export type DrawerContentOptions = $Shape<{|
+  declare export type DrawerContentOptions = $Partial<{|
     ...DrawerItemListBaseOptions,
     +contentContainerStyle: ViewStyleProp,
     +style: ViewStyleProp,

--- a/definitions/npm/@react-navigation/devtools_v5.x.x/flow_v0.104.x-/devtools_v5.x.x.js
+++ b/definitions/npm/@react-navigation/devtools_v5.x.x/flow_v0.104.x-/devtools_v5.x.x.js
@@ -416,7 +416,7 @@ declare module '@react-navigation/devtools' {
   >;
   declare type $IsUndefined<X> = $IsA<X, void>;
 
-  declare type $Partial<T> = $Rest<T, {...}>;
+  declare type $Partial<T> = $ReadOnly<$Rest<T, {...}>>;
 
   /**
    * Actions, state, etc.

--- a/definitions/npm/@react-navigation/devtools_v5.x.x/flow_v0.104.x-/devtools_v5.x.x.js
+++ b/definitions/npm/@react-navigation/devtools_v5.x.x/flow_v0.104.x-/devtools_v5.x.x.js
@@ -263,7 +263,7 @@ declare module '@react-navigation/devtools' {
   // Copied from
   // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
   declare type Stringish = string;
-  declare type EdgeInsetsProp = $ReadOnly<$Shape<EdgeInsets>>;
+  declare type EdgeInsetsProp = $ReadOnly<$Partial<EdgeInsets>>;
   declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
     accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
     accessibilityElementsHidden?: ?boolean,
@@ -841,12 +841,12 @@ declare module '@react-navigation/devtools' {
       State,
       EventMap,
     >>,
-    +setOptions: (options: $Shape<ScreenOptions>) => void,
+    +setOptions: (options: $Partial<ScreenOptions>) => void,
     +setParams: (
       params: $If<
         $IsUndefined<$ElementType<ParamList, RouteName>>,
         empty,
-        $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+        $Partial<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
       >,
     ) => void,
     ...
@@ -893,7 +893,7 @@ declare module '@react-navigation/devtools' {
           route: RouteProp<ParamList, RouteName>,
           navigation: NavProp,
         |}) => ScreenListeners<EventMap, State>,
-    +initialParams?: $Shape<$ElementType<ParamList, RouteName>>,
+    +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
   |};
 
   declare export type ScreenProps<
@@ -1176,7 +1176,7 @@ declare module '@react-navigation/devtools' {
     +styleInterpolator: StackHeaderStyleInterpolator,
   |};
 
-  declare export type StackHeaderLeftButtonProps = $Shape<{|
+  declare export type StackHeaderLeftButtonProps = $Partial<{|
     +onPress: (() => void),
     +pressColorAndroid: string;
     +backImage: (props: {| tintColor: string |}) => React$Node,
@@ -1204,7 +1204,7 @@ declare module '@react-navigation/devtools' {
   declare export type StackHeaderTitleInputProps =
     $Exact<StackHeaderTitleInputBase>;
 
-  declare export type StackOptions = $Shape<{|
+  declare export type StackOptions = $Partial<{|
     +title: string,
     +header: StackHeaderProps => React$Node,
     +headerShown: boolean,
@@ -1217,7 +1217,7 @@ declare module '@react-navigation/devtools' {
     +gestureEnabled: boolean,
     +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
     +gestureVelocityImpact: number,
-    +safeAreaInsets: $Shape<EdgeInsets>,
+    +safeAreaInsets: $Partial<EdgeInsets>,
     // Transition
     ...TransitionPreset,
     // Header
@@ -1349,7 +1349,7 @@ declare module '@react-navigation/devtools' {
         >,
       |};
 
-  declare export type BottomTabOptions = $Shape<{|
+  declare export type BottomTabOptions = $Partial<{|
     +title: string,
     +tabBarLabel:
       | string
@@ -1364,7 +1364,7 @@ declare module '@react-navigation/devtools' {
     +tabBarAccessibilityLabel: string,
     +tabBarTestID: string,
     +tabBarVisible: boolean,
-    +tabBarVisibilityAnimationConfig: $Shape<{|
+    +tabBarVisibilityAnimationConfig: $Partial<{|
       +show: TabBarVisibilityAnimationConfig,
       +hide: TabBarVisibilityAnimationConfig,
     |}>,
@@ -1432,7 +1432,7 @@ declare module '@react-navigation/devtools' {
     BottomTabOptions,
   >;
 
-  declare export type BottomTabBarOptions = $Shape<{|
+  declare export type BottomTabBarOptions = $Partial<{|
     +keyboardHidesTabBar: boolean,
     +activeTintColor: string,
     +inactiveTintColor: string,
@@ -1446,7 +1446,7 @@ declare module '@react-navigation/devtools' {
     +tabStyle: ViewStyleProp,
     +labelPosition: 'beside-icon' | 'below-icon',
     +adaptive: boolean,
-    +safeAreaInsets: $Shape<EdgeInsets>,
+    +safeAreaInsets: $Partial<EdgeInsets>,
     +style: ViewStyleProp,
   |}>;
 
@@ -1485,7 +1485,7 @@ declare module '@react-navigation/devtools' {
    * Material bottom tab options
    */
 
-  declare export type MaterialBottomTabOptions = $Shape<{|
+  declare export type MaterialBottomTabOptions = $Partial<{|
     +title: string,
     +tabBarColor: string,
     +tabBarLabel: string,
@@ -1632,7 +1632,7 @@ declare module '@react-navigation/devtools' {
    * Material top tab options
    */
 
-  declare export type MaterialTopTabOptions = $Shape<{|
+  declare export type MaterialTopTabOptions = $Partial<{|
     +title: string,
     +tabBarLabel:
       | string
@@ -1687,14 +1687,14 @@ declare module '@react-navigation/devtools' {
     +swipeEnabled: boolean,
     +swipeVelocityImpact?: number,
     +springVelocityScale?: number,
-    +springConfig: $Shape<{|
+    +springConfig: $Partial<{|
       +damping: number,
       +mass: number,
       +stiffness: number,
       +restSpeedThreshold: number,
       +restDisplacementThreshold: number,
     |}>,
-    +timingConfig: $Shape<{|
+    +timingConfig: $Partial<{|
       +duration: number,
     |}>,
   |};
@@ -1724,7 +1724,7 @@ declare module '@react-navigation/devtools' {
     +getTabWidth: number => number,
   |};
 
-  declare export type MaterialTopTabBarOptions = $Shape<{|
+  declare export type MaterialTopTabBarOptions = $Partial<{|
     +scrollEnabled: boolean,
     +bounces: boolean,
     +pressColor: string,
@@ -1770,7 +1770,7 @@ declare module '@react-navigation/devtools' {
     ...$Partial<MaterialTopTabPagerCommonProps>,
     +position?: any, // Reanimated.Value<number>
     +tabBarPosition?: 'top' | 'bottom',
-    +initialLayout?: $Shape<{| +width: number, +height: number |}>,
+    +initialLayout?: $Partial<{| +width: number, +height: number |}>,
     +lazy?: boolean,
     +lazyPreloadDistance?: number,
     +removeClippedSubviews?: boolean,
@@ -1801,7 +1801,7 @@ declare module '@react-navigation/devtools' {
    * Drawer options
    */
 
-  declare export type DrawerOptions = $Shape<{|
+  declare export type DrawerOptions = $Partial<{|
     title: string,
     drawerLabel:
       | string
@@ -1867,7 +1867,7 @@ declare module '@react-navigation/devtools' {
     DrawerOptions,
   >;
 
-  declare export type DrawerItemListBaseOptions = $Shape<{|
+  declare export type DrawerItemListBaseOptions = $Partial<{|
     +activeTintColor: string,
     +activeBackgroundColor: string,
     +inactiveTintColor: string,
@@ -1876,7 +1876,7 @@ declare module '@react-navigation/devtools' {
     +labelStyle: TextStyleProp,
   |}>;
 
-  declare export type DrawerContentOptions = $Shape<{|
+  declare export type DrawerContentOptions = $Partial<{|
     ...DrawerItemListBaseOptions,
     +contentContainerStyle: ViewStyleProp,
     +style: ViewStyleProp,

--- a/definitions/npm/@react-navigation/drawer_v5.x.x/flow_v0.104.x-/drawer_v5.x.x.js
+++ b/definitions/npm/@react-navigation/drawer_v5.x.x/flow_v0.104.x-/drawer_v5.x.x.js
@@ -416,7 +416,7 @@ declare module '@react-navigation/drawer' {
   >;
   declare type $IsUndefined<X> = $IsA<X, void>;
 
-  declare type $Partial<T> = $Rest<T, {...}>;
+  declare type $Partial<T> = $ReadOnly<$Rest<T, {...}>>;
 
   /**
    * Actions, state, etc.

--- a/definitions/npm/@react-navigation/drawer_v5.x.x/flow_v0.104.x-/drawer_v5.x.x.js
+++ b/definitions/npm/@react-navigation/drawer_v5.x.x/flow_v0.104.x-/drawer_v5.x.x.js
@@ -263,7 +263,7 @@ declare module '@react-navigation/drawer' {
   // Copied from
   // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
   declare type Stringish = string;
-  declare type EdgeInsetsProp = $ReadOnly<$Shape<EdgeInsets>>;
+  declare type EdgeInsetsProp = $ReadOnly<$Partial<EdgeInsets>>;
   declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
     accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
     accessibilityElementsHidden?: ?boolean,
@@ -841,12 +841,12 @@ declare module '@react-navigation/drawer' {
       State,
       EventMap,
     >>,
-    +setOptions: (options: $Shape<ScreenOptions>) => void,
+    +setOptions: (options: $Partial<ScreenOptions>) => void,
     +setParams: (
       params: $If<
         $IsUndefined<$ElementType<ParamList, RouteName>>,
         empty,
-        $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+        $Partial<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
       >,
     ) => void,
     ...
@@ -893,7 +893,7 @@ declare module '@react-navigation/drawer' {
           route: RouteProp<ParamList, RouteName>,
           navigation: NavProp,
         |}) => ScreenListeners<EventMap, State>,
-    +initialParams?: $Shape<$ElementType<ParamList, RouteName>>,
+    +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
   |};
 
   declare export type ScreenProps<
@@ -1176,7 +1176,7 @@ declare module '@react-navigation/drawer' {
     +styleInterpolator: StackHeaderStyleInterpolator,
   |};
 
-  declare export type StackHeaderLeftButtonProps = $Shape<{|
+  declare export type StackHeaderLeftButtonProps = $Partial<{|
     +onPress: (() => void),
     +pressColorAndroid: string;
     +backImage: (props: {| tintColor: string |}) => React$Node,
@@ -1204,7 +1204,7 @@ declare module '@react-navigation/drawer' {
   declare export type StackHeaderTitleInputProps =
     $Exact<StackHeaderTitleInputBase>;
 
-  declare export type StackOptions = $Shape<{|
+  declare export type StackOptions = $Partial<{|
     +title: string,
     +header: StackHeaderProps => React$Node,
     +headerShown: boolean,
@@ -1217,7 +1217,7 @@ declare module '@react-navigation/drawer' {
     +gestureEnabled: boolean,
     +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
     +gestureVelocityImpact: number,
-    +safeAreaInsets: $Shape<EdgeInsets>,
+    +safeAreaInsets: $Partial<EdgeInsets>,
     // Transition
     ...TransitionPreset,
     // Header
@@ -1349,7 +1349,7 @@ declare module '@react-navigation/drawer' {
         >,
       |};
 
-  declare export type BottomTabOptions = $Shape<{|
+  declare export type BottomTabOptions = $Partial<{|
     +title: string,
     +tabBarLabel:
       | string
@@ -1364,7 +1364,7 @@ declare module '@react-navigation/drawer' {
     +tabBarAccessibilityLabel: string,
     +tabBarTestID: string,
     +tabBarVisible: boolean,
-    +tabBarVisibilityAnimationConfig: $Shape<{|
+    +tabBarVisibilityAnimationConfig: $Partial<{|
       +show: TabBarVisibilityAnimationConfig,
       +hide: TabBarVisibilityAnimationConfig,
     |}>,
@@ -1432,7 +1432,7 @@ declare module '@react-navigation/drawer' {
     BottomTabOptions,
   >;
 
-  declare export type BottomTabBarOptions = $Shape<{|
+  declare export type BottomTabBarOptions = $Partial<{|
     +keyboardHidesTabBar: boolean,
     +activeTintColor: string,
     +inactiveTintColor: string,
@@ -1446,7 +1446,7 @@ declare module '@react-navigation/drawer' {
     +tabStyle: ViewStyleProp,
     +labelPosition: 'beside-icon' | 'below-icon',
     +adaptive: boolean,
-    +safeAreaInsets: $Shape<EdgeInsets>,
+    +safeAreaInsets: $Partial<EdgeInsets>,
     +style: ViewStyleProp,
   |}>;
 
@@ -1485,7 +1485,7 @@ declare module '@react-navigation/drawer' {
    * Material bottom tab options
    */
 
-  declare export type MaterialBottomTabOptions = $Shape<{|
+  declare export type MaterialBottomTabOptions = $Partial<{|
     +title: string,
     +tabBarColor: string,
     +tabBarLabel: string,
@@ -1632,7 +1632,7 @@ declare module '@react-navigation/drawer' {
    * Material top tab options
    */
 
-  declare export type MaterialTopTabOptions = $Shape<{|
+  declare export type MaterialTopTabOptions = $Partial<{|
     +title: string,
     +tabBarLabel:
       | string
@@ -1687,14 +1687,14 @@ declare module '@react-navigation/drawer' {
     +swipeEnabled: boolean,
     +swipeVelocityImpact?: number,
     +springVelocityScale?: number,
-    +springConfig: $Shape<{|
+    +springConfig: $Partial<{|
       +damping: number,
       +mass: number,
       +stiffness: number,
       +restSpeedThreshold: number,
       +restDisplacementThreshold: number,
     |}>,
-    +timingConfig: $Shape<{|
+    +timingConfig: $Partial<{|
       +duration: number,
     |}>,
   |};
@@ -1724,7 +1724,7 @@ declare module '@react-navigation/drawer' {
     +getTabWidth: number => number,
   |};
 
-  declare export type MaterialTopTabBarOptions = $Shape<{|
+  declare export type MaterialTopTabBarOptions = $Partial<{|
     +scrollEnabled: boolean,
     +bounces: boolean,
     +pressColor: string,
@@ -1770,7 +1770,7 @@ declare module '@react-navigation/drawer' {
     ...$Partial<MaterialTopTabPagerCommonProps>,
     +position?: any, // Reanimated.Value<number>
     +tabBarPosition?: 'top' | 'bottom',
-    +initialLayout?: $Shape<{| +width: number, +height: number |}>,
+    +initialLayout?: $Partial<{| +width: number, +height: number |}>,
     +lazy?: boolean,
     +lazyPreloadDistance?: number,
     +removeClippedSubviews?: boolean,
@@ -1801,7 +1801,7 @@ declare module '@react-navigation/drawer' {
    * Drawer options
    */
 
-  declare export type DrawerOptions = $Shape<{|
+  declare export type DrawerOptions = $Partial<{|
     title: string,
     drawerLabel:
       | string
@@ -1867,7 +1867,7 @@ declare module '@react-navigation/drawer' {
     DrawerOptions,
   >;
 
-  declare export type DrawerItemListBaseOptions = $Shape<{|
+  declare export type DrawerItemListBaseOptions = $Partial<{|
     +activeTintColor: string,
     +activeBackgroundColor: string,
     +inactiveTintColor: string,
@@ -1876,7 +1876,7 @@ declare module '@react-navigation/drawer' {
     +labelStyle: TextStyleProp,
   |}>;
 
-  declare export type DrawerContentOptions = $Shape<{|
+  declare export type DrawerContentOptions = $Partial<{|
     ...DrawerItemListBaseOptions,
     +contentContainerStyle: ViewStyleProp,
     +style: ViewStyleProp,

--- a/definitions/npm/@react-navigation/material-bottom-tabs_v5.x.x/flow_v0.104.x-/material-bottom-tabs_v5.x.x.js
+++ b/definitions/npm/@react-navigation/material-bottom-tabs_v5.x.x/flow_v0.104.x-/material-bottom-tabs_v5.x.x.js
@@ -263,7 +263,7 @@ declare module '@react-navigation/material-bottom-tabs' {
   // Copied from
   // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
   declare type Stringish = string;
-  declare type EdgeInsetsProp = $ReadOnly<$Shape<EdgeInsets>>;
+  declare type EdgeInsetsProp = $ReadOnly<$Partial<EdgeInsets>>;
   declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
     accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
     accessibilityElementsHidden?: ?boolean,
@@ -841,12 +841,12 @@ declare module '@react-navigation/material-bottom-tabs' {
       State,
       EventMap,
     >>,
-    +setOptions: (options: $Shape<ScreenOptions>) => void,
+    +setOptions: (options: $Partial<ScreenOptions>) => void,
     +setParams: (
       params: $If<
         $IsUndefined<$ElementType<ParamList, RouteName>>,
         empty,
-        $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+        $Partial<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
       >,
     ) => void,
     ...
@@ -893,7 +893,7 @@ declare module '@react-navigation/material-bottom-tabs' {
           route: RouteProp<ParamList, RouteName>,
           navigation: NavProp,
         |}) => ScreenListeners<EventMap, State>,
-    +initialParams?: $Shape<$ElementType<ParamList, RouteName>>,
+    +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
   |};
 
   declare export type ScreenProps<
@@ -1176,7 +1176,7 @@ declare module '@react-navigation/material-bottom-tabs' {
     +styleInterpolator: StackHeaderStyleInterpolator,
   |};
 
-  declare export type StackHeaderLeftButtonProps = $Shape<{|
+  declare export type StackHeaderLeftButtonProps = $Partial<{|
     +onPress: (() => void),
     +pressColorAndroid: string;
     +backImage: (props: {| tintColor: string |}) => React$Node,
@@ -1204,7 +1204,7 @@ declare module '@react-navigation/material-bottom-tabs' {
   declare export type StackHeaderTitleInputProps =
     $Exact<StackHeaderTitleInputBase>;
 
-  declare export type StackOptions = $Shape<{|
+  declare export type StackOptions = $Partial<{|
     +title: string,
     +header: StackHeaderProps => React$Node,
     +headerShown: boolean,
@@ -1217,7 +1217,7 @@ declare module '@react-navigation/material-bottom-tabs' {
     +gestureEnabled: boolean,
     +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
     +gestureVelocityImpact: number,
-    +safeAreaInsets: $Shape<EdgeInsets>,
+    +safeAreaInsets: $Partial<EdgeInsets>,
     // Transition
     ...TransitionPreset,
     // Header
@@ -1349,7 +1349,7 @@ declare module '@react-navigation/material-bottom-tabs' {
         >,
       |};
 
-  declare export type BottomTabOptions = $Shape<{|
+  declare export type BottomTabOptions = $Partial<{|
     +title: string,
     +tabBarLabel:
       | string
@@ -1364,7 +1364,7 @@ declare module '@react-navigation/material-bottom-tabs' {
     +tabBarAccessibilityLabel: string,
     +tabBarTestID: string,
     +tabBarVisible: boolean,
-    +tabBarVisibilityAnimationConfig: $Shape<{|
+    +tabBarVisibilityAnimationConfig: $Partial<{|
       +show: TabBarVisibilityAnimationConfig,
       +hide: TabBarVisibilityAnimationConfig,
     |}>,
@@ -1432,7 +1432,7 @@ declare module '@react-navigation/material-bottom-tabs' {
     BottomTabOptions,
   >;
 
-  declare export type BottomTabBarOptions = $Shape<{|
+  declare export type BottomTabBarOptions = $Partial<{|
     +keyboardHidesTabBar: boolean,
     +activeTintColor: string,
     +inactiveTintColor: string,
@@ -1446,7 +1446,7 @@ declare module '@react-navigation/material-bottom-tabs' {
     +tabStyle: ViewStyleProp,
     +labelPosition: 'beside-icon' | 'below-icon',
     +adaptive: boolean,
-    +safeAreaInsets: $Shape<EdgeInsets>,
+    +safeAreaInsets: $Partial<EdgeInsets>,
     +style: ViewStyleProp,
   |}>;
 
@@ -1485,7 +1485,7 @@ declare module '@react-navigation/material-bottom-tabs' {
    * Material bottom tab options
    */
 
-  declare export type MaterialBottomTabOptions = $Shape<{|
+  declare export type MaterialBottomTabOptions = $Partial<{|
     +title: string,
     +tabBarColor: string,
     +tabBarLabel: string,
@@ -1632,7 +1632,7 @@ declare module '@react-navigation/material-bottom-tabs' {
    * Material top tab options
    */
 
-  declare export type MaterialTopTabOptions = $Shape<{|
+  declare export type MaterialTopTabOptions = $Partial<{|
     +title: string,
     +tabBarLabel:
       | string
@@ -1687,14 +1687,14 @@ declare module '@react-navigation/material-bottom-tabs' {
     +swipeEnabled: boolean,
     +swipeVelocityImpact?: number,
     +springVelocityScale?: number,
-    +springConfig: $Shape<{|
+    +springConfig: $Partial<{|
       +damping: number,
       +mass: number,
       +stiffness: number,
       +restSpeedThreshold: number,
       +restDisplacementThreshold: number,
     |}>,
-    +timingConfig: $Shape<{|
+    +timingConfig: $Partial<{|
       +duration: number,
     |}>,
   |};
@@ -1724,7 +1724,7 @@ declare module '@react-navigation/material-bottom-tabs' {
     +getTabWidth: number => number,
   |};
 
-  declare export type MaterialTopTabBarOptions = $Shape<{|
+  declare export type MaterialTopTabBarOptions = $Partial<{|
     +scrollEnabled: boolean,
     +bounces: boolean,
     +pressColor: string,
@@ -1770,7 +1770,7 @@ declare module '@react-navigation/material-bottom-tabs' {
     ...$Partial<MaterialTopTabPagerCommonProps>,
     +position?: any, // Reanimated.Value<number>
     +tabBarPosition?: 'top' | 'bottom',
-    +initialLayout?: $Shape<{| +width: number, +height: number |}>,
+    +initialLayout?: $Partial<{| +width: number, +height: number |}>,
     +lazy?: boolean,
     +lazyPreloadDistance?: number,
     +removeClippedSubviews?: boolean,
@@ -1801,7 +1801,7 @@ declare module '@react-navigation/material-bottom-tabs' {
    * Drawer options
    */
 
-  declare export type DrawerOptions = $Shape<{|
+  declare export type DrawerOptions = $Partial<{|
     title: string,
     drawerLabel:
       | string
@@ -1867,7 +1867,7 @@ declare module '@react-navigation/material-bottom-tabs' {
     DrawerOptions,
   >;
 
-  declare export type DrawerItemListBaseOptions = $Shape<{|
+  declare export type DrawerItemListBaseOptions = $Partial<{|
     +activeTintColor: string,
     +activeBackgroundColor: string,
     +inactiveTintColor: string,
@@ -1876,7 +1876,7 @@ declare module '@react-navigation/material-bottom-tabs' {
     +labelStyle: TextStyleProp,
   |}>;
 
-  declare export type DrawerContentOptions = $Shape<{|
+  declare export type DrawerContentOptions = $Partial<{|
     ...DrawerItemListBaseOptions,
     +contentContainerStyle: ViewStyleProp,
     +style: ViewStyleProp,

--- a/definitions/npm/@react-navigation/material-bottom-tabs_v5.x.x/flow_v0.104.x-/material-bottom-tabs_v5.x.x.js
+++ b/definitions/npm/@react-navigation/material-bottom-tabs_v5.x.x/flow_v0.104.x-/material-bottom-tabs_v5.x.x.js
@@ -416,7 +416,7 @@ declare module '@react-navigation/material-bottom-tabs' {
   >;
   declare type $IsUndefined<X> = $IsA<X, void>;
 
-  declare type $Partial<T> = $Rest<T, {...}>;
+  declare type $Partial<T> = $ReadOnly<$Rest<T, {...}>>;
 
   /**
    * Actions, state, etc.

--- a/definitions/npm/@react-navigation/material-top-tabs_v5.x.x/flow_v0.104.x-/material-top-tabs_v5.x.x.js
+++ b/definitions/npm/@react-navigation/material-top-tabs_v5.x.x/flow_v0.104.x-/material-top-tabs_v5.x.x.js
@@ -416,7 +416,7 @@ declare module '@react-navigation/material-top-tabs' {
   >;
   declare type $IsUndefined<X> = $IsA<X, void>;
 
-  declare type $Partial<T> = $Rest<T, {...}>;
+  declare type $Partial<T> = $ReadOnly<$Rest<T, {...}>>;
 
   /**
    * Actions, state, etc.

--- a/definitions/npm/@react-navigation/material-top-tabs_v5.x.x/flow_v0.104.x-/material-top-tabs_v5.x.x.js
+++ b/definitions/npm/@react-navigation/material-top-tabs_v5.x.x/flow_v0.104.x-/material-top-tabs_v5.x.x.js
@@ -263,7 +263,7 @@ declare module '@react-navigation/material-top-tabs' {
   // Copied from
   // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
   declare type Stringish = string;
-  declare type EdgeInsetsProp = $ReadOnly<$Shape<EdgeInsets>>;
+  declare type EdgeInsetsProp = $ReadOnly<$Partial<EdgeInsets>>;
   declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
     accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
     accessibilityElementsHidden?: ?boolean,
@@ -841,12 +841,12 @@ declare module '@react-navigation/material-top-tabs' {
       State,
       EventMap,
     >>,
-    +setOptions: (options: $Shape<ScreenOptions>) => void,
+    +setOptions: (options: $Partial<ScreenOptions>) => void,
     +setParams: (
       params: $If<
         $IsUndefined<$ElementType<ParamList, RouteName>>,
         empty,
-        $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+        $Partial<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
       >,
     ) => void,
     ...
@@ -893,7 +893,7 @@ declare module '@react-navigation/material-top-tabs' {
           route: RouteProp<ParamList, RouteName>,
           navigation: NavProp,
         |}) => ScreenListeners<EventMap, State>,
-    +initialParams?: $Shape<$ElementType<ParamList, RouteName>>,
+    +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
   |};
 
   declare export type ScreenProps<
@@ -1176,7 +1176,7 @@ declare module '@react-navigation/material-top-tabs' {
     +styleInterpolator: StackHeaderStyleInterpolator,
   |};
 
-  declare export type StackHeaderLeftButtonProps = $Shape<{|
+  declare export type StackHeaderLeftButtonProps = $Partial<{|
     +onPress: (() => void),
     +pressColorAndroid: string;
     +backImage: (props: {| tintColor: string |}) => React$Node,
@@ -1204,7 +1204,7 @@ declare module '@react-navigation/material-top-tabs' {
   declare export type StackHeaderTitleInputProps =
     $Exact<StackHeaderTitleInputBase>;
 
-  declare export type StackOptions = $Shape<{|
+  declare export type StackOptions = $Partial<{|
     +title: string,
     +header: StackHeaderProps => React$Node,
     +headerShown: boolean,
@@ -1217,7 +1217,7 @@ declare module '@react-navigation/material-top-tabs' {
     +gestureEnabled: boolean,
     +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
     +gestureVelocityImpact: number,
-    +safeAreaInsets: $Shape<EdgeInsets>,
+    +safeAreaInsets: $Partial<EdgeInsets>,
     // Transition
     ...TransitionPreset,
     // Header
@@ -1349,7 +1349,7 @@ declare module '@react-navigation/material-top-tabs' {
         >,
       |};
 
-  declare export type BottomTabOptions = $Shape<{|
+  declare export type BottomTabOptions = $Partial<{|
     +title: string,
     +tabBarLabel:
       | string
@@ -1364,7 +1364,7 @@ declare module '@react-navigation/material-top-tabs' {
     +tabBarAccessibilityLabel: string,
     +tabBarTestID: string,
     +tabBarVisible: boolean,
-    +tabBarVisibilityAnimationConfig: $Shape<{|
+    +tabBarVisibilityAnimationConfig: $Partial<{|
       +show: TabBarVisibilityAnimationConfig,
       +hide: TabBarVisibilityAnimationConfig,
     |}>,
@@ -1432,7 +1432,7 @@ declare module '@react-navigation/material-top-tabs' {
     BottomTabOptions,
   >;
 
-  declare export type BottomTabBarOptions = $Shape<{|
+  declare export type BottomTabBarOptions = $Partial<{|
     +keyboardHidesTabBar: boolean,
     +activeTintColor: string,
     +inactiveTintColor: string,
@@ -1446,7 +1446,7 @@ declare module '@react-navigation/material-top-tabs' {
     +tabStyle: ViewStyleProp,
     +labelPosition: 'beside-icon' | 'below-icon',
     +adaptive: boolean,
-    +safeAreaInsets: $Shape<EdgeInsets>,
+    +safeAreaInsets: $Partial<EdgeInsets>,
     +style: ViewStyleProp,
   |}>;
 
@@ -1485,7 +1485,7 @@ declare module '@react-navigation/material-top-tabs' {
    * Material bottom tab options
    */
 
-  declare export type MaterialBottomTabOptions = $Shape<{|
+  declare export type MaterialBottomTabOptions = $Partial<{|
     +title: string,
     +tabBarColor: string,
     +tabBarLabel: string,
@@ -1632,7 +1632,7 @@ declare module '@react-navigation/material-top-tabs' {
    * Material top tab options
    */
 
-  declare export type MaterialTopTabOptions = $Shape<{|
+  declare export type MaterialTopTabOptions = $Partial<{|
     +title: string,
     +tabBarLabel:
       | string
@@ -1687,14 +1687,14 @@ declare module '@react-navigation/material-top-tabs' {
     +swipeEnabled: boolean,
     +swipeVelocityImpact?: number,
     +springVelocityScale?: number,
-    +springConfig: $Shape<{|
+    +springConfig: $Partial<{|
       +damping: number,
       +mass: number,
       +stiffness: number,
       +restSpeedThreshold: number,
       +restDisplacementThreshold: number,
     |}>,
-    +timingConfig: $Shape<{|
+    +timingConfig: $Partial<{|
       +duration: number,
     |}>,
   |};
@@ -1724,7 +1724,7 @@ declare module '@react-navigation/material-top-tabs' {
     +getTabWidth: number => number,
   |};
 
-  declare export type MaterialTopTabBarOptions = $Shape<{|
+  declare export type MaterialTopTabBarOptions = $Partial<{|
     +scrollEnabled: boolean,
     +bounces: boolean,
     +pressColor: string,
@@ -1770,7 +1770,7 @@ declare module '@react-navigation/material-top-tabs' {
     ...$Partial<MaterialTopTabPagerCommonProps>,
     +position?: any, // Reanimated.Value<number>
     +tabBarPosition?: 'top' | 'bottom',
-    +initialLayout?: $Shape<{| +width: number, +height: number |}>,
+    +initialLayout?: $Partial<{| +width: number, +height: number |}>,
     +lazy?: boolean,
     +lazyPreloadDistance?: number,
     +removeClippedSubviews?: boolean,
@@ -1801,7 +1801,7 @@ declare module '@react-navigation/material-top-tabs' {
    * Drawer options
    */
 
-  declare export type DrawerOptions = $Shape<{|
+  declare export type DrawerOptions = $Partial<{|
     title: string,
     drawerLabel:
       | string
@@ -1867,7 +1867,7 @@ declare module '@react-navigation/material-top-tabs' {
     DrawerOptions,
   >;
 
-  declare export type DrawerItemListBaseOptions = $Shape<{|
+  declare export type DrawerItemListBaseOptions = $Partial<{|
     +activeTintColor: string,
     +activeBackgroundColor: string,
     +inactiveTintColor: string,
@@ -1876,7 +1876,7 @@ declare module '@react-navigation/material-top-tabs' {
     +labelStyle: TextStyleProp,
   |}>;
 
-  declare export type DrawerContentOptions = $Shape<{|
+  declare export type DrawerContentOptions = $Partial<{|
     ...DrawerItemListBaseOptions,
     +contentContainerStyle: ViewStyleProp,
     +style: ViewStyleProp,

--- a/definitions/npm/@react-navigation/native_v5.x.x/flow_v0.104.x-/native_v5.x.x.js
+++ b/definitions/npm/@react-navigation/native_v5.x.x/flow_v0.104.x-/native_v5.x.x.js
@@ -263,7 +263,7 @@ declare module '@react-navigation/native' {
   // Copied from
   // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
   declare type Stringish = string;
-  declare type EdgeInsetsProp = $ReadOnly<$Shape<EdgeInsets>>;
+  declare type EdgeInsetsProp = $ReadOnly<$Partial<EdgeInsets>>;
   declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
     accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
     accessibilityElementsHidden?: ?boolean,
@@ -841,12 +841,12 @@ declare module '@react-navigation/native' {
       State,
       EventMap,
     >>,
-    +setOptions: (options: $Shape<ScreenOptions>) => void,
+    +setOptions: (options: $Partial<ScreenOptions>) => void,
     +setParams: (
       params: $If<
         $IsUndefined<$ElementType<ParamList, RouteName>>,
         empty,
-        $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+        $Partial<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
       >,
     ) => void,
     ...
@@ -893,7 +893,7 @@ declare module '@react-navigation/native' {
           route: RouteProp<ParamList, RouteName>,
           navigation: NavProp,
         |}) => ScreenListeners<EventMap, State>,
-    +initialParams?: $Shape<$ElementType<ParamList, RouteName>>,
+    +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
   |};
 
   declare export type ScreenProps<
@@ -1176,7 +1176,7 @@ declare module '@react-navigation/native' {
     +styleInterpolator: StackHeaderStyleInterpolator,
   |};
 
-  declare export type StackHeaderLeftButtonProps = $Shape<{|
+  declare export type StackHeaderLeftButtonProps = $Partial<{|
     +onPress: (() => void),
     +pressColorAndroid: string;
     +backImage: (props: {| tintColor: string |}) => React$Node,
@@ -1204,7 +1204,7 @@ declare module '@react-navigation/native' {
   declare export type StackHeaderTitleInputProps =
     $Exact<StackHeaderTitleInputBase>;
 
-  declare export type StackOptions = $Shape<{|
+  declare export type StackOptions = $Partial<{|
     +title: string,
     +header: StackHeaderProps => React$Node,
     +headerShown: boolean,
@@ -1217,7 +1217,7 @@ declare module '@react-navigation/native' {
     +gestureEnabled: boolean,
     +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
     +gestureVelocityImpact: number,
-    +safeAreaInsets: $Shape<EdgeInsets>,
+    +safeAreaInsets: $Partial<EdgeInsets>,
     // Transition
     ...TransitionPreset,
     // Header
@@ -1349,7 +1349,7 @@ declare module '@react-navigation/native' {
         >,
       |};
 
-  declare export type BottomTabOptions = $Shape<{|
+  declare export type BottomTabOptions = $Partial<{|
     +title: string,
     +tabBarLabel:
       | string
@@ -1364,7 +1364,7 @@ declare module '@react-navigation/native' {
     +tabBarAccessibilityLabel: string,
     +tabBarTestID: string,
     +tabBarVisible: boolean,
-    +tabBarVisibilityAnimationConfig: $Shape<{|
+    +tabBarVisibilityAnimationConfig: $Partial<{|
       +show: TabBarVisibilityAnimationConfig,
       +hide: TabBarVisibilityAnimationConfig,
     |}>,
@@ -1432,7 +1432,7 @@ declare module '@react-navigation/native' {
     BottomTabOptions,
   >;
 
-  declare export type BottomTabBarOptions = $Shape<{|
+  declare export type BottomTabBarOptions = $Partial<{|
     +keyboardHidesTabBar: boolean,
     +activeTintColor: string,
     +inactiveTintColor: string,
@@ -1446,7 +1446,7 @@ declare module '@react-navigation/native' {
     +tabStyle: ViewStyleProp,
     +labelPosition: 'beside-icon' | 'below-icon',
     +adaptive: boolean,
-    +safeAreaInsets: $Shape<EdgeInsets>,
+    +safeAreaInsets: $Partial<EdgeInsets>,
     +style: ViewStyleProp,
   |}>;
 
@@ -1485,7 +1485,7 @@ declare module '@react-navigation/native' {
    * Material bottom tab options
    */
 
-  declare export type MaterialBottomTabOptions = $Shape<{|
+  declare export type MaterialBottomTabOptions = $Partial<{|
     +title: string,
     +tabBarColor: string,
     +tabBarLabel: string,
@@ -1632,7 +1632,7 @@ declare module '@react-navigation/native' {
    * Material top tab options
    */
 
-  declare export type MaterialTopTabOptions = $Shape<{|
+  declare export type MaterialTopTabOptions = $Partial<{|
     +title: string,
     +tabBarLabel:
       | string
@@ -1687,14 +1687,14 @@ declare module '@react-navigation/native' {
     +swipeEnabled: boolean,
     +swipeVelocityImpact?: number,
     +springVelocityScale?: number,
-    +springConfig: $Shape<{|
+    +springConfig: $Partial<{|
       +damping: number,
       +mass: number,
       +stiffness: number,
       +restSpeedThreshold: number,
       +restDisplacementThreshold: number,
     |}>,
-    +timingConfig: $Shape<{|
+    +timingConfig: $Partial<{|
       +duration: number,
     |}>,
   |};
@@ -1724,7 +1724,7 @@ declare module '@react-navigation/native' {
     +getTabWidth: number => number,
   |};
 
-  declare export type MaterialTopTabBarOptions = $Shape<{|
+  declare export type MaterialTopTabBarOptions = $Partial<{|
     +scrollEnabled: boolean,
     +bounces: boolean,
     +pressColor: string,
@@ -1770,7 +1770,7 @@ declare module '@react-navigation/native' {
     ...$Partial<MaterialTopTabPagerCommonProps>,
     +position?: any, // Reanimated.Value<number>
     +tabBarPosition?: 'top' | 'bottom',
-    +initialLayout?: $Shape<{| +width: number, +height: number |}>,
+    +initialLayout?: $Partial<{| +width: number, +height: number |}>,
     +lazy?: boolean,
     +lazyPreloadDistance?: number,
     +removeClippedSubviews?: boolean,
@@ -1801,7 +1801,7 @@ declare module '@react-navigation/native' {
    * Drawer options
    */
 
-  declare export type DrawerOptions = $Shape<{|
+  declare export type DrawerOptions = $Partial<{|
     title: string,
     drawerLabel:
       | string
@@ -1867,7 +1867,7 @@ declare module '@react-navigation/native' {
     DrawerOptions,
   >;
 
-  declare export type DrawerItemListBaseOptions = $Shape<{|
+  declare export type DrawerItemListBaseOptions = $Partial<{|
     +activeTintColor: string,
     +activeBackgroundColor: string,
     +inactiveTintColor: string,
@@ -1876,7 +1876,7 @@ declare module '@react-navigation/native' {
     +labelStyle: TextStyleProp,
   |}>;
 
-  declare export type DrawerContentOptions = $Shape<{|
+  declare export type DrawerContentOptions = $Partial<{|
     ...DrawerItemListBaseOptions,
     +contentContainerStyle: ViewStyleProp,
     +style: ViewStyleProp,

--- a/definitions/npm/@react-navigation/native_v5.x.x/flow_v0.104.x-/native_v5.x.x.js
+++ b/definitions/npm/@react-navigation/native_v5.x.x/flow_v0.104.x-/native_v5.x.x.js
@@ -416,7 +416,7 @@ declare module '@react-navigation/native' {
   >;
   declare type $IsUndefined<X> = $IsA<X, void>;
 
-  declare type $Partial<T> = $Rest<T, {...}>;
+  declare type $Partial<T> = $ReadOnly<$Rest<T, {...}>>;
 
   /**
    * Actions, state, etc.

--- a/definitions/npm/@react-navigation/stack_v5.x.x/flow_v0.104.x-/stack_v5.x.x.js
+++ b/definitions/npm/@react-navigation/stack_v5.x.x/flow_v0.104.x-/stack_v5.x.x.js
@@ -263,7 +263,7 @@ declare module '@react-navigation/stack' {
   // Copied from
   // react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
   declare type Stringish = string;
-  declare type EdgeInsetsProp = $ReadOnly<$Shape<EdgeInsets>>;
+  declare type EdgeInsetsProp = $ReadOnly<$Partial<EdgeInsets>>;
   declare type TouchableWithoutFeedbackProps = $ReadOnly<{|
     accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
     accessibilityElementsHidden?: ?boolean,
@@ -841,12 +841,12 @@ declare module '@react-navigation/stack' {
       State,
       EventMap,
     >>,
-    +setOptions: (options: $Shape<ScreenOptions>) => void,
+    +setOptions: (options: $Partial<ScreenOptions>) => void,
     +setParams: (
       params: $If<
         $IsUndefined<$ElementType<ParamList, RouteName>>,
         empty,
-        $Shape<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
+        $Partial<$NonMaybeType<$ElementType<ParamList, RouteName>>>,
       >,
     ) => void,
     ...
@@ -893,7 +893,7 @@ declare module '@react-navigation/stack' {
           route: RouteProp<ParamList, RouteName>,
           navigation: NavProp,
         |}) => ScreenListeners<EventMap, State>,
-    +initialParams?: $Shape<$ElementType<ParamList, RouteName>>,
+    +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
   |};
 
   declare export type ScreenProps<
@@ -1176,7 +1176,7 @@ declare module '@react-navigation/stack' {
     +styleInterpolator: StackHeaderStyleInterpolator,
   |};
 
-  declare export type StackHeaderLeftButtonProps = $Shape<{|
+  declare export type StackHeaderLeftButtonProps = $Partial<{|
     +onPress: (() => void),
     +pressColorAndroid: string;
     +backImage: (props: {| tintColor: string |}) => React$Node,
@@ -1204,7 +1204,7 @@ declare module '@react-navigation/stack' {
   declare export type StackHeaderTitleInputProps =
     $Exact<StackHeaderTitleInputBase>;
 
-  declare export type StackOptions = $Shape<{|
+  declare export type StackOptions = $Partial<{|
     +title: string,
     +header: StackHeaderProps => React$Node,
     +headerShown: boolean,
@@ -1217,7 +1217,7 @@ declare module '@react-navigation/stack' {
     +gestureEnabled: boolean,
     +gestureResponseDistance: {| vertical?: number, horizontal?: number |},
     +gestureVelocityImpact: number,
-    +safeAreaInsets: $Shape<EdgeInsets>,
+    +safeAreaInsets: $Partial<EdgeInsets>,
     // Transition
     ...TransitionPreset,
     // Header
@@ -1349,7 +1349,7 @@ declare module '@react-navigation/stack' {
         >,
       |};
 
-  declare export type BottomTabOptions = $Shape<{|
+  declare export type BottomTabOptions = $Partial<{|
     +title: string,
     +tabBarLabel:
       | string
@@ -1364,7 +1364,7 @@ declare module '@react-navigation/stack' {
     +tabBarAccessibilityLabel: string,
     +tabBarTestID: string,
     +tabBarVisible: boolean,
-    +tabBarVisibilityAnimationConfig: $Shape<{|
+    +tabBarVisibilityAnimationConfig: $Partial<{|
       +show: TabBarVisibilityAnimationConfig,
       +hide: TabBarVisibilityAnimationConfig,
     |}>,
@@ -1432,7 +1432,7 @@ declare module '@react-navigation/stack' {
     BottomTabOptions,
   >;
 
-  declare export type BottomTabBarOptions = $Shape<{|
+  declare export type BottomTabBarOptions = $Partial<{|
     +keyboardHidesTabBar: boolean,
     +activeTintColor: string,
     +inactiveTintColor: string,
@@ -1446,7 +1446,7 @@ declare module '@react-navigation/stack' {
     +tabStyle: ViewStyleProp,
     +labelPosition: 'beside-icon' | 'below-icon',
     +adaptive: boolean,
-    +safeAreaInsets: $Shape<EdgeInsets>,
+    +safeAreaInsets: $Partial<EdgeInsets>,
     +style: ViewStyleProp,
   |}>;
 
@@ -1485,7 +1485,7 @@ declare module '@react-navigation/stack' {
    * Material bottom tab options
    */
 
-  declare export type MaterialBottomTabOptions = $Shape<{|
+  declare export type MaterialBottomTabOptions = $Partial<{|
     +title: string,
     +tabBarColor: string,
     +tabBarLabel: string,
@@ -1632,7 +1632,7 @@ declare module '@react-navigation/stack' {
    * Material top tab options
    */
 
-  declare export type MaterialTopTabOptions = $Shape<{|
+  declare export type MaterialTopTabOptions = $Partial<{|
     +title: string,
     +tabBarLabel:
       | string
@@ -1687,14 +1687,14 @@ declare module '@react-navigation/stack' {
     +swipeEnabled: boolean,
     +swipeVelocityImpact?: number,
     +springVelocityScale?: number,
-    +springConfig: $Shape<{|
+    +springConfig: $Partial<{|
       +damping: number,
       +mass: number,
       +stiffness: number,
       +restSpeedThreshold: number,
       +restDisplacementThreshold: number,
     |}>,
-    +timingConfig: $Shape<{|
+    +timingConfig: $Partial<{|
       +duration: number,
     |}>,
   |};
@@ -1724,7 +1724,7 @@ declare module '@react-navigation/stack' {
     +getTabWidth: number => number,
   |};
 
-  declare export type MaterialTopTabBarOptions = $Shape<{|
+  declare export type MaterialTopTabBarOptions = $Partial<{|
     +scrollEnabled: boolean,
     +bounces: boolean,
     +pressColor: string,
@@ -1770,7 +1770,7 @@ declare module '@react-navigation/stack' {
     ...$Partial<MaterialTopTabPagerCommonProps>,
     +position?: any, // Reanimated.Value<number>
     +tabBarPosition?: 'top' | 'bottom',
-    +initialLayout?: $Shape<{| +width: number, +height: number |}>,
+    +initialLayout?: $Partial<{| +width: number, +height: number |}>,
     +lazy?: boolean,
     +lazyPreloadDistance?: number,
     +removeClippedSubviews?: boolean,
@@ -1801,7 +1801,7 @@ declare module '@react-navigation/stack' {
    * Drawer options
    */
 
-  declare export type DrawerOptions = $Shape<{|
+  declare export type DrawerOptions = $Partial<{|
     title: string,
     drawerLabel:
       | string
@@ -1867,7 +1867,7 @@ declare module '@react-navigation/stack' {
     DrawerOptions,
   >;
 
-  declare export type DrawerItemListBaseOptions = $Shape<{|
+  declare export type DrawerItemListBaseOptions = $Partial<{|
     +activeTintColor: string,
     +activeBackgroundColor: string,
     +inactiveTintColor: string,
@@ -1876,7 +1876,7 @@ declare module '@react-navigation/stack' {
     +labelStyle: TextStyleProp,
   |}>;
 
-  declare export type DrawerContentOptions = $Shape<{|
+  declare export type DrawerContentOptions = $Partial<{|
     ...DrawerItemListBaseOptions,
     +contentContainerStyle: ViewStyleProp,
     +style: ViewStyleProp,
@@ -2069,10 +2069,10 @@ declare module '@react-navigation/stack' {
 
   declare export var Header: React$ComponentType<StackHeaderProps>;
 
-  declare export type StackHeaderTitleProps = $Shape<StackHeaderTitleInputBase>;
+  declare export type StackHeaderTitleProps = $Partial<StackHeaderTitleInputBase>;
   declare export var HeaderTitle: React$ComponentType<StackHeaderTitleProps>;
 
-  declare export type HeaderBackButtonProps = $Shape<{|
+  declare export type HeaderBackButtonProps = $Partial<{|
     ...StackHeaderLeftButtonProps,
     +disabled: boolean,
     +accessibilityLabel: string,
@@ -2081,7 +2081,7 @@ declare module '@react-navigation/stack' {
     HeaderBackButtonProps,
   >;
 
-  declare export type HeaderBackgroundProps = $Shape<{
+  declare export type HeaderBackgroundProps = $Partial<{
     +children: React$Node,
     +style: AnimatedViewStyleProp,
     ...

--- a/definitions/npm/@react-navigation/stack_v5.x.x/flow_v0.104.x-/stack_v5.x.x.js
+++ b/definitions/npm/@react-navigation/stack_v5.x.x/flow_v0.104.x-/stack_v5.x.x.js
@@ -416,7 +416,7 @@ declare module '@react-navigation/stack' {
   >;
   declare type $IsUndefined<X> = $IsA<X, void>;
 
-  declare type $Partial<T> = $Rest<T, {...}>;
+  declare type $Partial<T> = $ReadOnly<$Rest<T, {...}>>;
 
   /**
    * Actions, state, etc.


### PR DESCRIPTION
Putting this PR up to get feedback. Is this a wise change to make? `$Shape` seems to have all sorts of issues, and it appears that the hack using `$Rest` is a good workaround.