### PR TITLE
[jest-useragent-mock] Add def

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
 
-- Links to documentation:
+- Links to documentation: 
 - Link to GitHub or NPM: 
 - Type of contribution: new definition | addition | fix | refactor
 

--- a/definitions/npm/jest-useragent-mock_v0.1.x/flow_v0.83.x-/jest-useragent-mock_v0.1.x.js
+++ b/definitions/npm/jest-useragent-mock_v0.1.x/flow_v0.83.x-/jest-useragent-mock_v0.1.x.js
@@ -1,5 +1,5 @@
 declare module 'jest-useragent-mock' {
-  export declare function mockUserAgent(userAgent?: string): void;
+  declare export function mockUserAgent(userAgent?: string): void;
 
-  export declare function clear(): void;
+  declare export function clear(): void;
 }

--- a/definitions/npm/jest-useragent-mock_v0.1.x/flow_v0.83.x-/jest-useragent-mock_v0.1.x.js
+++ b/definitions/npm/jest-useragent-mock_v0.1.x/flow_v0.83.x-/jest-useragent-mock_v0.1.x.js
@@ -1,0 +1,5 @@
+declare module 'jest-useragent-mock' {
+  export declare function mockUserAgent(userAgent?: string): void;
+
+  export declare function clear(): void;
+}

--- a/definitions/npm/jest-useragent-mock_v0.1.x/flow_v0.83.x-/jest-useragent-mock_v0.1.x.js
+++ b/definitions/npm/jest-useragent-mock_v0.1.x/flow_v0.83.x-/jest-useragent-mock_v0.1.x.js
@@ -1,5 +1,5 @@
 declare module 'jest-useragent-mock' {
-  declare export function mockUserAgent(userAgent?: string): void;
+  declare export function mockUserAgent(userAgent?: string | null): void;
 
   declare export function clear(): void;
 }

--- a/definitions/npm/jest-useragent-mock_v0.1.x/flow_v0.83.x-/test_jest-useragent-mock_v0.1.x.js
+++ b/definitions/npm/jest-useragent-mock_v0.1.x/flow_v0.83.x-/test_jest-useragent-mock_v0.1.x.js
@@ -1,0 +1,23 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+
+import { mockUserAgent, clear } from 'jest-useragent-mock';
+
+describe('jest-useragent-mock', () => {
+  it('mockUserAgent', () => {
+    // can take no params
+    (mockUserAgent(): void);
+    // can take one param
+    mockUserAgent('test');
+    // $FlowExpectedError must be string
+    mockUserAgent(1);
+    // $FlowExpectedError takes a max of one arg
+    mockUserAgent('test', 'test2');
+  });
+
+  it('clear', () => {
+    (clear(): void);
+    // $FlowExpectedError takes no args
+    clear('test');
+  });
+});

--- a/definitions/npm/jest-useragent-mock_v0.1.x/flow_v0.83.x-/test_jest-useragent-mock_v0.1.x.js
+++ b/definitions/npm/jest-useragent-mock_v0.1.x/flow_v0.83.x-/test_jest-useragent-mock_v0.1.x.js
@@ -7,6 +7,8 @@ describe('jest-useragent-mock', () => {
   it('mockUserAgent', () => {
     // can take no params
     (mockUserAgent(): void);
+    // can take null
+    mockUserAgent(null);
     // can take one param
     mockUserAgent('test');
     // $FlowExpectedError[incompatible-call] must be string

--- a/definitions/npm/jest-useragent-mock_v0.1.x/flow_v0.83.x-/test_jest-useragent-mock_v0.1.x.js
+++ b/definitions/npm/jest-useragent-mock_v0.1.x/flow_v0.83.x-/test_jest-useragent-mock_v0.1.x.js
@@ -9,15 +9,15 @@ describe('jest-useragent-mock', () => {
     (mockUserAgent(): void);
     // can take one param
     mockUserAgent('test');
-    // $FlowExpectedError must be string
+    // $FlowExpectedError[incompatible-call] must be string
     mockUserAgent(1);
-    // $FlowExpectedError takes a max of one arg
+    // $FlowExpectedError[extra-arg] takes a max of one arg
     mockUserAgent('test', 'test2');
   });
 
   it('clear', () => {
     (clear(): void);
-    // $FlowExpectedError takes no args
+    // $FlowExpectedError[extra-arg] takes no args
     clear('test');
   });
 });


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/ariesjia/jest-useragent-mock/blob/master/index.d.ts
- Link to GitHub or NPM: https://www.npmjs.com/package/jest-useragent-mock
- Type of contribution: new definition

Other notes: I also added an extra space to `- Links to documentation: ` line because there's always a space after `- Link to GitHub or NPM: ` in the PR template and it's always kind of annoyed me, hope this is fine. 

