### PR TITLE
formik_v2.X.X missing type

### DIFF
--- a/definitions/npm/formik_v2.x.x/flow_v0.104.x-/formik_v2.x.x.js
+++ b/definitions/npm/formik_v2.x.x/flow_v0.104.x-/formik_v2.x.x.js
@@ -130,6 +130,12 @@ declare module 'formik/@flow-typed' {
     onChange: $ElementType<FormikHandlers, 'handleChange'>,
     onBlur: $ElementType<FormikHandlers, 'handleBlur'>,
   |}>;
+
+  declare export type FieldHelperProps = $ReadOnly<{|
+    setValue: (value: any, shouldValidate?: boolean) => void,
+    setTouched: (value: boolean, shouldValidate?: boolean) => void,
+    setError: (value: any) => void,
+  |}>;
 }
 
 declare module 'formik/@withFormik' {
@@ -179,7 +185,8 @@ declare module 'formik/@Field' {
     FormikProps,
     FieldMetaProps,
     FieldInputProps,
-    FieldValidator
+    FieldValidator,
+    FieldHelperProps,
   } from 'formik/@flow-typed';
 
   declare export type FieldProps<Value> = {|
@@ -213,7 +220,7 @@ declare module 'formik/@Field' {
 
   declare export function useField<Value>(
     propsOrFieldName: string | UseFieldConfig<Value>
-  ): [FieldInputProps<Value>, FieldMetaProps<Value>];
+  ): [FieldInputProps<Value>, FieldMetaProps<Value>, FieldHelperProps];
 
   declare export var Field: { <Props, Value>(props: FieldAttributes<Props, Value>): React$Node, ... };
 

--- a/definitions/npm/formik_v2.x.x/flow_v0.104.x-/formik_v2.x.x.js
+++ b/definitions/npm/formik_v2.x.x/flow_v0.104.x-/formik_v2.x.x.js
@@ -67,7 +67,7 @@ declare module 'formik/@flow-typed' {
 
   declare export type FormikConfig<Values> = {|
     ...FormikSharedConfig,
-    onSubmit: (values: Values, formikHelpers: FormikHelpers<Values>) => void,
+    onSubmit: (values: Values, formikHelpers: FormikHelpers<Values>) => void | Promise<any>,
 
     component?: React$ComponentType<FormikProps<Values>> | React$Node,
     render?: (props: FormikProps<Values>) => React$Node,

--- a/definitions/npm/formik_v2.x.x/flow_v0.104.x-/test_formik.js
+++ b/definitions/npm/formik_v2.x.x/flow_v0.104.x-/test_formik.js
@@ -335,6 +335,9 @@ describe('Formik', () => {
     it('should work properly', () => {
       <Formik onSubmit={() => {}} />;
     });
+    it('onSumbit can return promise', () => {
+      <Formik onSubmit={() => Promise.resolve(null)} />;
+    });
   });
 
   describe('hook', () => {

--- a/definitions/npm/formik_v2.x.x/flow_v0.104.x-/test_formik.js
+++ b/definitions/npm/formik_v2.x.x/flow_v0.104.x-/test_formik.js
@@ -173,6 +173,16 @@ describe('useField hook', () => {
     // $FlowExpectedError[incompatible-cast] - check any
     (meta.error: number);
   });
+
+  it('should return FieldHelperProps', () => {
+    const [, , helpers] = useField<string>('name');
+
+    helpers.setValue('a name');
+    helpers.setValue('a name', false);
+    helpers.setTouched(true);
+    helpers.setTouched(true, false);
+    helpers.setError('an error');
+  });
 });
 
 describe('Field and FastField', () => {

--- a/definitions/npm/formik_v2.x.x/flow_v0.69.0-v0.103.x/formik_v2.x.x.js
+++ b/definitions/npm/formik_v2.x.x/flow_v0.69.0-v0.103.x/formik_v2.x.x.js
@@ -67,7 +67,7 @@ declare module 'formik/@flow-typed' {
 
   declare export type FormikConfig<Values> = {|
     ...FormikSharedConfig,
-    onSubmit: (values: Values, formikHelpers: FormikHelpers<Values>) => void,
+    onSubmit: (values: Values, formikHelpers: FormikHelpers<Values>) => void | Promise<any>,
 
     component?: React$ComponentType<FormikProps<Values>> | React$Node,
     render?: (props: FormikProps<Values>) => React$Node,

--- a/definitions/npm/formik_v2.x.x/flow_v0.69.0-v0.103.x/formik_v2.x.x.js
+++ b/definitions/npm/formik_v2.x.x/flow_v0.69.0-v0.103.x/formik_v2.x.x.js
@@ -129,6 +129,12 @@ declare module 'formik/@flow-typed' {
     onChange: $ElementType<FormikHandlers, 'handleChange'>,
     onBlur: $ElementType<FormikHandlers, 'handleBlur'>,
   |}>;
+
+  declare export type FieldHelperProps = $ReadOnly<{|
+    setValue: (value: any, shouldValidate?: boolean) => void,
+    setTouched: (value: boolean, shouldValidate?: boolean) => void,
+    setError: (value: any) => void,
+  |}>;
 }
 
 declare module 'formik/@withFormik' {
@@ -178,7 +184,8 @@ declare module 'formik/@Field' {
     FormikProps,
     FieldMetaProps,
     FieldInputProps,
-    FieldValidator
+    FieldValidator,
+    FieldHelperProps,
   } from 'formik/@flow-typed';
 
   declare export type FieldProps<Value> = {|
@@ -213,7 +220,7 @@ declare module 'formik/@Field' {
 
   declare export function useField<Value>(
     propsOrFieldName: string | UseFieldConfig<Value>
-  ): [FieldInputProps<Value>, FieldMetaProps<Value>];
+  ): [FieldInputProps<Value>, FieldMetaProps<Value>, FieldHelperProps];
 
   declare export var Field: {
     <Props, Value>(props: FieldAttributes<Props, Value>): React$Node,

--- a/definitions/npm/formik_v2.x.x/flow_v0.69.0-v0.103.x/test_formik.js
+++ b/definitions/npm/formik_v2.x.x/flow_v0.69.0-v0.103.x/test_formik.js
@@ -335,6 +335,9 @@ describe('Formik', () => {
     it('should work properly', () => {
       <Formik onSubmit={() => {}} />;
     });
+    it('onSumbit can return promise', () => {
+      <Formik onSubmit={() => Promise.resolve(null)} />;
+    });
   });
 
   describe('hook', () => {

--- a/definitions/npm/formik_v2.x.x/flow_v0.69.0-v0.103.x/test_formik.js
+++ b/definitions/npm/formik_v2.x.x/flow_v0.69.0-v0.103.x/test_formik.js
@@ -173,6 +173,16 @@ describe('useField hook', () => {
     // $FlowExpectedError[incompatible-cast] - check any
     (meta.error: number);
   });
+
+  it('should return FieldHelperProps', () => {
+    const [, , helpers] = useField<string>('name');
+
+    helpers.setValue('a name');
+    helpers.setValue('a name', false);
+    helpers.setTouched(true);
+    helpers.setTouched(true, false);
+    helpers.setError('an error');
+  });
 });
 
 describe('Field and FastField', () => {


### PR DESCRIPTION
Hi, some typing were missing in Formik.

- `onSubmit` return `void | Promise<any>`
- `useField` return an array of 3 objects including `FieldHelperProps`.

Links to documentation: 
  - https://formik.org/docs/api/useField#usefieldvalue--anyname-string--fieldhookconfigvalue-fieldinputpropsvalue-fieldmetapropsvalue-fieldhelperprops
  - https://formik.org/docs/api/formik#onsubmit-values-values-formikbag-formikbag--void--promiseany


