### PR TITLE
[koa-] update supporting libs to module.exports

### DIFF
--- a/definitions/npm/koa-json-body_v5.x.x/flow_v0.53.x-/koa-json-body_v5.x.x.js
+++ b/definitions/npm/koa-json-body_v5.x.x/flow_v0.53.x-/koa-json-body_v5.x.x.js
@@ -9,5 +9,5 @@ declare module 'koa-json-body' {
     strict: boolean,
   |}>;
 
-  declare export default function body(options?: Options): Middleware;
+  declare module.exports: (options?: Options) => Middleware;
 }

--- a/definitions/npm/koa-json-body_v5.x.x/test_koa-json-body_v5.js
+++ b/definitions/npm/koa-json-body_v5.x.x/test_koa-json-body_v5.js
@@ -20,7 +20,7 @@ describe('koa-json-body', () => {
       limit: 1000000,
     });
 
-    // $FlowExpectedError
+    // $FlowExpectedError[prop-missing]
     body({
       foo: 'bar',
     });

--- a/definitions/npm/koa-send_v4.x.x/flow_v0.104.x-/koa-send_v4.x.x.js
+++ b/definitions/npm/koa-send_v4.x.x/flow_v0.104.x-/koa-send_v4.x.x.js
@@ -20,5 +20,5 @@ declare module 'koa-send' {
 
   declare export type SendResult = Promise<string>;
 
-  declare export default function send(ctx: Context, path: string, opts?: Options): SendResult;
+  declare module.exports: (ctx: Context, path: string, opts?: Options) => SendResult;
 }

--- a/definitions/npm/koa-send_v4.x.x/flow_v0.104.x-/test_koa-send_v4.x.x.js
+++ b/definitions/npm/koa-send_v4.x.x/flow_v0.104.x-/test_koa-send_v4.x.x.js
@@ -4,22 +4,22 @@ import type { Options, SendResult } from "koa-send";
 const ctx = {};
 const path = "/";
 
-// $FlowExpectedError (Must have ctx and path)
+// $FlowExpectedError[incompatible-call] (Must have ctx and path)
 send();
-// $FlowExpectedError (Must have path)
+// $FlowExpectedError[incompatible-call] (Must have path)
 send(ctx);
 send(ctx, path);
 
-// $FlowExpectedError (Can't use invalid option names)
+// $FlowExpectedError[prop-missing] (Can't use invalid option names)
 send(ctx, path, { hide: true });
 send(ctx, path, { hidden: true });
 
-// $FlowExpectedError (Must use proper types for options)
+// $FlowExpectedError[incompatible-call] (Must use proper types for options)
 send(ctx, path, { immutable: "true" });
 send(ctx, path, { immutable: true });
 
 send(ctx, path).then(result => {
-  // $FlowExpectedError (result should be a string)
+  // $FlowExpectedError[incompatible-cast] (result should be a string)
   (result: number);
   (result: string);
 });

--- a/definitions/npm/koa-send_v4.x.x/flow_v0.56.x-v0.103.x/koa-send_v4.x.x.js
+++ b/definitions/npm/koa-send_v4.x.x/flow_v0.56.x-v0.103.x/koa-send_v4.x.x.js
@@ -20,5 +20,5 @@ declare module 'koa-send' {
 
   declare export type SendResult = Promise<string>;
 
-  declare export default function send(ctx: Context, path: string, opts?: Options): SendResult;
+  declare module.exports: (ctx: Context, path: string, opts?: Options) => SendResult;
 }

--- a/definitions/npm/koa-send_v4.x.x/flow_v0.56.x-v0.103.x/test_koa-send_v4.x.x.js
+++ b/definitions/npm/koa-send_v4.x.x/flow_v0.56.x-v0.103.x/test_koa-send_v4.x.x.js
@@ -4,22 +4,22 @@ import type { Options, SendResult } from "koa-send";
 const ctx = {};
 const path = "/";
 
-// $FlowExpectedError (Must have ctx and path)
+// $FlowExpectedError[incompatible-call] (Must have ctx and path)
 send();
-// $FlowExpectedError (Must have path)
+// $FlowExpectedError[incompatible-call] (Must have path)
 send(ctx);
 send(ctx, path);
 
-// $FlowExpectedError (Can't use invalid option names)
+// $FlowExpectedError[prop-missing] (Can't use invalid option names)
 send(ctx, path, { hide: true });
 send(ctx, path, { hidden: true });
 
-// $FlowExpectedError (Must use proper types for options)
+// $FlowExpectedError[incompatible-call] (Must use proper types for options)
 send(ctx, path, { immutable: "true" });
 send(ctx, path, { immutable: true });
 
 send(ctx, path).then(result => {
-  // $FlowExpectedError (result should be a string)
+  // $FlowExpectedError[incompatible-cast] (result should be a string)
   (result: number);
   (result: string);
 });

--- a/definitions/npm/koa-static_v4.x.x/flow_v0.104.x-/koa-static_v4.x.x.js
+++ b/definitions/npm/koa-static_v4.x.x/flow_v0.104.x-/koa-static_v4.x.x.js
@@ -24,10 +24,8 @@ declare module "koa-static" {
     extensions?: Array<string> | false
   |};
 
