### PR TITLE
Update CI node versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '10', '12' ]
+        node: [ '12', '14' ]
     name: Node ${{ matrix.node }} sample
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Node 10 being out of the game, just use the two LTS (maintenance and current). 

See https://nodejs.org/en/about/releases



