### PR TITLE
[webpack] Fix import errors

### DIFF
--- a/definitions/npm/webpack_v4.x.x/flow_v0.104.x-/webpack_v4.x.x.js
+++ b/definitions/npm/webpack_v4.x.x/flow_v0.104.x-/webpack_v4.x.x.js
@@ -1,7 +1,7 @@
-import * as http from 'http';
-import fs from 'fs';
-
 declare module 'webpack' {
+  import typeof { Server } from 'http';
+  import typeof { Stats as FsStats } from 'fs';
+
   declare class $WebpackError extends Error {
     constructor(message: string): WebpackError;
     inspect(): string;
@@ -448,9 +448,9 @@ declare module 'webpack' {
     context?: string,
     dependencies?: Array<string>,
     devServer?: {
-      after?: (app: any, server: http.Server) => void,
+      after?: (app: any, server: Server) => void,
       allowedHosts?: string[],
-      before?: (app: any, server: http.Server) => void,
+      before?: (app: any, server: Server) => void,
       bonjour?: boolean,
       clientLogLevel?: 'none' | 'info' | 'error' | 'warning',
       compress?: boolean,
@@ -512,9 +512,9 @@ declare module 'webpack' {
         maxAge?: number,
         redirect?: boolean,
         setHeaders?: (
-          res: http.OutgoingMessage,
+          res: any,
           path: string,
-          stat: fs.Stat
+          stat: FsStats,
         ) => void,
         ...
       },
@@ -569,14 +569,6 @@ declare module 'webpack' {
       | false,
     entry?: Entry,
     externals?: Externals,
-    infrastructureLogging?: {|
-      level?: 'none' | 'error' | 'warn' | 'info' | 'log' | 'verbose',
-      debug?:
-        | string
-        | RegExp
-        | ((string) => boolean)
-        | Array<string | RegExp | ((string) => boolean)>,
-    |},
     loader?: { [k: string]: any, ... },
     mode?: 'development' | 'production' | 'none',
     module?: ModuleOptions,

--- a/definitions/npm/webpack_v4.x.x/flow_v0.104.x-/webpack_v4.x.x.js
+++ b/definitions/npm/webpack_v4.x.x/flow_v0.104.x-/webpack_v4.x.x.js
@@ -569,6 +569,14 @@ declare module 'webpack' {
       | false,
     entry?: Entry,
     externals?: Externals,
+    infrastructureLogging?: {|
+      level?: 'none' | 'error' | 'warn' | 'info' | 'log' | 'verbose',
+      debug?:
+        | string
+        | RegExp
+        | ((string) => boolean)
+        | Array<string | RegExp | ((string) => boolean)>,
+    |},
     loader?: { [k: string]: any, ... },
     mode?: 'development' | 'production' | 'none',
     module?: ModuleOptions,


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
After updating to 0.143.0 new errors in lib defs are being highlighted. We should not be importing outside of a module declaration.

- Links to documentation: https://github.com/webpack/webpack
- Link to GitHub or NPM: https://github.com/webpack/webpack
- Type of contribution: fix

Other notes: `OutgoingMessage` doesn't exist in `http` module. Should probably be added in flow but that's probably a different problem to solve. This at least doesn't break the type and keeps it as it was before which would have exposed `any`

