### PR TITLE
Fix the return type for useLazyQuery

### DIFF
--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
@@ -61,7 +61,10 @@ declare module '@apollo/react-hooks' {
   declare export function useLazyQuery<TData, TVariables>(
     query: DocumentNode,
     options?: LazyQueryHookOptions<TData, TVariables>
-  ): QueryTuple<TData, TVariables>;
+  ): [
+    (options?: QueryLazyOptions<TVariables>) => void,
+    QueryResult<TData, TVariables>
+  ];
 
   declare export function useSubscription<TData, TVariables>(
     query: DocumentNode,

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.58.x-v0.103.x/react-hooks_v3.x.x.js
@@ -47,7 +47,10 @@ declare module '@apollo/react-hooks' {
   declare export function useLazyQuery<TData, TVariables>(
     query: DocumentNode,
     options?: LazyQueryHookOptions<TData, TVariables>
-  ): QueryTuple<TData, TVariables>;
+  ): [
+    (options?: QueryLazyOptions<TVariables>) => void,
+    QueryResult<TData, TVariables>
+  ];
 
   declare export function useSubscription<TData, TVariables>(
     query: DocumentNode,


### PR DESCRIPTION
- Links to documentation: https://www.apollographql.com/docs/react/api/react/hooks/#function-signature-1
- Link to GitHub or NPM: https://github.com/apollographql/apollo-client
- Type of contribution: fix
