### PR TITLE
feat(jest): update jest-dom custom matcher typedefs for jest v26

### DIFF
--- a/definitions/npm/jest_v26.x.x/flow_v0.104.x-v0.133.x/jest_v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.104.x-v0.133.x/jest_v26.x.x.js
@@ -256,6 +256,9 @@ type DomTestingLibraryType = {
   // 5.x
   toHaveDisplayValue(value: string | string[]): void,
   toBeChecked(): void,
+  toBeEmptyDOMElement(): void,
+  toBePartiallyChecked(): void,
+  toHaveDescription(text: string | RegExp): void,
   ...
 };
 

--- a/definitions/npm/jest_v26.x.x/flow_v0.104.x-v0.133.x/test_jest-v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.104.x-v0.133.x/test_jest-v26.x.x.js
@@ -600,6 +600,15 @@ expect(wrapper).toHaveDisplayName(true);
   expect(element).toHaveDisplayValue('test');
   expect(element).toHaveDisplayValue(['foo', 'bar']);
   expect(element).toBeChecked();
+  expect(element).toBeEmptyDOMElement();
+  expect(element).toBePartiallyChecked();
+
+  // $FlowExpectedError[incompatible-call]: expected description should be present
+  expect(element).toHaveDescription();
+  expect(element).toHaveDescription('foo');
+  expect(element).toHaveDescription(/[0-9]/);
+  // $FlowExpectedError[incompatible-call]
+  expect(element).toHaveDescription(true);
 }
 
 {

--- a/definitions/npm/jest_v26.x.x/flow_v0.134.x-/jest_v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.134.x-/jest_v26.x.x.js
@@ -256,6 +256,9 @@ type DomTestingLibraryType = {
   // 5.x
   toHaveDisplayValue(value: string | string[]): void,
   toBeChecked(): void,
+  toBeEmptyDOMElement(): void,
+  toBePartiallyChecked(): void,
+  toHaveDescription(text: string | RegExp): void,
   ...
 };
 

--- a/definitions/npm/jest_v26.x.x/flow_v0.134.x-/test_jest-v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.134.x-/test_jest-v26.x.x.js
@@ -608,6 +608,16 @@ expect(wrapper).toHaveDisplayName(true);
   expect(element).toHaveDisplayValue('test');
   expect(element).toHaveDisplayValue(['foo', 'bar']);
   expect(element).toBeChecked();
+  expect(element).toBeEmptyDOMElement();
+  expect(element).toBePartiallyChecked();
+
+  // $FlowExpectedError[incompatible-call]: expected description should be present
+  expect(element).toHaveDescription();
+  expect(element).toHaveDescription('foo');
+  expect(element).toHaveDescription(/[0-9]/);
+  // $FlowExpectedError[incompatible-call]
+  expect(element).toHaveDescription(true);
+
 }
 
 {


### PR DESCRIPTION
- Links to documentation: https://github.com/testing-library/jest-dom#jest-dom
- Link to GitHub or NPM: https://github.com/testing-library/jest-dom
- Type of contribution: addition

Other notes:
Adding typedefs for three new functions in `@testing-library/jest-dom`: `toBeEmptyDOMElement()`,  `toBePartiallyChecked()`,  `toHaveDescription(text: string | RegExp)`

