### PR TITLE
[testing-library/react] fix missing types error

### DIFF
--- a/definitions/npm/@testing-library/react_v10.x.x/flow_v0.104.x-/react_v10.x.x.js
+++ b/definitions/npm/@testing-library/react_v10.x.x/flow_v0.104.x-/react_v10.x.x.js
@@ -134,7 +134,7 @@ declare module '@testing-library/react' {
   ) => Promise<HTMLElement>;
 
   declare type FindAllByRole = (
-    role: Matcher,
+    role: any,
     options?: ByRoleOptions,
     waitForElementOptions?: WaitForElementOptions
   ) => Promise<HTMLElement[]>;
@@ -235,7 +235,7 @@ declare module '@testing-library/react' {
     container?: HTMLElement,
     baseElement?: HTMLElement,
     hydrate?: boolean,
-    wrapper?: React.ComponentType,
+    wrapper?: React$ComponentType<any>,
   |};
 
   declare export type RenderOptionsWithCustomQueries<
@@ -245,17 +245,17 @@ declare module '@testing-library/react' {
     container?: HTMLElement,
     baseElement?: HTMLElement,
     hydrate?: boolean,
-    wrapper?: React.ComponentType,
+    wrapper?: React$ComponentType<any>,
   |};
 
   declare export function render(
-    ui: React.ReactElement<any>,
+    ui: React$Node,
     options?: RenderOptionsWithoutCustomQueries
   ): RenderResult<>;
   declare export function render<
     CustomQueries: { [string]: (...args: Array<any>) => any, ... }
   >(
-    ui: React.ReactElement<any>,
+    ui: React$Node,
     options: RenderOptionsWithCustomQueries<CustomQueries>
   ): RenderResult<CustomQueries>;
 


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Because of flow 0.143.0, lib defs now better throw errors. These are the errors caught from react testing library for types that don't exist.

- Links to documentation: https://github.com/testing-library/react-testing-library
- Link to GitHub or NPM: https://github.com/testing-library/react-testing-library
- Type of contribution: fix

Other notes:

