### PR TITLE
[@ginkgo-bioworks/react-json-schema-form] Add 'null' to allowed types…

### DIFF
--- a/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder_v2.x.x/flow_v0.92.x-/react-json-schema-form-builder_v2.x.x.js
+++ b/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder_v2.x.x/flow_v0.92.x-/react-json-schema-form-builder_v2.x.x.js
@@ -1,6 +1,6 @@
 declare module '@ginkgo-bioworks/react-json-schema-form-builder' {
   declare type Parameters = {|
-    [string]: string | number | boolean | Array<string | number>,
+    [string]: any,
     name: string,
     path: string,
     definitionData: { [string]: any, ... },
@@ -21,6 +21,7 @@ declare module '@ginkgo-bioworks/react-json-schema-form-builder' {
     | 'integer'
     | 'array'
     | 'object'
+    | 'null';
 
   declare type MatchType = {|
     types: Array<DataType>,

--- a/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder_v2.x.x/test_react-json-schema-form-builder_v2.x.x.js
+++ b/definitions/npm/@ginkgo-bioworks/react-json-schema-form-builder_v2.x.x/test_react-json-schema-form-builder_v2.x.x.js
@@ -59,6 +59,23 @@ describe('@ginkgo-bioworks/react-json-schema-form-builder', () => {
             field: 'customFormInput1',
           }],
         },
+        customFormInput2: {
+          displayName: 'custom form input 2',
+          defaultDataSchema: {
+            'type': 'string',
+          },
+          defaultUiSchema: {
+            'ui:field': 'customFormInput2',
+          },
+          type: 'string',
+          cardBody: (props: CardBodyProps) => <div/>,
+          modalBody: (props: CardBodyProps) => <div/>,
+          matchIf: [{
+            types: ['null'],
+            field: 'customFormInput2',
+          }],
+        },
+
       },
       tooltipDescriptions: {
         add: 'add text',


### PR DESCRIPTION
… in matchIf

- Add 'null' to DataType.
- Change allowed types of Parameters values to any

Links to documentation: https://react-json-schema-form-builder.readthedocs.io/en/main/
Link to GitHub or NPM: https://github.com/ginkgobioworks/react-json-schema-form-builder
Type of contribution: addition
