### PR TITLE
Adapted cy.request to return Cypress$Global rather than a promise

### DIFF
--- a/definitions/npm/cypress_v6.x.x/flow_v0.25.x-/cypress_v6.x.x.js
+++ b/definitions/npm/cypress_v6.x.x/flow_v0.25.x-/cypress_v6.x.x.js
@@ -446,15 +446,15 @@ declare interface Cypress$Chainable {
   /**
    * @see https://docs.cypress.io/api/commands/request.html
    */
-  request(url: string): Promise<Cypress$RequestResponse>,
-  request(url: string, body: Cypress$RequestBody): Promise<Cypress$RequestResponse>,
-  request(method: Cypress$HttpMethod, url: string): Promise<Cypress$RequestResponse>,
+  request(url: string): Cypress$Global,
+  request(url: string, body: Cypress$RequestBody): Cypress$Global,
+  request(method: Cypress$HttpMethod, url: string): Cypress$Global,
   request(
     method: Cypress$HttpMethod,
     url: string,
     body: Cypress$RequestBody,
-  ): Promise<Cypress$RequestResponse>,
-  request(options: Cypress$RequestOptions): Promise<Cypress$RequestResponse>,
+  ): Cypress$Global,
+  request(options: Cypress$RequestOptions): Cypress$Global,
 
   /**
    * @see https://docs.cypress.io/api/commands/root.html

--- a/definitions/npm/cypress_v6.x.x/flow_v0.25.x-/cypress_v6.x.x.js
+++ b/definitions/npm/cypress_v6.x.x/flow_v0.25.x-/cypress_v6.x.x.js
@@ -43,6 +43,8 @@ declare type Cypress$ViewportPreset =
 
 declare type Cypress$RequestBody = string | { ... };
 
+/* This type is no longer used in this libdef.
+   It is kept for backward-compatibility (projects may still rely on it) */
 declare type Cypress$RequestResponse = {
   status: any,
   body: any,

--- a/definitions/npm/cypress_v6.x.x/test_cypress_v6.x.x.js
+++ b/definitions/npm/cypress_v6.x.x/test_cypress_v6.x.x.js
@@ -143,25 +143,25 @@ cy.readFile('path', 'encoding');
 cy.reload();
 cy.reload(true);
 
-cy.request('test').then(({ body }) => {
+cy.request('test').then(({ body }: Cypress$RequestResponse) => {
 
 });
-cy.request('test', 'body').then(({ headers }) => {
+cy.request('test', 'body').then(({ headers }: Cypress$RequestResponse) => {
 
 });
-cy.request('test', {}).then(({ status }) => {
+cy.request('test', {}).then(({ status }: Cypress$RequestResponse) => {
 
 });
-cy.request('GET', 'test').then(({ duration }) => {
+cy.request('GET', 'test').then(({ duration }: Cypress$RequestResponse) => {
 
 });
-cy.request('GET', 'test', 'body').then(({ duration }) => {
+cy.request('GET', 'test', 'body').then(({ duration }: Cypress$RequestResponse) => {
 
 });
-cy.request('GET', 'test', {}).then(({ duration }) => {
+cy.request('GET', 'test', {}).then(({ duration }: Cypress$RequestResponse) => {
 
 });
-cy.request({ url: 'test' }).then(({ duration }) => {
+cy.request({ url: 'test' }).then(({ duration }: Cypress$RequestResponse) => {
 
 });
 

--- a/definitions/npm/cypress_v6.x.x/test_cypress_v6.x.x.js
+++ b/definitions/npm/cypress_v6.x.x/test_cypress_v6.x.x.js
@@ -165,6 +165,14 @@ cy.request({ url: 'test' }).then(({ duration }) => {
 
 });
 
+cy.request('test').as('response');
+cy.request('test', 'body').as('response');
+cy.request('test', {}).as('response');
+cy.request('GET', 'test').as('response');
+cy.request('GET', 'test', 'body').as('response');
+cy.request('GET', 'test', {}).as('response');
+cy.request({ url: 'test' }).as('response');
+
 cy.root().click();
 
 cy.route('url').as('test');


### PR DESCRIPTION
- Links to documentation: https://docs.cypress.io/api/commands/request.html
- Link to GitHub or NPM: /
- Type of contribution: fix

Other notes: `cy.request` does not actually return a Promise (though it is `then`able). Such as stated in the [examples section](https://docs.cypress.io/api/commands/request.html#Examples), you can chain the result with other Cypress commands

```
cy.request('/admin').its('body');
cy.request('https://jsonplaceholder.cypress.io/comments').as('comments')
```

So it makes more sense for `cy.request` to return `Cypress$Global`, as many other commands. 

Unfortunately, by returning `Cypress$Global` we lose the typing information of what the command actually yields (`Cypress$RequestResponse`). In the future, maybe  `Cypress$Global` should be parametrized ?

@Brianzchen FYI