### PR TITLE
react-query_v3.x.x updates

### DIFF
--- a/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/react-query_v3.x.x.js
+++ b/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/react-query_v3.x.x.js
@@ -11,7 +11,7 @@ declare module "react-query" {
   declare type QueryCacheListener = (query?: Query<any, any, any>) => void;
 
   declare export class QueryCache extends Subscribable<QueryCacheListener> {
-    build<TQueryFnData, TError: Error, TData = TQueryFnData>(
+    build<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
       client: QueryClient,
       options: QueryOptions<TQueryFnData, TError, TData>,
       state?: QueryState<TData, TError>
@@ -19,22 +19,22 @@ declare module "react-query" {
     add(query: Query<any, any, any>): void;
     remove(query: Query<any, any, any>): void;
     clear(): void;
-    get<TQueryFnData, TError: Error, TData = TQueryFnData>(
+    get<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
       queryHash: string
     ): ?Query<TQueryFnData, TError, TData>;
     getAll(): Query<any, any, any>[];
-    find<TQueryFnData, TError: Error, TData = TQueryFnData>(
+    find<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
       queryKey: QueryKey,
       filters?: QueryFilters
     ): ?Query<TQueryFnData, TError, TData>;
-    findAll<TQueryFnData, TError: Error, TData = TQueryFnData>(
+    findAll<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
       queryKey?: QueryKey,
       filters?: QueryFilters
     ): Query<TQueryFnData, TError, TData>[];
-    findAll<TQueryFnData, TError: Error, TData = TQueryFnData>(
+    findAll<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
       filters?: QueryFilters
     ): Query<TQueryFnData, TError, TData>[];
-    notify<TQueryFnData, TError: Error, TData = TQueryFnData>(
+    notify<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
       query?: Query<TQueryFnData, TError, TData>
     ): void;
     onFocus(): void;
@@ -57,7 +57,7 @@ declare module "react-query" {
     /**
      * Include queries matching this predicate function
      */
-    predicate?: <TQueryFnData, TError: Error, TData = TQueryFnData>(
+    predicate?: <TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
       query: Query<TQueryFnData, TError, TData>
     ) => boolean,
     /**
@@ -99,7 +99,7 @@ declare module "react-query" {
       updater: Updater<?TData, TData>,
       options?: SetDataOptions
     ): TData;
-    getQueryState<TData, TError: Error>(
+    getQueryState<TData = mixed, TError = mixed>(
       queryKey: QueryKey,
       filters?: QueryFilters
     ): ?QueryState<TData, TError>;
@@ -137,27 +137,27 @@ declare module "react-query" {
       options?: RefetchOptions
     ): Promise<void>;
 
-    fetchQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
+    fetchQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
       options: FetchQueryOptions<TQueryFnData, TError, TData>
     ): Promise<TData>;
-    fetchQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
+    fetchQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
       queryKey: QueryKey,
       options?: FetchQueryOptions<TQueryFnData, TError, TData>
     ): Promise<TData>;
-    fetchQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
+    fetchQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
       queryKey: QueryKey,
       queryFn: QueryFunction<TQueryFnData | TData>,
       options?: FetchQueryOptions<TQueryFnData, TError, TData>
     ): Promise<TData>;
 
-    prefetchQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
+    prefetchQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
       options: FetchQueryOptions<TQueryFnData, TError, TData>
     ): Promise<void>;
-    prefetchQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
+    prefetchQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
       queryKey: QueryKey,
       options?: FetchQueryOptions<TQueryFnData, TError, TData>
     ): Promise<void>;
-    prefetchQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
+    prefetchQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
       queryKey: QueryKey,
       queryFn: QueryFunction<TQueryFnData>,
       options?: FetchQueryOptions<TQueryFnData, TError, TData>
@@ -214,15 +214,15 @@ declare module "react-query" {
   declare type FetchPreviousPageOptions<T> = FetchNextPageOptions<T>;
 
   // retry related
-  declare type RetryValue<TError: Error> =
+  declare type RetryValue<TError = mixed> =
     | boolean
     | number
     | ShouldRetryFunction<TError>;
-  declare type ShouldRetryFunction<TError: Error> = (
+  declare type ShouldRetryFunction<TError = mixed> = (
     failureCount: number,
     error: TError
   ) => boolean;
-  declare type RetryDelayValue<TError: Error> =
+  declare type RetryDelayValue<TError = mixed> =
     | number
     | RetryDelayFunction<TError>;
   declare type RetryDelayFunction<TError> = (
@@ -252,7 +252,7 @@ declare module "react-query" {
     dataUpdatedAt?: number,
   |};
 
-  declare type ErrorAction<TError: Error> = {|
+  declare type ErrorAction<TError = mixed> = {|
     type: "error",
     error: TError,
   |};
@@ -269,17 +269,17 @@ declare module "react-query" {
     type: "continue",
   |};
 
-  declare type SetStateAction<TData, TError: Error, TVariables, TContext> = {|
+  declare type SetStateAction<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
     type: "setState",
     state: MutationState<TData, TError, TVariables, TContext>,
   |};
 
-  declare type SetQueryStateAction<TData, TError: Error> = {|
+  declare type SetQueryStateAction<TData = mixed, TError = mixed> = {|
     type: "setState",
     state: QueryState<TData, TError>,
   |};
 
-  declare export type Action<TData, TError: Error, TVariables, TContext> =
+  declare export type Action<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> =
     | ContinueAction
     | ErrorAction<TError>
     | FailedAction
@@ -288,7 +288,7 @@ declare module "react-query" {
     | SetStateAction<TData, TError, TVariables, TContext>
     | SuccessAction<TData>;
 
-  declare export type QueryAction<TData, TError: Error> =
+  declare export type QueryAction<TData = mixed, TError = mixed> =
     | ContinueAction
     | ErrorAction<TError>
     | FailedAction
@@ -303,17 +303,17 @@ declare module "react-query" {
     cancelRefresh?: boolean,
     meta?: mixed,
   |};
-  declare type FetchContext<TQueryFnData, TError: Error, TData = TQueryFnData> = {|
+  declare type FetchContext<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData> = {|
     fetchFn: () => mixed | Promise<mixed>,
     fetchOptions?: FetchOptions,
     options: QueryOptions<TQueryFnData, TError, TData>,
     queryKey: QueryKey,
     state: QueryState<TData, TError>,
   |};
-  declare type QueryBehavior<TQueryFnData, TError: Error, TData = TQueryFnData> = {|
+  declare type QueryBehavior<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData> = {|
     onFetch: (context: FetchContext<TQueryFnData, TError, TData>) => void,
   |};
-  declare type QueryConfig<TQueryFnData, TError: Error, TData = TQueryFnData> = {|
+  declare type QueryConfig<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData> = {|
     cache: QueryCache,
     queryKey: QueryKey,
     queryHash: string,
@@ -323,7 +323,7 @@ declare module "react-query" {
   |};
   declare type EnumStatus = "idle" | "loading" | "success" | "error";
   declare export type QueryStatus = EnumStatus;
-  declare type QueryState<TData, TError: Error> = {|
+  declare type QueryState<TData = mixed, TError = mixed> = {|
     data: ?TData,
     dataUpdateCount: number,
     dataUpdatedAt: number,
@@ -338,25 +338,26 @@ declare module "react-query" {
     status: QueryStatus,
   |};
 
-  declare type InitialDataFunction<T> = () => ?T;
-  declare type QueryKey = string | mixed[];
+  declare type InitialDataFunction<TData> = () => ?TData;
+  declare type QueryKey = string | $ReadOnlyArray<mixed>;
+  declare type PageParam = mixed;
   declare type QueryKeyHashFunction = (queryKey: QueryKey) => string;
-  declare type QueryFunctionContext<TQueryKey: QueryKey, TPageParam> = {|
+  declare type QueryFunctionContext<TQueryKey = QueryKey, TPageParam = PageParam> = {|
     queryKey: TQueryKey,
     pageParam?: TPageParam,
   |};
-  declare type QueryFunction<T> = (
-    context: QueryFunctionContext<QueryKey, any>
-  ) => Promise<T> | T;
-  declare type GetPreviousPageParamFunction<TQueryFnData, U> = (
+  declare type QueryFunction<TQueryFnData, TQueryKey = QueryKey, TPageParam = PageParam> = (
+    context: QueryFunctionContext<QueryKey, PageParam>
+  ) => Promise<TQueryFnData> | TQueryFnData;
+  declare type GetPreviousPageParamFunction<TQueryFnData = mixed, U = mixed> = (
     firstPage: TQueryFnData,
     allPages: TQueryFnData[]
   ) => U;
-  declare type GetNextPageParamFunction<TQueryFnData, U> = (
+  declare type GetNextPageParamFunction<TQueryFnData = mixed, U = mixed> = (
     lastPage: TQueryFnData,
     allPages: TQueryFnData[]
   ) => U;
-  declare type QueryOptions<TQueryFnData, TError: Error, TData = TQueryFnData> = {|
+  declare type QueryOptions<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData> = {|
     retry?: RetryValue<TError>,
     retryDelay?: RetryDelayValue<TError>,
     cacheTime?: number,
@@ -383,7 +384,7 @@ declare module "react-query" {
      */
     getNextPageParam?: GetNextPageParamFunction<TQueryFnData, any>,
   |};
-  declare export type FetchQueryOptions<TQueryFnData, TError: Error, TData = TQueryFnData> = {|
+  declare export type FetchQueryOptions<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData> = {|
     ...QueryOptions<TQueryFnData, TError, TData>,
     staleTime?: number,
   |};
@@ -391,7 +392,7 @@ declare module "react-query" {
 
   declare export type QueryObserverOptions<
     TQueryFnData,
-    TError: Error,
+    TError = mixed,
     TData = TQueryFnData,
     TQueryData = TQueryFnData
   > = {|
@@ -490,12 +491,12 @@ declare module "react-query" {
     placeholderData?: TData | PlaceholderDataFunction<TData>,
   |};
 
-  // declare type InfiniteQueryObserverOptions<TQueryFnData, TError: Error, TData = TQueryFnData, TQueryData: TQueryFnData> = QueryObserverOptions<InfiniteData<TData>,
+  // declare type InfiniteQueryObserverOptions<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData, TQueryData: TQueryFnData> = QueryObserverOptions<InfiniteData<TData>,
   //   TError,
   //   TQueryFnData,
   //   InfiniteData<TQueryData>>;
 
-  declare type QueryObserverBaseResult<TData, TError: Error> = {|
+  declare type QueryObserverBaseResult<TData = mixed, TError = mixed> = {|
     data: ?TData,
     dataUpdatedAt: number,
     error: TError | null,
@@ -520,7 +521,7 @@ declare module "react-query" {
     status: QueryStatus,
   |};
 
-  declare type QueryObserverIdleResult<TData, TError: Error> = {|
+  declare type QueryObserverIdleResult<TData = mixed, TError = mixed> = {|
     ...QueryObserverBaseResult<TData, TError>,
     // data: null, // TODO should be undefined
     error: null,
@@ -533,7 +534,7 @@ declare module "react-query" {
     status: "idle",
   |};
 
-  declare type QueryObserverLoadingResult<TData, TError: Error> = {|
+  declare type QueryObserverLoadingResult<TData = mixed, TError = mixed> = {|
     ...QueryObserverBaseResult<TData, TError>,
     // data: null, // TODO should be undefined
     error: null,
@@ -546,7 +547,7 @@ declare module "react-query" {
     status: "loading",
   |};
 
-  declare type QueryObserverLoadingErrorResult<TData, TError: Error> = {|
+  declare type QueryObserverLoadingErrorResult<TData = mixed, TError = mixed> = {|
     ...QueryObserverBaseResult<TData, TError>,
     // data: null, // TODO should be undefined
     error: TError,
@@ -559,7 +560,7 @@ declare module "react-query" {
     status: "error",
   |};
 
-  declare type QueryObserverRefetchErrorResult<TData, TError: Error> = {|
+  declare type QueryObserverRefetchErrorResult<TData = mixed, TError = mixed> = {|
     ...QueryObserverBaseResult<TData, TError>,
     data: TData,
     error: TError,
@@ -572,7 +573,7 @@ declare module "react-query" {
     status: "error",
   |};
 
-  declare type QueryObserverSuccessResult<TData, TError: Error> = {|
+  declare type QueryObserverSuccessResult<TData = mixed, TError = mixed> = {|
     ...QueryObserverBaseResult<TData, TError>,
     data: TData,
     error: null,
@@ -586,7 +587,7 @@ declare module "react-query" {
   |};
 
   // exported for testing
-  declare export type QueryObserverResult<TData, TError: Error> =
+  declare export type QueryObserverResult<TData = mixed, TError = mixed> =
     | QueryObserverIdleResult<TData, TError>
     | QueryObserverLoadingErrorResult<TData, TError>
     | QueryObserverLoadingResult<TData, TError>
@@ -597,7 +598,7 @@ declare module "react-query" {
   //   pages: TData[],
   //   pageParams: mixed[],
   // |};
-  // declare type InfiniteQueryObserverBaseResult<TData, TError: Error> = {|
+  // declare type InfiniteQueryObserverBaseResult<TData = mixed, TError = mixed> = {|
   //   ...QueryObserverBaseResult<InfiniteData<TData>, TError>,
   //   fetchNextPage: (
   //     options?: FetchNextPageOptions<*>
@@ -611,7 +612,7 @@ declare module "react-query" {
   //   isFetchingPreviousPage: boolean,
   // |};
 
-  // declare type InfiniteQueryObserverIdleResult<TData, TError: Error> = {|
+  // declare type InfiniteQueryObserverIdleResult<TData = mixed, TError = mixed> = {|
   //   ...InfiniteQueryObserverBaseResult<TData, TError>,
   //   data: null, // TODO should be undefined
   //   error: null,
@@ -624,7 +625,7 @@ declare module "react-query" {
   //   status: "idle",
   // |};
 
-  // declare type InfiniteQueryObserverLoadingResult<TData, TError: Error> = {|
+  // declare type InfiniteQueryObserverLoadingResult<TData = mixed, TError = mixed> = {|
   //   ...InfiniteQueryObserverBaseResult<TData, TError>,
   //   data: null, // TODO should be undefined
   //   error: null,
@@ -637,7 +638,7 @@ declare module "react-query" {
   //   status: "loading",
   // |};
 
-  // declare type InfiniteQueryObserverLoadingErrorResult<TData, TError: Error> = {|
+  // declare type InfiniteQueryObserverLoadingErrorResult<TData = mixed, TError = mixed> = {|
   //   ...InfiniteQueryObserverBaseResult<TData, TError>,
   //   data: null, // TODO should be undefined
   //   error: TError,
@@ -650,7 +651,7 @@ declare module "react-query" {
   //   status: "error",
   // |};
 
-  // declare type InfiniteQueryObserverRefetchErrorResult<TData, TError: Error> = {|
+  // declare type InfiniteQueryObserverRefetchErrorResult<TData = mixed, TError = mixed> = {|
   //   ...InfiniteQueryObserverBaseResult<TData, TError>,
   //   data: InfiniteData<TData>,
   //   error: TError,
@@ -663,7 +664,7 @@ declare module "react-query" {
   //   status: "error",
   // |};
 
-  // declare type InfiniteQueryObserverSuccessResult<TData, TError: Error> = {|
+  // declare type InfiniteQueryObserverSuccessResult<TData = mixed, TError = mixed> = {|
   //   ...InfiniteQueryObserverBaseResult<TData, TError>,
   //   data: InfiniteData<TData>,
   //   error: null,
@@ -676,14 +677,14 @@ declare module "react-query" {
   //   status: "success",
   // |};
 
-  // declare type InfiniteQueryObserverResult<TData, TError: Error> =
+  // declare type InfiniteQueryObserverResult<TData = mixed, TError = mixed> =
   //   | InfiniteQueryObserverIdleResult<TData, TError>
   //   | InfiniteQueryObserverLoadingErrorResult<TData, TError>
   //   | InfiniteQueryObserverLoadingResult<TData, TError>
   //   | InfiniteQueryObserverRefetchErrorResult<TData, TError>
   //   | InfiniteQueryObserverSuccessResult<TData, TError>;
 
-  declare type QueryObserverListener<TData, TError: Error> = (
+  declare type QueryObserverListener<TData = mixed, TError = mixed> = (
     result: QueryObserverResult<TData, TError>
   ) => void;
 
@@ -694,7 +695,7 @@ declare module "react-query" {
 
   declare export class QueryObserver<
       TQueryFnData,
-      TError: Error,
+      TError = mixed,
       TData = TQueryFnData,
       TQueryData = TQueryFnData,
     >
@@ -727,12 +728,12 @@ declare module "react-query" {
     onQueryUpdate(action: Action<TData, TError>): void;
   }
 
-  declare type QueriesObserverListener<TData, TError: Error> = (
+  declare type QueriesObserverListener<TData = mixed, TError = mixed> = (
     result: $ReadOnlyArray<QueryObserverResult<TData, TError>>
   ) => void;
   declare export class QueriesObserver<
       TQueryFnData,
-      TError: Error,
+      TError = mixed,
       TData = TQueryFnData,
       TQueryData = TQueryFnData,
     >
@@ -748,13 +749,13 @@ declare module "react-query" {
     getCurrentResult(): QueryObserverResult<TData, TError>[];
   }
 
-  // declare type InfiniteQueryObserverListener<TData, TError: Error> = (
+  // declare type InfiniteQueryObserverListener<TData = mixed, TError = mixed> = (
   //   result: InfiniteQueryObserverResult<TData, TError>
   // ) => void;
 
   // declare export class InfiniteQueryObserver<
   //     TData,
-  //     TError: Error,
+  //     TError = mixed,
   //     TQueryFnData: TData,
   //     TQueryData: TQueryFnData
   //   >
@@ -801,7 +802,7 @@ declare module "react-query" {
 
   declare type SetDataOptions = {| updatedAt?: number |};
 
-  declare class Query<TQueryFnData, TError: Error, TData = TQueryFnData> {
+  declare class Query<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData> {
     +queryKey: QueryKey;
     +queryHash: string;
     +options: QueryOptions<TQueryFnData, TError, TData>;
@@ -835,7 +836,7 @@ declare module "react-query" {
    *
    */
 
-  declare type MutationConfig<TData, TError: Error, TVariables, TContext> = {|
+  declare type MutationConfig<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
     mutationId: number,
     mutationCache: MutationCache,
     options: MutationOptions<TData, TError, TVariables, TContext>,
@@ -850,7 +851,7 @@ declare module "react-query" {
     variables: TVariables
   ) => Promise<TData>;
 
-  declare type MutationOptions<TData, TError: Error, TVariables, TContext> = {|
+  declare type MutationOptions<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
     mutationFn?: MutationFunction<TData, TVariables>,
     mutationKey?: MutationKey,
     variables?: TVariables,
@@ -876,16 +877,16 @@ declare module "react-query" {
   |};
 
   declare type MutationObserverOptions<
-    TData,
-    TError: Error,
-    TVariables,
-    TContext
+    TData = mixed,
+    TError = mixed,
+    TVariables = mixed,
+    TContext = mixed,
   > = {|
     ...MutationOptions<TData, TError, TVariables, TContext>,
     useErrorBoundary?: boolean,
   |};
 
-  declare type MutateOptions<TData, TError: Error, TVariables, TContext> = {|
+  declare type MutateOptions<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
     onSuccess?: (
       data: TData,
       variables: TVariables,
@@ -904,16 +905,16 @@ declare module "react-query" {
     ) => Promise<void> | void,
   |};
 
-  declare type MutateFunction<TData, TError: Error, TVariables, TContext> = (
+  declare type MutateFunction<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = (
     variables: TVariables,
     options?: MutateOptions<TData, TError, TVariables, TContext>
   ) => Promise<TData>;
 
   declare type MutationObserverResult<
-    TData,
-    TError: Error,
-    TVariables,
-    TContext
+    TData = mixed,
+    TError = mixed,
+    TVariables = mixed,
+    TContext = mixed,
   > = {|
     ...MutationState<TData, TError, TVariables, TContext>,
     isError: boolean,
@@ -928,7 +929,7 @@ declare module "react-query" {
     queries?: QueryObserverOptions<any, any, any, any>,
     mutations?: MutationObserverOptions<any, any, any, any>,
   |};
-  declare type MutationState<TData, TError: Error, TVariables, TContext> = {|
+  declare type MutationState<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
     context: ?TContext,
     data: ?TData,
     error: TError | null,
@@ -945,16 +946,16 @@ declare module "react-query" {
   |};
 
   declare type SetMutationStateAction<
-    TData,
-    TError: Error,
-    TVariables,
-    TContext
+    TData = mixed,
+    TError = mixed,
+    TVariables = mixed,
+    TContext = mixed,
   > = {|
     type: "setState",
     state: MutationState<TData, TError, TVariables, TContext>,
   |};
 
-  declare type MutationAction<TData, TError: Error, TVariables, TContext> =
+  declare type MutationAction<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> =
     | ContinueAction
     | ErrorAction<TError>
     | FailedAction
@@ -963,7 +964,7 @@ declare module "react-query" {
     | SetMutationStateAction<TData, TError, TVariables, TContext>
     | SuccessAction<TData>;
 
-  declare export class Mutation<TData, TError: Error, TVariables, TContext> {
+  declare export class Mutation<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> {
     +state: MutationState<TData, TError, TVariables, TContext>;
     +options: MutationOptions<TData, TError, TVariables, TContext>;
     +mutationId: number;
@@ -979,18 +980,18 @@ declare module "react-query" {
   }
 
   declare type MutationObserverListener<
-    TData,
-    TError: Error,
-    TVariables,
-    TContext
+    TData = mixed,
+    TError = mixed,
+    TVariables = mixed,
+    TContext = mixed,
   > = (
     result: MutationObserverResult<TData, TError, TVariables, TContext>
   ) => void;
   declare export class MutationObserver<
-      TData,
-      TError: Error,
-      TVariables,
-      TContext
+      TData = mixed,
+      TError = mixed,
+      TVariables = mixed,
+      TContext = mixed,
     >
     extends
       Subscribable<
@@ -1040,14 +1041,14 @@ declare module "react-query" {
 
   declare type UseBaseQueryOptions<
     TQueryFnData,
-    TError: Error,
+    TError = mixed,
     TData = TQueryFnData,
     TQueryData = TQueryFnData,
   > = QueryObserverOptions<TQueryFnData, TError, TData, TQueryData>;
 
   declare export type UseQueryOptions<
     TQueryFnData,
-    TError: Error,
+    TError = mixed,
     TData = TQueryFnData,
   > = UseBaseQueryOptions<TQueryFnData, TError, TData, TQueryFnData>;
 
@@ -1058,11 +1059,11 @@ declare module "react-query" {
   //   TQueryData: TQueryFnData
   // > = InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryData>;
 
-  declare type UseBaseQueryResult<TData, TError: Error> = QueryObserverResult<
+  declare type UseBaseQueryResult<TData = mixed, TError = mixed> = QueryObserverResult<
     TData,
     TError>;
 
-  declare export type UseQueryResult<TData, TError: Error> = UseBaseQueryResult<
+  declare export type UseQueryResult<TData = mixed, TError = mixed> = UseBaseQueryResult<
     TData,
     TError>;
 
@@ -1072,10 +1073,10 @@ declare module "react-query" {
   // > = InfiniteQueryObserverResult<TData, TError>;
 
   declare type UseMutationOptions<
-    TData,
-    TError: Error,
-    TVariables,
-    TContext
+    TData = mixed,
+    TError = mixed,
+    TVariables = mixed,
+    TContext = mixed,
   > = {|
     mutationKey?: MutationKey,
     onMutate?: (variables: TVariables) => Promise<TContext> | TContext,
@@ -1100,26 +1101,26 @@ declare module "react-query" {
     useErrorBoundary?: boolean,
   |};
 
-  declare type UseMutateFunction<TData, TError: Error, TVariables, TContext> = (
+  declare type UseMutateFunction<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = (
     variables: TVariables,
     options?: MutateOptions<TData, TError, TVariables, TContext>
   ) => void;
 
   declare type UseMutateAsyncFunction<
-    TData,
-    TError: Error,
-    TVariables,
-    TContext
+    TData = mixed,
+    TError = mixed,
+    TVariables = mixed,
+    TContext = mixed,
   > = (
     variables: TVariables,
     options?: MutateOptions<TData, TError, TVariables, TContext>
   ) => Promise<TData>;
 
   declare export type UseMutationResult<
-    TData,
-    TError: Error,
-    TVariables,
-    TContext
+    TData = mixed,
+    TError = mixed,
+    TVariables = mixed,
+    TContext = mixed,
   > = {|
     context: ?TContext,
     data: ?TData,
@@ -1137,20 +1138,20 @@ declare module "react-query" {
     variables: ?TVariables,
   |};
 
-  declare export function useQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
+  declare export function useQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
     options: UseQueryOptions<TQueryFnData, TError, TData>
   ): UseQueryResult<TData, TError>;
-  declare export function useQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
+  declare export function useQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
     queryKey: QueryKey,
     options?: UseQueryOptions<TQueryFnData, TError, TData>
   ): UseQueryResult<TData, TError>;
-  declare export function useQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
+  declare export function useQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
     queryKey: QueryKey,
     queryFn: QueryFunction<TQueryFnData>,
     options?: UseQueryOptions<TQueryFnData, TError, TData>
   ): UseQueryResult<TData, TError>;
 
-  declare export function useQueries<TQueryFnData, TError: Error, TData = TQueryFnData>(
+  declare export function useQueries<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
     queries: UseQueryOptions<TQueryFnData, TError, TData>[]
   ): UseQueryResult<TData, TError>[];
 
@@ -1161,8 +1162,8 @@ declare module "react-query" {
     options?: any
   ): any;
   declare export function useInfiniteQuery<
-    TQueryFnData,
-    TError: Error,
+    TQueryFnData = mixed,
+    TError = mixed,
     TData = TQueryFnData
   >(
     queryKey: QueryKey,
@@ -1170,50 +1171,50 @@ declare module "react-query" {
     options?: any
   ): any;
 
-  // declare export function useInfiniteQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
+  // declare export function useInfiniteQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
   //   options: UseInfiniteQueryOptions<TQueryFnData, TError, TData>
   // ): UseInfiniteQueryResult<TData, TError>;
-  // declare export function useInfiniteQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
+  // declare export function useInfiniteQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
   //   queryKey: QueryKey,
   //   options?: UseInfiniteQueryOptions<TQueryFnData, TError, TData>
   // ): UseInfiniteQueryResult<TData, TError>;
-  // declare export function useInfiniteQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
+  // declare export function useInfiniteQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
   //   queryKey: QueryKey,
   //   queryFn: QueryFunction<TQueryFnData | TData>,
   //   options?: UseInfiniteQueryOptions<TQueryFnData, TError, TData>
   // ): UseInfiniteQueryResult<TData, TError>;
 
   declare export function useMutation<
-    TData,
-    TError: Error,
-    TVariables,
-    TContext
+    TData = mixed,
+    TError = mixed,
+    TVariables = mixed,
+    TContext = mixed,
   >(
     options: UseMutationOptions<TData, TError, TVariables, TContext>
   ): UseMutationResult<TData, TError, TVariables, TContext>;
   declare export function useMutation<
-    TData,
-    TError: Error,
-    TVariables,
-    TContext
+    TData = mixed,
+    TError = mixed,
+    TVariables = mixed,
+    TContext = mixed,
   >(
     mutationFn: MutationFunction<TData, TVariables>,
     options?: UseMutationOptions<TData, TError, TVariables, TContext>
   ): UseMutationResult<TData, TError, TVariables, TContext>;
   declare export function useMutation<
-    TData,
-    TError: Error,
-    TVariables,
-    TContext
+    TData = mixed,
+    TError = mixed,
+    TVariables = mixed,
+    TContext = mixed,
   >(
     mutationKey: MutationKey,
     options?: UseMutationOptions<TData, TError, TVariables, TContext>
   ): UseMutationResult<TData, TError, TVariables, TContext>;
   declare export function useMutation<
-    TData,
-    TError: Error,
-    TVariables,
-    TContext
+    TData = mixed,
+    TError = mixed,
+    TVariables = mixed,
+    TContext = mixed,
   >(
     mutationKey: MutationKey,
     mutationFn?: MutationFunction<TData, TVariables>,

--- a/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/react-query_v3.x.x.js
+++ b/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/react-query_v3.x.x.js
@@ -93,7 +93,7 @@ declare module "react-query" {
     isFetching(filters?: QueryFilters): number;
     isFetching(queryKey?: QueryKey, filters?: QueryFilters): number;
 
-    getQueryData<TData>(queryKey: QueryKey, filters?: QueryFilters): ?TData;
+    getQueryData<TData>(queryKey: QueryKey, filters?: QueryFilters): void | TData;
     setQueryData<TData>(
       queryKey: QueryKey,
       updater: Updater<?TData, TData>,
@@ -247,7 +247,7 @@ declare module "react-query" {
   |};
 
   declare type SuccessAction<TData> = {|
-    data: ?TData,
+    data: void | TData,
     type: "success",
     dataUpdatedAt?: number,
   |};
@@ -324,7 +324,7 @@ declare module "react-query" {
   declare type EnumStatus = "idle" | "loading" | "success" | "error";
   declare export type QueryStatus = EnumStatus;
   declare type QueryState<TData = mixed, TError = mixed> = {|
-    data: ?TData,
+    data: void | TData,
     dataUpdateCount: number,
     dataUpdatedAt: number,
     error: TError | null,
@@ -338,7 +338,7 @@ declare module "react-query" {
     status: QueryStatus,
   |};
 
-  declare type InitialDataFunction<TData> = () => ?TData;
+  declare type InitialDataFunction<TData> = () => void | TData;
   declare type QueryKey = string | $ReadOnlyArray<mixed>;
   declare type PageParam = mixed;
   declare type QueryKeyHashFunction = (queryKey: QueryKey) => string;
@@ -361,7 +361,7 @@ declare module "react-query" {
     retry?: RetryValue<TError>,
     retryDelay?: RetryDelayValue<TError>,
     cacheTime?: number,
-    isDataEqual?: (oldData: ?TData, newData: TData) => boolean,
+    isDataEqual?: (oldData: void | TData, newData: TData) => boolean,
     queryFn?: QueryFunction<TQueryFnData>,
     queryHash?: string,
     queryKey?: QueryKey,
@@ -388,7 +388,7 @@ declare module "react-query" {
     ...QueryOptions<TQueryFnData, TError, TData>,
     staleTime?: number,
   |};
-  declare type PlaceholderDataFunction<TResult> = () => ?TResult;
+  declare type PlaceholderDataFunction<TResult> = () => void | TResult;
 
   declare export type QueryObserverOptions<
     TQueryFnData,
@@ -464,7 +464,7 @@ declare module "react-query" {
     /**
      * This callback will fire any time the query is either successfully fetched or errors and be passed either the data or error.
      */
-    onSettled?: (data: ?TData, error: TError | null) => void,
+    onSettled?: (data: void | TData, error: TError | null) => void,
     /**
      * Whether errors should be thrown instead of setting the `error` property.
      * Defaults to `false`.
@@ -497,7 +497,7 @@ declare module "react-query" {
   //   InfiniteData<TQueryData>>;
 
   declare type QueryObserverBaseResult<TData = mixed, TError = mixed> = {|
-    data: ?TData,
+    data: void | TData,
     dataUpdatedAt: number,
     error: TError | null,
     errorUpdatedAt: number,
@@ -523,7 +523,6 @@ declare module "react-query" {
 
   declare type QueryObserverIdleResult<TData = mixed, TError = mixed> = {|
     ...QueryObserverBaseResult<TData, TError>,
-    // data: null, // TODO should be undefined
     error: null,
     isError: false,
     isIdle: true,
@@ -536,7 +535,6 @@ declare module "react-query" {
 
   declare type QueryObserverLoadingResult<TData = mixed, TError = mixed> = {|
     ...QueryObserverBaseResult<TData, TError>,
-    // data: null, // TODO should be undefined
     error: null,
     isError: false,
     isIdle: false,
@@ -549,7 +547,6 @@ declare module "react-query" {
 
   declare type QueryObserverLoadingErrorResult<TData = mixed, TError = mixed> = {|
     ...QueryObserverBaseResult<TData, TError>,
-    // data: null, // TODO should be undefined
     error: TError,
     isError: true,
     isIdle: false,
@@ -859,18 +856,18 @@ declare module "react-query" {
     onSuccess?: (
       data: TData,
       variables: TVariables,
-      context: ?TContext
+      context: TContext
     ) => Promise<void> | void,
     onError?: (
       error: TError,
       variables: TVariables,
-      context: ?TContext
+      context: TContext
     ) => Promise<void> | void,
     onSettled?: (
-      data: ?TData,
+      data: void | TData,
       error: TError | null,
       variables: TVariables,
-      context: ?TContext
+      context: TContext
     ) => Promise<void> | void,
     retry?: RetryValue<TError>,
     retryDelay?: RetryDelayValue<TError>,
@@ -890,18 +887,18 @@ declare module "react-query" {
     onSuccess?: (
       data: TData,
       variables: TVariables,
-      context: ?TContext
+      context: TContext
     ) => Promise<void> | void,
     onError?: (
       error: TError,
       variables: TVariables,
-      context: ?TContext
+      context: void | TContext
     ) => Promise<void> | void,
     onSettled?: (
-      data: ?TData,
+      data: void | TData,
       error: TError | null,
       variables: TVariables,
-      context: ?TContext
+      context: void | TContext
     ) => Promise<void> | void,
   |};
 
@@ -931,7 +928,7 @@ declare module "react-query" {
   |};
   declare type MutationState<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
     context: ?TContext,
-    data: ?TData,
+    data: void | TData,
     error: TError | null,
     failureCount: number,
     isPaused: boolean,
@@ -1091,7 +1088,7 @@ declare module "react-query" {
       context: ?TContext
     ) => Promise<void> | void,
     onSettled?: (
-      data: ?TData,
+      data: void | TData,
       error: TError | null,
       variables: TVariables,
       context: ?TContext
@@ -1123,7 +1120,7 @@ declare module "react-query" {
     TContext = mixed,
   > = {|
     context: ?TContext,
-    data: ?TData,
+    data: void | TData,
     error: TError | null,
     failureCount: number,
     isError: boolean,

--- a/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/react-query_v3.x.x.js
+++ b/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/react-query_v3.x.x.js
@@ -1,7 +1,7 @@
 // @flow
 
 // NOTE: useInfiniteQuery is currently very poorly typed. The relevant type definitions have been
-// commented out. useInfiniteQuery will accept `any` config options return `any`.
+// commented out. useInfiniteQuery will accept `any` config options and return `any`.
 
 declare module "react-query" {
   declare class Subscribable<TListener> {
@@ -205,13 +205,13 @@ declare module "react-query" {
     throwOnError?: boolean,
     cancelRefetch?: boolean,
   |};
-  declare type RefetchOptions = ResultOptions;
-  declare type InvalidateOptions = ResultOptions;
-  declare type FetchNextPageOptions<T> = {|
+  declare export type RefetchOptions = ResultOptions;
+  declare export type InvalidateOptions = ResultOptions;
+  declare export type FetchNextPageOptions<T> = {|
     ...ResultOptions,
     pageParam?: T,
   |};
-  declare type FetchPreviousPageOptions<T> = FetchNextPageOptions<T>;
+  declare export type FetchPreviousPageOptions<T> = FetchNextPageOptions<T>;
 
   // retry related
   declare type RetryValue<TError = mixed> =
@@ -448,11 +448,11 @@ declare module "react-query" {
      * If set, the component will only re-render if any of the listed properties change.
      * When set to `['data', 'error']`, the component will only re-render when the `data` or `error` properties change.
      */
-    notifyOnChangeProps?: string[], // TODO: was Array<$Keys<InfiniteQueryObserverResult<_, _>>>,
+    notifyOnChangeProps?: string[],
     /**
      * If set, the component will not re-render if any of the listed properties change.
      */
-    notifyOnChangePropsExclusions?: string[], // TODO: was Array<$Keys<InfiniteQueryObserverResult<_, _>>>,
+    notifyOnChangePropsExclusions?: string[],
     /**
      * This callback will fire any time the query successfully fetches new data.
      */
@@ -491,10 +491,13 @@ declare module "react-query" {
     placeholderData?: TData | PlaceholderDataFunction<TData>,
   |};
 
-  // declare type InfiniteQueryObserverOptions<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData, TQueryData: TQueryFnData> = QueryObserverOptions<InfiniteData<TData>,
-  //   TError,
-  //   TQueryFnData,
-  //   InfiniteData<TQueryData>>;
+  declare type InfiniteQueryObserverOptions<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData, TQueryData = TQueryFnData> =
+    QueryObserverOptions<
+      TQueryFnData,
+      TError,
+      InfiniteData<TData>,
+      InfiniteData<TQueryData>
+    >;
 
   declare type QueryObserverBaseResult<TData = mixed, TError = mixed> = {|
     data: void | TData,
@@ -591,95 +594,93 @@ declare module "react-query" {
     | QueryObserverRefetchErrorResult<TData, TError>
     | QueryObserverSuccessResult<TData, TError>;
 
-  // declare type InfiniteData<TData> = {|
-  //   pages: TData[],
-  //   pageParams: mixed[],
-  // |};
-  // declare type InfiniteQueryObserverBaseResult<TData = mixed, TError = mixed> = {|
-  //   ...QueryObserverBaseResult<InfiniteData<TData>, TError>,
-  //   fetchNextPage: (
-  //     options?: FetchNextPageOptions<*>
-  //   ) => Promise<InfiniteQueryObserverResult<TData, TError>>,
-  //   fetchPreviousPage: (
-  //     options?: FetchPreviousPageOptions<*>
-  //   ) => Promise<InfiniteQueryObserverResult<TData, TError>>,
-  //   hasNextPage?: boolean,
-  //   hasPreviousPage?: boolean,
-  //   isFetchingNextPage: boolean,
-  //   isFetchingPreviousPage: boolean,
-  // |};
+  declare export type InfiniteData<TData> = {|
+    pages: TData[],
+    pageParams: mixed[],
+  |};
 
-  // declare type InfiniteQueryObserverIdleResult<TData = mixed, TError = mixed> = {|
-  //   ...InfiniteQueryObserverBaseResult<TData, TError>,
-  //   data: null, // TODO should be undefined
-  //   error: null,
-  //   isError: false,
-  //   isIdle: true,
-  //   isLoading: false,
-  //   isLoadingError: false,
-  //   isRefetchError: false,
-  //   isSuccess: false,
-  //   status: "idle",
-  // |};
+  declare type InfiniteQueryObserverBaseResult<TData = mixed, TError = mixed> = {|
+    ...QueryObserverBaseResult<InfiniteData<TData>, TError>,
+    fetchNextPage: (
+      options?: FetchNextPageOptions<mixed>
+    ) => Promise<InfiniteQueryObserverResult<TData, TError>>,
+    fetchPreviousPage: (
+      options?: FetchPreviousPageOptions<mixed>
+    ) => Promise<InfiniteQueryObserverResult<TData, TError>>,
+    hasNextPage?: boolean,
+    hasPreviousPage?: boolean,
+    isFetchingNextPage: boolean,
+    isFetchingPreviousPage: boolean,
+  |};
 
-  // declare type InfiniteQueryObserverLoadingResult<TData = mixed, TError = mixed> = {|
-  //   ...InfiniteQueryObserverBaseResult<TData, TError>,
-  //   data: null, // TODO should be undefined
-  //   error: null,
-  //   isError: false,
-  //   isIdle: false,
-  //   isLoading: true,
-  //   isLoadingError: false,
-  //   isRefetchError: false,
-  //   isSuccess: false,
-  //   status: "loading",
-  // |};
+  declare type InfiniteQueryObserverIdleResult<TData = mixed, TError = mixed> = {|
+    ...InfiniteQueryObserverBaseResult<TData, TError>,
+    error: null,
+    isError: false,
+    isIdle: true,
+    isLoading: false,
+    isLoadingError: false,
+    isRefetchError: false,
+    isSuccess: false,
+    status: "idle",
+  |};
 
-  // declare type InfiniteQueryObserverLoadingErrorResult<TData = mixed, TError = mixed> = {|
-  //   ...InfiniteQueryObserverBaseResult<TData, TError>,
-  //   data: null, // TODO should be undefined
-  //   error: TError,
-  //   isError: true,
-  //   isIdle: false,
-  //   isLoading: false,
-  //   isLoadingError: true,
-  //   isRefetchError: false,
-  //   isSuccess: false,
-  //   status: "error",
-  // |};
+  declare type InfiniteQueryObserverLoadingResult<TData = mixed, TError = mixed> = {|
+    ...InfiniteQueryObserverBaseResult<TData, TError>,
+    error: null,
+    isError: false,
+    isIdle: false,
+    isLoading: true,
+    isLoadingError: false,
+    isRefetchError: false,
+    isSuccess: false,
+    status: "loading",
+  |};
 
-  // declare type InfiniteQueryObserverRefetchErrorResult<TData = mixed, TError = mixed> = {|
-  //   ...InfiniteQueryObserverBaseResult<TData, TError>,
-  //   data: InfiniteData<TData>,
-  //   error: TError,
-  //   isError: true,
-  //   isIdle: false,
-  //   isLoading: false,
-  //   isLoadingError: false,
-  //   isRefetchError: true,
-  //   isSuccess: false,
-  //   status: "error",
-  // |};
+  declare type InfiniteQueryObserverLoadingErrorResult<TData = mixed, TError = mixed> = {|
+    ...InfiniteQueryObserverBaseResult<TData, TError>,
+    error: TError,
+    isError: true,
+    isIdle: false,
+    isLoading: false,
+    isLoadingError: true,
+    isRefetchError: false,
+    isSuccess: false,
+    status: "error",
+  |};
 
-  // declare type InfiniteQueryObserverSuccessResult<TData = mixed, TError = mixed> = {|
-  //   ...InfiniteQueryObserverBaseResult<TData, TError>,
-  //   data: InfiniteData<TData>,
-  //   error: null,
-  //   isError: false,
-  //   isIdle: false,
-  //   isLoading: false,
-  //   isLoadingError: false,
-  //   isRefetchError: false,
-  //   isSuccess: true,
-  //   status: "success",
-  // |};
+  declare type InfiniteQueryObserverRefetchErrorResult<TData = mixed, TError = mixed> = {|
+    ...InfiniteQueryObserverBaseResult<TData, TError>,
+    data: InfiniteData<TData>,
+    error: TError,
+    isError: true,
+    isIdle: false,
+    isLoading: false,
+    isLoadingError: false,
+    isRefetchError: true,
+    isSuccess: false,
+    status: "error",
+  |};
 
-  // declare type InfiniteQueryObserverResult<TData = mixed, TError = mixed> =
-  //   | InfiniteQueryObserverIdleResult<TData, TError>
-  //   | InfiniteQueryObserverLoadingErrorResult<TData, TError>
-  //   | InfiniteQueryObserverLoadingResult<TData, TError>
-  //   | InfiniteQueryObserverRefetchErrorResult<TData, TError>
-  //   | InfiniteQueryObserverSuccessResult<TData, TError>;
+  declare type InfiniteQueryObserverSuccessResult<TData = mixed, TError = mixed> = {|
+    ...InfiniteQueryObserverBaseResult<TData, TError>,
+    data: InfiniteData<TData>,
+    error: null,
+    isError: false,
+    isIdle: false,
+    isLoading: false,
+    isLoadingError: false,
+    isRefetchError: false,
+    isSuccess: true,
+    status: "success",
+  |};
+
+  declare export type InfiniteQueryObserverResult<TData = mixed, TError = mixed> =
+    | InfiniteQueryObserverIdleResult<TData, TError>
+    | InfiniteQueryObserverLoadingErrorResult<TData, TError>
+    | InfiniteQueryObserverLoadingResult<TData, TError>
+    | InfiniteQueryObserverRefetchErrorResult<TData, TError>
+    | InfiniteQueryObserverSuccessResult<TData, TError>;
 
   declare type QueryObserverListener<TData = mixed, TError = mixed> = (
     result: QueryObserverResult<TData, TError>
@@ -691,7 +692,7 @@ declare module "react-query" {
   |};
 
   declare export class QueryObserver<
-      TQueryFnData,
+      TQueryFnData = mixed,
       TError = mixed,
       TData = TQueryFnData,
       TQueryData = TQueryFnData,
@@ -746,56 +747,69 @@ declare module "react-query" {
     getCurrentResult(): QueryObserverResult<TData, TError>[];
   }
 
-  // declare type InfiniteQueryObserverListener<TData = mixed, TError = mixed> = (
-  //   result: InfiniteQueryObserverResult<TData, TError>
-  // ) => void;
+  declare type InfiniteQueryObserverListener<TData = mixed, TError = mixed> = (
+    result: InfiniteQueryObserverResult<TData, TError>
+  ) => void;
 
-  // declare export class InfiniteQueryObserver<
-  //     TData,
-  //     TError = mixed,
-  //     TQueryFnData: TData,
-  //     TQueryData: TQueryFnData
-  //   >
-  //   extends
-  //     QueryObserver<
-  //       InfiniteData<TData>,
-  //       TError,
-  //       TQueryFnData,
-  //       InfiniteData<TQueryData>
-  //     > {
-  //   constructor(
-  //     client: QueryClient,
-  //     options: InfiniteQueryObserverOptions<
-  //       InfiniteData<TData>,
-  //       TError,
-  //       TQueryFnData,
-  //       InfiniteData<TQueryData>
-  //     >
-  //   ): this;
+  declare export class InfiniteQueryObserver<
+      TQueryFnData = mixed,
+      TError = mixed,
+      TData = TQueryFnData,
+      TQueryData = TQueryFnData,
+    >
+    extends Subscribable<InfiniteQueryObserverListener<TData, TError>> {
+    constructor(
+      client: QueryClient,
+      options: InfiniteQueryObserverOptions<
+        TQueryFnData,
+        TError,
+        TData,
+        TQueryData
+      >
+    ): this;
 
-  //   // Type override
-  //   subscribe(
-  //     listener?: InfiniteQueryObserverListener<InfiniteData<TData>, TError>
-  //   ): () => void;
+    // Type override
+    subscribe(
+      listener?: InfiniteQueryObserverListener<TData, TError>
+    ): () => void;
 
-  //   // Type override
-  //   getCurrentResult(): InfiniteQueryObserverResult<InfiniteData<TData>, TError>;
+    // Type override
+    getCurrentResult(): InfiniteQueryObserverResult<TData, TError>;
 
-  //   setOptions(
-  //     options?: InfiniteQueryObserverOptions<
-  //       InfiniteData<TData>,
-  //       TError,
-  //       TQueryFnData,
-  //       TQueryData
-  //     >
-  //   ): void;
-  //   fetchNextPage<T>(
-  //     options?: FetchNextPageOptions<T>
-  //   ): Promise<InfiniteQueryObserverResult<TData, TError>>;
-  //   fetchPreviousPage<T>(
-  //     options?: FetchPreviousPageOptions<T>
-  //   ): Promise<InfiniteQueryObserverResult<TData, TError>>;
-  // }
+    willLoadOnMount(): boolean;
+    willRefetchOnMount(): boolean;
+    willFetchOnMount(): boolean;
+    willFetchOnReconnect(): boolean;
+    willFetchOnWindowFocus(): boolean;
+    destroy(): void;
+    getCurrentResult(): InfiniteQueryObserverResult<TData, TError>;
+    getNextResult(
+      options?: ResultOptions
+    ): Promise<InfiniteQueryObserverResult<TData, TError>>;
+    getCurrentQuery(): Query<TQueryData, TError, TQueryFnData>;
+    remove(): void;
+    refetch(
+      options?: RefetchOptions
+    ): Promise<InfiniteQueryObserverResult<TData, TError>>;
+    onQueryUpdate(action: Action<TData, TError>): void;
+
+    ////////////////////
+
+    setOptions(
+      options?: InfiniteQueryObserverOptions<
+        TQueryFnData,
+        TError,
+        TData,
+        TQueryData
+      >
+    ): void;
+    fetchNextPage<T>(
+      options?: FetchNextPageOptions<T>
+    ): Promise<InfiniteQueryObserverResult<TData, TError>>;
+    fetchPreviousPage<T>(
+      options?: FetchPreviousPageOptions<T>
+    ): Promise<InfiniteQueryObserverResult<TData, TError>>;
+  }
 
   declare type SetDataOptions = {| updatedAt?: number |};
 
@@ -927,13 +941,13 @@ declare module "react-query" {
     mutations?: MutationObserverOptions<any, any, any, any>,
   |};
   declare type MutationState<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
-    context: ?TContext,
+    context: void | TContext,
     data: void | TData,
     error: TError | null,
     failureCount: number,
     isPaused: boolean,
     status: MutationStatus,
-    variables: ?TVariables,
+    variables: void | TVariables,
   |};
 
   declare type LoadingAction<TVariables, TContext> = {|
@@ -1037,24 +1051,24 @@ declare module "react-query" {
   }
 
   declare type UseBaseQueryOptions<
-    TQueryFnData,
+    TQueryFnData = mixed,
     TError = mixed,
     TData = TQueryFnData,
     TQueryData = TQueryFnData,
   > = QueryObserverOptions<TQueryFnData, TError, TData, TQueryData>;
 
   declare export type UseQueryOptions<
-    TQueryFnData,
+    TQueryFnData = mixed,
     TError = mixed,
     TData = TQueryFnData,
   > = UseBaseQueryOptions<TQueryFnData, TError, TData, TQueryFnData>;
 
-  // declare type UseInfiniteQueryOptions<
-  //   TData,
-  //   TError,
-  //   TQueryFnData: TData,
-  //   TQueryData: TQueryFnData
-  // > = InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryData>;
+  declare type UseInfiniteQueryOptions<
+    TQueryFnData = mixed,
+    TError = mixed,
+    TData = TQueryFnData,
+    TQueryData = TQueryFnData,
+  > = InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryData>;
 
   declare type UseBaseQueryResult<TData = mixed, TError = mixed> = QueryObserverResult<
     TData,
@@ -1064,10 +1078,10 @@ declare module "react-query" {
     TData,
     TError>;
 
-  // declare type UseInfiniteQueryResult<
-  //   TData,
-  //   TError
-  // > = InfiniteQueryObserverResult<TData, TError>;
+  declare type UseInfiniteQueryResult<
+    TData,
+    TError
+  > = InfiniteQueryObserverResult<TData, TError>;
 
   declare type UseMutationOptions<
     TData = mixed,
@@ -1152,34 +1166,20 @@ declare module "react-query" {
     queries: UseQueryOptions<TQueryFnData, TError, TData>[]
   ): UseQueryResult<TData, TError>[];
 
-  // stub until bugs can be worked out:
-  declare export function useInfiniteQuery(options: any): any;
-  declare export function useInfiniteQuery(
+  declare export function useInfiniteQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(options: UseInfiniteQueryOptions<TQueryFnData, TError, TData>): UseInfiniteQueryResult<TData, TError>;
+  declare export function useInfiniteQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
     queryKey: QueryKey,
-    options?: any
-  ): any;
+    options?: UseInfiniteQueryOptions<TQueryFnData, TError, TData>
+  ): UseInfiniteQueryResult<TData, TError>;
   declare export function useInfiniteQuery<
     TQueryFnData = mixed,
     TError = mixed,
     TData = TQueryFnData
   >(
     queryKey: QueryKey,
-    queryFn: QueryFunction<TData | TQueryFnData>,
-    options?: any
-  ): any;
-
-  // declare export function useInfiniteQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
-  //   options: UseInfiniteQueryOptions<TQueryFnData, TError, TData>
-  // ): UseInfiniteQueryResult<TData, TError>;
-  // declare export function useInfiniteQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
-  //   queryKey: QueryKey,
-  //   options?: UseInfiniteQueryOptions<TQueryFnData, TError, TData>
-  // ): UseInfiniteQueryResult<TData, TError>;
-  // declare export function useInfiniteQuery<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
-  //   queryKey: QueryKey,
-  //   queryFn: QueryFunction<TQueryFnData | TData>,
-  //   options?: UseInfiniteQueryOptions<TQueryFnData, TError, TData>
-  // ): UseInfiniteQueryResult<TData, TError>;
+    queryFn: QueryFunction<TQueryFnData>,
+    options?: UseInfiniteQueryOptions<TQueryFnData, TError, TData>
+  ): UseInfiniteQueryResult<TData, TError>;
 
   declare export function useMutation<
     TData = mixed,

--- a/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/react-query_v3.x.x.js
+++ b/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/react-query_v3.x.x.js
@@ -4,11 +4,11 @@
 // commented out. useInfiniteQuery will accept `any` config options and return `any`.
 
 declare module "react-query" {
-  declare class Subscribable<TListener> {
+  declare export class Subscribable<TListener> {
     subscribe(listener?: TListener): () => void;
     hasListeners(): boolean;
   }
-  declare type QueryCacheListener = (query?: Query<any, any, any>) => void;
+  declare export type QueryCacheListener = (query?: Query<any, any, any>) => void;
 
   declare export class QueryCache extends Subscribable<QueryCacheListener> {
     build<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData>(
@@ -41,7 +41,7 @@ declare module "react-query" {
     onOnline(): void;
   }
 
-  declare type QueryFilters = {|
+  declare export type QueryFilters = {|
     /**
      * Include or exclude active queries
      */
@@ -73,13 +73,13 @@ declare module "react-query" {
      */
     fetching?: boolean,
   |};
-  declare type InvalidateQueryFilters = {|
+  declare export type InvalidateQueryFilters = {|
     ...QueryFilters,
     refetchActive?: boolean,
     refetchInactive?: boolean,
   |};
 
-  declare type QueryClientConfig = {|
+  declare export type QueryClientConfig = {|
     queryCache?: QueryCache,
     mutationCache?: MutationCache,
     defaultOptions?: DefaultOptions,
@@ -197,11 +197,11 @@ declare module "react-query" {
     clear(): void;
   }
 
-  declare type CancelOptions = {|
+  declare export type CancelOptions = {|
     revert?: boolean,
     silent?: boolean,
   |};
-  declare type ResultOptions = {|
+  declare export type ResultOptions = {|
     throwOnError?: boolean,
     cancelRefetch?: boolean,
   |};
@@ -214,67 +214,67 @@ declare module "react-query" {
   declare export type FetchPreviousPageOptions<T> = FetchNextPageOptions<T>;
 
   // retry related
-  declare type RetryValue<TError = mixed> =
+  declare export type RetryValue<TError = mixed> =
     | boolean
     | number
     | ShouldRetryFunction<TError>;
-  declare type ShouldRetryFunction<TError = mixed> = (
+  declare export type ShouldRetryFunction<TError = mixed> = (
     failureCount: number,
     error: TError
   ) => boolean;
-  declare type RetryDelayValue<TError = mixed> =
+  declare export type RetryDelayValue<TError = mixed> =
     | number
     | RetryDelayFunction<TError>;
-  declare type RetryDelayFunction<TError> = (
+  declare export type RetryDelayFunction<TError> = (
     failureCount: number,
     error: TError
   ) => number;
 
   // updater
-  declare type DataUpdateFunction<TInput, TOutput> = (input: TInput) => TOutput;
-  declare type Updater<TInput, TOutput> =
+  declare export type DataUpdateFunction<TInput, TOutput> = (input: TInput) => TOutput;
+  declare export type Updater<TInput, TOutput> =
     | TOutput
     | DataUpdateFunction<TInput, TOutput>;
 
   // Action
-  declare type FailedAction = {|
+  declare export type FailedAction = {|
     type: "failed",
   |};
 
-  declare type FetchAction = {|
+  declare export type FetchAction = {|
     type: "fetch",
     meta?: mixed,
   |};
 
-  declare type SuccessAction<TData> = {|
+  declare export type SuccessAction<TData> = {|
     data: void | TData,
     type: "success",
     dataUpdatedAt?: number,
   |};
 
-  declare type ErrorAction<TError = mixed> = {|
+  declare export type ErrorAction<TError = mixed> = {|
     type: "error",
     error: TError,
   |};
 
-  declare type InvalidateAction = {|
+  declare export type InvalidateAction = {|
     type: "invalidate",
   |};
 
-  declare type PauseAction = {|
+  declare export type PauseAction = {|
     type: "pause",
   |};
 
-  declare type ContinueAction = {|
+  declare export type ContinueAction = {|
     type: "continue",
   |};
 
-  declare type SetStateAction<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
+  declare export type SetStateAction<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
     type: "setState",
     state: MutationState<TData, TError, TVariables, TContext>,
   |};
 
-  declare type SetQueryStateAction<TData = mixed, TError = mixed> = {|
+  declare export type SetQueryStateAction<TData = mixed, TError = mixed> = {|
     type: "setState",
     state: QueryState<TData, TError>,
   |};
@@ -299,21 +299,21 @@ declare module "react-query" {
     | SuccessAction<TData>;
 
   // query types
-  declare type FetchOptions = {|
+  declare export type FetchOptions = {|
     cancelRefresh?: boolean,
     meta?: mixed,
   |};
-  declare type FetchContext<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData> = {|
+  declare export type FetchContext<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData> = {|
     fetchFn: () => mixed | Promise<mixed>,
     fetchOptions?: FetchOptions,
     options: QueryOptions<TQueryFnData, TError, TData>,
     queryKey: QueryKey,
     state: QueryState<TData, TError>,
   |};
-  declare type QueryBehavior<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData> = {|
+  declare export type QueryBehavior<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData> = {|
     onFetch: (context: FetchContext<TQueryFnData, TError, TData>) => void,
   |};
-  declare type QueryConfig<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData> = {|
+  declare export type QueryConfig<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData> = {|
     cache: QueryCache,
     queryKey: QueryKey,
     queryHash: string,
@@ -321,9 +321,9 @@ declare module "react-query" {
     defaultOptions?: QueryOptions<TQueryFnData, TError, TData>,
     state?: QueryState<TData, TError>,
   |};
-  declare type EnumStatus = "idle" | "loading" | "success" | "error";
+  declare export type EnumStatus = "idle" | "loading" | "success" | "error";
   declare export type QueryStatus = EnumStatus;
-  declare type QueryState<TData = mixed, TError = mixed> = {|
+  declare export type QueryState<TData = mixed, TError = mixed> = {|
     data: void | TData,
     dataUpdateCount: number,
     dataUpdatedAt: number,
@@ -338,26 +338,26 @@ declare module "react-query" {
     status: QueryStatus,
   |};
 
-  declare type InitialDataFunction<TData> = () => void | TData;
-  declare type QueryKey = string | $ReadOnlyArray<mixed>;
-  declare type PageParam = mixed;
-  declare type QueryKeyHashFunction = (queryKey: QueryKey) => string;
-  declare type QueryFunctionContext<TQueryKey = QueryKey, TPageParam = PageParam> = {|
+  declare export type InitialDataFunction<TData> = () => void | TData;
+  declare export type QueryKey = string | $ReadOnlyArray<mixed>;
+  declare export type PageParam = mixed;
+  declare export type QueryKeyHashFunction = (queryKey: QueryKey) => string;
+  declare export type QueryFunctionContext<TQueryKey = QueryKey, TPageParam = PageParam> = {|
     queryKey: TQueryKey,
     pageParam?: TPageParam,
   |};
-  declare type QueryFunction<TQueryFnData, TQueryKey = QueryKey, TPageParam = PageParam> = (
+  declare export type QueryFunction<TQueryFnData, TQueryKey = QueryKey, TPageParam = PageParam> = (
     context: QueryFunctionContext<QueryKey, PageParam>
   ) => Promise<TQueryFnData> | TQueryFnData;
-  declare type GetPreviousPageParamFunction<TQueryFnData = mixed, U = mixed> = (
+  declare export type GetPreviousPageParamFunction<TQueryFnData = mixed, U = mixed> = (
     firstPage: TQueryFnData,
     allPages: TQueryFnData[]
   ) => U;
-  declare type GetNextPageParamFunction<TQueryFnData = mixed, U = mixed> = (
+  declare export type GetNextPageParamFunction<TQueryFnData = mixed, U = mixed> = (
     lastPage: TQueryFnData,
     allPages: TQueryFnData[]
   ) => U;
-  declare type QueryOptions<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData> = {|
+  declare export type QueryOptions<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData> = {|
     retry?: RetryValue<TError>,
     retryDelay?: RetryDelayValue<TError>,
     cacheTime?: number,
@@ -388,7 +388,7 @@ declare module "react-query" {
     ...QueryOptions<TQueryFnData, TError, TData>,
     staleTime?: number,
   |};
-  declare type PlaceholderDataFunction<TResult> = () => void | TResult;
+  declare export type PlaceholderDataFunction<TResult> = () => void | TResult;
 
   declare export type QueryObserverOptions<
     TQueryFnData,
@@ -491,7 +491,7 @@ declare module "react-query" {
     placeholderData?: TData | PlaceholderDataFunction<TData>,
   |};
 
-  declare type InfiniteQueryObserverOptions<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData, TQueryData = TQueryFnData> =
+  declare export type InfiniteQueryObserverOptions<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData, TQueryData = TQueryFnData> =
     QueryObserverOptions<
       TQueryFnData,
       TError,
@@ -499,7 +499,7 @@ declare module "react-query" {
       InfiniteData<TQueryData>
     >;
 
-  declare type QueryObserverBaseResult<TData = mixed, TError = mixed> = {|
+  declare export type QueryObserverBaseResult<TData = mixed, TError = mixed> = {|
     data: void | TData,
     dataUpdatedAt: number,
     error: TError | null,
@@ -524,7 +524,7 @@ declare module "react-query" {
     status: QueryStatus,
   |};
 
-  declare type QueryObserverIdleResult<TData = mixed, TError = mixed> = {|
+  declare export type QueryObserverIdleResult<TData = mixed, TError = mixed> = {|
     ...QueryObserverBaseResult<TData, TError>,
     error: null,
     isError: false,
@@ -536,7 +536,7 @@ declare module "react-query" {
     status: "idle",
   |};
 
-  declare type QueryObserverLoadingResult<TData = mixed, TError = mixed> = {|
+  declare export type QueryObserverLoadingResult<TData = mixed, TError = mixed> = {|
     ...QueryObserverBaseResult<TData, TError>,
     error: null,
     isError: false,
@@ -548,7 +548,7 @@ declare module "react-query" {
     status: "loading",
   |};
 
-  declare type QueryObserverLoadingErrorResult<TData = mixed, TError = mixed> = {|
+  declare export type QueryObserverLoadingErrorResult<TData = mixed, TError = mixed> = {|
     ...QueryObserverBaseResult<TData, TError>,
     error: TError,
     isError: true,
@@ -560,7 +560,7 @@ declare module "react-query" {
     status: "error",
   |};
 
-  declare type QueryObserverRefetchErrorResult<TData = mixed, TError = mixed> = {|
+  declare export type QueryObserverRefetchErrorResult<TData = mixed, TError = mixed> = {|
     ...QueryObserverBaseResult<TData, TError>,
     data: TData,
     error: TError,
@@ -573,7 +573,7 @@ declare module "react-query" {
     status: "error",
   |};
 
-  declare type QueryObserverSuccessResult<TData = mixed, TError = mixed> = {|
+  declare export type QueryObserverSuccessResult<TData = mixed, TError = mixed> = {|
     ...QueryObserverBaseResult<TData, TError>,
     data: TData,
     error: null,
@@ -599,7 +599,7 @@ declare module "react-query" {
     pageParams: mixed[],
   |};
 
-  declare type InfiniteQueryObserverBaseResult<TData = mixed, TError = mixed> = {|
+  declare export type InfiniteQueryObserverBaseResult<TData = mixed, TError = mixed> = {|
     ...QueryObserverBaseResult<InfiniteData<TData>, TError>,
     fetchNextPage: (
       options?: FetchNextPageOptions<mixed>
@@ -613,7 +613,7 @@ declare module "react-query" {
     isFetchingPreviousPage: boolean,
   |};
 
-  declare type InfiniteQueryObserverIdleResult<TData = mixed, TError = mixed> = {|
+  declare export type InfiniteQueryObserverIdleResult<TData = mixed, TError = mixed> = {|
     ...InfiniteQueryObserverBaseResult<TData, TError>,
     error: null,
     isError: false,
@@ -625,7 +625,7 @@ declare module "react-query" {
     status: "idle",
   |};
 
-  declare type InfiniteQueryObserverLoadingResult<TData = mixed, TError = mixed> = {|
+  declare export type InfiniteQueryObserverLoadingResult<TData = mixed, TError = mixed> = {|
     ...InfiniteQueryObserverBaseResult<TData, TError>,
     error: null,
     isError: false,
@@ -637,7 +637,7 @@ declare module "react-query" {
     status: "loading",
   |};
 
-  declare type InfiniteQueryObserverLoadingErrorResult<TData = mixed, TError = mixed> = {|
+  declare export type InfiniteQueryObserverLoadingErrorResult<TData = mixed, TError = mixed> = {|
     ...InfiniteQueryObserverBaseResult<TData, TError>,
     error: TError,
     isError: true,
@@ -649,7 +649,7 @@ declare module "react-query" {
     status: "error",
   |};
 
-  declare type InfiniteQueryObserverRefetchErrorResult<TData = mixed, TError = mixed> = {|
+  declare export type InfiniteQueryObserverRefetchErrorResult<TData = mixed, TError = mixed> = {|
     ...InfiniteQueryObserverBaseResult<TData, TError>,
     data: InfiniteData<TData>,
     error: TError,
@@ -662,7 +662,7 @@ declare module "react-query" {
     status: "error",
   |};
 
-  declare type InfiniteQueryObserverSuccessResult<TData = mixed, TError = mixed> = {|
+  declare export type InfiniteQueryObserverSuccessResult<TData = mixed, TError = mixed> = {|
     ...InfiniteQueryObserverBaseResult<TData, TError>,
     data: InfiniteData<TData>,
     error: null,
@@ -682,11 +682,11 @@ declare module "react-query" {
     | InfiniteQueryObserverRefetchErrorResult<TData, TError>
     | InfiniteQueryObserverSuccessResult<TData, TError>;
 
-  declare type QueryObserverListener<TData = mixed, TError = mixed> = (
+  declare export type QueryObserverListener<TData = mixed, TError = mixed> = (
     result: QueryObserverResult<TData, TError>
   ) => void;
 
-  declare type ObserverFetchOptions = {|
+  declare export type ObserverFetchOptions = {|
     ...FetchOptions,
     throwOnError?: boolean,
   |};
@@ -726,7 +726,7 @@ declare module "react-query" {
     onQueryUpdate(action: Action<TData, TError>): void;
   }
 
-  declare type QueriesObserverListener<TData = mixed, TError = mixed> = (
+  declare export type QueriesObserverListener<TData = mixed, TError = mixed> = (
     result: $ReadOnlyArray<QueryObserverResult<TData, TError>>
   ) => void;
   declare export class QueriesObserver<
@@ -747,7 +747,7 @@ declare module "react-query" {
     getCurrentResult(): QueryObserverResult<TData, TError>[];
   }
 
-  declare type InfiniteQueryObserverListener<TData = mixed, TError = mixed> = (
+  declare export type InfiniteQueryObserverListener<TData = mixed, TError = mixed> = (
     result: InfiniteQueryObserverResult<TData, TError>
   ) => void;
 
@@ -811,9 +811,9 @@ declare module "react-query" {
     ): Promise<InfiniteQueryObserverResult<TData, TError>>;
   }
 
-  declare type SetDataOptions = {| updatedAt?: number |};
+  declare export type SetDataOptions = {| updatedAt?: number |};
 
-  declare class Query<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData> {
+  declare export class Query<TQueryFnData = mixed, TError = mixed, TData = TQueryFnData> {
     +queryKey: QueryKey;
     +queryHash: string;
     +options: QueryOptions<TQueryFnData, TError, TData>;
@@ -847,7 +847,7 @@ declare module "react-query" {
    *
    */
 
-  declare type MutationConfig<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
+  declare export type MutationConfig<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
     mutationId: number,
     mutationCache: MutationCache,
     options: MutationOptions<TData, TError, TVariables, TContext>,
@@ -855,14 +855,14 @@ declare module "react-query" {
     state?: MutationState<TData, TError, TVariables, TContext>,
   |};
 
-  declare type MutationKey = QueryKey;
+  declare export type MutationKey = QueryKey;
   declare export type MutationStatus = EnumStatus;
 
-  declare type MutationFunction<TData, TVariables> = (
+  declare export type MutationFunction<TData, TVariables> = (
     variables: TVariables
   ) => Promise<TData>;
 
-  declare type MutationOptions<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
+  declare export type MutationOptions<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
     mutationFn?: MutationFunction<TData, TVariables>,
     mutationKey?: MutationKey,
     variables?: TVariables,
@@ -887,7 +887,7 @@ declare module "react-query" {
     retryDelay?: RetryDelayValue<TError>,
   |};
 
-  declare type MutationObserverOptions<
+  declare export type MutationObserverOptions<
     TData = mixed,
     TError = mixed,
     TVariables = mixed,
@@ -897,7 +897,7 @@ declare module "react-query" {
     useErrorBoundary?: boolean,
   |};
 
-  declare type MutateOptions<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
+  declare export type MutateOptions<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
     onSuccess?: (
       data: TData,
       variables: TVariables,
@@ -916,12 +916,12 @@ declare module "react-query" {
     ) => Promise<void> | void,
   |};
 
-  declare type MutateFunction<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = (
+  declare export type MutateFunction<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = (
     variables: TVariables,
     options?: MutateOptions<TData, TError, TVariables, TContext>
   ) => Promise<TData>;
 
-  declare type MutationObserverResult<
+  declare export type MutationObserverResult<
     TData = mixed,
     TError = mixed,
     TVariables = mixed,
@@ -936,11 +936,11 @@ declare module "react-query" {
     reset: () => void,
   |};
 
-  declare type DefaultOptions = {|
+  declare export type DefaultOptions = {|
     queries?: QueryObserverOptions<any, any, any, any>,
     mutations?: MutationObserverOptions<any, any, any, any>,
   |};
-  declare type MutationState<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
+  declare export type MutationState<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = {|
     context: void | TContext,
     data: void | TData,
     error: TError | null,
@@ -950,13 +950,13 @@ declare module "react-query" {
     variables: void | TVariables,
   |};
 
-  declare type LoadingAction<TVariables, TContext> = {|
+  declare export type LoadingAction<TVariables, TContext> = {|
     type: "loading",
     variables?: TVariables,
     context?: TContext,
   |};
 
-  declare type SetMutationStateAction<
+  declare export type SetMutationStateAction<
     TData = mixed,
     TError = mixed,
     TVariables = mixed,
@@ -966,7 +966,7 @@ declare module "react-query" {
     state: MutationState<TData, TError, TVariables, TContext>,
   |};
 
-  declare type MutationAction<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> =
+  declare export type MutationAction<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> =
     | ContinueAction
     | ErrorAction<TError>
     | FailedAction
@@ -990,7 +990,7 @@ declare module "react-query" {
     execute(): Promise<TData>;
   }
 
-  declare type MutationObserverListener<
+  declare export type MutationObserverListener<
     TData = mixed,
     TError = mixed,
     TVariables = mixed,
@@ -1030,7 +1030,7 @@ declare module "react-query" {
     ): Promise<TData>;
   }
 
-  declare type MutationCacheListener = (
+  declare export type MutationCacheListener = (
     mutation?: Mutation<any, any, any, any>
   ) => void;
   declare export class MutationCache
@@ -1050,7 +1050,7 @@ declare module "react-query" {
     resumePausedMutations(): Promise<void>;
   }
 
-  declare type UseBaseQueryOptions<
+  declare export type UseBaseQueryOptions<
     TQueryFnData = mixed,
     TError = mixed,
     TData = TQueryFnData,
@@ -1063,14 +1063,14 @@ declare module "react-query" {
     TData = TQueryFnData,
   > = UseBaseQueryOptions<TQueryFnData, TError, TData, TQueryFnData>;
 
-  declare type UseInfiniteQueryOptions<
+  declare export type UseInfiniteQueryOptions<
     TQueryFnData = mixed,
     TError = mixed,
     TData = TQueryFnData,
     TQueryData = TQueryFnData,
   > = InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryData>;
 
-  declare type UseBaseQueryResult<TData = mixed, TError = mixed> = QueryObserverResult<
+  declare export type UseBaseQueryResult<TData = mixed, TError = mixed> = QueryObserverResult<
     TData,
     TError>;
 
@@ -1078,12 +1078,12 @@ declare module "react-query" {
     TData,
     TError>;
 
-  declare type UseInfiniteQueryResult<
+  declare export type UseInfiniteQueryResult<
     TData,
     TError
   > = InfiniteQueryObserverResult<TData, TError>;
 
-  declare type UseMutationOptions<
+  declare export type UseMutationOptions<
     TData = mixed,
     TError = mixed,
     TVariables = mixed,
@@ -1112,12 +1112,12 @@ declare module "react-query" {
     useErrorBoundary?: boolean,
   |};
 
-  declare type UseMutateFunction<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = (
+  declare export type UseMutateFunction<TData = mixed, TError = mixed, TVariables = mixed, TContext = mixed> = (
     variables: TVariables,
     options?: MutateOptions<TData, TError, TVariables, TContext>
   ) => void;
 
-  declare type UseMutateAsyncFunction<
+  declare export type UseMutateAsyncFunction<
     TData = mixed,
     TError = mixed,
     TVariables = mixed,
@@ -1232,7 +1232,7 @@ declare module "react-query" {
         children?: React$Node,
       |}> {}
 
-  declare type QueryErrorResetBoundaryValue = {|
+  declare export type QueryErrorResetBoundaryValue = {|
     clearReset: () => void,
     isReset: () => boolean,
     reset: () => void,
@@ -1251,11 +1251,11 @@ declare module "react-query" {
     error: (...args: mixed[]) => void,
   |}): void;
 
-  declare type NotifyCallback = () => void;
-  declare type NotifyFunction = (callback: () => void) => void;
-  declare type BatchNotifyFunction = (callback: () => void) => void;
+  declare export type NotifyCallback = () => void;
+  declare export type NotifyFunction = (callback: () => void) => void;
+  declare export type BatchNotifyFunction = (callback: () => void) => void;
 
-  declare class NotifyManager {
+  declare export class NotifyManager {
     batch<T>(callback: () => T): T;
     schedule(callback: NotifyCallback): void;
     batchCalls<T>(callback: T): T;

--- a/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/react-query_v3.x.x.js
+++ b/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/react-query_v3.x.x.js
@@ -11,31 +11,31 @@ declare module "react-query" {
   declare type QueryCacheListener = (query?: Query<any, any, any>) => void;
 
   declare export class QueryCache extends Subscribable<QueryCacheListener> {
-    build<TData, TError: Error, TQueryFnData: TData>(
+    build<TQueryFnData, TError: Error, TData = TQueryFnData>(
       client: QueryClient,
-      options: QueryOptions<TData, TError, TQueryFnData>,
+      options: QueryOptions<TQueryFnData, TError, TData>,
       state?: QueryState<TData, TError>
-    ): Query<TData, TError, TQueryFnData>;
+    ): Query<TQueryFnData, TError, TData>;
     add(query: Query<any, any, any>): void;
     remove(query: Query<any, any, any>): void;
     clear(): void;
-    get<TData, TError: Error, TQueryFnData: TData>(
+    get<TQueryFnData, TError: Error, TData = TQueryFnData>(
       queryHash: string
-    ): ?Query<TData, TError, TQueryFnData>;
+    ): ?Query<TQueryFnData, TError, TData>;
     getAll(): Query<any, any, any>[];
-    find<TData, TError: Error, TQueryFnData: TData>(
+    find<TQueryFnData, TError: Error, TData = TQueryFnData>(
       queryKey: QueryKey,
       filters?: QueryFilters
-    ): ?Query<TData, TError, TQueryFnData>;
-    findAll<TData, TError: Error, TQueryFnData: TData>(
+    ): ?Query<TQueryFnData, TError, TData>;
+    findAll<TQueryFnData, TError: Error, TData = TQueryFnData>(
       queryKey?: QueryKey,
       filters?: QueryFilters
-    ): Query<TData, TError, TQueryFnData>[];
-    findAll<TData, TError: Error, TQueryFnData: TData>(
+    ): Query<TQueryFnData, TError, TData>[];
+    findAll<TQueryFnData, TError: Error, TData = TQueryFnData>(
       filters?: QueryFilters
-    ): Query<TData, TError, TQueryFnData>[];
-    notify<TData, TError: Error, TQueryFnData: TData>(
-      query?: Query<TData, TError, TQueryFnData>
+    ): Query<TQueryFnData, TError, TData>[];
+    notify<TQueryFnData, TError: Error, TData = TQueryFnData>(
+      query?: Query<TQueryFnData, TError, TData>
     ): void;
     onFocus(): void;
     onOnline(): void;
@@ -57,8 +57,8 @@ declare module "react-query" {
     /**
      * Include queries matching this predicate function
      */
-    predicate?: <TData, TError: Error, TQueryFnData: TData>(
-      query: Query<TData, TError, TQueryFnData>
+    predicate?: <TQueryFnData, TError: Error, TData = TQueryFnData>(
+      query: Query<TQueryFnData, TError, TData>
     ) => boolean,
     /**
      * Include queries matching this query key
@@ -137,30 +137,30 @@ declare module "react-query" {
       options?: RefetchOptions
     ): Promise<void>;
 
-    fetchQuery<TData, TError: Error, TQueryFnData: TData>(
-      options: FetchQueryOptions<TData, TError, TQueryFnData>
+    fetchQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
+      options: FetchQueryOptions<TQueryFnData, TError, TData>
     ): Promise<TData>;
-    fetchQuery<TData, TError: Error, TQueryFnData: TData>(
+    fetchQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
       queryKey: QueryKey,
-      options?: FetchQueryOptions<TData, TError, TQueryFnData>
+      options?: FetchQueryOptions<TQueryFnData, TError, TData>
     ): Promise<TData>;
-    fetchQuery<TData, TError: Error, TQueryFnData: TData>(
+    fetchQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
       queryKey: QueryKey,
       queryFn: QueryFunction<TQueryFnData | TData>,
-      options?: FetchQueryOptions<TData, TError, TQueryFnData>
+      options?: FetchQueryOptions<TQueryFnData, TError, TData>
     ): Promise<TData>;
 
-    prefetchQuery<TData, TError: Error, TQueryFnData: TData>(
-      options: FetchQueryOptions<TData, TError, TQueryFnData>
+    prefetchQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
+      options: FetchQueryOptions<TQueryFnData, TError, TData>
     ): Promise<void>;
-    prefetchQuery<TData, TError: Error, TQueryFnData: TData>(
+    prefetchQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
       queryKey: QueryKey,
-      options?: FetchQueryOptions<TData, TError, TQueryFnData>
+      options?: FetchQueryOptions<TQueryFnData, TError, TData>
     ): Promise<void>;
-    prefetchQuery<TData, TError: Error, TQueryFnData: TData>(
+    prefetchQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
       queryKey: QueryKey,
       queryFn: QueryFunction<TQueryFnData>,
-      options?: FetchQueryOptions<TData, TError, TQueryFnData>
+      options?: FetchQueryOptions<TQueryFnData, TError, TData>
     ): Promise<void>;
 
     cancelMutations(): Promise<void>;
@@ -303,22 +303,22 @@ declare module "react-query" {
     cancelRefresh?: boolean,
     meta?: mixed,
   |};
-  declare type FetchContext<TData, TError: Error, TQueryFnData: TData> = {|
+  declare type FetchContext<TQueryFnData, TError: Error, TData = TQueryFnData> = {|
     fetchFn: () => mixed | Promise<mixed>,
     fetchOptions?: FetchOptions,
-    options: QueryOptions<TData, TError, TQueryFnData>,
+    options: QueryOptions<TQueryFnData, TError, TData>,
     queryKey: QueryKey,
     state: QueryState<TData, TError>,
   |};
-  declare type QueryBehavior<TData, TError: Error, TQueryFnData: TData> = {|
-    onFetch: (context: FetchContext<TData, TError, TQueryFnData>) => void,
+  declare type QueryBehavior<TQueryFnData, TError: Error, TData = TQueryFnData> = {|
+    onFetch: (context: FetchContext<TQueryFnData, TError, TData>) => void,
   |};
-  declare type QueryConfig<TData, TError: Error, TQueryFnData: TData> = {|
+  declare type QueryConfig<TQueryFnData, TError: Error, TData = TQueryFnData> = {|
     cache: QueryCache,
     queryKey: QueryKey,
     queryHash: string,
-    options?: QueryOptions<TData, TError, TQueryFnData>,
-    defaultOptions?: QueryOptions<TData, TError, TQueryFnData>,
+    options?: QueryOptions<TQueryFnData, TError, TData>,
+    defaultOptions?: QueryOptions<TQueryFnData, TError, TData>,
     state?: QueryState<TData, TError>,
   |};
   declare type EnumStatus = "idle" | "loading" | "success" | "error";
@@ -356,7 +356,7 @@ declare module "react-query" {
     lastPage: TQueryFnData,
     allPages: TQueryFnData[]
   ) => U;
-  declare type QueryOptions<TData, TError: Error, TQueryFnData: TData> = {|
+  declare type QueryOptions<TQueryFnData, TError: Error, TData = TQueryFnData> = {|
     retry?: RetryValue<TError>,
     retryDelay?: RetryDelayValue<TError>,
     cacheTime?: number,
@@ -366,7 +366,7 @@ declare module "react-query" {
     queryKey?: QueryKey,
     queryKeyHashFn?: QueryKeyHashFunction,
     initialData?: TData | InitialDataFunction<TData>,
-    behavior?: QueryBehavior<TData, TError, TQueryFnData>,
+    behavior?: QueryBehavior<TQueryFnData, TError, TData>,
     /**
      * Set this to `false` to disable structural sharing between query results.
      * Defaults to `true`.
@@ -383,19 +383,19 @@ declare module "react-query" {
      */
     getNextPageParam?: GetNextPageParamFunction<TQueryFnData, any>,
   |};
-  declare export type FetchQueryOptions<TData, TError: Error, TQueryFnData: TData> = {|
-    ...QueryOptions<TData, TError, TQueryFnData>,
+  declare export type FetchQueryOptions<TQueryFnData, TError: Error, TData = TQueryFnData> = {|
+    ...QueryOptions<TQueryFnData, TError, TData>,
     staleTime?: number,
   |};
   declare type PlaceholderDataFunction<TResult> = () => ?TResult;
 
   declare export type QueryObserverOptions<
-    TData,
+    TQueryFnData,
     TError: Error,
-    TQueryFnData: TData,
-    TQueryData: TQueryFnData
+    TData = TQueryFnData,
+    TQueryData = TQueryFnData
   > = {|
-    ...QueryOptions<TData, TError, TQueryFnData>,
+    ...QueryOptions<TQueryFnData, TError, TData>,
     /**
      * Set this to `false` to disable automatic refetching when the query mounts or changes query keys.
      * To refetch the query, use the `refetch` method returned from the `useQuery` instance.
@@ -490,7 +490,7 @@ declare module "react-query" {
     placeholderData?: TData | PlaceholderDataFunction<TData>,
   |};
 
-  // declare type InfiniteQueryObserverOptions<TData, TError: Error, TQueryFnData: TData, TQueryData: TQueryFnData> = QueryObserverOptions<InfiniteData<TData>,
+  // declare type InfiniteQueryObserverOptions<TQueryFnData, TError: Error, TData = TQueryFnData, TQueryData: TQueryFnData> = QueryObserverOptions<InfiniteData<TData>,
   //   TError,
   //   TQueryFnData,
   //   InfiniteData<TQueryData>>;
@@ -693,17 +693,17 @@ declare module "react-query" {
   |};
 
   declare export class QueryObserver<
-      TData,
+      TQueryFnData,
       TError: Error,
-      TQueryFnData: TData,
-      TQueryData
+      TData = TQueryFnData,
+      TQueryData = TQueryFnData,
     >
     extends Subscribable<QueryObserverListener<TData, TError>> {
-    +options: QueryObserverOptions<TData, TError, TQueryFnData, TQueryData>;
+    +options: QueryObserverOptions<TQueryFnData, TError, TData, TQueryData>;
 
     constructor(
       client: QueryClient,
-      options: QueryObserverOptions<TData, TError, TQueryFnData, TQueryData>
+      options: QueryObserverOptions<TQueryFnData, TError, TData, TQueryData>
     ): this;
 
     willLoadOnMount(): boolean;
@@ -713,7 +713,7 @@ declare module "react-query" {
     willFetchOnWindowFocus(): boolean;
     destroy(): void;
     setOptions(
-      options?: QueryObserverOptions<TData, TError, TQueryFnData, TQueryData>
+      options?: QueryObserverOptions<TQueryFnData, TError, TData, TQueryData>
     ): void;
     getCurrentResult(): QueryObserverResult<TData, TError>;
     getNextResult(
@@ -731,19 +731,19 @@ declare module "react-query" {
     result: $ReadOnlyArray<QueryObserverResult<TData, TError>>
   ) => void;
   declare export class QueriesObserver<
-      TData,
+      TQueryFnData,
       TError: Error,
-      TQueryFnData: TData,
-      TQueryData
+      TData = TQueryFnData,
+      TQueryData = TQueryFnData,
     >
     extends Subscribable<QueriesObserverListener<TData, TError>> {
     constructor(
       client: QueryClient,
-      queries?: QueryObserverOptions<TData, TError, TQueryFnData, TQueryData>[]
+      queries?: QueryObserverOptions<TQueryFnData, TError, TData, TQueryData>[]
     ): this;
     destroy(): void;
     setQueries(
-      queries: QueryObserverOptions<TData, TError, TQueryFnData, TQueryData>[]
+      queries: QueryObserverOptions<TQueryFnData, TError, TData, TQueryData>[]
     ): void;
     getCurrentResult(): QueryObserverResult<TData, TError>[];
   }
@@ -801,15 +801,15 @@ declare module "react-query" {
 
   declare type SetDataOptions = {| updatedAt?: number |};
 
-  declare class Query<TData, TError: Error, TQueryFnData: TData> {
+  declare class Query<TQueryFnData, TError: Error, TData = TQueryFnData> {
     +queryKey: QueryKey;
     +queryHash: string;
-    +options: QueryOptions<TData, TError, TQueryFnData>;
+    +options: QueryOptions<TQueryFnData, TError, TData>;
     +state: QueryState<TData, TError>;
     +cacheTime: number;
 
-    constructor(config: QueryConfig<TData, TError, TQueryFnData>): this;
-    setDefaultOptions(options: QueryOptions<TData, TError, TQueryFnData>): void;
+    constructor(config: QueryConfig<TQueryFnData, TError, TData>): this;
+    setDefaultOptions(options: QueryOptions<TQueryFnData, TError, TData>): void;
     setData(updater: Updater<?TData, TData>, options?: SetDataOptions): TData;
     setState(state: QueryState<TData, TError>): void;
     cancel(options?: CancelOptions): Promise<void>;
@@ -824,7 +824,7 @@ declare module "react-query" {
     removeObserver(observer: QueryObserver<any, any, any, any>): void;
     invalidate(): void;
     fetch(
-      options?: QueryOptions<TData, TError, TQueryFnData>,
+      options?: QueryOptions<TQueryFnData, TError, TData>,
       fetchOptions?: FetchOptions
     ): Promise<TData>;
   }
@@ -1039,24 +1039,24 @@ declare module "react-query" {
   }
 
   declare type UseBaseQueryOptions<
-    TData,
+    TQueryFnData,
     TError: Error,
-    TQueryFnData: TData,
-    TQueryData: TQueryFnData
-  > = QueryObserverOptions<TData, TError, TQueryFnData, TQueryData>;
+    TData = TQueryFnData,
+    TQueryData = TQueryFnData,
+  > = QueryObserverOptions<TQueryFnData, TError, TData, TQueryData>;
 
   declare export type UseQueryOptions<
-    TData,
+    TQueryFnData,
     TError: Error,
-    TQueryFnData: TData
-  > = UseBaseQueryOptions<TData, TError, TQueryFnData, TQueryFnData>;
+    TData = TQueryFnData,
+  > = UseBaseQueryOptions<TQueryFnData, TError, TData, TQueryFnData>;
 
   // declare type UseInfiniteQueryOptions<
   //   TData,
   //   TError,
   //   TQueryFnData: TData,
   //   TQueryData: TQueryFnData
-  // > = InfiniteQueryObserverOptions<TData, TError, TQueryFnData, TQueryData>;
+  // > = InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryData>;
 
   declare type UseBaseQueryResult<TData, TError: Error> = QueryObserverResult<
     TData,
@@ -1137,21 +1137,21 @@ declare module "react-query" {
     variables: ?TVariables,
   |};
 
-  declare export function useQuery<TData, TError: Error, TQueryFnData: TData>(
-    options: UseQueryOptions<TData, TError, TQueryFnData>
+  declare export function useQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
+    options: UseQueryOptions<TQueryFnData, TError, TData>
   ): UseQueryResult<TData, TError>;
-  declare export function useQuery<TData, TError: Error, TQueryFnData: TData>(
+  declare export function useQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
     queryKey: QueryKey,
-    options?: UseQueryOptions<TData, TError, TQueryFnData>
+    options?: UseQueryOptions<TQueryFnData, TError, TData>
   ): UseQueryResult<TData, TError>;
-  declare export function useQuery<TData, TError: Error, TQueryFnData: TData>(
+  declare export function useQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
     queryKey: QueryKey,
     queryFn: QueryFunction<TQueryFnData>,
-    options?: UseQueryOptions<TData, TError, TQueryFnData>
+    options?: UseQueryOptions<TQueryFnData, TError, TData>
   ): UseQueryResult<TData, TError>;
 
-  declare export function useQueries<TData, TError: Error, TQueryFnData: TData>(
-    queries: UseQueryOptions<TData, TError, TQueryFnData>[]
+  declare export function useQueries<TQueryFnData, TError: Error, TData = TQueryFnData>(
+    queries: UseQueryOptions<TQueryFnData, TError, TData>[]
   ): UseQueryResult<TData, TError>[];
 
   // stub until bugs can be worked out:
@@ -1161,26 +1161,26 @@ declare module "react-query" {
     options?: any
   ): any;
   declare export function useInfiniteQuery<
-    TData,
+    TQueryFnData,
     TError: Error,
-    TQueryFnData: TData
+    TData = TQueryFnData
   >(
     queryKey: QueryKey,
     queryFn: QueryFunction<TData | TQueryFnData>,
     options?: any
   ): any;
 
-  // declare export function useInfiniteQuery<TData, TError: Error, TQueryFnData: TData>(
-  //   options: UseInfiniteQueryOptions<TData, TError, TQueryFnData>
+  // declare export function useInfiniteQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
+  //   options: UseInfiniteQueryOptions<TQueryFnData, TError, TData>
   // ): UseInfiniteQueryResult<TData, TError>;
-  // declare export function useInfiniteQuery<TData, TError: Error, TQueryFnData: TData>(
+  // declare export function useInfiniteQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
   //   queryKey: QueryKey,
-  //   options?: UseInfiniteQueryOptions<TData, TError, TQueryFnData>
+  //   options?: UseInfiniteQueryOptions<TQueryFnData, TError, TData>
   // ): UseInfiniteQueryResult<TData, TError>;
-  // declare export function useInfiniteQuery<TData, TError: Error, TQueryFnData: TData>(
+  // declare export function useInfiniteQuery<TQueryFnData, TError: Error, TData = TQueryFnData>(
   //   queryKey: QueryKey,
   //   queryFn: QueryFunction<TQueryFnData | TData>,
-  //   options?: UseInfiniteQueryOptions<TData, TError, TQueryFnData>
+  //   options?: UseInfiniteQueryOptions<TQueryFnData, TError, TData>
   // ): UseInfiniteQueryResult<TData, TError>;
 
   declare export function useMutation<

--- a/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/test_react-query.js
+++ b/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/test_react-query.js
@@ -2,17 +2,16 @@
 import { describe, it } from "flow-typed-test";
 import * as React from "react";
 import {
-  MutationCache,
-  QueryCache,
-  QueryClient,
-  QueryClientProvider,
-  QueryErrorResetBoundary,
-  type QueryObserverResult,
   focusManager,
   hashQueryKey,
   isCancelledError,
   isError,
+  MutationCache,
   onlineManager,
+  QueryCache,
+  QueryClient,
+  QueryClientProvider,
+  QueryErrorResetBoundary,
   setLogger,
   useInfiniteQuery,
   useIsFetching,
@@ -21,6 +20,12 @@ import {
   useQuery,
   useQueryClient,
   useQueryErrorResetBoundary,
+  type FetchNextPageOptions,
+  type FetchPreviousPageOptions,
+  type InfiniteData,
+  type InfiniteQueryObserverResult,
+  type QueryObserverResult,
+  type RefetchOptions,
 } from "react-query";
 
 describe("react-query", () => {
@@ -51,23 +56,6 @@ describe("react-query", () => {
 
     // $FlowExpectedError[incompatible-call]
     useIsFetching(() => {});
-  });
-
-  // basically not implemented. See comment at the top of the libdef file
-  it("useInfiniteQuery", () => {
-    // overloaded method calls
-    useInfiniteQuery({});
-    useInfiniteQuery("key", {});
-    useInfiniteQuery("key", () => true, {});
-
-    // should be an expected error but poorly typed
-    useInfiniteQuery(() => true);
-    // should be an expected error but poorly typed
-    useInfiniteQuery("key", []);
-    // should be an expected error but poorly typed
-    useInfiniteQuery("key", () => true, []);
-
-    (useInfiniteQuery({}): any); // poorly typed
   });
 
   // somewhat copied from the react-query unit tests https://github.com/tannerlinsley/react-query/tree/master/src/react/tests
@@ -119,10 +107,7 @@ describe("react-query", () => {
     (fromQueryFn.dataUpdatedAt: number);
     (fromQueryFn.errorUpdatedAt: number);
     (fromQueryFn.failureCount: number);
-    (fromQueryFn.refetch: (options?: {|
-      throwOnError?: boolean,
-      cancelRefetch?: boolean,
-    |}) => Promise<QueryObserverResult<string, null | Error>>);
+    (fromQueryFn.refetch: (options?: RefetchOptions) => Promise<QueryObserverResult<string, null | Error>>);
     (fromQueryFn.remove: () => void);
 
     // it should be possible to specify the result type
@@ -313,6 +298,242 @@ describe("react-query", () => {
     (out[1].data: ?boolean);
     (out[0].error: Error | null);
     (out[1].error: Error | null);
+  });
+
+  it("useInfiniteQuery", () => {
+    let queryInfo;
+
+    // overloaded method calls
+    useInfiniteQuery({});
+    useInfiniteQuery("key", {});
+    useInfiniteQuery("key", () => true, {});
+
+    // $FlowExpectedError[incompatible-call]
+    useInfiniteQuery(() => true);
+    // $FlowExpectedError[incompatible-call]
+    useInfiniteQuery("key", []);
+    // $FlowExpectedError[incompatible-call]
+    useInfiniteQuery("key", () => true, []);
+
+    // should accept tuple query key but will not be a tuple in query function context
+    queryInfo = useInfiniteQuery((["key"]: ["key"]), (context) => {
+      // ideally the query key type would be preserved
+      (context.queryKey[0]: mixed);
+      (context.queryKey[1]: mixed);
+    });
+
+    const noQueryFn = useInfiniteQuery("key");
+    (noQueryFn.data: void | InfiniteData<void>);
+    // $FlowExpectedError[incompatible-cast]
+    (noQueryFn.data: null);
+    (noQueryFn.error: null);
+
+    // it should infer the result type from the query function
+    const fromQueryFn = useInfiniteQuery("key", () => "test");
+    (fromQueryFn.data: void | InfiniteData<string>);
+    (fromQueryFn.error: null | Error);
+    (fromQueryFn.status: string);
+    (fromQueryFn.isIdle: boolean);
+    (fromQueryFn.isLoading: boolean);
+    (fromQueryFn.isSuccess: boolean);
+    (fromQueryFn.isError: boolean);
+    (fromQueryFn.isLoadingError: boolean);
+    (fromQueryFn.isRefetchError: boolean);
+    (fromQueryFn.isStale: boolean);
+    (fromQueryFn.isPlaceholderData: boolean);
+    (fromQueryFn.isPreviousData: boolean);
+    (fromQueryFn.isFetched: boolean);
+    (fromQueryFn.isFetchedAfterMount: boolean);
+    (fromQueryFn.isFetching: boolean);
+    (fromQueryFn.dataUpdatedAt: number);
+    (fromQueryFn.errorUpdatedAt: number);
+    (fromQueryFn.failureCount: number);
+    (fromQueryFn.refetch: (
+      options?: RefetchOptions
+    ) => Promise<QueryObserverResult<InfiniteData<string>, null | Error>>);
+    (fromQueryFn.remove: () => void);
+
+    (fromQueryFn.fetchNextPage: (
+      options?: FetchNextPageOptions<mixed>
+    ) => Promise<InfiniteQueryObserverResult<string, null | Error>>);
+    (fromQueryFn.fetchPreviousPage: (
+      options?: FetchPreviousPageOptions<mixed>
+    ) => Promise<InfiniteQueryObserverResult<string, null | Error>>);
+    (fromQueryFn.hasNextPage: void | boolean);
+    (fromQueryFn.hasPreviousPage: void | boolean);
+    (fromQueryFn.isFetchingNextPage: boolean);
+    (fromQueryFn.isFetchingPreviousPage: boolean);
+
+    // it should be possible to specify the result type
+    const withResult = useInfiniteQuery<string, _, _>("key", () => "test");
+    (withResult.data: void | InfiniteData<string>);
+    (withResult.error: Error | null);
+
+    // it should be possible to specify the error type
+    const withError = useInfiniteQuery<string, ReferenceError, _>("key", () => "test");
+    (withError.data: void | InfiniteData<string>);
+    (withError.error: ReferenceError | null);
+
+    // it should provide the result type in the configuration
+    useInfiniteQuery(["key"], async () => true, {
+      onSuccess: (data) => {
+        (data: InfiniteData<boolean>);
+      },
+      onSettled: (data) => {
+        (data: void | InfiniteData<boolean>);
+      },
+    });
+
+    // should error when the query function result does not match with the specified type
+    // $FlowExpectedError[incompatible-call]
+    useInfiniteQuery<number, _, _>("key", () => "test");
+
+    // it should infer the result type from a generic query function
+    function queryFn<T: string>(a?: T): Promise<T> {
+      // force cast
+      const out = (("": any): Promise<T>);
+      return out;
+    }
+
+    const fromGenericQueryFn = useInfiniteQuery("key", () => queryFn());
+    (fromGenericQueryFn.data: void | InfiniteData<string>);
+    (fromGenericQueryFn.error: Error | null);
+
+    const fromGenericOptionsQueryFn = useInfiniteQuery({
+      queryKey: "key",
+      queryFn: () => queryFn(),
+    });
+    (fromGenericOptionsQueryFn.data: void | InfiniteData<string>);
+    (fromGenericOptionsQueryFn.error: Error | null);
+
+    // All input options
+    useInfiniteQuery({
+      queryKey: "key",
+      queryFn: () => 10,
+      enabled: true,
+      retry: true,
+      retryOnMount: true,
+      retryDelay: 1,
+      staleTime: Infinity,
+      cacheTime: 5,
+      refetchInterval: false,
+      refetchIntervalInBackground: true,
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+      refetchOnMount: true,
+      retryOnMount: false,
+      notifyOnChangeProps: ["foo", "bar"],
+      notifyOnChangePropsExclusions: ["baz"],
+      onSuccess: (data) => {
+        (data: InfiniteData<number>);
+      },
+      onError: (error) => {
+        (error: Error);
+      },
+      onSettled: (data, error) => {
+        (data: void | InfiniteData<number>);
+        (error: Error | null);
+      },
+      useErrorBoundary: false,
+      select: (data) => {
+        return (data: InfiniteData<number>);
+      },
+      suspense: false,
+      keepPreviousData: false,
+      placeholderData: () => ({pages: [], pageParams: []}),
+    });
+
+    // retry
+    useInfiniteQuery({
+      queryKey: "key",
+      queryFn: () => true,
+      retry: 4,
+    });
+    useInfiniteQuery({
+      queryKey: "key",
+      queryFn: () => true,
+      retry: (failureCount, error) => {
+        (failureCount: number);
+        (error: Error);
+        return true;
+      },
+    });
+    // $FlowExpectedError[incompatible-call]
+    useInfiniteQuery({
+      queryKey: "key",
+      queryFn: () => true,
+      retry: "wrong",
+    });
+
+    // retryDelay
+    useInfiniteQuery({
+      queryKey: "key",
+      queryFn: () => true,
+      retryDelay: (failureCount, error) => {
+        (failureCount: number);
+        (error: Error);
+        return 10;
+      },
+    });
+
+    // refetchInterval
+    useInfiniteQuery({
+      queryKey: "key",
+      queryFn: () => true,
+      refetchInterval: 10,
+    });
+
+    // the "always" types
+    useInfiniteQuery({
+      queryKey: "key",
+      queryFn: () => true,
+      refetchOnWindowFocus: "always",
+      refetchOnReconnect: "always",
+      refetchOnMount: "always",
+    });
+    // $FlowExpectedError[incompatible-call]
+    useInfiniteQuery({
+      queryKey: "key",
+      queryFn: () => true,
+      refetchOnWindowFocus: "sometimes",
+    });
+    // $FlowExpectedError[incompatible-call]
+    useInfiniteQuery({
+      queryKey: "key",
+      queryFn: () => true,
+      refetchOnReconnect: "sometimes",
+    });
+    // $FlowExpectedError[incompatible-call]
+    useInfiniteQuery({
+      queryKey: "key",
+      queryFn: () => true,
+      refetchOnMount: "sometimes",
+    });
+
+    // placeholderData
+    useInfiniteQuery({
+      queryKey: "key",
+      queryFn: (): string => "string",
+      placeholderData: () => ({pages: ['diffstring'], pageParams: [0]}),
+    });
+    queryInfo = useInfiniteQuery<string, _, string>({
+      queryKey: "key",
+      queryFn: () => "string",
+      // $FlowExpectedError[incompatible-call]
+      placeholderData: () => ({wrong: 'stuff'}),
+    });
+    (queryInfo.data: void | InfiniteData<string>);
+
+    // select
+    // should be possible to change data type with select function
+    // queryInfo = useInfiniteQuery<string, _, number>("key", () => Promise.resolve("test"), {select: data => 123});
+    // (queryInfo.data: void | number);
+
+    // // should error if select function returns different type then specified
+    // useInfiniteQuery<string, _, number>("key", () => Promise.resolve("test"), {
+    //   // $FlowExpectedError[incompatible-call]
+    //   select: data => "hello"
+    // });
   });
 
   it("useMutation", () => {

--- a/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/test_react-query.js
+++ b/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/test_react-query.js
@@ -72,6 +72,8 @@ describe("react-query", () => {
 
   // somewhat copied from the react-query unit tests https://github.com/tannerlinsley/react-query/tree/master/src/react/tests
   it("useQuery", () => {
+    let queryInfo;
+
     // overloaded method calls
     useQuery({});
     useQuery("key", {});
@@ -264,11 +266,23 @@ describe("react-query", () => {
       queryFn: (): string => "string",
       placeholderData: () => "diffString",
     });
-    useQuery<string, _, _>({
+    queryInfo = useQuery<string, _, string>({
       queryKey: "key",
       queryFn: () => "string",
       // $FlowExpectedError[incompatible-call]
       placeholderData: () => 10,
+    });
+    (queryInfo.data: ?string);
+
+    // select
+    // should be possible to change data type with select function
+    queryInfo = useQuery<string, _, number>("key", () => Promise.resolve("test"), {select: data => 123});
+    (queryInfo.data: ?number);
+
+    // should error if select function returns different type then specified
+    useQuery<string, _, number>("key", () => Promise.resolve("test"), {
+      // $FlowExpectedError[incompatible-call]
+      select: data => "hello"
     });
   });
 

--- a/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/test_react-query.js
+++ b/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/test_react-query.js
@@ -526,14 +526,16 @@ describe("react-query", () => {
 
     // select
     // should be possible to change data type with select function
-    // queryInfo = useInfiniteQuery<string, _, number>("key", () => Promise.resolve("test"), {select: data => 123});
-    // (queryInfo.data: void | number);
+    queryInfo = useInfiniteQuery<string, _, number>("key", () => Promise.resolve("test"), {
+      select: data => ({...data, pages: data.pages.map(() => 123)}),
+    });
+    (queryInfo.data: void | InfiniteData<number>);
 
-    // // should error if select function returns different type then specified
-    // useInfiniteQuery<string, _, number>("key", () => Promise.resolve("test"), {
-    //   // $FlowExpectedError[incompatible-call]
-    //   select: data => "hello"
-    // });
+    // should error if select function returns different type then specified InfiniteData type
+    useInfiniteQuery<string, _, string>("key", () => Promise.resolve("test"), {
+      // $FlowExpectedError[incompatible-call]
+      select: data => "hello"
+    });
   });
 
   it("useMutation", () => {

--- a/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/test_react-query.js
+++ b/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/test_react-query.js
@@ -86,6 +86,13 @@ describe("react-query", () => {
     // $FlowExpectedError[incompatible-call]
     useQuery("key", () => true, []);
 
+    // should accept tuple query key but will not be a tuple in query function context
+    queryInfo = useQuery((["key"]: ["key"]), (context) => {
+      // ideally the query key type would be preserved
+      (context.queryKey[0]: mixed);
+      (context.queryKey[1]: mixed);
+    });
+
     const noQueryFn = useQuery("key");
     (noQueryFn.data: any);
     (noQueryFn.error: Error | null);

--- a/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/test_react-query.js
+++ b/definitions/npm/react-query_v3.x.x/flow_v0.104.x-/test_react-query.js
@@ -94,13 +94,15 @@ describe("react-query", () => {
     });
 
     const noQueryFn = useQuery("key");
-    (noQueryFn.data: any);
-    (noQueryFn.error: Error | null);
+    (noQueryFn.data: void);
+    // $FlowExpectedError[incompatible-cast]
+    (noQueryFn.data: null);
+    (noQueryFn.error: null);
 
     // it should infer the result type from the query function
     const fromQueryFn = useQuery("key", () => "test");
-    (fromQueryFn.data: ?string);
-    (fromQueryFn.error: any);
+    (fromQueryFn.data: void | string);
+    (fromQueryFn.error: null | Error);
     (fromQueryFn.status: string);
     (fromQueryFn.isIdle: boolean);
     (fromQueryFn.isLoading: boolean);
@@ -120,7 +122,7 @@ describe("react-query", () => {
     (fromQueryFn.refetch: (options?: {|
       throwOnError?: boolean,
       cancelRefetch?: boolean,
-    |}) => Promise<QueryObserverResult<string, Error>>);
+    |}) => Promise<QueryObserverResult<string, null | Error>>);
     (fromQueryFn.remove: () => void);
 
     // it should be possible to specify the result type
@@ -194,7 +196,9 @@ describe("react-query", () => {
         (error: Error | null);
       },
       useErrorBoundary: false,
-      select: (data) => data,
+      select: (data) => {
+        return (data: number);
+      },
       suspense: false,
       keepPreviousData: false,
       placeholderData: 0,
@@ -279,12 +283,12 @@ describe("react-query", () => {
       // $FlowExpectedError[incompatible-call]
       placeholderData: () => 10,
     });
-    (queryInfo.data: ?string);
+    (queryInfo.data: void | string);
 
     // select
     // should be possible to change data type with select function
     queryInfo = useQuery<string, _, number>("key", () => Promise.resolve("test"), {select: data => 123});
-    (queryInfo.data: ?number);
+    (queryInfo.data: void | number);
 
     // should error if select function returns different type then specified
     useQuery<string, _, number>("key", () => Promise.resolve("test"), {


### PR DESCRIPTION
- Links to documentation: react-query.tanstack.com
- Link to GitHub or NPM: https://github.com/tannerlinsley/react-query
- Type of contribution: fix

Other notes:
This fix a few issues.
- Infer data type from query function instead of reverse. See https://github.com/tannerlinsley/react-query/pull/1470
- Default generics to `mixed` like TypeScript does with `unknown`
- Use `$ReadOnlyArray` for query keys. See https://github.com/tannerlinsley/react-query/pull/1854
- Remove impossible null states (`void | T` instead of `?T`)
- Attempt to fix infinite query types
- Export all types
