### PR TITLE
Add flow-typed definitions for match-sorter_v5.x.x

### DIFF
--- a/definitions/npm/match-sorter_v5.x.x/flow_v0.104.x-/match-sorter_v5.x.x.js
+++ b/definitions/npm/match-sorter_v5.x.x/flow_v0.104.x-/match-sorter_v5.x.x.js
@@ -1,25 +1,26 @@
-type $npm$matchSorter$KeyFn<T> = (item: T) => string | Array<String>;
-type $npm$matchSorter$KeyObj = {|
-  key: string,
-  minRanking?: number,
-  maxRanking?: number,
-  threshold?: number,
-|};
-
-type $npm$matchSorter$Rankings = {|
-  CASE_SENSITIVE_EQUAL: number,
-  EQUAL: number,
-  STARTS_WITH: number,
-  WORD_STARTS_WITH: number,
-  CONTAINS: number,
-  ACRONYM: number,
-  MATCHES: number,
-  NO_MATCH: number,
-|};
-
 declare module 'match-sorter' {
+  declare type Rankings = {|
+    CASE_SENSITIVE_EQUAL: number,
+    EQUAL: number,
+    STARTS_WITH: number,
+    WORD_STARTS_WITH: number,
+    CONTAINS: number,
+    ACRONYM: number,
+    MATCHES: number,
+    NO_MATCH: number,
+  |};
+
+  declare type KeyFn<T> = (item: T) => string | Array<String>;
+
+  declare type KeyObj = {|
+    key: string,
+    minRanking?: number,
+    maxRanking?: number,
+    threshold?: number,
+  |};
+
   declare type Options<T> = {|
-    keys: Array<string | $npm$matchSorter$KeyFn<T> | $npm$matchSorter$KeyObj>,
+    keys: Array<string | KeyFn<T> | KeyObj>,
     threshold?: number,
     keepDiacritics?: boolean,
   |};
@@ -30,6 +31,6 @@ declare module 'match-sorter' {
       value: string,
       options?: Options<T>
     ): Array<T>,
-    rankings: $npm$matchSorter$Rankings,
+    rankings: Rankings,
   |};
 }

--- a/definitions/npm/match-sorter_v5.x.x/flow_v0.104.x-/match-sorter_v5.x.x.js
+++ b/definitions/npm/match-sorter_v5.x.x/flow_v0.104.x-/match-sorter_v5.x.x.js
@@ -24,12 +24,12 @@ declare module 'match-sorter' {
     keepDiacritics?: boolean,
   |};
 
-  declare module.exports: {
+  declare module.exports: {|
     matchSorter<T>(
       items: Array<T>,
       value: string,
-      options?: Options<T>,
+      options?: Options<T>
     ): Array<T>,
     rankings: $npm$matchSorter$Rankings,
-  };
+  |};
 }

--- a/definitions/npm/match-sorter_v5.x.x/flow_v0.104.x-/match-sorter_v5.x.x.js
+++ b/definitions/npm/match-sorter_v5.x.x/flow_v0.104.x-/match-sorter_v5.x.x.js
@@ -1,0 +1,35 @@
+type $npm$matchSorter$KeyFn<T> = (item: T) => string | Array<String>;
+type $npm$matchSorter$KeyObj = {|
+  key: string,
+  minRanking?: number,
+  maxRanking?: number,
+  threshold?: number,
+|};
+
+type $npm$matchSorter$Rankings = {|
+  CASE_SENSITIVE_EQUAL: number,
+  EQUAL: number,
+  STARTS_WITH: number,
+  WORD_STARTS_WITH: number,
+  CONTAINS: number,
+  ACRONYM: number,
+  MATCHES: number,
+  NO_MATCH: number,
+|};
+
+declare module 'match-sorter' {
+  declare type Options<T> = {|
+    keys: Array<string | $npm$matchSorter$KeyFn<T> | $npm$matchSorter$KeyObj>,
+    threshold?: number,
+    keepDiacritics?: boolean,
+  |};
+
+  declare module.exports: {
+    matchSorter<T>(
+      items: Array<T>,
+      value: string,
+      options?: Options<T>,
+    ): Array<T>,
+    rankings: $npm$matchSorter$Rankings,
+  };
+}

--- a/definitions/npm/match-sorter_v5.x.x/test_match-sorter-v5.x.x.js
+++ b/definitions/npm/match-sorter_v5.x.x/test_match-sorter-v5.x.x.js
@@ -1,18 +1,18 @@
 // @flow
 
