### PR TITLE
Export a bunch of types from @apollo/react-{common,components,hooks}, fix a few other issues

### DIFF
--- a/definitions/npm/@apollo/react-common_v3.x.x/flow_v0.104.x-/react-common_v3.x.x.js
+++ b/definitions/npm/@apollo/react-common_v3.x.x/flow_v0.104.x-/react-common_v3.x.x.js
@@ -2,22 +2,22 @@ declare module '@apollo/react-common' {
   import type { Node } from 'react';
 
   /* start utils */
-  declare type Record<T, U> = {
+  declare export type Record<T, U> = {
     [key: $Keys<T>]: U,
-    ...
+    ...,
   };
   /* end utils */
 
   /* start graphql */
-  declare type DocumentNode = any;
-  declare type ExecutionResult<T> = {
+  declare export type DocumentNode = any;
+  declare export type ExecutionResult<T> = {
     data?: T,
     extensions?: { [string]: any, ... },
     errors?: any[],
     ...
   };
-  declare type GraphQLError = any;
-  declare type VariableDefinitionNode = any;
+  declare export type GraphQLError = any;
+  declare export type VariableDefinitionNode = any;
   /* end graphql */
 
   /* start context */
@@ -25,7 +25,7 @@ declare module '@apollo/react-common' {
     client?: ApolloClient<any>,
     renderPromises?: Record<any, any>,
     ...
-  }
+  };
 
   declare export type ApolloProviderProps<TCache> = {
     client: ApolloClient<TCache>,
@@ -74,14 +74,14 @@ declare module '@apollo/react-common' {
   /* end context */
 
   /* start parser */
-  declare export type DocumentType = 'Query' | 'Mutation' | 'Subscription'
+  declare export type DocumentType = 'Query' | 'Mutation' | 'Subscription';
 
   declare export type IDocumentDefinition = {
     type: DocumentType,
     name: string,
     variables: $ReadonlyArray<VariableDefinitionNode>,
     ...
-  }
+  };
 
   declare export function operationName(type: DocumentType): string;
 
@@ -250,7 +250,10 @@ declare module '@apollo/react-common' {
 
   /* start apollo-client types */
 
-  declare class ObservableQuery<T, V = { [key: string]: any, ... }> extends Observable<ApolloQueryResult<T>> {
+  declare class ObservableQuery<
+    T,
+    V = { [key: string]: any, ... }
+  > extends Observable<ApolloQueryResult<T>> {
     options: WatchQueryOptions;
     queryId: string;
     variables: V;
@@ -477,13 +480,13 @@ declare module '@apollo/react-common' {
     reset(): Promise<void>;
   }
 
-  declare type QueryWithUpdater = {
+  declare export type QueryWithUpdater = {
     updater: MutationQueryReducer<any>,
     query: QueryStoreValue,
     ...
   };
 
-  declare interface MutationStoreValue {
+  declare export interface MutationStoreValue {
     mutationString: string;
     variables: any;
     loading: boolean;
@@ -503,7 +506,7 @@ declare module '@apollo/react-common' {
     ): void;
   }
 
-  declare interface FetchMoreOptions<TData, TVariables> {
+  declare export interface FetchMoreOptions<TData, TVariables> {
     updateQuery: (
       previousQueryResult: TData,
       options: {
@@ -514,11 +517,11 @@ declare module '@apollo/react-common' {
     ) => TData;
   }
 
-  declare interface UpdateQueryOptions {
+  declare export interface UpdateQueryOptions {
     variables?: any;
   }
 
-  declare type ApolloCurrentResult<T> = {
+  declare export type ApolloCurrentResult<T> = {
     data: T | { ... },
     errors?: Array<GraphQLError>,
     loading: boolean,
@@ -528,9 +531,10 @@ declare module '@apollo/react-common' {
     ...
   };
 
-  declare type ModifiableWatchQueryOptions = {
+  declare export type ModifiableWatchQueryOptions = {
     variables?: {
-      [key: string]: any, ...
+      [key: string]: any,
+      ...,
     },
     pollInterval?: number,
     fetchPolicy?: FetchPolicy,
@@ -540,7 +544,7 @@ declare module '@apollo/react-common' {
     ...
   };
 
-  declare type WatchQueryOptions = {
+  declare export type WatchQueryOptions = {
     ...$Exact<ModifiableWatchQueryOptions>,
     query: DocumentNode,
     metadata?: any,
@@ -548,11 +552,14 @@ declare module '@apollo/react-common' {
     ...
   };
 
-  declare type RefetchQueryDescription = Array<string | PureQueryOptions>;
+  declare export type RefetchQueryDescription = Array<
+    string | PureQueryOptions
+  >;
 
-  declare interface MutationBaseOptions<
+  declare export interface MutationBaseOptions<
     T = {
-      [key: string]: any, ...
+      [key: string]: any,
+      ...,
     }
   > {
     optimisticResponse?: any;
@@ -566,7 +573,7 @@ declare module '@apollo/react-common' {
     variables?: any;
   }
 
-  declare type FetchPolicy =
+  declare export type FetchPolicy =
     | 'cache-first'
     | 'cache-and-network'
     | 'network-only'
@@ -574,13 +581,13 @@ declare module '@apollo/react-common' {
     | 'no-cache'
     | 'standby';
 
-  declare type ErrorPolicy = 'none' | 'ignore' | 'all';
+  declare export type ErrorPolicy = 'none' | 'ignore' | 'all';
 
-  declare interface FetchMoreQueryOptions<TVariables> {
+  declare export interface FetchMoreQueryOptions<TVariables> {
     variables: $Shape<TVariables>;
   }
 
-  declare type SubscribeToMoreOptions<
+  declare export type SubscribeToMoreOptions<
     TData,
     TSubscriptionData,
     TSubscriptionVariables = void
@@ -602,24 +609,24 @@ declare module '@apollo/react-common' {
     ...
   };
 
-  declare type MutationUpdaterFn<T = OperationVariables> = (
+  declare export type MutationUpdaterFn<T = OperationVariables> = (
     proxy: DataProxy,
     mutationResult: FetchResult<T>
   ) => void;
 
-  declare type NetworkStatusRaw = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+  declare export type NetworkStatusRaw = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
   declare export class NetworkStatus {
-    [NetworkStatusRaw]: string,
-    string: NetworkStatusRaw,
+    [NetworkStatusRaw]: string;
+    string: NetworkStatusRaw;
   }
 
-  declare type QueryListener = (
+  declare export type QueryListener = (
     queryStoreValue: QueryStoreValue,
     newData?: any
   ) => void;
 
-  declare type QueryStoreValue = {
+  declare export type QueryStoreValue = {
     document: DocumentNode,
     variables: any,
     previousVariables: any,
@@ -630,15 +637,16 @@ declare module '@apollo/react-common' {
     ...
   };
 
-  declare type PureQueryOptions = {
+  declare export type PureQueryOptions = {
     query: DocumentNode,
     variables?: {
-      [key: string]: any, ...
+      [key: string]: any,
+      ...,
     },
     ...
   };
 
-  declare type ApolloQueryResult<T> = {
+  declare export type ApolloQueryResult<T> = {
     data: T,
     errors?: Array<GraphQLError>,
     loading: boolean,
@@ -647,27 +655,31 @@ declare module '@apollo/react-common' {
     ...
   };
 
-  declare type FetchType = 1 | 2 | 3;
+  declare export type FetchType = 1 | 2 | 3;
 
-  declare type MutationQueryReducer<T> = (
+  declare export type MutationQueryReducer<T> = (
     previousResult: {
-      [key: string]: any, ...
+      [key: string]: any,
+      ...,
     },
     options: {
       mutationResult: FetchResult<T>,
       queryName: string | void,
       queryVariables: {
-        [key: string]: any, ...
+        [key: string]: any,
+        ...,
       },
       ...
     }
   ) => {
-    [key: string]: any, ...
+    [key: string]: any,
+    ...,
   };
 
-  declare type MutationQueryReducersMap<
+  declare export type MutationQueryReducersMap<
     T = {
-      [key: string]: any, ...
+      [key: string]: any,
+      ...,
     }
   > = {
     [queryName: string]: MutationQueryReducer<T>,
@@ -683,20 +695,20 @@ declare module '@apollo/react-common' {
   }
   declare export type ApolloError = $ApolloError;
 
-  declare interface ErrorConstructor {
+  declare export interface ErrorConstructor {
     graphQLErrors?: Array<GraphQLError>;
     networkError?: Error | null;
     errorMessage?: string;
     extraInfo?: any;
   }
 
-  declare interface DefaultOptions {
+  declare export interface DefaultOptions {
     +watchQuery?: ModifiableWatchQueryOptions;
     +query?: ModifiableWatchQueryOptions;
     +mutate?: MutationBaseOptions<>;
   }
 
-  declare type ApolloClientOptions<TCacheShape> = {
+  declare export type ApolloClientOptions<TCacheShape> = {
     link: ApolloLink,
     cache: ApolloCache<TCacheShape>,
     ssrMode?: boolean,
@@ -774,46 +786,56 @@ declare module '@apollo/react-common' {
     ): Observable<FetchResult<>> | null;
   }
 
-  declare interface GraphQLRequest {
+  declare export interface GraphQLRequest {
     query: DocumentNode;
     variables?: {
-      [key: string]: any, ...
+      [key: string]: any,
+      ...,
     };
     operationName?: string;
     context?: {
-      [key: string]: any, ...
+      [key: string]: any,
+      ...,
     };
     extensions?: {
-      [key: string]: any, ...
+      [key: string]: any,
+      ...,
     };
   }
 
-  declare interface Operation {
+  declare export interface Operation {
     query: DocumentNode;
     variables: {
-      [key: string]: any, ...
+      [key: string]: any,
+      ...,
     };
     operationName: string;
     extensions: {
-      [key: string]: any, ...
+      [key: string]: any,
+      ...,
     };
     setContext: (context: {
-      [key: string]: any, ...
+      [key: string]: any,
+      ...,
     }) => {
-      [key: string]: any, ...
+      [key: string]: any,
+      ...,
     };
     getContext: () => {
-      [key: string]: any, ...
+      [key: string]: any,
+      ...,
     };
     toKey: () => string;
   }
 
-  declare type FetchResult<
+  declare export type FetchResult<
     C = {
-      [key: string]: any, ...
+      [key: string]: any,
+      ...,
     },
     E = {
-      [key: string]: any, ...
+      [key: string]: any,
+      ...,
     }
   > = ExecutionResult<C> & {
     extension?: E,
@@ -821,9 +843,11 @@ declare module '@apollo/react-common' {
     ...
   };
 
-  declare type NextLink = (operation: Operation) => Observable<FetchResult<>>;
+  declare export type NextLink = (
+    operation: Operation
+  ) => Observable<FetchResult<>>;
 
-  declare type RequestHandler = (
+  declare export type RequestHandler = (
     operation: Operation,
     forward?: NextLink
   ) => Observable<FetchResult<>> | null;
@@ -848,42 +872,42 @@ declare module '@apollo/react-common' {
     of<R>(...args: Array<R>): Observable<R>;
   }
 
-  declare interface Observer<T> {
+  declare export interface Observer<T> {
     start?: (subscription: SubscriptionLINK) => any;
     next?: (value: T) => void;
     error?: (errorValue: any) => void;
     complete?: () => void;
   }
 
-  declare interface SubscriptionLINK {
+  declare export interface SubscriptionLINK {
     closed: boolean;
     unsubscribe(): void;
   }
 
-  declare interface ZenObservableSubscriptionObserver<T> {
+  declare export interface ZenObservableSubscriptionObserver<T> {
     closed: boolean;
     next(value: T): void;
     error(errorValue: any): void;
     complete(): void;
   }
 
-  declare interface ZenObservableSubscription {
+  declare export interface ZenObservableSubscription {
     closed: boolean;
     unsubscribe(): void;
   }
 
-  declare interface ZenObservableObserver<T> {
+  declare export interface ZenObservableObserver<T> {
     start?: (subscription: ZenObservableSubscription) => any;
     next?: (value: T) => void;
     error?: (errorValue: any) => void;
     complete?: () => void;
   }
 
-  declare type ZenObservableSubscriber<T> = (
+  declare export type ZenObservableSubscriber<T> = (
     observer: ZenObservableSubscriptionObserver<T>
   ) => void | (() => void) | SubscriptionLINK;
 
-  declare interface ZenObservableObservableLike<T> {
+  declare export interface ZenObservableObservableLike<T> {
     subscribe?: ZenObservableSubscriber<T>;
   }
   /* apollo-link types */
@@ -923,67 +947,69 @@ declare module '@apollo/react-common' {
     writeData<TData>(options: CacheWriteDataOptions<TData>): void;
   }
 
-  declare type Transaction<T> = (c: ApolloCache<T>) => void;
+  declare export type Transaction<T> = (c: ApolloCache<T>) => void;
 
-  declare type CacheWatchCallback = (newData: any) => void;
+  declare export type CacheWatchCallback = (newData: any) => void;
 
-  declare interface CacheEvictionResult {
+  declare export interface CacheEvictionResult {
     success: boolean;
   }
 
-  declare interface CacheReadOptions extends DataProxyReadQueryOptions {
+  declare export interface CacheReadOptions extends DataProxyReadQueryOptions {
     rootId?: string;
     previousResult?: any;
     optimistic: boolean;
   }
 
-  declare interface CacheWriteOptions extends DataProxyReadQueryOptions {
+  declare export interface CacheWriteOptions extends DataProxyReadQueryOptions {
     dataId: string;
     result: any;
   }
 
-  declare interface CacheDiffOptions extends CacheReadOptions {
+  declare export interface CacheDiffOptions extends CacheReadOptions {
     returnPartialData?: boolean;
   }
 
-  declare interface CacheWatchOptions extends CacheReadOptions {
+  declare export interface CacheWatchOptions extends CacheReadOptions {
     callback: CacheWatchCallback;
   }
 
-  declare interface CacheEvictOptions extends DataProxyReadQueryOptions {
+  declare export interface CacheEvictOptions extends DataProxyReadQueryOptions {
     rootId?: string;
   }
 
-  declare type CacheDiffResult<T> = DataProxyDiffResult<T>;
-  declare type CacheWriteQueryOptions<
+  declare export type CacheDiffResult<T> = DataProxyDiffResult<T>;
+  declare export type CacheWriteQueryOptions<
     TData,
     TVariables
   > = DataProxyWriteQueryOptions<TData, TVariables>;
-  declare type CacheWriteFragmentOptions<
+  declare export type CacheWriteFragmentOptions<
     TData,
     TVariables
   > = DataProxyWriteFragmentOptions<TData, TVariables>;
-  declare type CacheWriteDataOptions<TData> = DataProxyWriteDataOptions<TData>;
+  declare export type CacheWriteDataOptions<
+    TData
+  > = DataProxyWriteDataOptions<TData>;
 
-  declare interface DataProxyReadQueryOptions {
+  declare export interface DataProxyReadQueryOptions {
     query: DocumentNode;
     variables?: TVariables;
   }
 
-  declare interface DataProxyReadFragmentOptions<TVariables> {
+  declare export interface DataProxyReadFragmentOptions<TVariables> {
     id: string;
     fragment: DocumentNode;
     fragmentName?: string;
     variables?: TVariables;
   }
 
-  declare interface DataProxyWriteQueryOptions<TData, TVariables> {
+  declare export interface DataProxyWriteQueryOptions<TData, TVariables> {
     data: TData;
     query: DocumentNode;
     variables?: TVariables;
   }
 
-  declare interface DataProxyWriteFragmentOptions<TData, TVariables> {
+  declare export interface DataProxyWriteFragmentOptions<TData, TVariables> {
     data: TData;
     id: string;
     fragment: DocumentNode;
@@ -991,18 +1017,18 @@ declare module '@apollo/react-common' {
     variables?: TVariables;
   }
 
-  declare interface DataProxyWriteDataOptions<TData> {
+  declare export interface DataProxyWriteDataOptions<TData> {
     data: TData;
     id?: string;
   }
 
-  declare type DataProxyDiffResult<T> = {
+  declare export type DataProxyDiffResult<T> = {
     result?: T,
     complete?: boolean,
     ...
   };
 
-  declare interface DataProxy {
+  declare export interface DataProxy {
     readQuery<QueryType, TVariables>(
       options: DataProxyReadQueryOptions,
       optimistic?: boolean

--- a/definitions/npm/@apollo/react-common_v3.x.x/flow_v0.104.x-/react-common_v3.x.x.js
+++ b/definitions/npm/@apollo/react-common_v3.x.x/flow_v0.104.x-/react-common_v3.x.x.js
@@ -79,7 +79,7 @@ declare module '@apollo/react-common' {
   declare export type IDocumentDefinition = {
     type: DocumentType,
     name: string,
-    variables: $ReadonlyArray<VariableDefinitionNode>,
+    variables: $ReadOnlyArray <VariableDefinitionNode>,
     ...
   };
 

--- a/definitions/npm/@apollo/react-components_v3.x.x/flow_v0.104.x-/react-components_v3.x.x.js
+++ b/definitions/npm/@apollo/react-components_v3.x.x/flow_v0.104.x-/react-components_v3.x.x.js
@@ -1,20 +1,26 @@
 declare module '@apollo/react-components' {
   import type { ComponentType, Element, Node } from 'react';
 
-  declare type MakeOptional = <V>(V) => ?V;
-  declare type MakeDataOptional<TData> = $ObjMap<TData, MakeOptional> | void;
+  declare export type MakeOptional = <V>(V) => ?V;
+  declare export type MakeDataOptional<TData> = $ObjMap<
+    TData,
+    MakeOptional
+  > | void;
 
-  declare type Record<T, U> = {
+  declare export type Record<T, U> = {
     [key: T]: U,
     ...,
   };
 
-  declare type Dict = Record<string, any>;
+  declare export type Dict = Record<string, any>;
   /**
    * Copied types from Apollo Client libdef
    * Please update apollo-client libdef as well if updating these types
    */
-  declare class ObservableQuery<T, V = { [key: string]: any, ... }> extends Observable<ApolloQueryResult<T>> {
+  declare class ObservableQuery<
+    T,
+    V = { [key: string]: any, ... }
+  > extends Observable<ApolloQueryResult<T>> {
     options: WatchQueryOptions;
     queryId: string;
     variables: V;
@@ -226,13 +232,13 @@ declare module '@apollo/react-components' {
     reset(): Promise<void>;
   }
 
-  declare type QueryWithUpdater = {
+  declare export type QueryWithUpdater = {
     updater: MutationQueryReducer<any>,
     query: QueryStoreValue,
     ...
   };
 
-  declare interface MutationStoreValue {
+  declare export interface MutationStoreValue {
     mutationString: string;
     variables: any;
     loading: boolean;
@@ -274,7 +280,7 @@ declare module '@apollo/react-components' {
     ...
   };
 
-  declare interface ModifiableWatchQueryOptions {
+  declare export interface ModifiableWatchQueryOptions {
     variables?: Dict;
     pollInterval?: number;
     fetchPolicy?: FetchPolicy;
@@ -294,7 +300,7 @@ declare module '@apollo/react-components' {
     string | PureQueryOptions
   >;
 
-  declare interface MutationBaseOptions<T = Dict> {
+  declare export interface MutationBaseOptions<T = Dict> {
     optimisticResponse?: Dict;
     updateQueries?: MutationQueryReducersMap<T>;
     refetchQueries?:
@@ -414,14 +420,14 @@ declare module '@apollo/react-components' {
   }
   declare export type ApolloError = $ApolloError;
 
-  declare interface ErrorConstructor {
+  declare export interface ErrorConstructor {
     graphQLErrors?: Array<GraphQLError>;
     networkError?: Error | null;
     errorMessage?: string;
     extraInfo?: any;
   }
 
-  declare interface DefaultOptions {
+  declare export interface DefaultOptions {
     +watchQuery?: ModifiableWatchQueryOptions;
     +query?: ModifiableWatchQueryOptions;
     +mutate?: MutationBaseOptions<>;
@@ -505,7 +511,7 @@ declare module '@apollo/react-components' {
     ): Observable<FetchResult<>> | null;
   }
 
-  declare interface GraphQLRequest {
+  declare export interface GraphQLRequest {
     query: DocumentNode;
     variables?: Dict;
     operationName?: string;
@@ -513,7 +519,7 @@ declare module '@apollo/react-components' {
     extensions?: Dict;
   }
 
-  declare interface Operation {
+  declare export interface Operation {
     query: DocumentNode;
     variables: Dict;
     operationName: string;
@@ -529,9 +535,11 @@ declare module '@apollo/react-components' {
     ...
   };
 
-  declare type NextLink = (operation: Operation) => Observable<FetchResult<>>;
+  declare export type NextLink = (
+    operation: Operation
+  ) => Observable<FetchResult<>>;
 
-  declare type RequestHandler = (
+  declare export type RequestHandler = (
     operation: Operation,
     forward?: NextLink
   ) => Observable<FetchResult<>> | null;
@@ -563,42 +571,42 @@ declare module '@apollo/react-components' {
     of<R>(...args: Array<R>): Observable<R>;
   }
 
-  declare interface Observer<T> {
+  declare export interface Observer<T> {
     start?: (subscription: SubscriptionLINK) => any;
     next?: (value: T) => void;
     error?: (errorValue: any) => void;
     complete?: () => void;
   }
 
-  declare interface SubscriptionLINK {
+  declare export interface SubscriptionLINK {
     closed: boolean;
     unsubscribe(): void;
   }
 
-  declare interface ZenObservableSubscriptionObserver<T> {
+  declare export interface ZenObservableSubscriptionObserver<T> {
     closed: boolean;
     next(value: T): void;
     error(errorValue: any): void;
     complete(): void;
   }
 
-  declare interface ZenObservableSubscription {
+  declare export interface ZenObservableSubscription {
     closed: boolean;
     unsubscribe(): void;
   }
 
-  declare interface ZenObservableObserver<T> {
+  declare export interface ZenObservableObserver<T> {
     start?: (subscription: ZenObservableSubscription) => mixed;
     next?: (value: T) => mixed;
     error?: (errorValue: any) => mixed;
     complete?: () => mixed;
   }
 
-  declare type ZenObservableSubscriber<T> = (
+  declare export type ZenObservableSubscriber<T> = (
     observer: ZenObservableSubscriptionObserver<T>
   ) => mixed | (() => mixed) | SubscriptionLINK;
 
-  declare interface ZenObservableObservableLike<T> {
+  declare export interface ZenObservableObservableLike<T> {
     subscribe?: ZenObservableSubscriber<T>;
   }
   /* apollo-link types */
@@ -639,61 +647,61 @@ declare module '@apollo/react-components' {
     writeData(options: CacheWriteDataOptions): void;
   }
 
-  declare type Transaction<T> = (c: ApolloCache<T>) => mixed;
+  declare export type Transaction<T> = (c: ApolloCache<T>) => mixed;
 
-  declare type CacheWatchCallback = (newData: any) => mixed;
+  declare export type CacheWatchCallback = (newData: any) => mixed;
 
-  declare interface CacheEvictionResult {
+  declare export interface CacheEvictionResult {
     success: boolean;
   }
 
-  declare interface CacheReadOptions extends DataProxyReadQueryOptions {
+  declare export interface CacheReadOptions extends DataProxyReadQueryOptions {
     rootId?: string;
     previousResult?: any;
     optimistic: boolean;
   }
 
-  declare interface CacheWriteOptions extends DataProxyReadQueryOptions {
+  declare export interface CacheWriteOptions extends DataProxyReadQueryOptions {
     dataId: string;
     result: any;
   }
 
-  declare interface CacheDiffOptions extends CacheReadOptions {
+  declare export interface CacheDiffOptions extends CacheReadOptions {
     returnPartialData?: boolean;
   }
 
-  declare interface CacheWatchOptions extends CacheReadOptions {
+  declare export interface CacheWatchOptions extends CacheReadOptions {
     callback: CacheWatchCallback;
   }
 
-  declare interface CacheEvictOptions extends DataProxyReadQueryOptions {
+  declare export interface CacheEvictOptions extends DataProxyReadQueryOptions {
     rootId?: string;
   }
 
-  declare type CacheDiffResult<T> = DataProxyDiffResult<T>;
-  declare type CacheWriteQueryOptions = DataProxyWriteQueryOptions;
-  declare type CacheWriteFragmentOptions = DataProxyWriteFragmentOptions;
-  declare type CacheWriteDataOptions = DataProxyWriteDataOptions;
+  declare export type CacheDiffResult<T> = DataProxyDiffResult<T>;
+  declare export type CacheWriteQueryOptions = DataProxyWriteQueryOptions;
+  declare export type CacheWriteFragmentOptions = DataProxyWriteFragmentOptions;
+  declare export type CacheWriteDataOptions = DataProxyWriteDataOptions;
 
-  declare interface DataProxyReadQueryOptions {
+  declare export interface DataProxyReadQueryOptions {
     query: DocumentNode;
     variables?: any;
   }
 
-  declare interface DataProxyReadFragmentOptions {
+  declare export interface DataProxyReadFragmentOptions {
     id: string;
     fragment: DocumentNode;
     fragmentName?: string;
     variables?: any;
   }
 
-  declare interface DataProxyWriteQueryOptions {
+  declare export interface DataProxyWriteQueryOptions {
     data: any;
     query: DocumentNode;
     variables?: any;
   }
 
-  declare interface DataProxyWriteFragmentOptions {
+  declare export interface DataProxyWriteFragmentOptions {
     data: any;
     id: string;
     fragment: DocumentNode;
@@ -701,12 +709,12 @@ declare module '@apollo/react-components' {
     variables?: any;
   }
 
-  declare interface DataProxyWriteDataOptions {
+  declare export interface DataProxyWriteDataOptions {
     data: any;
     id?: string;
   }
 
-  declare type DataProxyDiffResult<T> = {
+  declare export type DataProxyDiffResult<T> = {
     result?: T,
     complete?: boolean,
     ...
@@ -733,15 +741,15 @@ declare module '@apollo/react-components' {
    * Types From graphql
    * graphql types are maintained in the graphql-js repo
    */
-  declare type DocumentNode = any;
-  declare type ExecutionResult<T> = {
+  declare export type DocumentNode = any;
+  declare export type ExecutionResult<T> = {
     data?: T,
     extensions?: { [string]: any, ... },
     errors?: any[],
     ...
   };
-  declare type GraphQLError = any;
-  declare type VariableDefinitionNode = any;
+  declare export type GraphQLError = any;
+  declare export type VariableDefinitionNode = any;
   /** End From graphql */
 
   declare export interface ApolloProviderProps<TCache> {
@@ -975,7 +983,10 @@ declare module '@apollo/react-components' {
     ...
   };
 
-  declare type SubscriptionProps<TData, TVariables = OperationVariables> = {
+  declare export type SubscriptionProps<
+    TData,
+    TVariables = OperationVariables
+  > = {
     subscription: DocumentNode,
     variables?: TVariables,
     shouldResubscribe?:
@@ -993,7 +1004,7 @@ declare module '@apollo/react-components' {
     SubscriptionProps<TData, TVariables>
   > {}
 
-  declare type OperationVariables = Dict;
+  declare export type OperationVariables = Dict;
 
   declare export type MutationFunction<
     TData = any,

--- a/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
+++ b/definitions/npm/@apollo/react-hooks_v3.x.x/flow_v0.104.x-/react-hooks_v3.x.x.js
@@ -1,12 +1,9 @@
-// flow-typed signature: d6583f94eec029c4723062cbbe8065ec
-// flow-typed version: 35be10a6f7/@apollo/react-hooks_v3.x.x/flow_>=v0.104.x
-
 declare module '@apollo/react-hooks' {
   import type { ComponentType, Element, Node } from 'react';
 
   /* start graphql types */
-  declare type DocumentNode = any;
-  declare type GraphQLError = any;
+  declare export type DocumentNode = any;
+  declare export type GraphQLError = any;
   /* end graphql types */
 
   /* start @apollo/react-common types */
@@ -51,7 +48,7 @@ declare module '@apollo/react-hooks' {
   /* end @apollo/react-common types */
 
   /* start @apollo/react-hooks types */
-  declare type Record<T, U> = {| [key: $Keys<T>]: U |};
+  declare export type Record<T, U> = {| [key: $Keys<T>]: U |};
 
   declare export function useQuery<TData, TVariables>(
     query: DocumentNode,
@@ -237,13 +234,13 @@ declare module '@apollo/react-hooks' {
     refetch: $PropertyType<ObservableQuery<TData, TVariables>, 'refetch'>,
     variables: $PropertyType<ObservableQuery<TData, TVariables>, 'variables'>,
     fetchMore: (<TVariables>(fetchMoreOptions: {|
-      ...FetchMoreQueryOptions<TVariables>,
-      ...FetchMoreOptions<TData, TVariables>,
+      ...$Exact<FetchMoreQueryOptions<TVariables>>,
+      ...$Exact<FetchMoreOptions<TData, TVariables>>,
     |}) => Promise<ApolloQueryResult<TData>>) &
       (<TData2, TVariables2>(fetchMoreOptions: {|
         query?: DocumentNode,
-        ...FetchMoreQueryOptions<TVariables2>,
-        ...FetchMoreOptions<TData2, TVariables2>,
+        ...$Exact<FetchMoreQueryOptions<TVariables2>>,
+        ...$Exact<FetchMoreOptions<TData2, TVariables2>>,
       |}) => Promise<ApolloQueryResult<TData2>>),
   |};
 
@@ -318,6 +315,7 @@ declare module '@apollo/react-hooks' {
 
   declare export type BaseSubscriptionOptions<TData, TVariables> = {|
     variables?: TVariables,
+    skip?: boolean,
     fetchPolicy?: FetchPolicy,
     shouldResubscribe?:
       | boolean
@@ -366,8 +364,8 @@ declare module '@apollo/react-hooks' {
     resetLastResults(): void;
     refetch(variables?: V): Promise<ApolloQueryResult<T>>;
     fetchMore(fetchMoreOptions: {|
-      ...FetchMoreQueryOptions<any>,
-      ...FetchMoreOptions<any, any>,
+      ...$Exact<FetchMoreQueryOptions<any>>,
+      ...$Exact<FetchMoreOptions<any>>,
     |}): Promise<ApolloQueryResult<T>>;
     subscribeToMore(options: SubscribeToMoreOptions<any, any>): () => void;
     setOptions(
@@ -398,7 +396,7 @@ declare module '@apollo/react-hooks' {
       onBroadcast?: () => void,
       ssrMode?: boolean,
     |}): this;
-    mutate<T>(options: MutationOptions<>): Promise<FetchResult<T>>;
+    mutate<T>(options: MutationOptions<T, any>): Promise<FetchResult<T>>;
     fetchQuery<T>(
       queryId: string,
       options: WatchQueryOptions,
@@ -543,12 +541,12 @@ declare module '@apollo/react-hooks' {
     reset(): Promise<void>;
   }
 
-  declare type QueryWithUpdater = {|
+  declare export type QueryWithUpdater = {|
     updater: MutationQueryReducer<any>,
     query: QueryStoreValue,
   |};
 
-  declare interface MutationStoreValue {
+  declare export interface MutationStoreValue {
     mutationString: string;
     variables: any;
     loading: boolean;
@@ -565,21 +563,21 @@ declare module '@apollo/react-hooks' {
     ): void;
   }
 
-  declare interface FetchMoreOptions<TData, TVariables> {
+  declare export type FetchMoreOptions<TData, TVariables> = {
     updateQuery: (
       previousQueryResult: TData,
       options: {|
         fetchMoreResult?: TData,
         variables: TVariables,
       |}
-    ) => TData;
-  }
+    ) => TData,
+  };
 
-  declare interface UpdateQueryOptions {
+  declare export interface UpdateQueryOptions {
     variables?: any;
   }
 
-  declare type ApolloCurrentResult<T> = {|
+  declare export type ApolloCurrentResult<T> = {|
     data: T | {||},
     errors?: Array<GraphQLError>,
     loading: boolean,
@@ -588,7 +586,7 @@ declare module '@apollo/react-hooks' {
     partial?: boolean,
   |};
 
-  declare type ModifiableWatchQueryOptions = {|
+  declare export type ModifiableWatchQueryOptions = {|
     variables?: {| [key: string]: any |},
     pollInterval?: number,
     fetchPolicy?: FetchPolicy,
@@ -597,16 +595,18 @@ declare module '@apollo/react-hooks' {
     notifyOnNetworkStatusChange?: boolean,
   |};
 
-  declare type WatchQueryOptions = {|
+  declare export type WatchQueryOptions = {|
     ...$Exact<ModifiableWatchQueryOptions>,
     query: DocumentNode,
     metadata?: any,
     context?: any,
   |};
 
-  declare type RefetchQueryDescription = Array<string | PureQueryOptions>;
+  declare export type RefetchQueryDescription = Array<
+    string | PureQueryOptions
+  >;
 
-  declare interface MutationBaseOptions<
+  declare export interface MutationBaseOptions<
     T = {
       [key: string]: any,
       ...,
@@ -623,7 +623,7 @@ declare module '@apollo/react-hooks' {
     variables?: any;
   }
 
-  declare type FetchPolicy =
+  declare export type FetchPolicy =
     | 'cache-first'
     | 'cache-and-network'
     | 'network-only'
@@ -631,13 +631,13 @@ declare module '@apollo/react-hooks' {
     | 'no-cache'
     | 'standby';
 
-  declare type ErrorPolicy = 'none' | 'ignore' | 'all';
+  declare export type ErrorPolicy = 'none' | 'ignore' | 'all';
 
-  declare interface FetchMoreQueryOptions<TVariables> {
-    variables: $Shape<TVariables>;
-  }
+  declare export type FetchMoreQueryOptions<TVariables> = {
+    variables: $Shape<TVariables>,
+  };
 
-  declare type SubscribeToMoreOptions<
+  declare export type SubscribeToMoreOptions<
     TData,
     TSubscriptionData,
     TSubscriptionVariables = void
@@ -654,19 +654,19 @@ declare module '@apollo/react-hooks' {
     onError?: (error: Error) => void,
   |};
 
-  declare type MutationUpdaterFn<T = OperationVariables> = (
+  declare export type MutationUpdaterFn<T = OperationVariables> = (
     proxy: DataProxy,
     mutationResult: FetchResult<T>
   ) => void;
 
-  declare type NetworkStatus = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+  declare export type NetworkStatus = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
-  declare type QueryListener = (
+  declare export type QueryListener = (
     queryStoreValue: QueryStoreValue,
     newData?: any
   ) => void;
 
-  declare type QueryStoreValue = {|
+  declare export type QueryStoreValue = {|
     document: DocumentNode,
     variables: any,
     previousVariables: any,
@@ -676,12 +676,12 @@ declare module '@apollo/react-hooks' {
     metadata: any,
   |};
 
-  declare type PureQueryOptions = {|
+  declare export type PureQueryOptions = {|
     query: DocumentNode,
     variables?: {| [key: string]: any |},
   |};
 
-  declare type ApolloQueryResult<T> = {|
+  declare export type ApolloQueryResult<T> = {|
     data: T,
     errors?: Array<GraphQLError>,
     loading: boolean,
@@ -689,9 +689,9 @@ declare module '@apollo/react-hooks' {
     stale: boolean,
   |};
 
-  declare type FetchType = 1 | 2 | 3;
+  declare export type FetchType = 1 | 2 | 3;
 
-  declare type MutationQueryReducer<T> = (
+  declare export type MutationQueryReducer<T> = (
     previousResult: {| [key: string]: any |},
     options: {|
       mutationResult: FetchResult<T>,
@@ -700,7 +700,7 @@ declare module '@apollo/react-hooks' {
     |}
   ) => {| [key: string]: any |};
 
-  declare type MutationQueryReducersMap<
+  declare export type MutationQueryReducersMap<
     T = {
       [key: string]: any,
       ...,
@@ -716,20 +716,20 @@ declare module '@apollo/react-hooks' {
   }
   declare export type ApolloError = $ApolloError;
 
-  declare interface ErrorConstructor {
+  declare export interface ErrorConstructor {
     graphQLErrors?: Array<GraphQLError>;
     networkError?: Error | null;
     errorMessage?: string;
     extraInfo?: any;
   }
 
-  declare interface DefaultOptions {
+  declare export interface DefaultOptions {
     +watchQuery?: ModifiableWatchQueryOptions;
     +query?: ModifiableWatchQueryOptions;
     +mutate?: MutationBaseOptions<>;
   }
 
-  declare type ApolloClientOptions<TCacheShape> = {|
+  declare export type ApolloClientOptions<TCacheShape> = {|
     link: ApolloLink,
     cache: ApolloCache<TCacheShape>,
     ssrMode?: boolean,
@@ -755,7 +755,7 @@ declare module '@apollo/react-hooks' {
     constructor(options: ApolloClientOptions<TCacheShape>): this;
     watchQuery<T>(options: WatchQueryOptions): ObservableQuery<T>;
     query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
-    mutate<T>(options: MutationOptions<T>): Promise<FetchResult<T>>;
+    mutate<T>(options: MutationOptions<T, any>): Promise<FetchResult<T>>;
     subscribe<T, D>(options: SubscriptionOptions<T, D>): Observable<any>;
     readQuery<T, D>(options: DataProxyReadQueryOptions<D>): T | null;
     readFragment<TData, TVariables>(
@@ -806,7 +806,7 @@ declare module '@apollo/react-hooks' {
     ): Observable<FetchResult<>> | null;
   }
 
-  declare interface GraphQLRequest {
+  declare export interface GraphQLRequest {
     query: DocumentNode;
     variables?: {| [key: string]: any |};
     operationName?: string;
@@ -814,7 +814,7 @@ declare module '@apollo/react-hooks' {
     extensions?: {| [key: string]: any |};
   }
 
-  declare interface Operation {
+  declare export interface Operation {
     query: DocumentNode;
     variables: {| [key: string]: any |};
     operationName: string;
@@ -824,7 +824,7 @@ declare module '@apollo/react-hooks' {
     toKey: () => string;
   }
 
-  declare type FetchResult<
+  declare export type FetchResult<
     C = {|
       [key: string]: any,
     |},
@@ -837,9 +837,11 @@ declare module '@apollo/react-hooks' {
     context?: C,
   |};
 
-  declare type NextLink = (operation: Operation) => Observable<FetchResult<>>;
+  declare export type NextLink = (
+    operation: Operation
+  ) => Observable<FetchResult<>>;
 
-  declare type RequestHandler = (
+  declare export type RequestHandler = (
     operation: Operation,
     forward?: NextLink
   ) => Observable<FetchResult<>> | null;
@@ -864,42 +866,42 @@ declare module '@apollo/react-hooks' {
     of<R>(...args: Array<R>): Observable<R>;
   }
 
-  declare interface Observer<T> {
+  declare export interface Observer<T> {
     start?: (subscription: SubscriptionLINK) => any;
     next?: (value: T) => void;
     error?: (errorValue: any) => void;
     complete?: () => void;
   }
 
-  declare interface SubscriptionLINK {
+  declare export interface SubscriptionLINK {
     closed: boolean;
     unsubscribe(): void;
   }
 
-  declare interface ZenObservableSubscriptionObserver<T> {
+  declare export interface ZenObservableSubscriptionObserver<T> {
     closed: boolean;
     next(value: T): void;
     error(errorValue: any): void;
     complete(): void;
   }
 
-  declare interface ZenObservableSubscription {
+  declare export interface ZenObservableSubscription {
     closed: boolean;
     unsubscribe(): void;
   }
 
-  declare interface ZenObservableObserver<T> {
+  declare export interface ZenObservableObserver<T> {
     start?: (subscription: ZenObservableSubscription) => any;
     next?: (value: T) => void;
     error?: (errorValue: any) => void;
     complete?: () => void;
   }
 
-  declare type ZenObservableSubscriber<T> = (
+  declare export type ZenObservableSubscriber<T> = (
     observer: ZenObservableSubscriptionObserver<T>
   ) => void | (() => void) | SubscriptionLINK;
 
-  declare interface ZenObservableObservableLike<T> {
+  declare export interface ZenObservableObservableLike<T> {
     subscribe?: ZenObservableSubscriber<T>;
   }
   /* apollo-link types */
@@ -939,67 +941,72 @@ declare module '@apollo/react-hooks' {
     writeData<TData>(options: CacheWriteDataOptions<TData>): void;
   }
 
-  declare type Transaction<T> = (c: ApolloCache<T>) => void;
+  declare export type Transaction<T> = (c: ApolloCache<T>) => void;
 
-  declare type CacheWatchCallback = (newData: any) => void;
+  declare export type CacheWatchCallback = (newData: any) => void;
 
-  declare interface CacheEvictionResult {
+  declare export interface CacheEvictionResult {
     success: boolean;
   }
 
-  declare interface CacheReadOptions extends DataProxyReadQueryOptions<any> {
+  declare export interface CacheReadOptions
+    extends DataProxyReadQueryOptions<any> {
     rootId?: string;
     previousResult?: any;
     optimistic: boolean;
   }
 
-  declare interface CacheWriteOptions extends DataProxyReadQueryOptions<any> {
+  declare export interface CacheWriteOptions
+    extends DataProxyReadQueryOptions<any> {
     dataId: string;
     result: any;
   }
 
-  declare interface CacheDiffOptions extends CacheReadOptions {
+  declare export interface CacheDiffOptions extends CacheReadOptions {
     returnPartialData?: boolean;
   }
 
-  declare interface CacheWatchOptions extends CacheReadOptions {
+  declare export interface CacheWatchOptions extends CacheReadOptions {
     callback: CacheWatchCallback;
   }
 
-  declare interface CacheEvictOptions extends DataProxyReadQueryOptions<any> {
+  declare export interface CacheEvictOptions
+    extends DataProxyReadQueryOptions<any> {
     rootId?: string;
   }
 
-  declare type CacheDiffResult<T> = DataProxyDiffResult<T>;
-  declare type CacheWriteQueryOptions<
+  declare export type CacheDiffResult<T> = DataProxyDiffResult<T>;
+  declare export type CacheWriteQueryOptions<
     TData,
     TVariables
   > = DataProxyWriteQueryOptions<TData, TVariables>;
-  declare type CacheWriteFragmentOptions<
+  declare export type CacheWriteFragmentOptions<
     TData,
     TVariables
   > = DataProxyWriteFragmentOptions<TData, TVariables>;
-  declare type CacheWriteDataOptions<TData> = DataProxyWriteDataOptions<TData>;
+  declare export type CacheWriteDataOptions<
+    TData
+  > = DataProxyWriteDataOptions<TData>;
 
-  declare interface DataProxyReadQueryOptions<D> {
+  declare export interface DataProxyReadQueryOptions<D> {
     query: DocumentNode;
     variables?: D;
   }
 
-  declare interface DataProxyReadFragmentOptions<TVariables> {
+  declare export interface DataProxyReadFragmentOptions<TVariables> {
     id: string;
     fragment: DocumentNode;
     fragmentName?: string;
     variables?: TVariables;
   }
 
-  declare interface DataProxyWriteQueryOptions<TData, TVariables> {
+  declare export interface DataProxyWriteQueryOptions<TData, TVariables> {
     data: TData;
     query: DocumentNode;
     variables?: TVariables;
   }
 
-  declare interface DataProxyWriteFragmentOptions<TData, TVariables> {
+  declare export interface DataProxyWriteFragmentOptions<TData, TVariables> {
     data: TData;
     id: string;
     fragment: DocumentNode;
@@ -1007,12 +1014,12 @@ declare module '@apollo/react-hooks' {
     variables?: TVariables;
   }
 
-  declare interface DataProxyWriteDataOptions<TData> {
+  declare export interface DataProxyWriteDataOptions<TData> {
     data: TData;
     id?: string;
   }
 
-  declare type DataProxyDiffResult<T> = {|
+  declare export type DataProxyDiffResult<T> = {|
     result?: T,
     complete?: boolean,
   |};


### PR DESCRIPTION
This is for Apollo client v3.  I'm still not using/don't have defs for v4.

Note: changes to `@apollo/react-hoc` are missing from this...hopefully not many people are using `@apollo/react-hoc` at this point, HoCs are gross

Anyone using `eslint-plugin-flow` will need a lot of these types to satisfy missing function argument warnings, etc.

I also fixed a few other issues I was having.

I know these are working on Flow 0.131.0, we'll see about newer versions...