### PR TITLE
Fix lowercase MiddlewareCallback to MiddleWareCallback

### DIFF
--- a/definitions/npm/yargs_v15.x.x/flow_v0.118.x-/yargs_v15.x.x.js
+++ b/definitions/npm/yargs_v15.x.x/flow_v0.118.x-/yargs_v15.x.x.js
@@ -67,7 +67,7 @@ declare module "yargs" {
     | (argv: Argv, yargsInstance?: Yargs) => void
     | (argv: Argv, yargsInstance?: Yargs) => Promise<void>;
 
-  declare type Middleware = MiddlewareCallback | Array<MiddleWareCallback>;
+  declare type Middleware = MiddleWareCallback | Array<MiddleWareCallback>;
 
   declare class Yargs {
     (args: Array<string>): Yargs;


### PR DESCRIPTION
The `yargs_v15.x.x.js` typedef had a typo for the `MiddleWareCallback`. Changed the `w` from lowercase to upperwase `W`.

Test plan:

Run `./build_and_test_cli.sh`
```
Test Suites: 9 passed, 9 total
Tests:       112 passed, 112 total
Snapshots:   0 total
Time:        8.836s
Ran all test suites.
$ eslint .
Done in 14.49s.
Done in 31.68s.
All libdefs are named and structured correctly. (Found 1787)
```

- Link to GitHub or NPM: https://github.com/yargs/yargs/blob/7ffb5e8ae4f4f94f94ffd10a3aa8b410b2ed2fe4/lib/middleware.ts
- Type of contribution: fix

Other notes:

While the source project uses `MiddlewareCallback`, I stuck to the notion of `yargs_v16.x.x.js`, which was using `MiddleWareCallback` throughout.