### PR TITLE
fix react testing library act() to work fine in flow >=0.153

### DIFF
--- a/definitions/npm/@testing-library/react_v10.x.x/flow_v0.104.x-/react_v10.x.x.js
+++ b/definitions/npm/@testing-library/react_v10.x.x/flow_v0.104.x-/react_v10.x.x.js
@@ -1,12 +1,10 @@
 declare module '@testing-library/react' {
-  // This type comes from
-  // https://github.com/facebook/flow/blob/v0.104.0/lib/react-dom.js#L64
-  declare type ReactDOMTestUtilsThenable = {
-    then(resolve: () => mixed, reject?: () => mixed): mixed,
-    ...
-  };
-  // This type comes from
-  // https://github.com/facebook/flow/blob/v0.104.0/lib/react-dom.js#L116
+  // This type comes from react-dom_v17.x.x.js
+  declare interface ReactDOMTestUtilsThenable {
+    then(resolve: () => mixed, reject?: () => mixed): mixed;
+  }
+
+  // This type comes from react-dom_v17.x.x.js
   declare type ReactDOMTestUtilsAct = (
     callback: () => void | ReactDOMTestUtilsThenable
   ) => ReactDOMTestUtilsThenable;
@@ -445,8 +443,6 @@ declare module '@testing-library/react' {
     text: TextMatch,
     options?: TextMatchOptions
   ): HTMLElement;
-  declare export function getNodeText(
-    node: HTMLElement,
-  ): string;
+  declare export function getNodeText(node: HTMLElement): string;
   declare export var screen: Screen<>;
 }

--- a/definitions/npm/@testing-library/react_v11.x.x/flow_v0.104.x-/react_v11.x.x.js
+++ b/definitions/npm/@testing-library/react_v11.x.x/flow_v0.104.x-/react_v11.x.x.js
@@ -164,14 +164,12 @@ declare module '@@aria-query' {
 declare module '@testing-library/react' {
   import type { ARIARole } from '@@aria-query';
 
-  // This type comes from
-  // https://github.com/facebook/flow/blob/v0.104.0/lib/react-dom.js#L64
-  declare type ReactDOMTestUtilsThenable = {
-    then(resolve: () => mixed, reject?: () => mixed): mixed,
-    ...
-  };
-  // This type comes from
-  // https://github.com/facebook/flow/blob/v0.104.0/lib/react-dom.js#L116
+  // This type comes from react-dom_v17.x.x.js
+  declare interface ReactDOMTestUtilsThenable {
+    then(resolve: () => mixed, reject?: () => mixed): mixed;
+  }
+
+  // This type comes from react-dom_v17.x.x.js
   declare type ReactDOMTestUtilsAct = (
     callback: () => void | ReactDOMTestUtilsThenable
   ) => ReactDOMTestUtilsThenable;

--- a/definitions/npm/@testing-library/react_v12.x.x/flow_v0.104.x-/react_v12.x.x.js
+++ b/definitions/npm/@testing-library/react_v12.x.x/flow_v0.104.x-/react_v12.x.x.js
@@ -164,14 +164,12 @@ declare module '@@aria-query' {
 declare module '@testing-library/react' {
   import type { ARIARole } from '@@aria-query';
 
-  // This type comes from
-  // https://github.com/facebook/flow/blob/v0.104.0/lib/react-dom.js#L64
-  declare type ReactDOMTestUtilsThenable = {
+  // This type comes from react-dom_v17.x.x.js
+  declare interface ReactDOMTestUtilsThenable {
     then(resolve: () => mixed, reject?: () => mixed): mixed,
-    ...
-  };
-  // This type comes from
-  // https://github.com/facebook/flow/blob/v0.104.0/lib/react-dom.js#L116
+  }
+
+  // This type comes from react-dom_v17.x.x.js
   declare type ReactDOMTestUtilsAct = (
     callback: () => void | ReactDOMTestUtilsThenable
   ) => ReactDOMTestUtilsThenable;

--- a/definitions/npm/@testing-library/react_v8.x.x/flow_v0.104.x-/react_v8.x.x.js
+++ b/definitions/npm/@testing-library/react_v8.x.x/flow_v0.104.x-/react_v8.x.x.js
@@ -1,12 +1,10 @@
 declare module '@testing-library/react' {
-  // This type comes from
-  // https://github.com/facebook/flow/blob/v0.104.0/lib/react-dom.js#L64
-  declare type ReactDOMTestUtilsThenable = {
-    then(resolve: () => mixed, reject?: () => mixed): mixed,
-    ...
-  };
-  // This type comes from
-  // https://github.com/facebook/flow/blob/v0.104.0/lib/react-dom.js#L116
+  // This type comes from react-dom_v17.x.x.js
+  declare interface ReactDOMTestUtilsThenable {
+    then(resolve: () => mixed, reject?: () => mixed): mixed;
+  }
+
+  // This type comes from react-dom_v17.x.x.js
   declare type ReactDOMTestUtilsAct = (
     callback: () => void | ReactDOMTestUtilsThenable
   ) => ReactDOMTestUtilsThenable;
@@ -135,10 +133,7 @@ declare module '@testing-library/react' {
   |};
 
   declare module.exports: {
-    render(
-      ui: React$Element<any>,
-      options?: RenderOptions
-    ): RenderResult<>,
+    render(ui: React$Element<any>, options?: RenderOptions): RenderResult<>,
 
     act: ReactDOMTestUtilsAct,
     cleanup: () => void,

--- a/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/react_v9.x.x.js
+++ b/definitions/npm/@testing-library/react_v9.x.x/flow_v0.104.x-/react_v9.x.x.js
@@ -1,12 +1,10 @@
 declare module '@testing-library/react' {
-  // This type comes from
-  // https://github.com/facebook/flow/blob/v0.104.0/lib/react-dom.js#L64
-  declare type ReactDOMTestUtilsThenable = {
-    then(resolve: () => mixed, reject?: () => mixed): mixed,
-    ...
-  };
-  // This type comes from
-  // https://github.com/facebook/flow/blob/v0.104.0/lib/react-dom.js#L116
+  // This type comes from react-dom_v17.x.x.js
+  declare interface ReactDOMTestUtilsThenable {
+    then(resolve: () => mixed, reject?: () => mixed): mixed;
+  }
+
+  // This type comes from react-dom_v17.x.x.js
   declare type ReactDOMTestUtilsAct = (
     callback: () => void | ReactDOMTestUtilsThenable
   ) => ReactDOMTestUtilsThenable;

--- a/definitions/npm/react-dom_v16.x.x/flow_v0.117.x-/react-dom_v16.x.x.js
+++ b/definitions/npm/react-dom_v16.x.x/flow_v0.117.x-/react-dom_v16.x.x.js
@@ -1,23 +1,23 @@
 declare module 'react-dom' {
   declare function findDOMNode(
-    componentOrElement: Element | ?React$Component<any, any>,
+    componentOrElement: Element | ?React$Component<any, any>
   ): null | Element | Text;
 
   declare function render<ElementType: React$ElementType>(
     element: React$Element<ElementType>,
     container: Element,
-    callback?: () => void,
+    callback?: () => void
   ): React$ElementRef<ElementType>;
 
   declare function hydrate<ElementType: React$ElementType>(
     element: React$Element<ElementType>,
     container: Element,
-    callback?: () => void,
+    callback?: () => void
   ): React$ElementRef<ElementType>;
 
   declare function createPortal(
     node: React$Node,
-    container: Element,
+    container: Element
   ): React$Portal;
 
   declare function unmountComponentAtNode(container: any): boolean;
@@ -29,15 +29,15 @@ declare module 'react-dom' {
     b: B,
     c: C,
     d: D,
-    e: E,
+    e: E
   ): void;
   declare function unstable_renderSubtreeIntoContainer<
-    ElementType: React$ElementType,
+    ElementType: React$ElementType
   >(
     parentComponent: React$Component<any, any>,
     nextElement: React$Element<ElementType>,
     container: any,
-    callback?: () => void,
+    callback?: () => void
   ): React$ElementRef<ElementType>;
 }
 
@@ -46,62 +46,67 @@ declare module 'react-dom/server' {
   declare function renderToStaticMarkup(element: React$Node): string;
   declare function renderToNodeStream(element: React$Node): stream$Readable;
   declare function renderToStaticNodeStream(
-    element: React$Node,
+    element: React$Node
   ): stream$Readable;
   declare var version: string;
 }
 
-type Thenable = { then(resolve: () => mixed, reject?: () => mixed): mixed, ... };
+declare interface Thenable {
+  then(resolve: () => mixed, reject?: () => mixed): mixed;
+}
 
 declare module 'react-dom/test-utils' {
-  declare var Simulate: { [eventName: string]: (element: Element, eventData?: Object) => void, ... };
+  declare var Simulate: {
+    [eventName: string]: (element: Element, eventData?: Object) => void,
+    ...,
+  };
   declare function renderIntoDocument(
-    instance: React$Element<any>,
+    instance: React$Element<any>
   ): React$Component<any, any>;
   declare function mockComponent(
     componentClass: React$ElementType,
-    mockTagName?: string,
+    mockTagName?: string
   ): Object;
   declare function isElement(element: React$Element<any>): boolean;
   declare function isElementOfType(
     element: React$Element<any>,
-    componentClass: React$ElementType,
+    componentClass: React$ElementType
   ): boolean;
   declare function isDOMComponent(instance: any): boolean;
   declare function isCompositeComponent(
-    instance: React$Component<any, any>,
+    instance: React$Component<any, any>
   ): boolean;
   declare function isCompositeComponentWithType(
     instance: React$Component<any, any>,
-    componentClass: React$ElementType,
+    componentClass: React$ElementType
   ): boolean;
   declare function findAllInRenderedTree(
     tree: React$Component<any, any>,
-    test: (child: React$Component<any, any>) => boolean,
+    test: (child: React$Component<any, any>) => boolean
   ): Array<React$Component<any, any>>;
   declare function scryRenderedDOMComponentsWithClass(
     tree: React$Component<any, any>,
-    className: string,
+    className: string
   ): Array<Element>;
   declare function findRenderedDOMComponentWithClass(
     tree: React$Component<any, any>,
-    className: string,
+    className: string
   ): ?Element;
   declare function scryRenderedDOMComponentsWithTag(
     tree: React$Component<any, any>,
-    tagName: string,
+    tagName: string
   ): Array<Element>;
   declare function findRenderedDOMComponentWithTag(
     tree: React$Component<any, any>,
-    tagName: string,
+    tagName: string
   ): ?Element;
   declare function scryRenderedComponentsWithType(
     tree: React$Component<any, any>,
-    componentClass: React$ElementType,
+    componentClass: React$ElementType
   ): Array<React$Component<any, any>>;
   declare function findRenderedComponentWithType(
     tree: React$Component<any, any>,
-    componentClass: React$ElementType,
+    componentClass: React$ElementType
   ): ?React$Component<any, any>;
   declare function act(callback: () => void | Thenable): Thenable;
 }

--- a/definitions/npm/react-dom_v16.x.x/flow_v0.117.x-/test_react-dom_v16.x.x.js
+++ b/definitions/npm/react-dom_v16.x.x/flow_v0.117.x-/test_react-dom_v16.x.x.js
@@ -7,33 +7,33 @@ import * as ReactDOM from 'react-dom';
 
 declare function test$getElementById(string): HTMLElement | null;
 
-declare class MyPortalComponent extends React.Component<{...}> {}
+declare class MyPortalComponent extends React.Component<{ ... }> {}
 
-class MyComponent extends React.Component<{...}> {
+class MyComponent extends React.Component<{ ... }> {
   render() {
     return ReactDOM.createPortal(
       <MyPortalComponent />,
-      // $FlowExpectedError
-      test$getElementById('portal'),
+      // $FlowExpectedError[incompatible-call]
+      test$getElementById('portal')
     );
   }
 }
 
-class JDiv extends React.Component<{id: string, ...}> {}
+class JDiv extends React.Component<{ id: string, ... }> {}
 
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-type]
 <JDiv id={42} />;
 
 class Example extends React.Component<{ bar: string, ... }> {
   render() {
-    return <div>{this.props.bar}</div>
+    return <div>{this.props.bar}</div>;
   }
 }
 
 ReactDOM.render(
-  // $FlowExpectedError
+  // $FlowExpectedError[prop-missing]
   <Example foo="foo" />,
-  // $FlowExpectedError
+  // $FlowExpectedError[incompatible-call]
   document.body
 );
 
@@ -49,17 +49,14 @@ function Clock(props) {
 function tick() {
   const element = document.getElementById('root');
   if (element) {
-    ReactDOM.render(
-      <Clock date={new Date()} />,
-      element
-    );
+    ReactDOM.render(<Clock date={new Date()} />, element);
   }
 }
 
 // test-utils tests
 import TestUtils from 'react-dom/test-utils';
 
-class MyTestingComponent extends React.Component<{...}> {
+class MyTestingComponent extends React.Component<{ ... }> {
   render() {
     return <button className="my-button" />;
   }
@@ -71,7 +68,7 @@ TestUtils.mockComponent(MyTestingComponent, 'span');
 (TestUtils.isElement(<MyTestingComponent />): boolean);
 (TestUtils.isElementOfType(
   <MyTestingComponent />,
-  MyTestingComponent,
+  MyTestingComponent
 ): boolean);
 (TestUtils.findRenderedDOMComponentWithClass(tree, 'my-button'): ?Element);
 (TestUtils.isDOMComponent(MyTestingComponent): boolean);
@@ -79,12 +76,12 @@ TestUtils.mockComponent(MyTestingComponent, 'span');
 (TestUtils.isCompositeComponentWithType(tree, MyTestingComponent): boolean);
 (TestUtils.findAllInRenderedTree(
   tree,
-  // $FlowExpectedError
-  child => child.tagName === 'BUTTON',
+  // $FlowExpectedError[prop-missing]
+  child => child.tagName === 'BUTTON'
 ): Array<React.Component<any, any>>);
 (TestUtils.scryRenderedDOMComponentsWithClass(
   tree,
-  'my-button',
+  'my-button'
 ): Array<Element>);
 
 const buttonEl = TestUtils.findRenderedDOMComponentWithClass(tree, 'my-button');
@@ -95,17 +92,17 @@ if (buttonEl != null) {
 (TestUtils.scryRenderedDOMComponentsWithTag(tree, 'button'): Array<Element>);
 (TestUtils.findRenderedDOMComponentWithTag(tree, 'button'): ?Element);
 (TestUtils.scryRenderedComponentsWithType(tree, MyTestingComponent): Array<
-  React.Component<any, any>,
+  React.Component<any, any>
 >);
 (TestUtils.findRenderedComponentWithType(
   tree,
-  MyTestingComponent,
+  MyTestingComponent
 ): ?React.Component<any, any>);
 TestUtils.act(() => {
   Math.random();
 });
-// $FlowExpectedError
-TestUtils.act(() => ({count: 123}));
+// $FlowExpectedError[incompatible-call]
+TestUtils.act(() => ({ count: 123 }));
 async function runTest() {
   await TestUtils.act(async () => {
     // .. some test code
@@ -122,31 +119,31 @@ async function runTest() {
 }
 
 // render callback tests
-declare function test$querySelector(selector: string): HTMLElement | null
+declare function test$querySelector(selector: string): HTMLElement | null;
 
 const Example2 = React.createClass({
-  propTypes: {
-  },
+  propTypes: {},
   render() {
-  	return <div>Hello</div>;
-  }
+    return <div>Hello</div>;
+  },
 });
 
-// $FlowExpectedError
-ReactDOM.render(<Example2/>, test$querySelector('#site'), () => {
-	console.log('Rendered - arrow callback');
+// $FlowExpectedError[incompatible-call]
+ReactDOM.render(<Example2 />, test$querySelector('#site'), () => {
+  console.log('Rendered - arrow callback');
 });
 
-// $FlowExpectedError
-ReactDOM.render(<Example2/>, test$querySelector('#site'), function() {
-	console.log('Rendered - function callback');
+// $FlowExpectedError[incompatible-call]
+ReactDOM.render(<Example2 />, test$querySelector('#site'), function() {
+  console.log('Rendered - function callback');
 });
 
-// $FlowExpectedError
-ReactDOM.render(<Example2/>, test$querySelector('#site'), 1);
-// $FlowExpectedError
-ReactDOM.render(<Example2/>, test$querySelector('#site'), {});
-// $FlowExpectedError
-ReactDOM.render(<Example2/>, test$querySelector('#site'), '');
-// $FlowExpectedError
-ReactDOM.render(<Example2/>, test$querySelector('#site'), null);
+// $FlowExpectedError[incompatible-call]
+ReactDOM.render(<Example2 />, test$querySelector('#site'), 1);
+// $FlowExpectedError[incompatible-call]
+// $FlowExpectedError[prop-missing]
+ReactDOM.render(<Example2 />, test$querySelector('#site'), {});
+// $FlowExpectedError[incompatible-call]
+ReactDOM.render(<Example2 />, test$querySelector('#site'), '');
+// $FlowExpectedError[incompatible-call]
+ReactDOM.render(<Example2 />, test$querySelector('#site'), null);

--- a/definitions/npm/react-dom_v17.x.x/flow_v0.127.x-/react-dom_v17.x.x.js
+++ b/definitions/npm/react-dom_v17.x.x/flow_v0.127.x-/react-dom_v17.x.x.js
@@ -58,10 +58,9 @@ declare module 'react-dom/server' {
 }
 
 declare module 'react-dom/test-utils' {
-  declare type Thenable = {
+  declare interface Thenable {
     then(resolve: () => mixed, reject?: () => mixed): mixed,
-    ...
-  };
+  }
 
   declare var Simulate: {
     [eventName: string]: (


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
This fixes this issue when trying to use react testing library `act()` with async functions in flow 0.153:
![image](https://user-images.githubusercontent.com/1849576/123616705-d6cb8e80-d806-11eb-86be-8c2f39b0de32.png)

This new error is caused by these new changes in flow: https://medium.com/flow-type/sound-typing-for-this-in-flow-d62db2af969e

- Links to documentation: 
- Link to GitHub or NPM: 
- Type of contribution: fix

Other notes:

