### PR TITLE
Add support for Next.js version 10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ library-definition test runner.
 ***We call this the "flow version directory".***
 
 This specifies that the definition you are contributing is compatible with the
-version range of the directiry. You MUST specify a version range with names like
+version range of the directory. You MUST specify a version range with names like
 `flow_v0.80.x-` ("any version at or after v0.80.x") or
 `flow_-v0.80.x` ("any version at or before v0.80.x") or
 `flow_v0.80.x-v0.106.x` ("any version inclusively between v0.80.x and

--- a/definitions/npm/next_v10.x.x/flow_v0.104.x-/next_v10.x.x.js
+++ b/definitions/npm/next_v10.x.x/flow_v0.104.x-/next_v10.x.x.js
@@ -1,0 +1,247 @@
+declare module "next" {
+  declare type RequestHandler = (
+    req: http$IncomingMessage<>,
+    res: http$ServerResponse,
+    parsedUrl: any
+  ) => Promise<void>;
+
+  declare type NextApp = {
+    prepare(): Promise<void>,
+    getRequestHandler(): RequestHandler,
+    setAssetPrefix(url: string): void,
+    render(
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse,
+      pathname: string,
+      query?: Object
+    ): Promise<void>,
+    renderToHTML(
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse,
+      pathname: string,
+      query?: Object
+    ): string,
+    renderError(
+      err: Error,
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse,
+      pathname: string,
+      query?: Object
+    ): Promise<void>,
+    renderErrorToHTML(
+      err: Error,
+      req: http$IncomingMessage<>,
+      res: http$ServerResponse,
+      pathname: string,
+      query?: Object
+    ): string,
+    ...
+  };
+
+  declare export type Options = {
+    dev?: boolean,
+    dir?: string,
+    quiet?: boolean,
+    staticMarkup?: boolean,
+    ...
+  };
+
+  declare export type Context = {
+    +pathname: string,
+    +query: any,
+    +req?: any,
+    +res?: any,
+    +xhr?: any,
+    +err?: any,
+    ...
+  };
+
+  declare export type Page<T, S> = {
+    ...React$Component<T, S>,
+    getInitialProps: (ctx: Context) => Promise<any>,
+    ...
+  };
+
+  declare export default (opts: Options) => NextApp;
+}
+
+declare module "next/head" {
+  declare module.exports: Class<React$Component<any, any>>;
+}
+
+declare module "next/config" {
+  declare module.exports: () => {
+    publicRuntimeConfig: { [string]: string, ... },
+    serverRuntimeConfig: { [string]: string, ... },
+    ...
+  };
+}
+
+declare type URLObject = {
+  +href?: string,
+  +protocol?: string,
+  +slashes?: boolean,
+  +auth?: string,
+  +hostname?: string,
+  +port?: string | number,
+  +host?: string,
+  +pathname?: string,
+  +search?: string,
+  +query?: Object,
+  +hash?: string,
+  ...
+};
+
+declare module "next/link" {
+  declare export type Props = {
+    prefetch?: boolean,
+    shallow?: boolean,
+    scroll?: boolean,
+    replace?: boolean,
+    onError?: (error: any) => void,
+    href: string | URLObject,
+    as?: string | URLObject,
+    passHref?: boolean,
+    ...
+  };
+
+  declare export default Class<React$Component<Props>>;
+}
+
+declare module "next/router" {
+  declare export type RouteError = Error & { cancelled: boolean, ... };
+  declare export type RouteCallback = (url: string) => void;
+  declare export type RouteErrorCallback = (
+    err: RouteError,
+    url: string
+  ) => void;
+
+  declare export interface RouterEvents {
+    on(event: "routeChangeStart", cb: RouteCallback): RouterEvents,
+    on(event: "routeChangeComplete", cb: RouteCallback): RouterEvents,
+    on(event: "routeChangeError", cb: RouteErrorCallback): RouterEvents,
+    on(event: "beforeHistoryChange", cb: RouteCallback): RouterEvents,
+    on(event: "hashChangeStart", cb: RouteCallback): RouterEvents,
+    on(event: "hashChangeComplete", cb: RouteCallback): RouterEvents,
+
+    off(event: "routeChangeStart", cb: RouteCallback): RouterEvents,
+    off(event: "routeChangeComplete", cb: RouteCallback): RouterEvents,
+    off(event: "routeChangeError", cb: RouteErrorCallback): RouterEvents,
+    off(event: "beforeHistoryChange", cb: RouteCallback): RouterEvents,
+    off(event: "hashChangeStart", cb: RouteCallback): RouterEvents,
+    off(event: "hashChangeComplete", cb: RouteCallback): RouterEvents
+  }
+
+  declare export type EventChangeOptions = {
+    [key: string]: any,
+    shallow?: boolean,
+    ...
+  };
+
+  declare export type BeforePopStateCallback = (options: {
+    url: string,
+    as: ?string,
+    options: EventChangeOptions,
+    ...
+  }) => boolean;
+
+  declare export type Router = {
+    +route: string,
+    +pathname: string,
+    +asPath: string,
+    +query: Object,
+    events: RouterEvents,
+    push(
+      url: string | URLObject,
+      as: ?(string | URLObject),
+      options?: EventChangeOptions
+    ): Promise<boolean>,
+    replace(
+      url: string | URLObject,
+      as: ?(string | URLObject),
+      options?: EventChangeOptions
+    ): Promise<boolean>,
+    prefetch(url: string): Promise<any>,
+    beforePopState(cb: BeforePopStateCallback): void,
+    ...
+  };
+
+  declare export function withRouter<T>(
+    Component: React$ComponentType<T & { router: Router, ... }>
+  ): Class<React$Component<T>>;
+
+  declare export function useRouter(): Router;
+
+  declare export default Router;
+}
+
+declare module "next/document" {
+  import type { Context } from "next";
+
+  declare type ComponentsEnhancer = any;
+
+  declare type RenderPageResult = {
+    html: string,
+    head?: Array<React$Node | null>,
+    ...
+  };
+
+  declare export type DocumentContext = Context & {
+    renderPage: (options?: ComponentsEnhancer) => RenderPageResult | Promise<RenderPageResult>,
+    ...
+  }
+
+  declare export var Head: Class<React$Component<any, any>>;
+  declare export var Main: Class<React$Component<any, any>>;
+  declare export var NextScript: Class<React$Component<any, any>>;
+  declare export default Class<React$Component<any, any>> & {
+    getInitialProps: (ctx: DocumentContext) => Promise<any>,
+    renderPage(cb: Function): void,
+    ...
+  };
+}
+
+declare module "next/app" {
+  import type { Context, Page } from "next";
+  import type { Router } from "next/router";
+
+  declare export var Container: Class<React$Component<any, any>>;
+
+  declare export type AppInitialProps = {
+    Component: Page<any, any>,
+    router: Router,
+    ctx: Context,
+    ...
+  };
+
+  declare export default Class<React$Component<any, any>> & { getInitialProps: (appInitialProps: AppInitialProps) => Promise<any>, ... };
+}
+
+declare module "next/dynamic" {
+  declare type ImportedComponent = Promise<null | React$ElementType>;
+  declare type ComponentMapping = { [componentName: string]: ImportedComponent, ... };
+
+  declare type NextDynamicOptions = {
+    loader?: ComponentMapping | (() => ImportedComponent),
+    loading?: React$ElementType,
+    timeout?: number,
+    delay?: number,
+    ssr?: boolean,
+    render?: (
+      props: any,
+      loaded: { [componentName: string]: React$ElementType, ... }
+    ) => React$ElementType,
+    modules?: () => ComponentMapping,
+    loadableGenerated?: {
+      webpack?: any,
+      modules?: any,
+      ...
+    },
+    ...
+  };
+
+  declare export default function dynamic(
+    dynamicOptions: any,
+    options: ?NextDynamicOptions
+  ): Object;
+}

--- a/definitions/npm/next_v10.x.x/flow_v0.104.x-/next_v10.x.x.js
+++ b/definitions/npm/next_v10.x.x/flow_v0.104.x-/next_v10.x.x.js
@@ -146,10 +146,16 @@ declare module "next/router" {
   }) => boolean;
 
   declare export type Router = {
-    +route: string,
     +pathname: string,
-    +asPath: string,
     +query: Object,
+    +asPath: string,
+    +isFallback: boolean,
+    +basePath: string,
+    +locale: string,
+    +locales: string[],
+    +defaultLocale: string,
+    +isReady: boolean,
+    +isPreview: boolean,
     events: RouterEvents,
     push(
       url: string | URLObject,

--- a/definitions/npm/next_v10.x.x/flow_v0.104.x-/test_next_v10.x.x.js
+++ b/definitions/npm/next_v10.x.x/flow_v0.104.x-/test_next_v10.x.x.js
@@ -1,0 +1,173 @@
+import React from "react";
+import next, {type Context} from "next";
+import Link from "next/link";
+import Head from "next/head";
+import Router, {type RouteError, useRouter} from "next/router";
+import Document, {Head as DocumentHead, Main, NextScript, type DocumentContext} from "next/document";
+import App, {type AppInitialProps, Container} from "next/app";
+import dynamic from "next/dynamic";
+import getConfig from "next/config";
+
+const { createServer } = require("http");
+const { parse } = require("url");
+
+// server
+// $FlowExpectedError[incompatible-call]
+next({ dev: 1 });
+// $FlowExpectedError[incompatible-call]
+next({ dir: false });
+// $FlowExpectedError[incompatible-call]
+next({ quiet: "derp" });
+// $FlowExpectedError[incompatible-call]
+next({ staticMarkup: 42 });
+
+const app = next({ dev: true, dir: ".", quiet: false });
+const handle = app.getRequestHandler();
+app.prepare().then(() => {
+  createServer((req, res) => {
+    const parsedUrl = parse(req.url, true);
+    const { pathname, query } = parsedUrl;
+
+    let q: Object | void;
+
+    if (typeof query === "object") {
+      q = query;
+    }
+
+    if (pathname === "/") {
+      app.render(req, res, "/index", q);
+    } else if (pathname === "/foo") {
+      app.render(req, res, "/index", q);
+    } else if (pathname === "/about") {
+      app.render(req, res, "/about", q);
+    } else {
+      handle(req, res, parsedUrl);
+    }
+  }).listen("3500", err => {
+    if (err) throw err;
+    console.log("> Ready on http://localhost:3500");
+  });
+});
+
+app.setAssetPrefix('');
+
+class ConfigAwareComponent extends React.Component<any> {
+  render() {
+    const { publicRuntimeConfig, serverRuntimeConfig } = getConfig();
+    return (
+      <div>
+        {publicRuntimeConfig.publicConfigVar}
+        {serverRuntimeConfig.privateConfigVar}
+      </div>
+    );
+  }
+}
+
+<Head>
+  <meta charSet="utf-8" />
+</Head>;
+
+<Link href="/">Index</Link>;
+
+// $FlowExpectedError[incompatible-type]
+<Link href={1}>InvalidNumLink</Link>;
+
+// $FlowExpectedError[prop-missing]
+Router.onRouteChangeStart = {};
+
+// $FlowExpectedError[incompatible-call]
+Router.events.on('unknown', (url: string) => {});
+// $FlowExpectedError[incompatible-call]
+Router.events.off('unknown', (url: string) => {});
+
+Router.events.on('routeChangeStart', (url: string) => {});
+Router.events.off('routeChangeStart', (url: string) => {});
+
+Router.events.on('routeChangeComplete', (url: string) => {});
+Router.events.off('routeChangeComplete', (url: string) => {});
+
+Router.events.on('routeChangeError', (err: RouteError, url: string) => {
+  if (err.cancelled) {
+    console.log(`Route to ${url} was cancelled!`);
+  }
+});
+
+Router.push({});
+
+Router.push("/about");
+Router.push("/about", "/");
+Router.push("/about", "/", { shallow: true });
+Router.replace("/about");
+Router.replace("/about", "/");
+Router.prefetch("/dynamic");
+
+Router.beforePopState(({ url, as, options }) => true);
+
+const r: string = Router.route;
+const p: string = Router.pathname;
+const q: { ... } = Router.query;
+
+export default class TestDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext): Promise<any> {
+    const props = await Document.getInitialProps(ctx);
+    return { ...props, customValue: "hi there!" };
+  }
+
+  render(): React$Node {
+    return (
+      <html>
+        <DocumentHead />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    );
+  }
+}
+
+export class TestApp extends App {
+  static async getInitialProps({ Component, router, ctx }: AppInitialProps): Promise<any> {
+    const props = await Component.getInitialProps(ctx);
+    return { ...props }
+  }
+
+  render (): React$Node {
+    const { Component, pageProps } = this.props;
+
+    return (
+      <Container>
+        <Component {...pageProps} />
+      </Container>
+    )
+  }
+}
+
+export function TestFunctionComponent(): React$Node {
+  useRouter();
+  return <div />;
+}
+
+const DynamicComponent = dynamic(() => import('./test_next_v10.x.x'));
+
+const DynamicComponentWithCustomLoading = dynamic(() => import('./test_next_v10.x.x'), {
+  loading: () => <p>...</p>
+});
+
+const DynamicComponentWithNoSSR = dynamic(() => import('./test_next_v10.x.x'), {
+  ssr: false
+});
+
+const HelloBundle = dynamic({
+  modules: () => {
+    return {
+      Hello1: () => import('./test_next_v10.x.x'),
+      Hello2: () => import('./test_next_v10.x.x')
+    }
+  },
+  render: (props, { Hello1, Hello2 }) =>
+    <div>
+      <Hello1 />
+      <Hello2 />
+    </div>
+});

--- a/definitions/npm/next_v10.x.x/flow_v0.104.x-/test_next_v10.x.x.js
+++ b/definitions/npm/next_v10.x.x/flow_v0.104.x-/test_next_v10.x.x.js
@@ -103,9 +103,11 @@ Router.prefetch("/dynamic");
 
 Router.beforePopState(({ url, as, options }) => true);
 
-const r: string = Router.route;
 const p: string = Router.pathname;
 const q: { ... } = Router.query;
+const a: string = Router.asPath;
+const l: string = Router.locale;
+const i: boolean = Router.isReady;
 
 export default class TestDocument extends Document {
   static async getInitialProps(ctx: DocumentContext): Promise<any> {
@@ -144,7 +146,7 @@ export class TestApp extends App {
 }
 
 export function TestFunctionComponent(): React$Node {
-  useRouter();
+  const { pathname, locale }: { +pathname: string, +locale: string, +isReady: boolean, ... } = useRouter();
   return <div />;
 }
 


### PR DESCRIPTION
Derived from the previous version 9 + updated `Router` type.

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://nextjs.org/docs/api-reference/next/router#router-object
- Link to GitHub or NPM: https://www.npmjs.com/package/next
- Type of contribution: new definition | addition

