### PR TITLE
[cli] Fix tests not running in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - name: Setup Node
         uses: actions/setup-node@v1
         with:

--- a/cli/src/lib/git.js
+++ b/cli/src/lib/git.js
@@ -82,6 +82,8 @@ export async function getDiff() {
     }
     return stdout.split('\n');
   } catch (e) {
+    console.error('Unable to find diffs!')
+    console.error(e);
     return [];
   }
 }

--- a/cli/src/lib/git.js
+++ b/cli/src/lib/git.js
@@ -82,7 +82,7 @@ export async function getDiff() {
     }
     return stdout.split('\n');
   } catch (e) {
-    console.error('Unable to find diffs!')
+    console.error('Unable to find diffs!');
     console.error(e);
     return [];
   }

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -246,7 +246,7 @@ async function parseLibDefsFromPkgDir(
   }
 
   if (flowDirs.length === 0) {
-    throw new ValidationError('No libdef files found!');
+    throw new ValidationError(`No libdef files found for ${pkgDirPath}!`);
   }
 
   const libDefs = [];


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Fixes #3999. It turns out after moving to github actions, it wasn't able to fetch diffs because the github action `actions/checkout@v2` does a shallow clone of a single commit unless you specify the fetch depth.

I was testing for reference on https://github.com/flow-typed/flow-typed/pull/4009 but that PR starting getting pretty large from fixing `@testing-library/react` so breaking it up to just fix the tests here

- Links to documentation: N/A
- Link to GitHub or NPM: N/A
- Type of contribution: fix

Other notes:
Update some of the logging because it took me a bit of trial and error to find out what was happening, it turned out when it fetched git diffs it was silently failing and returning `[]` so these will help people track down issues easier in the future.

```
{
  stderr: "fatal: ambiguous argument 'HEAD~1': unknown revision or path not in the working tree.\n" +
    "Use '--' to separate paths from revisions, like this:\n" +
    "'git <command> [<revision>...] -- [<file>...]'\n",
  stdout: '',
  exitCode: 128
}
```

cc: @pascalduez @AndrewSouthpaw @GAntoine @villesau 
