### PR TITLE
Jest: add missing `test.skip.each`

### DIFF
--- a/definitions/npm/jest_v26.x.x/flow_v0.134.x-/jest_v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.134.x-/jest_v26.x.x.js
@@ -1044,11 +1044,20 @@ declare var it: {
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
-  skip(
-    name: JestTestName,
-    fn?: (done: JestDoneFn) => ?Promise<mixed>,
-    timeout?: number
-  ): void,
+  skip: {|
+    (
+      name: JestTestName,
+      fn?: (done: JestDoneFn) => ?Promise<mixed>,
+      timeout?: number
+    ): void,
+    each(
+      ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+    ): (
+      name: JestTestName,
+      fn?: (...args: Array<any>) => ?Promise<mixed>,
+      timeout?: number
+    ) => void,
+  |},
   /**
    * Highlight planned tests in the summary output
    *

--- a/definitions/npm/jest_v26.x.x/flow_v0.134.x-/test_jest-v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.134.x-/test_jest-v26.x.x.js
@@ -202,6 +202,14 @@ test.each`
 `('returns $expected when $a is added $b', ({ a, b, expected }) => {
   expect(a + b).toBe(expected);
 });
+test.skip.each`
+  a    | b    | expected
+  ${1} | ${1} | ${2}
+  ${1} | ${2} | ${3}
+  ${2} | ${1} | ${3}
+`('returns $expected when $a is added $b', ({ a, b, expected }) => {
+  expect(a + b).toBe(expected);
+});
 
 // $FlowExpectedError[prop-missing] property `fonly` not found in object type
 test.fonly('test', () => expect('foo').toMatchSnapshot());

--- a/definitions/npm/jest_v27.x.x/flow_v0.134.x-/jest_v27.x.x.js
+++ b/definitions/npm/jest_v27.x.x/flow_v0.134.x-/jest_v27.x.x.js
@@ -1037,11 +1037,20 @@ declare var it: {
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
-  skip(
-    name: JestTestName,
-    fn?: (done: JestDoneFn) => ?Promise<mixed>,
-    timeout?: number
-  ): void,
+  skip: {|
+    (
+      name: JestTestName,
+      fn?: (done: JestDoneFn) => ?Promise<mixed>,
+      timeout?: number
+    ): void,
+    each(
+      ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+    ): (
+      name: JestTestName,
+      fn?: (...args: Array<any>) => ?Promise<mixed>,
+      timeout?: number
+    ) => void,
+  |},
   /**
    * Highlight planned tests in the summary output
    *

--- a/definitions/npm/jest_v27.x.x/flow_v0.134.x-/test_jest-v27.x.x.js
+++ b/definitions/npm/jest_v27.x.x/flow_v0.134.x-/test_jest-v27.x.x.js
@@ -202,6 +202,14 @@ test.each`
 `('returns $expected when $a is added $b', ({ a, b, expected }) => {
   expect(a + b).toBe(expected);
 });
+test.skip.each`
+  a    | b    | expected
+  ${1} | ${1} | ${2}
+  ${1} | ${2} | ${3}
+  ${2} | ${1} | ${3}
+`('returns $expected when $a is added $b', ({ a, b, expected }) => {
+  expect(a + b).toBe(expected);
+});
 
 // $FlowExpectedError[prop-missing] property `fonly` not found in object type
 test.fonly('test', () => expect('foo').toMatchSnapshot());


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://jestjs.io/docs/api#testskipeachtablename-fn
- Link to GitHub or NPM: 
- Type of contribution: new definition | addition | fix | refactor

Other notes:

