### PR TITLE
[elegant-spinner] Add v1/v2 defs

### DIFF
--- a/definitions/npm/elegant-spinner_v1.x.x/flow_v0.83.x-/elegant-spinner_v1.x.x.js
+++ b/definitions/npm/elegant-spinner_v1.x.x/flow_v0.83.x-/elegant-spinner_v1.x.x.js
@@ -1,0 +1,6 @@
+declare module 'elegant-spinner' {
+  declare module.exports: {|
+    (): () => string,
+    frames: Array<string>,
+  |};
+}

--- a/definitions/npm/elegant-spinner_v1.x.x/flow_v0.83.x-/elegant-spinner_v1.x.x.js
+++ b/definitions/npm/elegant-spinner_v1.x.x/flow_v0.83.x-/elegant-spinner_v1.x.x.js
@@ -1,6 +1,6 @@
 declare module 'elegant-spinner' {
   declare module.exports: {|
     (): () => string,
-    frames: Array<string>,
+    +frames: Array<string>,
   |};
 }

--- a/definitions/npm/elegant-spinner_v1.x.x/flow_v0.83.x-/test_elegant-spinner_v1.x.x.js
+++ b/definitions/npm/elegant-spinner_v1.x.x/flow_v0.83.x-/test_elegant-spinner_v1.x.x.js
@@ -18,4 +18,9 @@ describe('elegant-spinner', () => {
     // $FlowExpectedError[incompatible-cast] Can't be an object
     (spinner.frames: Array<{ ... }>);
   });
+
+  it('frames is readonly', () => {
+    // $FlowExpectedError[cannot-write]
+    spinner.frames = [''];
+  })
 });

--- a/definitions/npm/elegant-spinner_v1.x.x/flow_v0.83.x-/test_elegant-spinner_v1.x.x.js
+++ b/definitions/npm/elegant-spinner_v1.x.x/flow_v0.83.x-/test_elegant-spinner_v1.x.x.js
@@ -1,0 +1,21 @@
+// @flow
+import { it, describe } from 'flow-typed-test';
+import spinner from 'elegant-spinner';
+
+describe('elegant-spinner', () => {
+  it('exports a function', () => {
+    (spinner()(): string);
+    // $FlowExpectedError[extra-arg] Takes no args
+    spinner('test');
+    // $FlowExpectedError[extra-arg] The returned function takes no args
+    spinner()('test');
+  });
+
+  it('export also has a frame property', () => {
+    (spinner.frames: Array<string>);
+    // $FlowExpectedError[incompatible-cast] Can't any other primitive
+    (spinner.frames: Array<number>);
+    // $FlowExpectedError[incompatible-cast] Can't be an object
+    (spinner.frames: Array<{ ... }>);
+  });
+});

--- a/definitions/npm/elegant-spinner_v2.x.x/flow_v0.83.x-/elegant-spinner_v2.x.x.js
+++ b/definitions/npm/elegant-spinner_v2.x.x/flow_v0.83.x-/elegant-spinner_v2.x.x.js
@@ -1,0 +1,6 @@
+declare module 'elegant-spinner' {
+  declare module.exports: {|
+    (): () => string,
+    +frames: Array<string>,
+  |};
+}

--- a/definitions/npm/elegant-spinner_v2.x.x/flow_v0.83.x-/test_elegant-spinner_v2.x.x.js
+++ b/definitions/npm/elegant-spinner_v2.x.x/flow_v0.83.x-/test_elegant-spinner_v2.x.x.js
@@ -1,0 +1,26 @@
+// @flow
+import { it, describe } from 'flow-typed-test';
+import spinner from 'elegant-spinner';
+
+describe('elegant-spinner', () => {
+  it('exports a function', () => {
+    (spinner()(): string);
+    // $FlowExpectedError[extra-arg] Takes no args
+    spinner('test');
+    // $FlowExpectedError[extra-arg] The returned function takes no args
+    spinner()('test');
+  });
+
+  it('export also has a frame property', () => {
+    (spinner.frames: Array<string>);
+    // $FlowExpectedError[incompatible-cast] Can't any other primitive
+    (spinner.frames: Array<number>);
+    // $FlowExpectedError[incompatible-cast] Can't be an object
+    (spinner.frames: Array<{ ... }>);
+  });
+
+  it('frames is readonly', () => {
+    // $FlowExpectedError[cannot-write]
+    spinner.frames = [''];
+  })
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Adding both v1 and v2 of `elegant-spinner` since they're quite small in their defs

V1 has no type TS defs so it's based on the source code at the time of the tag: https://github.com/sindresorhus/elegant-spinner/blob/669a9813b4ee7d459b982dd623e72672d9f4f114/index.js though they actually both have the same definition

- Links to documentation: https://github.com/sindresorhus/elegant-spinner/blob/main/index.d.ts
- Link to GitHub or NPM: https://www.npmjs.com/package/elegant-spinner
- Type of contribution: new definition

Other notes:

