### PR TITLE
[cli] Remove peerDependencies from list to parse

### DIFF
--- a/cli/src/lib/npm/npmProjectUtils.js
+++ b/cli/src/lib/npm/npmProjectUtils.js
@@ -34,7 +34,6 @@ export type PnpResolver = {|
 const PKG_JSON_DEP_FIELDS = [
   'dependencies',
   'devDependencies',
-  'peerDependencies',
   'bundledDependencies',
 ];
 export async function findPackageJsonDepVersionStr(


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Closes https://github.com/flow-typed/flow-typed/issues/3833

Deps listed in `peerDependencies` really shouldn't be considered when looking for lib defs to install. These are dependencies that are specified for consumers to read so they install the right dependency of their dependency. If a project wants to use a dependency that should be driven by the dependency installed by their consumer it should really be specified in the `devDependencies` section because specifying `peerDependencies` doesn't actually install anything anyways when running `yarn` or `npm i`

- Links to documentation: N/A
- Link to GitHub or NPM:  N/A
- Type of contribution: fix

Other notes:

