### PR TITLE
Next.js: add missing `Router.route`

### DIFF
--- a/definitions/npm/next_v10.x.x/flow_v0.104.x-/next_v10.x.x.js
+++ b/definitions/npm/next_v10.x.x/flow_v0.104.x-/next_v10.x.x.js
@@ -146,6 +146,7 @@ declare module "next/router" {
   }) => boolean;
 
   declare export type Router = {
+    +route: string,
     +pathname: string,
     +query: Object,
     +asPath: string,

--- a/definitions/npm/next_v10.x.x/flow_v0.104.x-/test_next_v10.x.x.js
+++ b/definitions/npm/next_v10.x.x/flow_v0.104.x-/test_next_v10.x.x.js
@@ -103,6 +103,7 @@ Router.prefetch("/dynamic");
 
 Router.beforePopState(({ url, as, options }) => true);
 
+const r: string = Router.route;
 const p: string = Router.pathname;
 const q: { ... } = Router.query;
 const a: string = Router.asPath;
@@ -146,7 +147,18 @@ export class TestApp extends App {
 }
 
 export function TestFunctionComponent(): React$Node {
-  const { pathname, locale }: { +pathname: string, +locale: string, +isReady: boolean, ... } = useRouter();
+  const {
+    route,
+    pathname,
+    locale,
+    isReady,
+  }: {
+    +route: string,
+    +pathname: string,
+    +locale: string,
+    +isReady: boolean,
+    ...
+  } = useRouter();
   return <div />;
 }
 


### PR DESCRIPTION
I incorrectly removed this property in a9cb5131e41a177e3b3c07ae634afcf5690b0716 because it was not documented (see: https://nextjs.org/docs/api-reference/next/router#router-object). However, I can confirm it actually exists in Next.js version 10.

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://nextjs.org/docs/api-reference/next/router#router-object
- Link to GitHub or NPM: https://www.npmjs.com/package/next
- Type of contribution: fix



