### PR TITLE
npm/chance: Add options for syllable, hour, minute

### DIFF
--- a/definitions/npm/chance_v1.x.x/flow_v0.104.x-/chance_v1.x.x.js
+++ b/definitions/npm/chance_v1.x.x/flow_v0.104.x-/chance_v1.x.x.js
@@ -212,11 +212,7 @@ declare module 'chance' {
       ...
     };
     month(): string;
-    second(options?: {
-      min?: number,
-      max?: number,
-      ...
-    }): number;
+    second(): number;
     timestamp(): number;
     timezone(): Timezone;
     weekday(options?: { weekday_only?: boolean, ... }): string;

--- a/definitions/npm/chance_v1.x.x/flow_v0.104.x-/chance_v1.x.x.js
+++ b/definitions/npm/chance_v1.x.x/flow_v0.104.x-/chance_v1.x.x.js
@@ -200,7 +200,7 @@ declare module 'chance' {
       ...
     }): number;
     millisecond(): number;
-    minute(options? :{
+    minute(options?: {
       min?: number,
       max: number,
       ...

--- a/definitions/npm/chance_v1.x.x/flow_v0.104.x-/chance_v1.x.x.js
+++ b/definitions/npm/chance_v1.x.x/flow_v0.104.x-/chance_v1.x.x.js
@@ -49,7 +49,11 @@ declare module 'chance' {
     buffer(options?: { length?: number, ... }): Buffer;
     paragraph(options?: { sentences: number, ... }): string;
     sentence(options?: { words: number, ... }): string;
-    syllable(): string;
+    syllable(options?: {
+      length?: number,
+      capitalize?: boolean,
+      ...
+    }): string;
     word(options?: {
       syllables?: number,
       length?: number,
@@ -189,9 +193,18 @@ declare module 'chance' {
       ...
     }): Date;
     hammertime(): number;
-    hour(): number;
+    hour(options?: {
+      twentyfour?: boolean,
+      min?: number,
+      max?: number,
+      ...
+    }): number;
     millisecond(): number;
-    minute(): number;
+    minute(options? :{
+      min?: number,
+      max: number,
+      ...
+    }): number;
     month(options: { raw: true, ... }): {
       name: string,
       short_name: string,
@@ -199,7 +212,11 @@ declare module 'chance' {
       ...
     };
     month(): string;
-    second(): number;
+    second(options?: {
+      min?: number,
+      max?: number,
+      ...
+    }): number;
     timestamp(): number;
     timezone(): Timezone;
     weekday(options?: { weekday_only?: boolean, ... }): string;

--- a/definitions/npm/chance_v1.x.x/test_chance-v1.x.x.js
+++ b/definitions/npm/chance_v1.x.x/test_chance-v1.x.x.js
@@ -27,7 +27,5 @@ const ccType = chance.cc_type({ raw: true });
 (chance.hour(): number);
 (chance.minute({ min: 0, max: 30 }): number);
 (chance.minute(): number);
-(chance.second({ min: 0, max: 50 }): number);
-(chance.second(): number);
 (chance.syllable(): string);
 (chance.syllable({ length: 5, capitalize: true }): string);

--- a/definitions/npm/chance_v1.x.x/test_chance-v1.x.x.js
+++ b/definitions/npm/chance_v1.x.x/test_chance-v1.x.x.js
@@ -22,3 +22,12 @@ const ccType = chance.cc_type({ raw: true });
 (ccType.length: number);
 
 (chance.hash(): string);
+(chance.hour({ twentyfour: true }): number);
+(chance.hour({ min: 0, max: 3 }): number);
+(chance.hour(): number);
+(chance.minute({ min: 0, max: 30 }): number);
+(chance.minute(): number);
+(chance.second({ min: 0, max: 50 }): number);
+(chance.second(): number);
+(chance.syllable(): string);
+(chance.syllable({ length: 5, capitalize: true }): string);


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation:  https://chancejs.com/
- Link to GitHub or NPM: 
  - minute: https://github.com/chancejs/chancejs/blob/93b384673074fe959c9691d02d2a0fec8cd394fa/chance.js#L2128
  - syllable: https://github.com/chancejs/chancejs/blob/93b384673074fe959c9691d02d2a0fec8cd394fa/chance.js#L821
  - hour: https://github.com/chancejs/chancejs/blob/93b384673074fe959c9691d02d2a0fec8cd394fa/chance.js#L2110-L2113
- Type of contribution: fix

Other notes:

