### PR TITLE
[next_v9.x.x] Add useRouter definition

### DIFF
--- a/definitions/npm/next_v2.x.x/flow_v0.104.x-/next_v2.x.x.js
+++ b/definitions/npm/next_v2.x.x/flow_v0.104.x-/next_v2.x.x.js
@@ -2,7 +2,7 @@
 
 declare module "next" {
   declare export type RequestHandler = (
-    req: http$IncomingMessage,
+    req: http$IncomingMessage<>,
     res: http$ServerResponse, parsedUrl: any
   ) => Promise<void>;
 
@@ -10,27 +10,27 @@ declare module "next" {
     prepare(): Promise<void>,
     getRequestHandler(): RequestHandler,
     render(
-      req: http$IncomingMessage,
+      req: http$IncomingMessage<>,
       res: http$ServerResponse,
       pathname: string,
       query: any
     ): any,
     renderToHTML(
-      req: http$IncomingMessage,
+      req: http$IncomingMessage<>,
       res: http$ServerResponse,
       pathname: string,
       query: string
     ): string,
     renderError(
       err: Error,
-      req: http$IncomingMessage,
+      req: http$IncomingMessage<>,
       res: http$ServerResponse,
       pathname: any,
       query: any
     ): any,
     renderErrorToHTML(
       err: Error,
-      req: http$IncomingMessage,
+      req: http$IncomingMessage<>,
       res: http$ServerResponse,
       pathname: string,
       query: any
@@ -51,7 +51,7 @@ declare module "next" {
 declare module "next/head" {
   import type { Component } from 'react';
 
-  declare export default Class<Component<*, *>>;
+  declare export default Class<Component<any, any>>;
 }
 
 declare module "next/link" {
@@ -126,11 +126,11 @@ declare module "next/document" {
     ...
   };
 
-  declare export var Head: Class<Component<*, *>>;
-  declare export var Main: Class<Component<*, *>>;
-  declare export var NextScript: Class<Component<*, *>>;
-  declare export default Class<Component<*, *>> & {
-    getInitialProps: (ctx: Context) => Promise<*>,
+  declare export var Head: Class<Component<any, any>>;
+  declare export var Main: Class<Component<any, any>>;
+  declare export var NextScript: Class<Component<any, any>>;
+  declare export default Class<Component<any, any>> & {
+    getInitialProps: (ctx: Context) => Promise<any>,
     renderPage(cb: Function): void,
     ...
   };

--- a/definitions/npm/next_v2.x.x/flow_v0.104.x-/test_next_v2.x.x.js
+++ b/definitions/npm/next_v2.x.x/flow_v0.104.x-/test_next_v2.x.x.js
@@ -16,13 +16,13 @@ const { createServer } = require('http')
 const { parse } = require('url')
 
 // server
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 next({ dev: 1 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 next({ dir: false });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 next({ quiet: 'derp' });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 next({ staticMarkup: 42 });
 
 const app = next({ dev: true, dir: ".", quiet: false});
@@ -57,13 +57,13 @@ app.prepare()
 <Prefetch href='/'>Prefetch</Prefetch>;
 <Prefetch href='/' prefetch={false}>Prefetch</Prefetch>;
 
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-type]
 <Link href={1}>InvalidNumLink</Link>;
 
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-type]
 <Prefetch href='/' prefetch={() => {}}>Prefetch</Prefetch>;
 
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 Router.onRouteChangeStart = {};
 
 Router.onRouteChangeStart = (url: string) => {};
@@ -88,12 +88,12 @@ const p: string = Router.pathname;
 const q: { ... } = Router.query;
 
 export default class TestDocument extends Document {
-  static async getInitialProps (ctx: Context) {
+  static async getInitialProps (ctx: Context): Promise<any> {
     const props = await Document.getInitialProps(ctx)
     return { ...props, customValue: 'hi there!' }
   }
 
-  render () {
+  render(): React$Node {
     return (
      <html>
        <DocumentHead>

--- a/definitions/npm/next_v2.x.x/flow_v0.53.x-v0.103.x/next_v2.x.x.js
+++ b/definitions/npm/next_v2.x.x/flow_v0.53.x-v0.103.x/next_v2.x.x.js
@@ -49,7 +49,7 @@ declare module "next" {
 declare module "next/head" {
   import type { Component } from 'react';
 
-  declare export default Class<Component<*, *>>;
+  declare export default Class<Component<any, any>>;
 }
 
 declare module "next/link" {
@@ -119,11 +119,11 @@ declare module "next/document" {
     err?: any,
   };
 
-  declare export var Head: Class<Component<*, *>>;
-  declare export var Main: Class<Component<*, *>>;
-  declare export var NextScript: Class<Component<*, *>>;
-  declare export default Class<Component<*, *>> & {
-    getInitialProps: (ctx: Context) => Promise<*>;
+  declare export var Head: Class<Component<any, any>>;
+  declare export var Main: Class<Component<any, any>>;
+  declare export var NextScript: Class<Component<any, any>>;
+  declare export default Class<Component<any, any>> & {
+    getInitialProps: (ctx: Context) => Promise<any>;
     renderPage(cb: Function): void;
   };
 }

--- a/definitions/npm/next_v4.x.x/flow_v0.104.x-/next_v4.x.x.js
+++ b/definitions/npm/next_v4.x.x/flow_v0.104.x-/next_v4.x.x.js
@@ -1,6 +1,6 @@
 declare module "next" {
   declare type RequestHandler = (
-    req: http$IncomingMessage,
+    req: http$IncomingMessage<>,
     res: http$ServerResponse,
     parsedUrl: any
   ) => Promise<void>;
@@ -9,27 +9,27 @@ declare module "next" {
     prepare(): Promise<void>,
     getRequestHandler(): RequestHandler,
     render(
-      req: http$IncomingMessage,
+      req: http$IncomingMessage<>,
       res: http$ServerResponse,
       pathname: string,
       query?: Object
     ): Promise<void>,
     renderToHTML(
-      req: http$IncomingMessage,
+      req: http$IncomingMessage<>,
       res: http$ServerResponse,
       pathname: string,
       query?: Object
     ): string,
     renderError(
       err: Error,
-      req: http$IncomingMessage,
+      req: http$IncomingMessage<>,
       res: http$ServerResponse,
       pathname: string,
       query?: Object
     ): Promise<void>,
     renderErrorToHTML(
       err: Error,
-      req: http$IncomingMessage,
+      req: http$IncomingMessage<>,
       res: http$ServerResponse,
       pathname: string,
       query?: Object
@@ -142,7 +142,7 @@ declare module "next/document" {
   declare export var Main: Class<React$Component<any, any>>;
   declare export var NextScript: Class<React$Component<any, any>>;
   declare export default Class<React$Component<any, any>> & {
-    getInitialProps: (ctx: Context) => Promise<*>,
+    getInitialProps: (ctx: Context) => Promise<any>,
     renderPage(cb: Function): void,
     ...
   }

--- a/definitions/npm/next_v4.x.x/flow_v0.104.x-/test_next_v4.x.x.js
+++ b/definitions/npm/next_v4.x.x/flow_v0.104.x-/test_next_v4.x.x.js
@@ -13,13 +13,13 @@ const { createServer } = require("http");
 const { parse } = require("url");
 
 // server
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 next({ dev: 1 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 next({ dir: false });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 next({ quiet: "derp" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 next({ staticMarkup: 42 });
 
 const app = next({ dev: true, dir: ".", quiet: false });
@@ -56,10 +56,10 @@ app.prepare().then(() => {
 
 <Link href="/">Index</Link>;
 
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-type]
 <Link href={1}>InvalidNumLink</Link>;
 
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 Router.onRouteChangeStart = {};
 
 Router.onRouteChangeStart = (url: string) => {};
@@ -74,7 +74,7 @@ Router.onRouteChangeError = (err, url) => {
   }
 };
 
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 Router.push({});
 
 Router.push("/about");
@@ -87,12 +87,12 @@ const p: string = Router.pathname;
 const q: { ... } = Router.query;
 
 export default class TestDocument extends Document {
-  static async getInitialProps(ctx: Context) {
+  static async getInitialProps(ctx: Context): Promise<any> {
     const props = await Document.getInitialProps(ctx);
     return { ...props, customValue: "hi there!" };
   }
 
-  render() {
+  render(): React$Node {
     return (
       <html>
         <DocumentHead />

--- a/definitions/npm/next_v4.x.x/flow_v0.53.x-v0.103.x/next_v4.x.x.js
+++ b/definitions/npm/next_v4.x.x/flow_v0.53.x-v0.103.x/next_v4.x.x.js
@@ -135,7 +135,7 @@ declare module "next/document" {
   declare export var Main: Class<React$Component<any, any>>;
   declare export var NextScript: Class<React$Component<any, any>>;
   declare export default Class<React$Component<any, any>> & {
-    getInitialProps: (ctx: Context) => Promise<*>,
+    getInitialProps: (ctx: Context) => Promise<any>,
     renderPage(cb: Function): void
   }
 }

--- a/definitions/npm/next_v7.x.x/flow_v0.104.x-/next_v7.x.x.js
+++ b/definitions/npm/next_v7.x.x/flow_v0.104.x-/next_v7.x.x.js
@@ -58,7 +58,7 @@ declare module "next" {
 
   declare export type Page<T, S> = {
     ...React$Component<T, S>,
-    getInitialProps: (ctx: Context) => Promise<*>,
+    getInitialProps: (ctx: Context) => Promise<any>,
     ...
   };
 
@@ -161,7 +161,7 @@ declare module "next/router" {
       as: ?(string | URLObject),
       options?: EventChangeOptions
     ): Promise<boolean>,
-    prefetch(url: string): Promise<*>,
+    prefetch(url: string): Promise<any>,
     beforePopState(cb: BeforePopStateCallback): void,
     ...
   };
@@ -180,7 +180,7 @@ declare module "next/document" {
   declare export var Main: Class<React$Component<any, any>>;
   declare export var NextScript: Class<React$Component<any, any>>;
   declare export default Class<React$Component<any, any>> & {
-    getInitialProps: (ctx: Context) => Promise<*>,
+    getInitialProps: (ctx: Context) => Promise<any>,
     renderPage(cb: Function): void,
     ...
   };
@@ -199,7 +199,7 @@ declare module "next/app" {
     ...
   };
 
-  declare export default Class<React$Component<any, any>> & { getInitialProps: (appInitialProps: AppInitialProps) => Promise<*>, ... };
+  declare export default Class<React$Component<any, any>> & { getInitialProps: (appInitialProps: AppInitialProps) => Promise<any>, ... };
 }
 
 declare module "next/dynamic" {

--- a/definitions/npm/next_v7.x.x/flow_v0.104.x-/test_next_v7.x.x.js
+++ b/definitions/npm/next_v7.x.x/flow_v0.104.x-/test_next_v7.x.x.js
@@ -8,17 +8,20 @@ import App, {type AppInitialProps, Container} from "next/app";
 import dynamic from "next/dynamic";
 import getConfig from "next/config";
 
+// $FlowExpectedError[missing-export]
+import {useRouter} from "next/router";
+
 const { createServer } = require("http");
 const { parse } = require("url");
 
 // server
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 next({ dev: 1 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 next({ dir: false });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 next({ quiet: "derp" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 next({ staticMarkup: 42 });
 
 const app = next({ dev: true, dir: ".", quiet: false });
@@ -51,8 +54,8 @@ app.prepare().then(() => {
 
 app.setAssetPrefix('');
 
-class ConfigAwareComponent extends React.Component<*> {
-  render() {
+class ConfigAwareComponent extends React.Component<any> {
+  render(): React$Node {
     const { publicRuntimeConfig, serverRuntimeConfig } = getConfig();
     return (
       <div>
@@ -69,15 +72,15 @@ class ConfigAwareComponent extends React.Component<*> {
 
 <Link href="/">Index</Link>;
 
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-type]
 <Link href={1}>InvalidNumLink</Link>;
 
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 Router.onRouteChangeStart = {};
 
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 Router.events.on('unknown', (url: string) => {});
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 Router.events.off('unknown', (url: string) => {});
 
 Router.events.on('routeChangeStart', (url: string) => {});
@@ -108,12 +111,12 @@ const p: string = Router.pathname;
 const q: { ... } = Router.query;
 
 export default class TestDocument extends Document {
-  static async getInitialProps(ctx: Context) {
+  static async getInitialProps(ctx: Context): Promise<any> {
     const props = await Document.getInitialProps(ctx);
     return { ...props, customValue: "hi there!" };
   }
 
-  render() {
+  render(): React$Node {
     return (
       <html>
         <DocumentHead />
@@ -127,12 +130,12 @@ export default class TestDocument extends Document {
 }
 
 export class TestApp extends App {
-  static async getInitialProps({ Component, router, ctx }: AppInitialProps) {
+  static async getInitialProps({ Component, router, ctx }: AppInitialProps): Promise<any> {
     const props = await Component.getInitialProps(ctx);
     return { ...props }
   }
 
-  render () {
+  render(): React$Node {
     const { Component, pageProps } = this.props;
 
     return (

--- a/definitions/npm/next_v7.x.x/flow_v0.53.x-v0.92.x/next_v7.x.x.js
+++ b/definitions/npm/next_v7.x.x/flow_v0.53.x-v0.92.x/next_v7.x.x.js
@@ -55,7 +55,7 @@ declare module "next" {
 
   declare export type Page<T, S> = {
     ...React$Component<T, S>,
-    getInitialProps: (ctx: Context) => Promise<*>
+    getInitialProps: (ctx: Context) => Promise<any>
   };
 
   declare export default (opts: Options) => NextApp;
@@ -152,7 +152,7 @@ declare module "next/router" {
       as: ?(string | URLObject),
       options?: EventChangeOptions
     ): Promise<boolean>,
-    prefetch(url: string): Promise<*>,
+    prefetch(url: string): Promise<any>,
     beforePopState(cb: BeforePopStateCallback): void
   };
 
@@ -170,7 +170,7 @@ declare module "next/document" {
   declare export var Main: Class<React$Component<any, any>>;
   declare export var NextScript: Class<React$Component<any, any>>;
   declare export default Class<React$Component<any, any>> & {
-    getInitialProps: (ctx: Context) => Promise<*>,
+    getInitialProps: (ctx: Context) => Promise<any>,
     renderPage(cb: Function): void
   };
 }
@@ -188,7 +188,7 @@ declare module "next/app" {
   };
 
   declare export default Class<React$Component<any, any>> & {
-    getInitialProps: (appInitialProps: AppInitialProps) => Promise<*>
+    getInitialProps: (appInitialProps: AppInitialProps) => Promise<any>
   };
 }
 

--- a/definitions/npm/next_v7.x.x/flow_v0.93.x-v0.103.x/next_v7.x.x.js
+++ b/definitions/npm/next_v7.x.x/flow_v0.93.x-v0.103.x/next_v7.x.x.js
@@ -55,7 +55,7 @@ declare module "next" {
 
   declare export type Page<T, S> = {
     ...React$Component<T, S>,
-    getInitialProps: (ctx: Context) => Promise<*>
+    getInitialProps: (ctx: Context) => Promise<any>
   };
 
   declare export default (opts: Options) => NextApp;
@@ -152,7 +152,7 @@ declare module "next/router" {
       as: ?(string | URLObject),
       options?: EventChangeOptions
     ): Promise<boolean>,
-    prefetch(url: string): Promise<*>,
+    prefetch(url: string): Promise<any>,
     beforePopState(cb: BeforePopStateCallback): void
   };
 
@@ -170,7 +170,7 @@ declare module "next/document" {
   declare export var Main: Class<React$Component<any, any>>;
   declare export var NextScript: Class<React$Component<any, any>>;
   declare export default Class<React$Component<any, any>> & {
-    getInitialProps: (ctx: Context) => Promise<*>,
+    getInitialProps: (ctx: Context) => Promise<any>,
     renderPage(cb: Function): void
   };
 }
@@ -188,7 +188,7 @@ declare module "next/app" {
   };
 
   declare export default Class<React$Component<any, any>> & {
-    getInitialProps: (appInitialProps: AppInitialProps) => Promise<*>
+    getInitialProps: (appInitialProps: AppInitialProps) => Promise<any>
   };
 }
 

--- a/definitions/npm/next_v9.x.x/flow_v0.104.x-/next_v9.x.x.js
+++ b/definitions/npm/next_v9.x.x/flow_v0.104.x-/next_v9.x.x.js
@@ -58,7 +58,7 @@ declare module "next" {
 
   declare export type Page<T, S> = {
     ...React$Component<T, S>,
-    getInitialProps: (ctx: Context) => Promise<*>,
+    getInitialProps: (ctx: Context) => Promise<any>,
     ...
   };
 
@@ -161,7 +161,7 @@ declare module "next/router" {
       as: ?(string | URLObject),
       options?: EventChangeOptions
     ): Promise<boolean>,
-    prefetch(url: string): Promise<*>,
+    prefetch(url: string): Promise<any>,
     beforePopState(cb: BeforePopStateCallback): void,
     ...
   };
@@ -169,6 +169,8 @@ declare module "next/router" {
   declare export function withRouter<T>(
     Component: React$ComponentType<T & { router: Router, ... }>
   ): Class<React$Component<T>>;
+
+  declare export function useRouter(): Router;
 
   declare export default Router;
 }
@@ -193,7 +195,7 @@ declare module "next/document" {
   declare export var Main: Class<React$Component<any, any>>;
   declare export var NextScript: Class<React$Component<any, any>>;
   declare export default Class<React$Component<any, any>> & {
-    getInitialProps: (ctx: DocumentContext) => Promise<*>,
+    getInitialProps: (ctx: DocumentContext) => Promise<any>,
     renderPage(cb: Function): void,
     ...
   };
@@ -212,7 +214,7 @@ declare module "next/app" {
     ...
   };
 
-  declare export default Class<React$Component<any, any>> & { getInitialProps: (appInitialProps: AppInitialProps) => Promise<*>, ... };
+  declare export default Class<React$Component<any, any>> & { getInitialProps: (appInitialProps: AppInitialProps) => Promise<any>, ... };
 }
 
 declare module "next/dynamic" {

--- a/definitions/npm/next_v9.x.x/flow_v0.104.x-/test_next_v9.x.x.js
+++ b/definitions/npm/next_v9.x.x/flow_v0.104.x-/test_next_v9.x.x.js
@@ -2,7 +2,7 @@ import React from "react";
 import next, {type Context} from "next";
 import Link from "next/link";
 import Head from "next/head";
-import Router, {type RouteError} from "next/router";
+import Router, {type RouteError, useRouter} from "next/router";
 import Document, {Head as DocumentHead, Main, NextScript, type DocumentContext} from "next/document";
 import App, {type AppInitialProps, Container} from "next/app";
 import dynamic from "next/dynamic";
@@ -12,13 +12,13 @@ const { createServer } = require("http");
 const { parse } = require("url");
 
 // server
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 next({ dev: 1 });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 next({ dir: false });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 next({ quiet: "derp" });
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 next({ staticMarkup: 42 });
 
 const app = next({ dev: true, dir: ".", quiet: false });
@@ -51,7 +51,7 @@ app.prepare().then(() => {
 
 app.setAssetPrefix('');
 
-class ConfigAwareComponent extends React.Component<*> {
+class ConfigAwareComponent extends React.Component<any> {
   render() {
     const { publicRuntimeConfig, serverRuntimeConfig } = getConfig();
     return (
@@ -69,15 +69,15 @@ class ConfigAwareComponent extends React.Component<*> {
 
 <Link href="/">Index</Link>;
 
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-type]
 <Link href={1}>InvalidNumLink</Link>;
 
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 Router.onRouteChangeStart = {};
 
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 Router.events.on('unknown', (url: string) => {});
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 Router.events.off('unknown', (url: string) => {});
 
 Router.events.on('routeChangeStart', (url: string) => {});
@@ -108,12 +108,12 @@ const p: string = Router.pathname;
 const q: { ... } = Router.query;
 
 export default class TestDocument extends Document {
-  static async getInitialProps(ctx: DocumentContext) {
+  static async getInitialProps(ctx: DocumentContext): Promise<any> {
     const props = await Document.getInitialProps(ctx);
     return { ...props, customValue: "hi there!" };
   }
 
-  render() {
+  render(): React$Node {
     return (
       <html>
         <DocumentHead />
@@ -127,12 +127,12 @@ export default class TestDocument extends Document {
 }
 
 export class TestApp extends App {
-  static async getInitialProps({ Component, router, ctx }: AppInitialProps) {
+  static async getInitialProps({ Component, router, ctx }: AppInitialProps): Promise<any> {
     const props = await Component.getInitialProps(ctx);
     return { ...props }
   }
 
-  render () {
+  render (): React$Node {
     const { Component, pageProps } = this.props;
 
     return (
@@ -141,6 +141,11 @@ export class TestApp extends App {
       </Container>
     )
   }
+}
+
+export function TestFunctionComponent(): React$Node {
+  useRouter();
+  return <div />;
 }
 
 const DynamicComponent = dynamic(() => import('./test_next_v9.x.x'));


### PR DESCRIPTION
`useRouter` is missing from next/router definition.

https://github.com/vercel/next.js/blob/canary/docs/api-reference/next/router.md#userouter