### PR TITLE
update jest-dom toBeEmpty and toBeEmptyDOMElement matchers

### DIFF
--- a/cli/flow-typed/npm/jest_v25.x.x.js
+++ b/cli/flow-typed/npm/jest_v25.x.x.js
@@ -253,6 +253,7 @@ type DomTestingLibraryType = {
  // 5.x
  toHaveDisplayValue(value: string | string[]): void,
  toBeChecked(): void,
+ toBeEmptyDOMElement(): void,
  ...
 };
 

--- a/definitions/npm/jest_v23.x.x/flow_v0.104.x-v0.133.x/jest_v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.104.x-v0.133.x/jest_v23.x.x.js
@@ -218,6 +218,7 @@ type EnzymeMatchersType = {
 type DomTestingLibraryType = {
  toBeDisabled(): void,
  toBeEmpty(): void,
+ toBeEmptyDOMElement(): void,
  toBeInTheDocument(): void,
  toBeVisible(): void,
  toContainElement(element: HTMLElement | null): void,

--- a/definitions/npm/jest_v23.x.x/flow_v0.104.x-v0.133.x/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.104.x-v0.133.x/test_jest-v23.x.x.js
@@ -504,6 +504,7 @@ expect(wrapper).toHaveDisplayName(true);
 
   expect(element).toBeDisabled();
   expect(element).toBeEmpty();
+  expect(element).toBeEmptyDOMElement();
   expect(element).toBeInTheDocument();
   expect(element).toBeVisible();
   // $FlowExpectedError[incompatible-call]

--- a/definitions/npm/jest_v23.x.x/flow_v0.134.x-/jest_v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.134.x-/jest_v23.x.x.js
@@ -218,6 +218,7 @@ type EnzymeMatchersType = {
 type DomTestingLibraryType = {
  toBeDisabled(): void,
  toBeEmpty(): void,
+ toBeEmptyDOMElement(): void,
  toBeInTheDocument(): void,
  toBeVisible(): void,
  toContainElement(element: HTMLElement | null): void,

--- a/definitions/npm/jest_v23.x.x/flow_v0.134.x-/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.134.x-/test_jest-v23.x.x.js
@@ -504,6 +504,7 @@ expect(wrapper).toHaveDisplayName(true);
 
   expect(element).toBeDisabled();
   expect(element).toBeEmpty();
+  expect(element).toBeEmptyDOMElement();
   expect(element).toBeInTheDocument();
   expect(element).toBeVisible();
   // $FlowExpectedError[incompatible-call]

--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-v0.103.x/jest_v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-v0.103.x/jest_v23.x.x.js
@@ -207,6 +207,7 @@ type EnzymeMatchersType = {
 type DomTestingLibraryType = {
   toBeDisabled(): void,
   toBeEmpty(): void,
+  toBeEmptyDOMElement(): void,
   toBeInTheDocument(): void,
   toBeVisible(): void,
   toContainElement(element: HTMLElement | null): void,

--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-v0.103.x/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-v0.103.x/test_jest-v23.x.x.js
@@ -508,6 +508,7 @@ expect(wrapper).toHaveDisplayName(true);
 
   expect(element).toBeDisabled();
   expect(element).toBeEmpty();
+  expect(element).toBeEmptyDOMElement();
   expect(element).toBeInTheDocument();
   expect(element).toBeVisible();
   // $FlowExpectedError

--- a/definitions/npm/jest_v24.x.x/flow_v0.104.x-v0.133.0/jest_v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.104.x-v0.133.0/jest_v24.x.x.js
@@ -227,6 +227,7 @@ type DomTestingLibraryType = {
  toBeInTheDocument(): void,
  toBeVisible(): void,
  toBeEmpty(): void,
+ toBeEmptyDOMElement(): void,
  toBeDisabled(): void,
  toBeEnabled(): void,
  toBeInvalid(): void,

--- a/definitions/npm/jest_v24.x.x/flow_v0.104.x-v0.133.0/test_jest-v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.104.x-v0.133.0/test_jest-v24.x.x.js
@@ -553,6 +553,7 @@ expect(wrapper).toHaveDisplayName(true);
   expect(element).toBeDisabled();
   expect(element).toBeEnabled();
   expect(element).toBeEmpty();
+  expect(element).toBeEmptyDOMElement();
   expect(element).toBeInTheDocument();
   expect(element).toBeVisible();
   // $FlowExpectedError[incompatible-call]

--- a/definitions/npm/jest_v24.x.x/flow_v0.134.x-/jest_v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.134.x-/jest_v24.x.x.js
@@ -227,6 +227,7 @@ type DomTestingLibraryType = {
  toBeInTheDocument(): void,
  toBeVisible(): void,
  toBeEmpty(): void,
+ toBeEmptyDOMElement(): void,
  toBeDisabled(): void,
  toBeEnabled(): void,
  toBeInvalid(): void,

--- a/definitions/npm/jest_v24.x.x/flow_v0.134.x-/test_jest-v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.134.x-/test_jest-v24.x.x.js
@@ -553,6 +553,7 @@ expect(wrapper).toHaveDisplayName(true);
   expect(element).toBeDisabled();
   expect(element).toBeEnabled();
   expect(element).toBeEmpty();
+  expect(element).toBeEmptyDOMElement();
   expect(element).toBeInTheDocument();
   expect(element).toBeVisible();
   // $FlowExpectedError[incompatible-call]

--- a/definitions/npm/jest_v24.x.x/flow_v0.61.x-v0.103.x/jest_v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.61.x-v0.103.x/jest_v24.x.x.js
@@ -220,6 +220,7 @@ type DomTestingLibraryType = {
   toBeInTheDocument(): void,
   toBeVisible(): void,
   toBeEmpty(): void,
+  toBeEmptyDOMElement(): void,
   toBeDisabled(): void,
   toBeEnabled(): void,
   toBeInvalid(): void,

--- a/definitions/npm/jest_v24.x.x/flow_v0.61.x-v0.103.x/test_jest-v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.61.x-v0.103.x/test_jest-v24.x.x.js
@@ -552,6 +552,7 @@ expect(wrapper).toHaveDisplayName(true);
   expect(element).toBeDisabled();
   expect(element).toBeEnabled();
   expect(element).toBeEmpty();
+  expect(element).toBeEmptyDOMElement();
   expect(element).toBeInTheDocument();
   expect(element).toBeVisible();
   // $FlowExpectedError

--- a/definitions/npm/jest_v25.x.x/flow_v0.104.x-v0.133.x/jest_v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.104.x-v0.133.x/jest_v25.x.x.js
@@ -224,11 +224,14 @@ type DomTestingLibraryType = {
   * @deprecated
   */
  toBeInTheDOM(container?: HTMLElement): void,
+  /**
+   * @deprecated
+   */
+  toBeEmpty(): void,
 
  // 4.x
  toBeInTheDocument(): void,
  toBeVisible(): void,
- toBeEmpty(): void,
  toBeDisabled(): void,
  toBeEnabled(): void,
  toBeInvalid(): void,
@@ -250,6 +253,7 @@ type DomTestingLibraryType = {
  // 5.x
  toHaveDisplayValue(value: string | string[]): void,
  toBeChecked(): void,
+ toBeEmptyDOMElement(): void,
  ...
 };
 

--- a/definitions/npm/jest_v25.x.x/flow_v0.104.x-v0.133.x/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.104.x-v0.133.x/test_jest-v25.x.x.js
@@ -556,6 +556,7 @@ expect(wrapper).toHaveDisplayName(true);
   expect(element).toBeDisabled();
   expect(element).toBeEnabled();
   expect(element).toBeEmpty();
+  expect(element).toBeEmptyDOMElement();
   expect(element).toBeInTheDocument();
   expect(element).toBeVisible();
   // $FlowExpectedError[incompatible-call]

--- a/definitions/npm/jest_v25.x.x/flow_v0.134.x-/jest_v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.134.x-/jest_v25.x.x.js
@@ -220,15 +220,18 @@ type EnzymeMatchersType = {
 // DOM testing library extensions (jest-dom)
 // https://github.com/testing-library/jest-dom
 type DomTestingLibraryType = {
- /**
+  /**
   * @deprecated
   */
- toBeInTheDOM(container?: HTMLElement): void,
+  toBeInTheDOM(container?: HTMLElement): void,
+  /**
+   * @deprecated
+   */
+  toBeEmpty(): void,
 
  // 4.x
  toBeInTheDocument(): void,
  toBeVisible(): void,
- toBeEmpty(): void,
  toBeDisabled(): void,
  toBeEnabled(): void,
  toBeInvalid(): void,
@@ -250,6 +253,7 @@ type DomTestingLibraryType = {
  // 5.x
  toHaveDisplayValue(value: string | string[]): void,
  toBeChecked(): void,
+ toBeEmptyDOMElement(): void,
  ...
 };
 

--- a/definitions/npm/jest_v25.x.x/flow_v0.134.x-/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.134.x-/test_jest-v25.x.x.js
@@ -556,6 +556,7 @@ expect(wrapper).toHaveDisplayName(true);
   expect(element).toBeDisabled();
   expect(element).toBeEnabled();
   expect(element).toBeEmpty();
+  expect(element).toBeEmptyDOMElement();
   expect(element).toBeInTheDocument();
   expect(element).toBeVisible();
   // $FlowExpectedError[incompatible-call]

--- a/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/jest_v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/jest_v25.x.x.js
@@ -216,10 +216,14 @@ type DomTestingLibraryType = {
    * @deprecated
    */
   toBeInTheDOM(container?: HTMLElement): void,
+  /**
+   * @deprecated
+   */
+  toBeEmpty(): void,
 
   toBeInTheDocument(): void,
   toBeVisible(): void,
-  toBeEmpty(): void,
+  toBeEmptyDOMElement(): void,
   toBeDisabled(): void,
   toBeEnabled(): void,
   toBeInvalid(): void,

--- a/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/test_jest-v25.x.x.js
@@ -552,6 +552,7 @@ expect(wrapper).toHaveDisplayName(true);
   expect(element).toBeDisabled();
   expect(element).toBeEnabled();
   expect(element).toBeEmpty();
+  expect(element).toBeEmptyDOMElement();
   expect(element).toBeInTheDocument();
   expect(element).toBeVisible();
   // $FlowExpectedError

--- a/definitions/npm/jest_v26.x.x/flow_v0.104.x-v0.133.x/jest_v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.104.x-v0.133.x/jest_v26.x.x.js
@@ -230,11 +230,14 @@ type DomTestingLibraryType = {
    * @deprecated
    */
   toBeInTheDOM(container?: HTMLElement): void,
+    /**
+   * @deprecated
+   */
+  toBeEmpty(): void,
 
   // 4.x
   toBeInTheDocument(): void,
   toBeVisible(): void,
-  toBeEmpty(): void,
   toBeDisabled(): void,
   toBeEnabled(): void,
   toBeInvalid(): void,

--- a/definitions/npm/jest_v26.x.x/flow_v0.104.x-v0.133.x/test_jest-v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.104.x-v0.133.x/test_jest-v26.x.x.js
@@ -564,6 +564,7 @@ expect(wrapper).toHaveDisplayName(true);
   expect(element).toBeDisabled();
   expect(element).toBeEnabled();
   expect(element).toBeEmpty();
+  expect(element).toBeEmptyDOMElement();
   expect(element).toBeInTheDocument();
   expect(element).toBeVisible();
   // $FlowExpectedError[incompatible-call]

--- a/definitions/npm/jest_v26.x.x/flow_v0.134.x-/jest_v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.134.x-/jest_v26.x.x.js
@@ -230,11 +230,14 @@ type DomTestingLibraryType = {
    * @deprecated
    */
   toBeInTheDOM(container?: HTMLElement): void,
+  /**
+   * @deprecated
+   */
+  toBeEmpty(): void,
 
   // 4.x
   toBeInTheDocument(): void,
   toBeVisible(): void,
-  toBeEmpty(): void,
   toBeDisabled(): void,
   toBeEnabled(): void,
   toBeInvalid(): void,

--- a/definitions/npm/jest_v26.x.x/flow_v0.134.x-/test_jest-v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.134.x-/test_jest-v26.x.x.js
@@ -572,6 +572,7 @@ expect(wrapper).toHaveDisplayName(true);
   expect(element).toBeDisabled();
   expect(element).toBeEnabled();
   expect(element).toBeEmpty();
+  expect(element).toBeEmptyDOMElement();
   expect(element).toBeInTheDocument();
   expect(element).toBeVisible();
   // $FlowExpectedError[incompatible-call]


### PR DESCRIPTION
According to the doc (linked below)
- add new matcher `toBeEmptyDOMElement`
- mark existing matcher `toBeEmpty` as deprecated

- Links to documentation:  https://github.com/testing-library/jest-dom#tobeempty
- Type of contribution: fix 


