### PR TITLE
[jest_27.x.x] Remove deprecated runTimersToTime method

### DIFF
--- a/definitions/npm/jest_v27.x.x/flow_v0.104.x-v0.133.x/jest_v27.x.x.js
+++ b/definitions/npm/jest_v27.x.x/flow_v0.104.x-v0.133.x/jest_v27.x.x.js
@@ -890,13 +890,6 @@ type JestObjectType = {
    */
   advanceTimersByTime(msToRun: number): void,
   /**
-   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
-   * or setInterval() and setImmediate()).
-   *
-   * Renamed to `advanceTimersByTime`.
-   */
-  runTimersToTime(msToRun: number): void,
-  /**
    * Executes only the macro-tasks that are currently pending (i.e., only the
    * tasks that have been queued by setTimeout() or setInterval() up to this
    * point)

--- a/definitions/npm/jest_v27.x.x/flow_v0.104.x-v0.133.x/test_jest-v27.x.x.js
+++ b/definitions/npm/jest_v27.x.x/flow_v0.104.x-v0.133.x/test_jest-v27.x.x.js
@@ -221,7 +221,7 @@ test('name', (done) => {
   done.fail();
   done(new Error('fail'));
   // $FlowExpectedError[incompatible-call]
-  done("foo");
+  done('foo');
 });
 
 test.todo('');
@@ -331,7 +331,6 @@ jest.spyOn({}, 'foo', 'get');
 
 jest.setTimeout(1000);
 
-jest.runTimersToTime(3000);
 jest.advanceTimersByTime(3000);
 
 expect.addSnapshotSerializer({

--- a/definitions/npm/jest_v27.x.x/flow_v0.134.x-/jest_v27.x.x.js
+++ b/definitions/npm/jest_v27.x.x/flow_v0.134.x-/jest_v27.x.x.js
@@ -894,13 +894,6 @@ type JestObjectType = {
    */
   advanceTimersByTime(msToRun: number): void,
   /**
-   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
-   * or setInterval() and setImmediate()).
-   *
-   * Renamed to `advanceTimersByTime`.
-   */
-  runTimersToTime(msToRun: number): void,
-  /**
    * Executes only the macro-tasks that are currently pending (i.e., only the
    * tasks that have been queued by setTimeout() or setInterval() up to this
    * point)

--- a/definitions/npm/jest_v27.x.x/flow_v0.134.x-/test_jest-v27.x.x.js
+++ b/definitions/npm/jest_v27.x.x/flow_v0.134.x-/test_jest-v27.x.x.js
@@ -221,7 +221,7 @@ test('name', (done) => {
   done.fail();
   done(new Error('fail'));
   // $FlowExpectedError[incompatible-call]
-  done("foo");
+  done('foo');
 });
 
 test.todo('');
@@ -339,7 +339,6 @@ jest.spyOn({}, 'foo', 'get');
 
 jest.setTimeout(1000);
 
-jest.runTimersToTime(3000);
 jest.advanceTimersByTime(3000);
 
 expect.addSnapshotSerializer({
@@ -617,7 +616,6 @@ expect(wrapper).toHaveDisplayName(true);
   expect(element).toHaveDescription(/[0-9]/);
   // $FlowExpectedError[incompatible-call]
   expect(element).toHaveDescription(true);
-
 }
 
 {


### PR DESCRIPTION
- Links to documentation: https://jestjs.io/blog/2021/05/25/jest-27#miscellaneous-breaking-changes
- Link to GitHub or NPM: https://github.com/facebook/jest
- Type of contribution: fix

