### PR TITLE
Update formik_v2.x.x.js [Fix innerRef type definition in FormikConfig]

### DIFF
--- a/definitions/npm/formik_v0.11.x/flow_v0.104.x-/test_formik.js
+++ b/definitions/npm/formik_v0.11.x/flow_v0.104.x-/test_formik.js
@@ -73,8 +73,11 @@ describe("formik", () => {
         }}
         onSubmit={(values) => {}}
         render={({
+          // $FlowExpectedError[incompatible-use]
           values,
+          // $FlowExpectedError[incompatible-use]
           errors,
+          // $FlowExpectedError[incompatible-use]
           touched,
           handleChange,
           handleBlur,
@@ -88,10 +91,8 @@ describe("formik", () => {
                 name="text"
                 onChange={handleChange}
                 onBlur={handleBlur}
-                // $FlowExpectedError - email missing in values
                 value={values.email}
               />
-              {/* $FlowExpectedError - touched missing in values */}
               {touched.email && errors.email && <div>{errors.email}</div>}
               <button type="submit" disabled={isSubmitting}>
                 Submit
@@ -108,13 +109,13 @@ describe("formik", () => {
         onSubmit={(values) => {}}
         render={({
           values,
+          // $FlowExpectedError[incompatible-use]
           setFieldValue,
         }) => {
           return (
             <form>
               <button onClick={() => {
                 setFieldValue("text", "new value")
-                // $FlowExpectedError setFieldValue must be type string
                 setFieldValue("text", 3)
               }}>
                 Submit
@@ -136,13 +137,13 @@ describe("formik", () => {
         initialValues={initialValues}
         onSubmit={values => {}}
         render={({
+          // $FlowExpectedError[incompatible-use]
           setFieldValue,
         }) => {
           return (
             <form>
               <button onClick={() => {
                 setFieldValue("requestState", "ready")
-                // $FlowExpectedError setFieldValue value must be "loading" or "ready"
                 setFieldValue("requestState", "asfuohasfuoh")
               }}>
                 Submit
@@ -163,7 +164,7 @@ describe("formik", () => {
 
       it("raises error when passed more than one argument", () => {
         const testFunc = (actions: FormikActions<Values>) => {
-          // $FlowExpectedError setStatus action expects only one argument
+          // $FlowExpectedError[extra-arg] - no more than 1 argument is expected
           actions.setStatus("text", "done");
         };
       });
@@ -178,7 +179,7 @@ describe("formik", () => {
 
       it("raises error when passed an unrecognized value key", () => {
         const testFunc = (actions: FormikActions<Values>) => {
-          // $FlowExpectedError setErrors keys must match value fields
+          // $FlowExpectedError[prop-missing] setErrors keys must match value fields
           actions.setErrors({ other: "Text is required" });
         };
       });
@@ -193,7 +194,7 @@ describe("formik", () => {
 
       it("raises error when passed a non-boolean", () => {
         const testFunc = (actions: FormikActions<Values>) => {
-          // $FlowExpectedError setSubmitting only takes a boolean
+          // $FlowExpectedError[incompatible-call] setSubmitting only takes a boolean
           actions.setSubmitting("false");
         };
       });
@@ -210,9 +211,9 @@ describe("formik", () => {
 
       it("raises error when passed an unrecognized field or a non-boolean", () => {
         const testFunc = (actions: FormikActions<Values>) => {
-          // $FlowExpectedError setTouched keys must match value fields
+          // $FlowExpectedError[prop-missing] - property `other` is missing in `Values`
           actions.setTouched({ other: true });
-          // $FlowExpectedError setTouched value must be a boolean
+           // $FlowExpectedError[incompatible-call] - string is incompatible with boolean
           actions.setTouched({ text: "true" });
         };
       });
@@ -229,7 +230,7 @@ describe("formik", () => {
 
       it("raises error when passed something other than Values", () => {
         const testFunc = (actions: FormikActions<Values>) => {
-          // $FlowExpectedError setValues keys must match value fields
+          // $FlowExpectedError[prop-missing] - property `text` is missing in object
           actions.setValues({ other: "Text" });
         };
       });
@@ -240,15 +241,15 @@ describe("formik", () => {
         const testFunc = (actions: FormikActions<Values>) => {
           actions.setFieldValue("text", "Value");
           actions.setFieldValue("text", "Value", true);
-          // $FlowExpectedError 'other' is not a key in values
+          // $FlowExpectedError[prop-missing] - property `other` is missing in `Values` 
           actions.setFieldValue("other", "Value");
         };
       });
 
       it("raises error when not passed a field", () => {
         const testFunc = (actions: FormikActions<Values>) => {
-          // $FlowExpectedError Field and value arguments expected
-          actions.setFieldValue({ text: "Text" });
+          // $FlowExpectedError[incompatible-call] - object literal is incompatible with key set
+          actions.setFieldValue<$Keys<Values>>({ text: "Text" });
         };
       });
     });
@@ -257,15 +258,22 @@ describe("formik", () => {
       it("passes when used properly", () => {
         const testFunc = (actions: FormikActions<Values>) => {
           actions.setFieldError("text", "Error");
-          // $FlowExpectedError 'other' is not a key in values
+           // $FlowExpectedError[prop-missing] - property `other` is missing in `Values`
           actions.setFieldError("other", "Error");
+        };
+      });
+
+      it("raises error when field does not exist", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          // $FlowExpectedError[prop-missing] - property `Error` is missing in `Values`
+          actions.setFieldError("Error",'');
         };
       });
 
       it("raises error when not passed a field", () => {
         const testFunc = (actions: FormikActions<Values>) => {
-          // $FlowExpectedError Field and value arguments expected
-          actions.setFieldError("Error");
+          // $FlowExpectedError[incompatible-call] - function requires another argument
+          actions.setFieldError("text");
         };
       });
     });
@@ -274,14 +282,14 @@ describe("formik", () => {
       it("passes when used properly", () => {
         const testFunc = (actions: FormikActions<Values>) => {
           actions.setFieldTouched("text", true);
-          // $FlowExpectedError 'other' is not a key in values
+          // $FlowExpectedError[prop-missing] - 'other' is not a key in values
           actions.setFieldTouched("other", true);
         };
       });
 
       it("raises error when not passed a field", () => {
         const testFunc = (actions: FormikActions<Values>) => {
-          // $FlowExpectedError Field and value arguments expected
+          // $FlowExpectedError[incompatible-call] - Field and value arguments expected
           actions.setFieldTouched(true);
         };
       });
@@ -306,7 +314,7 @@ describe("formik", () => {
 
       it("raises error if pass multiple arguments", () => {
         const testFunc = (actions: FormikActions<Values>) => {
-          // $FlowExpectedError resetForm expects 0 or 1 arguments
+          // $FlowExpectedError[extra-arg] - resetForm expects 0 or 1 arguments
           actions.resetForm("text", "Text");
         };
       });
@@ -321,7 +329,7 @@ describe("formik", () => {
 
       it("raises error if passed an argument", () => {
         const testFunc = (actions: FormikActions<Values>) => {
-          // $FlowExpectedError submitForm expects no arguments
+          // $FlowExpectedError[extra-arg] - submitForm expects no arguments
           actions.submitForm({ text: "Text" });
         };
       });
@@ -344,7 +352,7 @@ describe("formik", () => {
 
       it("raises error if return state shape other than FormikState<Values>", () => {
         const testFunc = (actions: FormikActions<Values>) => {
-          // $FlowExpectedError - must return correct state shape
+          // $FlowExpectedError[prop-missing] - must return correct state shape
           actions.setFormikState(({ values }) => ({
             text: `#${values.text}`
           }));

--- a/definitions/npm/formik_v0.9.x/test_formik.js
+++ b/definitions/npm/formik_v0.9.x/test_formik.js
@@ -21,8 +21,9 @@ import {
 const config1: FormikConfig = {
   onSubmit: (values: *, formikActions: FormikActions<*>) => {}
 };
-// $FlowExpectedError
+
 const configRequiresOnSubmit: FormikConfig = {
+  // $FlowExpectedError[incompatible-type]
   onSubmit: null
 };
 

--- a/definitions/npm/formik_v2.x.x/flow_v0.104.x-/formik_v2.x.x.js
+++ b/definitions/npm/formik_v2.x.x/flow_v0.104.x-/formik_v2.x.x.js
@@ -79,7 +79,7 @@ declare module 'formik/@flow-typed' {
     onReset?: (values: Values, formikHelpers: FormikHelpers<Values>) => void,
     validationSchema?: (() => Schema) | Schema,
     validate?: (values: Values) => void | {...} | Promise<FormikErrors<Values>>,
-    innerRef?: { current: FormikProps<Values> | null },
+    innerRef?: { current: FormikProps<Values> | null, ... },
   |};
 
   declare export type FormikProps<Values> = $ReadOnly<{|

--- a/definitions/npm/formik_v2.x.x/flow_v0.104.x-/formik_v2.x.x.js
+++ b/definitions/npm/formik_v2.x.x/flow_v0.104.x-/formik_v2.x.x.js
@@ -79,6 +79,7 @@ declare module 'formik/@flow-typed' {
     onReset?: (values: Values, formikHelpers: FormikHelpers<Values>) => void,
     validationSchema?: (() => Schema) | Schema,
     validate?: (values: Values) => void | {...} | Promise<FormikErrors<Values>>,
+    innerRef?: { current: FormikProps<Values> | null },
   |};
 
   declare export type FormikProps<Values> = $ReadOnly<{|

--- a/definitions/npm/formik_v2.x.x/flow_v0.104.x-/test_formik.js
+++ b/definitions/npm/formik_v2.x.x/flow_v0.104.x-/test_formik.js
@@ -58,20 +58,20 @@ describe('withFormik HOC', () => {
 
     it('should raise an error when pass invalid own props', () => {
       <WithFormikForm
-        // $FlowExpectedError: `__active` is missing in enum
+        // $FlowExpectedError[incompatible-type] -`__active` is missing in enum
         variant={'__active'}
         onSubmit={(v: FormValues) => {}}
       />;
 
       <WithFormikForm
         variant={'passive'}
-        // $FlowExpectedError: need function
+        // $FlowExpectedError[incompatible-type] - need function
         onSubmit={123}
       />;
     });
 
     it('should raise an error when pass injected formik props', () => {
-      // $FlowExpectedError: isSubmitting was extracted
+      // $FlowExpectedError[prop-missing] - isSubmitting was extracted
       <WithFormikForm
         isSubmitting={false}
         variant={'active'}
@@ -95,9 +95,9 @@ describe('withFormik HOC', () => {
             (values.age: number);
             (props.initialName: string);
 
-            // $FlowExpectedError: check any
+            // $FlowExpectedError[incompatible-cast] - check any
             (values.age: boolean);
-            // $FlowExpectedError: check any
+            // $FlowExpectedError[incompatible-cast] - check any
             (props.initialName: boolean);
           },
         });
@@ -115,7 +115,7 @@ describe('withFormik HOC', () => {
       it('should raise an error when `mapPropsToValues` return invalid values', () => {
         withFormik<Props, FormValues>({
           ...requiredOptions,
-          // $FlowExpectedError: `initialAge` is a number but `name` need a string
+          // $FlowExpectedError[incompatible-call] - `initialAge` is a number but `name` need a string
           mapPropsToValues: ({ initialAge }) => ({
             name: initialAge,
           }),
@@ -125,7 +125,7 @@ describe('withFormik HOC', () => {
       it('should raise an error when `mapPropsToValues` return not missing  value', () => {
         withFormik<Props, FormValues>({
           ...requiredOptions,
-          // $FlowExpectedError: `abc` is missing in values
+          // $FlowExpectedError[prop-missing] - `abc` is missing in values
           mapPropsToValues: ({ initialAge }) => ({
             abc: initialAge,
           }),
@@ -154,7 +154,7 @@ describe('useField hook', () => {
   });
 
   it('should raise error when pass object without required prop `name`', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     useField({ __name: 'name' });
   });
 
@@ -162,15 +162,15 @@ describe('useField hook', () => {
     const [props, meta] = useField<number>('name');
 
     (props.value: number);
-    // $FlowExpectedError: check any
+    // $FlowExpectedError[incompatible-cast] - check any
     (props.value: boolean);
 
     (meta.touched: boolean);
-    // $FlowExpectedError: check any
+    // $FlowExpectedError[incompatible-cast] - check any
     (meta.touched: number);
 
     (meta.error: ?string);
-    // $FlowExpectedError: check any
+    // $FlowExpectedError[incompatible-cast] - check any
     (meta.error: number);
   });
 });
@@ -182,12 +182,12 @@ describe('Field and FastField', () => {
   });
 
   it('should raise an error when pass incompatible name prop', () => {
-    // $FlowExpectedError: `name` must be a string
+    // $FlowExpectedError[incompatible-type] - `name` must be a string
     <Field name={111} />;
 
-    // $FlowExpectedError: `name` is required prop
+    // $FlowExpectedError[prop-missing] - `name` is required prop
     <Field />;
-    // $FlowExpectedError: `name` is required prop
+    // $FlowExpectedError[prop-missing] - `name` is required prop
     <FastField />;
   });
 
@@ -200,9 +200,9 @@ describe('Field and FastField', () => {
 
     Field<{ disabled: boolean, ... }, '1' | '2'>({
       name: 'count',
-      // $FlowExpectedError: need a boolean
+      // $FlowExpectedError[incompatible-call] - need a boolean
       disabled: 123,
-      // $FlowExpectedError: `12` is missing in enum
+      // $FlowExpectedError[incompatible-call] - `12` is missing in enum
       value: '12',
     });
   });
@@ -233,19 +233,19 @@ describe('FormikContext', () => {
       {value => {
         (value.validateOnBlur: ?boolean);
 
-        // $FlowExpectedError: check any
+        // $FlowExpectedError[incompatible-cast] - check any
         (value.validateOnBlur: ?string);
 
         (value.submitForm: () => Promise<void>);
 
-        // $FlowExpectedError: check any
+        // $FlowExpectedError[incompatible-cast] - check any
         (value.submitForm: number);
 
         return null;
       }}
     </FormikConsumer>;
 
-    // $FlowExpectedError: need valid formik context value
+    // $FlowExpectedError[incompatible-type] - need valid formik context value
     <FormikProvider value={123} />;
   });
 
@@ -253,7 +253,7 @@ describe('FormikContext', () => {
     const context = useFormikContext<{ age: number, ... }>();
 
     (context.values.age: number);
-    // $FlowExpectedError: check any
+    // $FlowExpectedError[incompatible-cast] - check any
     (context.values.age: string);
   });
 });
@@ -290,7 +290,7 @@ describe('ErrorMessage', () => {
   });
 
   it('should raise an error when do not pass required prop `name`', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[prop-missing]
     <ErrorMessage />;
   });
 });
@@ -309,10 +309,10 @@ describe('FieldArray', () => {
     });
 
     it('should raise an error when pass incompatible name prop', () => {
-      // $FlowExpectedError: `name` must be a string
+      // $FlowExpectedError[incompatible-type] - `name` must be a string
       <FieldArray name={111} />;
 
-      // $FlowExpectedError: `name` is required prop
+      // $FlowExpectedError[prop-missing] - `name` is required prop
       <FieldArray />;
     });
   });
@@ -323,10 +323,10 @@ it('should render Form', () => {
 
   <Form aria-hidden={'true'} />;
 
-  // $FlowExpectedError: `onSubmit` already provided to `form` yuo can't overwrite it
+  // $FlowExpectedError[incompatible-type] - `onSubmit` already provided to `form` yuo can't overwrite it
   <Form onSubmit={() => {}} />;
 
-  // $FlowExpectedError: `onReset` already provided to `form` yuo can't overwrite it
+  // $FlowExpectedError[incompatible-type] - `onReset` already provided to `form` yuo can't overwrite it
   <Form onReset={() => {}} />;
 });
 
@@ -348,18 +348,18 @@ describe('Formik', () => {
 
       formik.setFieldValue('name', '1', true);
 
-      // $FlowExpectedError: `name` is missing in `Values`
+      // $FlowExpectedError[prop-missing] - `name` is missing in `Values`
       formik.setFieldValue('__name', '1');
 
-      // $FlowExpectedError: `name` expect string value, not `123`
+      // $FlowExpectedError[incompatible-call] - `name` expect string value, not `123`
       formik.setFieldValue('name', 123);
 
       (formik.values.name: string);
       (formik.values.age: number);
 
-      // $FlowExpectedError: check any
+      // $FlowExpectedError[incompatible-cast] - check any
       (formik.values.name: boolean);
-      // $FlowExpectedError: check any
+      // $FlowExpectedError[incompatible-cast] - check any
       (formik.values.age: boolean);
     });
   });

--- a/definitions/npm/formik_v2.x.x/flow_v0.69.0-v0.103.x/formik_v2.x.x.js
+++ b/definitions/npm/formik_v2.x.x/flow_v0.69.0-v0.103.x/formik_v2.x.x.js
@@ -79,7 +79,7 @@ declare module 'formik/@flow-typed' {
     onReset?: (values: Values, formikHelpers: FormikHelpers<Values>) => void,
     validationSchema?: (() => Schema) | Schema,
     validate?: (values: Values) => void | {} | Promise<FormikErrors<Values>>,
-    innerRef?: React$Ref<FormikProps<Values>>,
+    innerRef?: { current: FormikProps<Values> | null },
   |};
 
   declare export type FormikProps<Values> = $ReadOnly<{|

--- a/definitions/npm/formik_v2.x.x/flow_v0.69.0-v0.103.x/formik_v2.x.x.js
+++ b/definitions/npm/formik_v2.x.x/flow_v0.69.0-v0.103.x/formik_v2.x.x.js
@@ -79,7 +79,7 @@ declare module 'formik/@flow-typed' {
     onReset?: (values: Values, formikHelpers: FormikHelpers<Values>) => void,
     validationSchema?: (() => Schema) | Schema,
     validate?: (values: Values) => void | {} | Promise<FormikErrors<Values>>,
-    innerRef?: { current: FormikProps<Values> | null },
+    innerRef?: { current: FormikProps<Values> | null, ... },
   |};
 
   declare export type FormikProps<Values> = $ReadOnly<{|

--- a/definitions/npm/formik_v2.x.x/flow_v0.69.0-v0.103.x/test_formik.js
+++ b/definitions/npm/formik_v2.x.x/flow_v0.69.0-v0.103.x/test_formik.js
@@ -58,20 +58,20 @@ describe('withFormik HOC', () => {
 
     it('should raise an error when pass invalid own props', () => {
       <WithFormikForm
-        // $FlowExpectedError: `__active` is missing in enum
+        // $FlowExpectedError[incompatible-type] -`__active` is missing in enum
         variant={'__active'}
         onSubmit={(v: FormValues) => {}}
       />;
 
       <WithFormikForm
         variant={'passive'}
-        // $FlowExpectedError: need function
+        // $FlowExpectedError[incompatible-type] - need function
         onSubmit={123}
       />;
     });
 
     it('should raise an error when pass injected formik props', () => {
-      // $FlowExpectedError: isSubmitting was extracted
+      // $FlowExpectedError[prop-missing] - isSubmitting was extracted
       <WithFormikForm
         isSubmitting={false}
         variant={'active'}
@@ -95,9 +95,9 @@ describe('withFormik HOC', () => {
             (values.age: number);
             (props.initialName: string);
 
-            // $FlowExpectedError: check any
+            // $FlowExpectedError[incompatible-cast] - check any
             (values.age: boolean);
-            // $FlowExpectedError: check any
+            // $FlowExpectedError[incompatible-cast] - check any
             (props.initialName: boolean);
           },
         });
@@ -115,7 +115,7 @@ describe('withFormik HOC', () => {
       it('should raise an error when `mapPropsToValues` return invalid values', () => {
         withFormik<Props, FormValues>({
           ...requiredOptions,
-          // $FlowExpectedError: `initialAge` is a number but `name` need a string
+          // $FlowExpectedError[incompatible-call] - `initialAge` is a number but `name` need a string
           mapPropsToValues: ({ initialAge }) => ({
             name: initialAge,
           }),
@@ -125,7 +125,7 @@ describe('withFormik HOC', () => {
       it('should raise an error when `mapPropsToValues` return not missing  value', () => {
         withFormik<Props, FormValues>({
           ...requiredOptions,
-          // $FlowExpectedError: `abc` is missing in values
+          // $FlowExpectedError[prop-missing] - `abc` is missing in values
           mapPropsToValues: ({ initialAge }) => ({
             abc: initialAge,
           }),
@@ -133,7 +133,7 @@ describe('withFormik HOC', () => {
       });
 
       it('should return partial of values', () => {
-        withFormik<Props, { name: string, age: number }>({
+        withFormik<Props, { name: string, age: number, ... }>({
           ...requiredOptions,
           mapPropsToValues: ({ initialAge }) => ({
             age: initialAge,
@@ -154,7 +154,7 @@ describe('useField hook', () => {
   });
 
   it('should raise error when pass object without required prop `name`', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     useField({ __name: 'name' });
   });
 
@@ -162,15 +162,15 @@ describe('useField hook', () => {
     const [props, meta] = useField<number>('name');
 
     (props.value: number);
-    // $FlowExpectedError: check any
+    // $FlowExpectedError[incompatible-cast] - check any
     (props.value: boolean);
 
     (meta.touched: boolean);
-    // $FlowExpectedError: check any
+    // $FlowExpectedError[incompatible-cast] - check any
     (meta.touched: number);
 
     (meta.error: ?string);
-    // $FlowExpectedError: check any
+    // $FlowExpectedError[incompatible-cast] - check any
     (meta.error: number);
   });
 });
@@ -182,27 +182,27 @@ describe('Field and FastField', () => {
   });
 
   it('should raise an error when pass incompatible name prop', () => {
-    // $FlowExpectedError: `name` must be a string
+    // $FlowExpectedError[incompatible-type] - `name` must be a string
     <Field name={111} />;
 
-    // $FlowExpectedError: `name` is required prop
+    // $FlowExpectedError[prop-missing] - `name` is required prop
     <Field />;
-    // $FlowExpectedError: `name` is required prop
+    // $FlowExpectedError[prop-missing] - `name` is required prop
     <FastField />;
   });
 
   it('should validate value', () => {
-    Field<{ disabled: boolean }, '1' | '2'>({
+    Field<{ disabled: boolean, ... }, '1' | '2'>({
       name: 'count',
       disabled: true,
       value: '1',
     });
 
-    Field<{ disabled: boolean }, '1' | '2'>({
+    Field<{ disabled: boolean, ... }, '1' | '2'>({
       name: 'count',
-      // $FlowExpectedError: need a boolean
+      // $FlowExpectedError[incompatible-call] - need a boolean
       disabled: 123,
-      // $FlowExpectedError: `12` is missing in enum
+      // $FlowExpectedError[incompatible-call] - `12` is missing in enum
       value: '12',
     });
   });
@@ -233,27 +233,27 @@ describe('FormikContext', () => {
       {value => {
         (value.validateOnBlur: ?boolean);
 
-        // $FlowExpectedError: check any
+        // $FlowExpectedError[incompatible-cast] - check any
         (value.validateOnBlur: ?string);
 
         (value.submitForm: () => Promise<void>);
 
-        // $FlowExpectedError: check any
+        // $FlowExpectedError[incompatible-cast] - check any
         (value.submitForm: number);
 
         return null;
       }}
     </FormikConsumer>;
 
-    // $FlowExpectedError: need valid formik context value
+    // $FlowExpectedError[incompatible-type] - need valid formik context value
     <FormikProvider value={123} />;
   });
 
   it('should return context with passed values', () => {
-    const context = useFormikContext<{ age: number }>();
+    const context = useFormikContext<{ age: number, ... }>();
 
     (context.values.age: number);
-    // $FlowExpectedError: check any
+    // $FlowExpectedError[incompatible-cast] - check any
     (context.values.age: string);
   });
 });
@@ -290,7 +290,7 @@ describe('ErrorMessage', () => {
   });
 
   it('should raise an error when do not pass required prop `name`', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[prop-missing]
     <ErrorMessage />;
   });
 });
@@ -309,10 +309,10 @@ describe('FieldArray', () => {
     });
 
     it('should raise an error when pass incompatible name prop', () => {
-      // $FlowExpectedError: `name` must be a string
+      // $FlowExpectedError[incompatible-type] - `name` must be a string
       <FieldArray name={111} />;
 
-      // $FlowExpectedError: `name` is required prop
+      // $FlowExpectedError[prop-missing] - `name` is required prop
       <FieldArray />;
     });
   });
@@ -323,10 +323,10 @@ it('should render Form', () => {
 
   <Form aria-hidden={'true'} />;
 
-  // $FlowExpectedError: `onSubmit` already provided to `form` yuo can't overwrite it
+  // $FlowExpectedError[incompatible-type] - `onSubmit` already provided to `form` yuo can't overwrite it
   <Form onSubmit={() => {}} />;
 
-  // $FlowExpectedError: `onReset` already provided to `form` yuo can't overwrite it
+  // $FlowExpectedError[incompatible-type] - `onReset` already provided to `form` yuo can't overwrite it
   <Form onReset={() => {}} />;
 });
 
@@ -348,18 +348,18 @@ describe('Formik', () => {
 
       formik.setFieldValue('name', '1', true);
 
-      // $FlowExpectedError: `name` is missing in `Values`
+      // $FlowExpectedError[prop-missing] - `name` is missing in `Values`
       formik.setFieldValue('__name', '1');
 
-      // $FlowExpectedError: `name` expect string value, not `123`
+      // $FlowExpectedError[incompatible-call] - `name` expect string value, not `123`
       formik.setFieldValue('name', 123);
 
       (formik.values.name: string);
       (formik.values.age: number);
 
-      // $FlowExpectedError: check any
+      // $FlowExpectedError[incompatible-cast] - check any
       (formik.values.name: boolean);
-      // $FlowExpectedError: check any
+      // $FlowExpectedError[incompatible-cast] - check any
       (formik.values.age: boolean);
     });
   });


### PR DESCRIPTION
Fix type definition of innerRef.

According to flow types for React, `React$Ref` type is incompatible with `FormikProps <Values>`.


- Links to documentation: 
issue with links #4027

- Link to GitHub or NPM: 
- Type of contribution: new definition | addition | fix | refactor