-  declare function serve(
+  declare module.exports: (
     root: string,
     opts?: Options
-  ): Middleware;
-
-  declare module.exports: typeof serve;
+  ) => Middleware;
 }

--- a/definitions/npm/koa-static_v4.x.x/flow_v0.104.x-/koa-static_v4.x.x.js
+++ b/definitions/npm/koa-static_v4.x.x/flow_v0.104.x-/koa-static_v4.x.x.js
@@ -24,8 +24,10 @@ declare module "koa-static" {
     extensions?: Array<string> | false
   |};
 
-  declare export default function serve(
+  declare function serve(
     root: string,
     opts?: Options
   ): Middleware;
+
+  declare module.exports: typeof serve;
 }

--- a/definitions/npm/koa-static_v4.x.x/flow_v0.104.x-/test_koa-static_v4.x.x.js
+++ b/definitions/npm/koa-static_v4.x.x/flow_v0.104.x-/test_koa-static_v4.x.x.js
@@ -1,13 +1,13 @@
-import serve from "koa-static";
+const serve = require('koa-static');
 
-// $FlowExpectedError (Must pass in a root)
+// $FlowExpectedError[incompatible-call] (Must pass in a root)
 serve();
 serve("/");
 
-// $FlowExpectedError (Can't use invalid option)
+// $FlowExpectedError[prop-missing] (Can't use invalid option)
 serve("/", { zip: true });
 serve("/", { gzip: true });
 
-// $FlowExpectedError (Options must have proper types)
+// $FlowExpectedError[incompatible-call] (Options must have proper types)
 serve("/", { format: "true" });
 serve("/", { format: true });

--- a/definitions/npm/koa-static_v4.x.x/flow_v0.104.x-/test_koa-static_v4.x.x.js
+++ b/definitions/npm/koa-static_v4.x.x/flow_v0.104.x-/test_koa-static_v4.x.x.js
@@ -1,4 +1,4 @@
-const serve = require('koa-static');
+import serve from "koa-static";
 
 // $FlowExpectedError[incompatible-call] (Must pass in a root)
 serve();

--- a/definitions/npm/koa-static_v4.x.x/flow_v0.56.x-v0.103.x/koa-static_v4.x.x.js
+++ b/definitions/npm/koa-static_v4.x.x/flow_v0.56.x-v0.103.x/koa-static_v4.x.x.js
@@ -24,10 +24,8 @@ declare module "koa-static" {
     extensions?: Array<string> | false
   |};
 
-  declare function serve(
+  declare module.exports: (
     root: string,
     opts?: Options
-  ): Middleware;
-
-  declare module.exports: typeof serve;
+  ) => Middleware;
 }

--- a/definitions/npm/koa-static_v4.x.x/flow_v0.56.x-v0.103.x/koa-static_v4.x.x.js
+++ b/definitions/npm/koa-static_v4.x.x/flow_v0.56.x-v0.103.x/koa-static_v4.x.x.js
@@ -24,8 +24,10 @@ declare module "koa-static" {
     extensions?: Array<string> | false
   |};
 
-  declare export default function serve(
+  declare function serve(
     root: string,
     opts?: Options
   ): Middleware;
+
+  declare module.exports: typeof serve;
 }

--- a/definitions/npm/koa-static_v4.x.x/flow_v0.56.x-v0.103.x/test_koa-static_v4.x.x.js
+++ b/definitions/npm/koa-static_v4.x.x/flow_v0.56.x-v0.103.x/test_koa-static_v4.x.x.js
@@ -1,13 +1,13 @@
-import serve from "koa-static";
+const serve = require('koa-static');
 
-// $FlowExpectedError (Must pass in a root)
+// $FlowExpectedError[incompatible-call] (Must pass in a root)
 serve();
 serve("/");
 
-// $FlowExpectedError (Can't use invalid option)
+// $FlowExpectedError[prop-missing] (Can't use invalid option)
 serve("/", { zip: true });
 serve("/", { gzip: true });
 
-// $FlowExpectedError (Options must have proper types)
+// $FlowExpectedError[incompatible-call] (Options must have proper types)
 serve("/", { format: "true" });
 serve("/", { format: true });

--- a/definitions/npm/koa-static_v4.x.x/flow_v0.56.x-v0.103.x/test_koa-static_v4.x.x.js
+++ b/definitions/npm/koa-static_v4.x.x/flow_v0.56.x-v0.103.x/test_koa-static_v4.x.x.js
@@ -1,4 +1,4 @@
-const serve = require('koa-static');
+import serve from "koa-static";
 
 // $FlowExpectedError[incompatible-call] (Must pass in a root)
 serve();


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Code written in node generally uses `require()` syntax instead of `import`. But some of the koa libraries were written with `declare export default` which isn't compatible with `require()` instead of `declare modules.export`.

- Links to documentation: N/A
- Link to GitHub or NPM: N/A
- Type of contribution: fix

Other notes:

