### PR TITLE
Jest v26: add missing `createMockFromModule`

### DIFF
--- a/definitions/npm/jest_v26.x.x/flow_v0.134.x-/jest_v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.134.x-/jest_v26.x.x.js
@@ -828,10 +828,14 @@ type JestObjectType = {
    */
   isMockFunction(fn: Function): boolean,
   /**
+   * Alias of `createMockFromModule`.
+   */
+  genMockFromModule(moduleName: string): any,
+  /**
    * Given the name of a module, use the automatic mocking system to generate a
    * mocked version of the module for you.
    */
-  genMockFromModule(moduleName: string): any,
+  createMockFromModule(moduleName: string): any,
   /**
    * Mocks a module with an auto-mocked version when it is being required.
    *

--- a/definitions/npm/jest_v26.x.x/flow_v0.134.x-/test_jest-v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.134.x-/test_jest-v26.x.x.js
@@ -316,6 +316,14 @@ jest.setSystemTime(new Date());
 // $FlowExpectedError[incompatible-call]
 jest.setSystemTime('');
 
+jest.genMockFromModule('../mocked');
+// $FlowExpectedError[incompatible-call]
+jest.genMockFromModule(1);
+
+jest.createMockFromModule('../mocked');
+// $FlowExpectedError[incompatible-call]
+jest.createMockFromModule(1);
+
 // Test method chaining fixes
 jest.doMock('testModule1', () => {}).doMock('testModule2', () => {});
 


### PR DESCRIPTION
See: https://jestjs.io/docs/jest-object#jestcreatemockfrommodulemodulename

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details.

- Links to documentation: 
- Link to GitHub or NPM: 
- Type of contribution: new definition | addition | fix | refactor

Other notes:

--->