### PR TITLE
[react-navigation] Fix issues exposed by newer versions of Flow

### DIFF
--- a/definitions/npm/@react-navigation/bottom-tabs_v5.x.x/flow_v0.104.x-/bottom-tabs_v5.x.x.js
+++ b/definitions/npm/@react-navigation/bottom-tabs_v5.x.x/flow_v0.104.x-/bottom-tabs_v5.x.x.js
@@ -317,6 +317,35 @@ declare module '@react-navigation/bottom-tabs' {
    * The following is copied from react-native-gesture-handler's libdef
    */
 
+  declare type StateUndetermined = 0;
+  declare type StateFailed = 1;
+  declare type StateBegan = 2;
+  declare type StateCancelled = 3;
+  declare type StateActive = 4;
+  declare type StateEnd = 5;
+
+  declare type GestureHandlerState =
+    | StateUndetermined
+    | StateFailed
+    | StateBegan
+    | StateCancelled
+    | StateActive
+    | StateEnd;
+
+  declare type $SyntheticEvent<T: { ... }> = {
+    +nativeEvent: $ReadOnly<$Exact<T>>,
+    ...
+  };
+
+  declare type $Event<T: { ... }> = $SyntheticEvent<{
+    handlerTag: number,
+    numberOfPointers: number,
+    state: GestureHandlerState,
+    oldState: GestureHandlerState,
+    ...$Exact<T>,
+    ...
+  }>;
+
   declare type $EventHandlers<ExtraProps: {...}> = {|
     onGestureEvent?: ($Event<ExtraProps>) => mixed,
     onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
@@ -567,7 +596,7 @@ declare module '@react-navigation/bottom-tabs' {
     +type: $PropertyType<State, 'type'>,
     +getInitialState: (options: RouterConfigOptions) => State,
     +getRehydratedState: (
-      partialState: PossibleStaleNavigationState,
+      partialState: PossiblyStaleNavigationState,
       options: RouterConfigOptions,
     ) => State,
     +getStateForRouteNamesChange: (
@@ -865,8 +894,8 @@ declare module '@react-navigation/bottom-tabs' {
   |};
 
   declare export type ScreenListeners<
-    EventMap: EventMapBase = EventMapCore<State>,
     State: NavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
   > = $ObjMapi<
     {| [name: $Keys<EventMap>]: empty |},
     <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
@@ -888,11 +917,11 @@ declare module '@react-navigation/bottom-tabs' {
           navigation: NavProp,
         |}) => ScreenOptions,
     +listeners?:
-      | ScreenListeners<EventMap, State>
+      | ScreenListeners<State, EventMap>
       | ({|
           route: RouteProp<ParamList, RouteName>,
           navigation: NavProp,
-        |}) => ScreenListeners<EventMap, State>,
+        |}) => ScreenListeners<State, EventMap>,
     +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
   |};
 
