### PR TITLE
[local-storage] Add definition

### DIFF
--- a/definitions/npm/local-storage-es5_v2.x.x/test_local-storage-es5_v2.x.x.js
+++ b/definitions/npm/local-storage-es5_v2.x.x/test_local-storage-es5_v2.x.x.js
@@ -6,31 +6,31 @@ const isSet: boolean = ls.set('test', 'test');
 // $FlowExpectedError[incompatible-type] cannot parse to anything not boolean
 const isNotSet: number = ls.set('test', 'test');
 
-// $FlowExpectedError[incompatible-call string only key
+// $FlowExpectedError[incompatible-call] string only key
 ls.set(123, 'test');
 
-// $FlowExpectedError[incompatible-call too few arguments
+// $FlowExpectedError[incompatible-call] too few arguments
 ls.set('test');
 
 // ---
 
 ls.get('test');
 
-// $FlowExpectedError[incompatible-call string only key
+// $FlowExpectedError[incompatible-call] string only key
 ls.get(123);
 
 // ---
 
 ls.remove('test');
 
-// $FlowExpectedError[incompatible-call string only key
+// $FlowExpectedError[incompatible-call] string only key
 ls.remove(123);
 
 // ---
 
 ls.clear('test');
 
-// $FlowExpectedError[incompatible-call string only key
+// $FlowExpectedError[incompatible-call] string only key
 ls.clear(123);
 
 // ---
@@ -39,7 +39,7 @@ ls.backend();
 ls.backend(window.localStorage);
 ls.backend(window.sessionStorage);
 
-// $FlowExpectedError[incompatible-call wrong arg type
+// $FlowExpectedError[incompatible-call] wrong arg type
 ls.backend('test');
 
 // ---

--- a/definitions/npm/local-storage_v2.x.x/flow_v0.25.x-/local-storage_v2.x.x.js
+++ b/definitions/npm/local-storage_v2.x.x/flow_v0.25.x-/local-storage_v2.x.x.js
@@ -1,0 +1,15 @@
+declare module 'local-storage' {
+  declare type Callback = (value: any, old: any, url: string) => void
+
+  declare type Accessor = {|
+    set: (key: string, value: string | number | boolean | { ... }) => boolean,
+    get: (key: string) => any,
+    remove: (key: string) => any,
+    clear: (key: string) => any,
+    backend: (store?: Storage) => Storage,
+    on: (key: string, fn: Callback) => void,
+    off: (key: string, fn: Callback) => void,
+  |};
+
+  declare module.exports: Accessor;
+}

--- a/definitions/npm/local-storage_v2.x.x/test_local-storage_v2.x.x.js
+++ b/definitions/npm/local-storage_v2.x.x/test_local-storage_v2.x.x.js
@@ -6,31 +6,31 @@ const isSet: boolean = ls.set('test', 'test');
 // $FlowExpectedError[incompatible-type] cannot parse to anything not boolean
 const isNotSet: number = ls.set('test', 'test');
 
-// $FlowExpectedError[incompatible-call string only key
+// $FlowExpectedError[incompatible-call] string only key
 ls.set(123, 'test');
 
-// $FlowExpectedError[incompatible-call too few arguments
+// $FlowExpectedError[incompatible-call] too few arguments
 ls.set('test');
 
 // ---
 
 ls.get('test');
 
-// $FlowExpectedError[incompatible-call string only key
+// $FlowExpectedError[incompatible-call] string only key
 ls.get(123);
 
 // ---
 
 ls.remove('test');
 
-// $FlowExpectedError[incompatible-call string only key
+// $FlowExpectedError[incompatible-call] string only key
 ls.remove(123);
 
 // ---
 
 ls.clear('test');
 
-// $FlowExpectedError[incompatible-call string only key
+// $FlowExpectedError[incompatible-call] string only key
 ls.clear(123);
 
 // ---
@@ -39,7 +39,7 @@ ls.backend();
 ls.backend(window.localStorage);
 ls.backend(window.sessionStorage);
 
-// $FlowExpectedError[incompatible-call wrong arg type
+// $FlowExpectedError[incompatible-call] wrong arg type
 ls.backend('test');
 
 // ---

--- a/definitions/npm/local-storage_v2.x.x/test_local-storage_v2.x.x.js
+++ b/definitions/npm/local-storage_v2.x.x/test_local-storage_v2.x.x.js
@@ -1,5 +1,5 @@
 // @flow
-import ls from 'local-storage-es5';
+import ls from 'local-storage';
 
 const isSet: boolean = ls.set('test', 'test');
 


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
`local-storage-es5` is a direct replica of `local-storage` that I forked myself for use with ie11. Though `local-storage` was never typed so I'm adding now for those that use the more popular `local-storage`

- Links to documentation: https://www.npmjs.com/package/local-storage
- Link to GitHub or NPM: https://www.npmjs.com/package/local-storage
- Type of contribution: new definition

Other notes: Also fix `local-storage-es5` suppression code errors

