### PR TITLE
[README] Add package health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
   width="400"
 />
 
-![Build](https://github.com/flow-typed/flow-typed/workflows/CI/badge.svg) [![npm](https://img.shields.io/npm/dm/flow-typed.svg)](https://www.npmjs.com/package/flow-typed)
+![Build](https://github.com/flow-typed/flow-typed/workflows/CI/badge.svg)
+[![npm](https://img.shields.io/npm/dm/flow-typed.svg)](https://www.npmjs.com/package/flow-typed)
 [![Join the chat at https://discordapp.com/invite/8ezwRUK](https://img.shields.io/discord/539606376339734558.svg?label=discord&logo=discord&logoColor=white)](https://discordapp.com/invite/8ezwRUK)
+[![flow-typed](https://snyk.io/advisor/npm-package/flow-typed/badge.svg)](https://snyk.io/advisor/npm-package/flow-typed)
 
 `flow-typed` is a [repository](https://github.com/flow-typed/flow-typed/tree/master/definitions) of third-party
 [library interface definitions](https://flow.org/en/docs/libdefs)


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Someone raised in this [issue](https://github.com/flow-typed/flow-typed/issues/3982) asking if this project is abandoned. It's not but I found this fancy dashboard from Snyk that also provides a package health badge which is pretty cool so users can see at a glimpse that this is a maintained project.

- Links to documentation: N/A
- Link to GitHub or NPM: N/A
- Type of contribution: N/A

Other notes:
Comes from here: https://snyk.io/advisor/npm-package/flow-typed

<img width="789" alt="Screen Shot 2021-03-23 at 9 20 39 am" src="https://user-images.githubusercontent.com/12436524/112066366-4f90ce00-8bba-11eb-93f6-2180cd16a5c8.png">


