### PR TITLE
[@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x] Several buxfixes

### DIFF
--- a/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x/flow_v0.92.x-/react-json-schema-form-builder_v1.x.x.js
+++ b/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x/flow_v0.92.x-/react-json-schema-form-builder_v1.x.x.js
@@ -1,45 +1,17 @@
 declare module '@ginkgo-bioworks/react-json-schema-form-builder' {
-  declare type CardProps = {|
-    name: string,
-    required: boolean,
-    dataOptions: {| [string]: any |},
-    uiOptions: {| [string]: any |},
-    $ref?: string,
-    dependents?: Array<{|
-      children: Array<string>,
-      value?: any,
-    |}>,
-    dependent?: boolean,
-    parent?: string,
-    propType: string,
-    neighborNames: Array<string>,
-  |};
-
-  declare type SectionProps = {|
-    name: string,
-    required: boolean,
-    schema: {| [string]: any |},
-    uischema: {| [string]: any |},
-    $ref?: string,
-    dependents?: Array<{|
-      children: Array<string>,
-      value?: any,
-    |}>,
-    dependent?: boolean,
-    propType: string,
-    neighborNames: Array<string>,
-  |};
-
-  declare type ElementProps = CardProps & SectionProps;
-
   declare type Parameters = {|
     [string]: string | number | boolean | Array<string | number>,
     name: string,
     path: string,
-    definitionData: {| [string]: any |},
-    definitionUi: {| [string]: any |},
+    definitionData: { [string]: any, ... },
+    definitionUi: { [string]: any, ... },
     category: string,
-    'ui:option': {| [string]: any |},
+    'ui:option': { [string]: any, ... },
+  |};
+
+  declare export type CardBodyProps = {|
+    parameters: Parameters,
+    onChange: (newParams: Parameters) => void,
   |};
 
   declare type DataType =
@@ -66,32 +38,28 @@ declare module '@ginkgo-bioworks/react-json-schema-form-builder' {
     matchIf: Array<MatchType>,
     // allowed keys for ui:options
     possibleOptions?: Array<string>,
-    defaultDataSchema: {|
+    defaultDataSchema: {
       [string]: any,
-    |},
-    defaultUiSchema: {|
+      ...
+    },
+    defaultUiSchema: {
       [string]: any,
-    |},
+      ...
+    },
     // the data schema type
     type: DataType,
     // inputs on the preview card
-    cardBody: React$AbstractComponent<{|
-      parameters: Parameters,
-      onChange: (newParams: Parameters) => void,
-      mods: {| [string]: any |},
-    |}>,
+    cardBody: React$ComponentType<CardBodyProps>,
     // inputs for the modal
-    modalBody?: React$AbstractComponent<{|
-      parameters: Parameters,
-      onChange: (newParams: Parameters) => void,
-    |}>,
+    modalBody?: React$ComponentType<CardBodyProps>,
   |};
 
   // optional properties that can add custom features to the form builder
   declare type Mods = {|
-    customFormInputs?: {|
+    customFormInputs?: {
       [string]: FormInput,
-    |},
+      ...
+    },
     tooltipDescriptions?: {|
       add?: string,
       cardObjectName?: string,

--- a/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x/test_react-json-schema-form-builder_v1.x.x.js
+++ b/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder_v1.x.x/test_react-json-schema-form-builder_v1.x.x.js
@@ -5,6 +5,7 @@ import {
   FormBuilder,
   PredefinedGallery,
 } from '@ginkgo-bioworks/react-json-schema-form-builder';
+import type { CardBodyProps } from '@ginkgo-bioworks/react-json-schema-form-builder';
 import { it, describe } from 'flow-typed-test';
 
 describe('@ginkgo-bioworks/react-json-schema-form-builder', () => {
@@ -20,7 +21,54 @@ describe('@ginkgo-bioworks/react-json-schema-form-builder', () => {
     mods: {},
     className: 'foo'
   };
-
+  const propsWithMods = {
+    schema: '',
+    uischema: '',
+    onChange: (newSchema, newUiSchema) => {},
+    mods: {
+      customFormInputs: {
+        customFormInput0: {
+          displayName: 'custom form input 0',
+          defaultDataSchema: {
+            'type': 'number',
+          },
+          defaultUiSchema: {
+            'ui:widget': 'customFormInput0',
+          },
+          type: 'number',
+          cardBody: (props: CardBodyProps) => <div/>,
+          modalBodyProps: (props: CardBodyProps) => <div/>,
+          matchIf: [{
+            types: ['number'],
+            widget: 'customFormInput0',
+          }],
+        },
+        customFormInput1: {
+          displayName: 'custom form input 1',
+          defaultDataSchema: {
+            'type': 'string',
+          },
+          defaultUiSchema: {
+            'ui:field': 'customFormInput1',
+          },
+          type: 'string',
+          cardBody: (props: CardBodyProps) => <div/>,
+          modalBodyProps: (props: CardBodyProps) => <div/>,
+          matchIf: [{
+            types: ['string'],
+            field: 'customFormInput1',
+          }],
+        },
+      },
+      tooltipDescriptions: {
+        add: 'add text',
+        cardObjectName: 'card object name text',
+        cardDisplayName: 'card display name text',
+        cardDescription: 'card description text',
+        cardInputType: 'card input type text',
+      },
+    },
+  };
   const extraneousProps = {
     schema: '',
     uischema: '',


### PR DESCRIPTION
Fix several issues with the flow-typed defintiions for react-json-schema-form-builder v1.x.x
- Remove `CardProps`, `SectionProps`, and `ElementProps`, which were vestigal and not currently being used.
- Remove exactness in object definitions with indexer properties, as they they are incompatible.
- Export a props type for `cardBody` and `modalBody` components so that these components can be defined externally.
- Use `React$ComponentType`, as `React$AbstractComponent` was incorrect.

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://react-json-schema-form-builder.readthedocs.io/en/main/
- Link to GitHub or NPM: https://github.com/ginkgobioworks/react-json-schema-form-builder
- Type of contribution:  fix 

Other notes:

