### PR TITLE
fix imports for morgan lib def

### DIFF
--- a/definitions/npm/morgan_v1.x.x/flow_v0.104.x-/morgan_v1.x.x.js
+++ b/definitions/npm/morgan_v1.x.x/flow_v0.104.x-/morgan_v1.x.x.js
@@ -1,7 +1,8 @@
 /* @flow */
-import type { Middleware, $Request, $Response } from "express";
 
 declare module "morgan" {
+  import type { Middleware, $Request, $Response } from "express";
+
   declare type FormatFn = (
     tokens: TokenIndexer,
     req: $Request,


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

Newer versions of flow-bin don't allow using import outside declare module blocks.
This PR fixes imports for morgan lib type definitions.