-import {matchSorter, rankings, caseRankings } from 'match-sorter';
+import { matchSorter, rankings } from 'match-sorter';
 import { describe, it } from 'flow-typed-test';
 
 describe('rankings', () => {
   it('should be a number', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const startsWith: string = rankings.STARTS_WITH;
 
     const equal: number = rankings.EQUAL;
   });
 
   it('should fail on unknown ranking', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[prop-missing]
     rankings.foo;
   });
 });
@@ -21,12 +21,12 @@ describe('matchSorter', () => {
   const sampleCollection = [{ baz: '1' }, { baz: '2' }, { baz: 'foooooo' }];
 
   it('should fail with invalid collection', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     matchSorter(1, 'foo');
   });
 
   it('query should be a string', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     matchSorter([], 2);
   });
 
@@ -35,13 +35,13 @@ describe('matchSorter', () => {
   });
 
   it('should fail on invalid search options', () => {
-    // $FlowExpectedError
-    matchSorter(sampleCollection, 'foo', { foo: bar });
+    // $FlowExpectedError[prop-missing]
+    matchSorter(sampleCollection, 'foo', { foo: 'bar' });
 
-    // $FlowExpectedError
+    // $FlowExpectedError[prop-missing]
     matchSorter(sampleCollection, 'foo', { invalidProp: 'bar' });
 
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     matchSorter(sampleCollection, 'foo', { keys: 1 });
   });
 
@@ -62,7 +62,7 @@ describe('matchSorter', () => {
   });
 
   it('should fail on unknown property in object key accessor', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     matchSorter(sampleCollection, 'foo', { keys: [{ foo: 'baz' }] });
   });
 });

--- a/definitions/npm/match-sorter_v5.x.x/test_match-sorter-v5.x.x.js
+++ b/definitions/npm/match-sorter_v5.x.x/test_match-sorter-v5.x.x.js
@@ -1,0 +1,68 @@
+// @flow
+
+import {matchSorter, rankings, caseRankings } from 'match-sorter';
+import { describe, it } from 'flow-typed-test';
+
+describe('rankings', () => {
+  it('should be a number', () => {
+    // $FlowExpectedError
+    const startsWith: string = rankings.STARTS_WITH;
+
+    const equal: number = rankings.EQUAL;
+  });
+
+  it('should fail on unknown ranking', () => {
+    // $FlowExpectedError
+    rankings.foo;
+  });
+});
+
+describe('matchSorter', () => {
+  const sampleCollection = [{ baz: '1' }, { baz: '2' }, { baz: 'foooooo' }];
+
+  it('should fail with invalid collection', () => {
+    // $FlowExpectedError
+    matchSorter(1, 'foo');
+  });
+
+  it('query should be a string', () => {
+    // $FlowExpectedError
+    matchSorter([], 2);
+  });
+
+  it('should return collection with same element type', () => {
+    const found1: Array<number> = matchSorter([1, 2, 3], '2');
+  });
+
+  it('should fail on invalid search options', () => {
+    // $FlowExpectedError
+    matchSorter(sampleCollection, 'foo', { foo: bar });
+
+    // $FlowExpectedError
+    matchSorter(sampleCollection, 'foo', { invalidProp: 'bar' });
+
+    // $FlowExpectedError
+    matchSorter(sampleCollection, 'foo', { keys: 1 });
+  });
+
+  it('should pass for string keys accessors', () => {
+    // string key accessor
+    const [found2] = matchSorter(sampleCollection, 'foo', { keys: ['baz'] });
+    const prop: string = found2.baz;
+  });
+
+  it('should pass for callback keys accessor', () => {
+    // callback key accessor
+    matchSorter(sampleCollection, 'foo', { keys: [item => item.baz] });
+  });
+
+  it('should pass for object keys accessor', () => {
+    // object key accessor
+    matchSorter(sampleCollection, 'foo', { keys: [{ key: 'baz' }] });
+  });
+
+  it('should fail on unknown property in object key accessor', () => {
+    // $FlowExpectedError
+    matchSorter(sampleCollection, 'foo', { keys: [{ foo: 'baz' }] });
+  });
+});


### PR DESCRIPTION
- Links to documentation: https://github.com/kentcdodds/match-sorter#usage
- Link to GitHub or NPM: https://github.com/kentcdodds/match-sorter
- Type of contribution: new definition

Other notes:

I based this on match-sorter_v2.3.x and then updated the definitions for the newer version. In particular, the tests are nearly identical.