@@ -1551,10 +1580,10 @@ declare module '@react-navigation/bottom-tabs' {
   |};
 
   declare export type PaperFonts = {|
-    +regular: Font,
-    +medium: Font,
-    +light: Font,
-    +thin: Font,
+    +regular: PaperFont,
+    +medium: PaperFont,
+    +light: PaperFont,
+    +thin: PaperFont,
   |};
 
   declare export type PaperTheme = {|

--- a/definitions/npm/@react-navigation/core_v5.x.x/flow_v0.104.x-/core_v5.x.x.js
+++ b/definitions/npm/@react-navigation/core_v5.x.x/flow_v0.104.x-/core_v5.x.x.js
@@ -317,6 +317,35 @@ declare module '@react-navigation/core' {
    * The following is copied from react-native-gesture-handler's libdef
    */
 
+  declare type StateUndetermined = 0;
+  declare type StateFailed = 1;
+  declare type StateBegan = 2;
+  declare type StateCancelled = 3;
+  declare type StateActive = 4;
+  declare type StateEnd = 5;
+
+  declare type GestureHandlerState =
+    | StateUndetermined
+    | StateFailed
+    | StateBegan
+    | StateCancelled
+    | StateActive
+    | StateEnd;
+
+  declare type $SyntheticEvent<T: { ... }> = {
+    +nativeEvent: $ReadOnly<$Exact<T>>,
+    ...
+  };
+
+  declare type $Event<T: { ... }> = $SyntheticEvent<{
+    handlerTag: number,
+    numberOfPointers: number,
+    state: GestureHandlerState,
+    oldState: GestureHandlerState,
+    ...$Exact<T>,
+    ...
+  }>;
+
   declare type $EventHandlers<ExtraProps: {...}> = {|
     onGestureEvent?: ($Event<ExtraProps>) => mixed,
     onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
@@ -567,7 +596,7 @@ declare module '@react-navigation/core' {
     +type: $PropertyType<State, 'type'>,
     +getInitialState: (options: RouterConfigOptions) => State,
     +getRehydratedState: (
-      partialState: PossibleStaleNavigationState,
+      partialState: PossiblyStaleNavigationState,
       options: RouterConfigOptions,
     ) => State,
     +getStateForRouteNamesChange: (
@@ -865,8 +894,8 @@ declare module '@react-navigation/core' {
   |};
 
   declare export type ScreenListeners<
-    EventMap: EventMapBase = EventMapCore<State>,
     State: NavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
   > = $ObjMapi<
     {| [name: $Keys<EventMap>]: empty |},
     <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
@@ -888,11 +917,11 @@ declare module '@react-navigation/core' {
           navigation: NavProp,
         |}) => ScreenOptions,
     +listeners?:
-      | ScreenListeners<EventMap, State>
+      | ScreenListeners<State, EventMap>
       | ({|
           route: RouteProp<ParamList, RouteName>,
           navigation: NavProp,
-        |}) => ScreenListeners<EventMap, State>,
+        |}) => ScreenListeners<State, EventMap>,
     +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
   |};
 
@@ -1551,10 +1580,10 @@ declare module '@react-navigation/core' {
   |};
 
   declare export type PaperFonts = {|
-    +regular: Font,
-    +medium: Font,
-    +light: Font,
-    +thin: Font,
+    +regular: PaperFont,
+    +medium: PaperFont,
+    +light: PaperFont,
+    +thin: PaperFont,
   |};
 
   declare export type PaperTheme = {|

--- a/definitions/npm/@react-navigation/devtools_v5.x.x/flow_v0.104.x-/devtools_v5.x.x.js
+++ b/definitions/npm/@react-navigation/devtools_v5.x.x/flow_v0.104.x-/devtools_v5.x.x.js
@@ -317,6 +317,35 @@ declare module '@react-navigation/devtools' {
    * The following is copied from react-native-gesture-handler's libdef
    */
 
+  declare type StateUndetermined = 0;
+  declare type StateFailed = 1;
+  declare type StateBegan = 2;
+  declare type StateCancelled = 3;
+  declare type StateActive = 4;
+  declare type StateEnd = 5;
+
+  declare type GestureHandlerState =
+    | StateUndetermined
+    | StateFailed
+    | StateBegan
+    | StateCancelled
+    | StateActive
+    | StateEnd;
+
+  declare type $SyntheticEvent<T: { ... }> = {
+    +nativeEvent: $ReadOnly<$Exact<T>>,
+    ...
+  };
+
+  declare type $Event<T: { ... }> = $SyntheticEvent<{
+    handlerTag: number,
+    numberOfPointers: number,
+    state: GestureHandlerState,
+    oldState: GestureHandlerState,
+    ...$Exact<T>,
+    ...
+  }>;
+
   declare type $EventHandlers<ExtraProps: {...}> = {|
     onGestureEvent?: ($Event<ExtraProps>) => mixed,
     onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
@@ -567,7 +596,7 @@ declare module '@react-navigation/devtools' {
     +type: $PropertyType<State, 'type'>,
     +getInitialState: (options: RouterConfigOptions) => State,
     +getRehydratedState: (
-      partialState: PossibleStaleNavigationState,
+      partialState: PossiblyStaleNavigationState,
       options: RouterConfigOptions,
     ) => State,
     +getStateForRouteNamesChange: (
@@ -865,8 +894,8 @@ declare module '@react-navigation/devtools' {
   |};
 
   declare export type ScreenListeners<
-    EventMap: EventMapBase = EventMapCore<State>,
     State: NavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
   > = $ObjMapi<
     {| [name: $Keys<EventMap>]: empty |},
     <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
@@ -888,11 +917,11 @@ declare module '@react-navigation/devtools' {
           navigation: NavProp,
         |}) => ScreenOptions,
     +listeners?:
-      | ScreenListeners<EventMap, State>
+      | ScreenListeners<State, EventMap>
       | ({|
           route: RouteProp<ParamList, RouteName>,
           navigation: NavProp,
-        |}) => ScreenListeners<EventMap, State>,
+        |}) => ScreenListeners<State, EventMap>,
     +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
   |};
 
@@ -1551,10 +1580,10 @@ declare module '@react-navigation/devtools' {
   |};
 
   declare export type PaperFonts = {|
-    +regular: Font,
-    +medium: Font,
-    +light: Font,
-    +thin: Font,
+    +regular: PaperFont,
+    +medium: PaperFont,
+    +light: PaperFont,
+    +thin: PaperFont,
   |};
 
   declare export type PaperTheme = {|

--- a/definitions/npm/@react-navigation/drawer_v5.x.x/flow_v0.104.x-/drawer_v5.x.x.js
+++ b/definitions/npm/@react-navigation/drawer_v5.x.x/flow_v0.104.x-/drawer_v5.x.x.js
@@ -317,6 +317,35 @@ declare module '@react-navigation/drawer' {
    * The following is copied from react-native-gesture-handler's libdef
    */
 
+  declare type StateUndetermined = 0;
+  declare type StateFailed = 1;
+  declare type StateBegan = 2;
+  declare type StateCancelled = 3;
+  declare type StateActive = 4;
+  declare type StateEnd = 5;
+
+  declare type GestureHandlerState =
+    | StateUndetermined
+    | StateFailed
+    | StateBegan
+    | StateCancelled
+    | StateActive
+    | StateEnd;
+
+  declare type $SyntheticEvent<T: { ... }> = {
+    +nativeEvent: $ReadOnly<$Exact<T>>,
+    ...
+  };
+
+  declare type $Event<T: { ... }> = $SyntheticEvent<{
+    handlerTag: number,
+    numberOfPointers: number,
+    state: GestureHandlerState,
+    oldState: GestureHandlerState,
+    ...$Exact<T>,
+    ...
+  }>;
+
   declare type $EventHandlers<ExtraProps: {...}> = {|
     onGestureEvent?: ($Event<ExtraProps>) => mixed,
     onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
@@ -567,7 +596,7 @@ declare module '@react-navigation/drawer' {
     +type: $PropertyType<State, 'type'>,
     +getInitialState: (options: RouterConfigOptions) => State,
     +getRehydratedState: (
-      partialState: PossibleStaleNavigationState,
+      partialState: PossiblyStaleNavigationState,
       options: RouterConfigOptions,
     ) => State,
     +getStateForRouteNamesChange: (
@@ -865,8 +894,8 @@ declare module '@react-navigation/drawer' {
   |};
 
   declare export type ScreenListeners<
-    EventMap: EventMapBase = EventMapCore<State>,
     State: NavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
   > = $ObjMapi<
     {| [name: $Keys<EventMap>]: empty |},
     <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
@@ -888,11 +917,11 @@ declare module '@react-navigation/drawer' {
           navigation: NavProp,
         |}) => ScreenOptions,
     +listeners?:
-      | ScreenListeners<EventMap, State>
+      | ScreenListeners<State, EventMap>
       | ({|
           route: RouteProp<ParamList, RouteName>,
           navigation: NavProp,
-        |}) => ScreenListeners<EventMap, State>,
+        |}) => ScreenListeners<State, EventMap>,
     +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
   |};
 
@@ -1551,10 +1580,10 @@ declare module '@react-navigation/drawer' {
   |};
 
   declare export type PaperFonts = {|
-    +regular: Font,
-    +medium: Font,
-    +light: Font,
-    +thin: Font,
+    +regular: PaperFont,
+    +medium: PaperFont,
+    +light: PaperFont,
+    +thin: PaperFont,
   |};
 
   declare export type PaperTheme = {|
@@ -2117,7 +2146,7 @@ declare module '@react-navigation/drawer' {
    */
 
   declare type GestureHandlerRef = React$Ref<
-    React$ComponentType<GestureHandlerProps>,
+    React$ComponentType<PanGestureHandlerProps>,
   >;
   declare export var DrawerGestureContext: React$Context<?GestureHandlerRef>;
 

--- a/definitions/npm/@react-navigation/material-bottom-tabs_v5.x.x/flow_v0.104.x-/material-bottom-tabs_v5.x.x.js
+++ b/definitions/npm/@react-navigation/material-bottom-tabs_v5.x.x/flow_v0.104.x-/material-bottom-tabs_v5.x.x.js
@@ -317,6 +317,35 @@ declare module '@react-navigation/material-bottom-tabs' {
    * The following is copied from react-native-gesture-handler's libdef
    */
 
+  declare type StateUndetermined = 0;
+  declare type StateFailed = 1;
+  declare type StateBegan = 2;
+  declare type StateCancelled = 3;
+  declare type StateActive = 4;
+  declare type StateEnd = 5;
+
+  declare type GestureHandlerState =
+    | StateUndetermined
+    | StateFailed
+    | StateBegan
+    | StateCancelled
+    | StateActive
+    | StateEnd;
+
+  declare type $SyntheticEvent<T: { ... }> = {
+    +nativeEvent: $ReadOnly<$Exact<T>>,
+    ...
+  };
+
+  declare type $Event<T: { ... }> = $SyntheticEvent<{
+    handlerTag: number,
+    numberOfPointers: number,
+    state: GestureHandlerState,
+    oldState: GestureHandlerState,
+    ...$Exact<T>,
+    ...
+  }>;
+
   declare type $EventHandlers<ExtraProps: {...}> = {|
     onGestureEvent?: ($Event<ExtraProps>) => mixed,
     onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
@@ -567,7 +596,7 @@ declare module '@react-navigation/material-bottom-tabs' {
     +type: $PropertyType<State, 'type'>,
     +getInitialState: (options: RouterConfigOptions) => State,
     +getRehydratedState: (
-      partialState: PossibleStaleNavigationState,
+      partialState: PossiblyStaleNavigationState,
       options: RouterConfigOptions,
     ) => State,
     +getStateForRouteNamesChange: (
@@ -865,8 +894,8 @@ declare module '@react-navigation/material-bottom-tabs' {
   |};
 
   declare export type ScreenListeners<
-    EventMap: EventMapBase = EventMapCore<State>,
     State: NavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
   > = $ObjMapi<
     {| [name: $Keys<EventMap>]: empty |},
     <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
@@ -888,11 +917,11 @@ declare module '@react-navigation/material-bottom-tabs' {
           navigation: NavProp,
         |}) => ScreenOptions,
     +listeners?:
-      | ScreenListeners<EventMap, State>
+      | ScreenListeners<State, EventMap>
       | ({|
           route: RouteProp<ParamList, RouteName>,
           navigation: NavProp,
-        |}) => ScreenListeners<EventMap, State>,
+        |}) => ScreenListeners<State, EventMap>,
     +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
   |};
 
@@ -1551,10 +1580,10 @@ declare module '@react-navigation/material-bottom-tabs' {
   |};
 
   declare export type PaperFonts = {|
-    +regular: Font,
-    +medium: Font,
-    +light: Font,
-    +thin: Font,
+    +regular: PaperFont,
+    +medium: PaperFont,
+    +light: PaperFont,
+    +thin: PaperFont,
   |};
 
   declare export type PaperTheme = {|

--- a/definitions/npm/@react-navigation/material-top-tabs_v5.x.x/flow_v0.104.x-/material-top-tabs_v5.x.x.js
+++ b/definitions/npm/@react-navigation/material-top-tabs_v5.x.x/flow_v0.104.x-/material-top-tabs_v5.x.x.js
@@ -317,6 +317,35 @@ declare module '@react-navigation/material-top-tabs' {
    * The following is copied from react-native-gesture-handler's libdef
    */
 
+  declare type StateUndetermined = 0;
+  declare type StateFailed = 1;
+  declare type StateBegan = 2;
+  declare type StateCancelled = 3;
+  declare type StateActive = 4;
+  declare type StateEnd = 5;
+
+  declare type GestureHandlerState =
+    | StateUndetermined
+    | StateFailed
+    | StateBegan
+    | StateCancelled
+    | StateActive
+    | StateEnd;
+
+  declare type $SyntheticEvent<T: { ... }> = {
+    +nativeEvent: $ReadOnly<$Exact<T>>,
+    ...
+  };
+
+  declare type $Event<T: { ... }> = $SyntheticEvent<{
+    handlerTag: number,
+    numberOfPointers: number,
+    state: GestureHandlerState,
+    oldState: GestureHandlerState,
+    ...$Exact<T>,
+    ...
+  }>;
+
   declare type $EventHandlers<ExtraProps: {...}> = {|
     onGestureEvent?: ($Event<ExtraProps>) => mixed,
     onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
@@ -567,7 +596,7 @@ declare module '@react-navigation/material-top-tabs' {
     +type: $PropertyType<State, 'type'>,
     +getInitialState: (options: RouterConfigOptions) => State,
     +getRehydratedState: (
-      partialState: PossibleStaleNavigationState,
+      partialState: PossiblyStaleNavigationState,
       options: RouterConfigOptions,
     ) => State,
     +getStateForRouteNamesChange: (
@@ -865,8 +894,8 @@ declare module '@react-navigation/material-top-tabs' {
   |};
 
   declare export type ScreenListeners<
-    EventMap: EventMapBase = EventMapCore<State>,
     State: NavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
   > = $ObjMapi<
     {| [name: $Keys<EventMap>]: empty |},
     <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
@@ -888,11 +917,11 @@ declare module '@react-navigation/material-top-tabs' {
           navigation: NavProp,
         |}) => ScreenOptions,
     +listeners?:
-      | ScreenListeners<EventMap, State>
+      | ScreenListeners<State, EventMap>
       | ({|
           route: RouteProp<ParamList, RouteName>,
           navigation: NavProp,
-        |}) => ScreenListeners<EventMap, State>,
+        |}) => ScreenListeners<State, EventMap>,
     +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
   |};
 
@@ -1551,10 +1580,10 @@ declare module '@react-navigation/material-top-tabs' {
   |};
 
   declare export type PaperFonts = {|
-    +regular: Font,
-    +medium: Font,
-    +light: Font,
-    +thin: Font,
+    +regular: PaperFont,
+    +medium: PaperFont,
+    +light: PaperFont,
+    +thin: PaperFont,
   |};
 
   declare export type PaperTheme = {|

--- a/definitions/npm/@react-navigation/native_v5.x.x/flow_v0.104.x-/native_v5.x.x.js
+++ b/definitions/npm/@react-navigation/native_v5.x.x/flow_v0.104.x-/native_v5.x.x.js
@@ -317,6 +317,35 @@ declare module '@react-navigation/native' {
    * The following is copied from react-native-gesture-handler's libdef
    */
 
+  declare type StateUndetermined = 0;
+  declare type StateFailed = 1;
+  declare type StateBegan = 2;
+  declare type StateCancelled = 3;
+  declare type StateActive = 4;
+  declare type StateEnd = 5;
+
+  declare type GestureHandlerState =
+    | StateUndetermined
+    | StateFailed
+    | StateBegan
+    | StateCancelled
+    | StateActive
+    | StateEnd;
+
+  declare type $SyntheticEvent<T: { ... }> = {
+    +nativeEvent: $ReadOnly<$Exact<T>>,
+    ...
+  };
+
+  declare type $Event<T: { ... }> = $SyntheticEvent<{
+    handlerTag: number,
+    numberOfPointers: number,
+    state: GestureHandlerState,
+    oldState: GestureHandlerState,
+    ...$Exact<T>,
+    ...
+  }>;
+
   declare type $EventHandlers<ExtraProps: {...}> = {|
     onGestureEvent?: ($Event<ExtraProps>) => mixed,
     onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
@@ -567,7 +596,7 @@ declare module '@react-navigation/native' {
     +type: $PropertyType<State, 'type'>,
     +getInitialState: (options: RouterConfigOptions) => State,
     +getRehydratedState: (
-      partialState: PossibleStaleNavigationState,
+      partialState: PossiblyStaleNavigationState,
       options: RouterConfigOptions,
     ) => State,
     +getStateForRouteNamesChange: (
@@ -865,8 +894,8 @@ declare module '@react-navigation/native' {
   |};
 
   declare export type ScreenListeners<
-    EventMap: EventMapBase = EventMapCore<State>,
     State: NavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
   > = $ObjMapi<
     {| [name: $Keys<EventMap>]: empty |},
     <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
@@ -888,11 +917,11 @@ declare module '@react-navigation/native' {
           navigation: NavProp,
         |}) => ScreenOptions,
     +listeners?:
-      | ScreenListeners<EventMap, State>
+      | ScreenListeners<State, EventMap>
       | ({|
           route: RouteProp<ParamList, RouteName>,
           navigation: NavProp,
-        |}) => ScreenListeners<EventMap, State>,
+        |}) => ScreenListeners<State, EventMap>,
     +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
   |};
 
@@ -1551,10 +1580,10 @@ declare module '@react-navigation/native' {
   |};
 
   declare export type PaperFonts = {|
-    +regular: Font,
-    +medium: Font,
-    +light: Font,
-    +thin: Font,
+    +regular: PaperFont,
+    +medium: PaperFont,
+    +light: PaperFont,
+    +thin: PaperFont,
   |};
 
   declare export type PaperTheme = {|
@@ -2182,7 +2211,7 @@ declare module '@react-navigation/native' {
   declare export function useLinkTo(): (path: string) => void;
 
   declare export function useLinkProps<To: string>(props: {|
-    +to: Top,
+    +to: To,
     +action?: GenericNavigationAction,
   |}): {|
     +href: To,

--- a/definitions/npm/@react-navigation/stack_v5.x.x/flow_v0.104.x-/stack_v5.x.x.js
+++ b/definitions/npm/@react-navigation/stack_v5.x.x/flow_v0.104.x-/stack_v5.x.x.js
@@ -317,6 +317,35 @@ declare module '@react-navigation/stack' {
    * The following is copied from react-native-gesture-handler's libdef
    */
 
+  declare type StateUndetermined = 0;
+  declare type StateFailed = 1;
+  declare type StateBegan = 2;
+  declare type StateCancelled = 3;
+  declare type StateActive = 4;
+  declare type StateEnd = 5;
+
+  declare type GestureHandlerState =
+    | StateUndetermined
+    | StateFailed
+    | StateBegan
+    | StateCancelled
+    | StateActive
+    | StateEnd;
+
+  declare type $SyntheticEvent<T: { ... }> = {
+    +nativeEvent: $ReadOnly<$Exact<T>>,
+    ...
+  };
+
+  declare type $Event<T: { ... }> = $SyntheticEvent<{
+    handlerTag: number,
+    numberOfPointers: number,
+    state: GestureHandlerState,
+    oldState: GestureHandlerState,
+    ...$Exact<T>,
+    ...
+  }>;
+
   declare type $EventHandlers<ExtraProps: {...}> = {|
     onGestureEvent?: ($Event<ExtraProps>) => mixed,
     onHandlerStateChange?: ($Event<ExtraProps>) => mixed,
@@ -567,7 +596,7 @@ declare module '@react-navigation/stack' {
     +type: $PropertyType<State, 'type'>,
     +getInitialState: (options: RouterConfigOptions) => State,
     +getRehydratedState: (
-      partialState: PossibleStaleNavigationState,
+      partialState: PossiblyStaleNavigationState,
       options: RouterConfigOptions,
     ) => State,
     +getStateForRouteNamesChange: (
@@ -865,8 +894,8 @@ declare module '@react-navigation/stack' {
   |};
 
   declare export type ScreenListeners<
-    EventMap: EventMapBase = EventMapCore<State>,
     State: NavigationState = NavigationState,
+    EventMap: EventMapBase = EventMapCore<State>,
   > = $ObjMapi<
     {| [name: $Keys<EventMap>]: empty |},
     <K: $Keys<EventMap>>(K, empty) => EventListenerCallback<K, State, EventMap>,
@@ -888,11 +917,11 @@ declare module '@react-navigation/stack' {
           navigation: NavProp,
         |}) => ScreenOptions,
     +listeners?:
-      | ScreenListeners<EventMap, State>
+      | ScreenListeners<State, EventMap>
       | ({|
           route: RouteProp<ParamList, RouteName>,
           navigation: NavProp,
-        |}) => ScreenListeners<EventMap, State>,
+        |}) => ScreenListeners<State, EventMap>,
     +initialParams?: $Partial<$ElementType<ParamList, RouteName>>,
   |};
 
@@ -1551,10 +1580,10 @@ declare module '@react-navigation/stack' {
   |};
 
   declare export type PaperFonts = {|
-    +regular: Font,
-    +medium: Font,
-    +light: Font,
-    +thin: Font,
+    +regular: PaperFont,
+    +medium: PaperFont,
+    +light: PaperFont,
+    +thin: PaperFont,
   |};
 
   declare export type PaperTheme = {|
@@ -2156,7 +2185,7 @@ declare module '@react-navigation/stack' {
    */
 
   declare type GestureHandlerRef = React$Ref<
-    React$ComponentType<GestureHandlerProps>,
+    React$ComponentType<PanGestureHandlerProps>,
   >;
   declare export var GestureHandlerRefContext: React$Context<
     ?GestureHandlerRef,


### PR DESCRIPTION
Newer versions of Flow revealed a lot of issues with these libdefs. This PR fixes all of them so `run-tests` is clean.