### PR TITLE
[react-navigation] Make route param to Navigate function $ReadOnly

### DIFF
--- a/definitions/npm/@react-navigation/bottom-tabs_v5.x.x/flow_v0.104.x-/bottom-tabs_v5.x.x.js
+++ b/definitions/npm/@react-navigation/bottom-tabs_v5.x.x/flow_v0.104.x-/bottom-tabs_v5.x.x.js
@@ -787,13 +787,13 @@ declare module '@react-navigation/bottom-tabs' {
     & <DestinationRouteName: $Keys<ParamList>>(
         route:
           | {|
-              key: string,
-              params?: $ElementType<ParamList, DestinationRouteName>,
+              +key: string,
+              +params?: $ElementType<ParamList, DestinationRouteName>,
             |}
           | {|
-              name: DestinationRouteName,
-              key?: string,
-              params?: $ElementType<ParamList, DestinationRouteName>,
+              +name: DestinationRouteName,
+              +key?: string,
+              +params?: $ElementType<ParamList, DestinationRouteName>,
             |},
       ) => void;
 

--- a/definitions/npm/@react-navigation/core_v5.x.x/flow_v0.104.x-/core_v5.x.x.js
+++ b/definitions/npm/@react-navigation/core_v5.x.x/flow_v0.104.x-/core_v5.x.x.js
@@ -787,13 +787,13 @@ declare module '@react-navigation/core' {
     & <DestinationRouteName: $Keys<ParamList>>(
         route:
           | {|
-              key: string,
-              params?: $ElementType<ParamList, DestinationRouteName>,
+              +key: string,
+              +params?: $ElementType<ParamList, DestinationRouteName>,
             |}
           | {|
-              name: DestinationRouteName,
-              key?: string,
-              params?: $ElementType<ParamList, DestinationRouteName>,
+              +name: DestinationRouteName,
+              +key?: string,
+              +params?: $ElementType<ParamList, DestinationRouteName>,
             |},
       ) => void;
 

--- a/definitions/npm/@react-navigation/devtools_v5.x.x/flow_v0.104.x-/devtools_v5.x.x.js
+++ b/definitions/npm/@react-navigation/devtools_v5.x.x/flow_v0.104.x-/devtools_v5.x.x.js
@@ -787,13 +787,13 @@ declare module '@react-navigation/devtools' {
     & <DestinationRouteName: $Keys<ParamList>>(
         route:
           | {|
-              key: string,
-              params?: $ElementType<ParamList, DestinationRouteName>,
+              +key: string,
+              +params?: $ElementType<ParamList, DestinationRouteName>,
             |}
           | {|
-              name: DestinationRouteName,
-              key?: string,
-              params?: $ElementType<ParamList, DestinationRouteName>,
+              +name: DestinationRouteName,
+              +key?: string,
+              +params?: $ElementType<ParamList, DestinationRouteName>,
             |},
       ) => void;
 

--- a/definitions/npm/@react-navigation/drawer_v5.x.x/flow_v0.104.x-/drawer_v5.x.x.js
+++ b/definitions/npm/@react-navigation/drawer_v5.x.x/flow_v0.104.x-/drawer_v5.x.x.js
@@ -787,13 +787,13 @@ declare module '@react-navigation/drawer' {
     & <DestinationRouteName: $Keys<ParamList>>(
         route:
           | {|
-              key: string,
-              params?: $ElementType<ParamList, DestinationRouteName>,
+              +key: string,
+              +params?: $ElementType<ParamList, DestinationRouteName>,
             |}
           | {|
-              name: DestinationRouteName,
-              key?: string,
-              params?: $ElementType<ParamList, DestinationRouteName>,
+              +name: DestinationRouteName,
+              +key?: string,
+              +params?: $ElementType<ParamList, DestinationRouteName>,
             |},
       ) => void;
 

--- a/definitions/npm/@react-navigation/material-bottom-tabs_v5.x.x/flow_v0.104.x-/material-bottom-tabs_v5.x.x.js
+++ b/definitions/npm/@react-navigation/material-bottom-tabs_v5.x.x/flow_v0.104.x-/material-bottom-tabs_v5.x.x.js
@@ -787,13 +787,13 @@ declare module '@react-navigation/material-bottom-tabs' {
     & <DestinationRouteName: $Keys<ParamList>>(
         route:
           | {|
-              key: string,
-              params?: $ElementType<ParamList, DestinationRouteName>,
+              +key: string,
+              +params?: $ElementType<ParamList, DestinationRouteName>,
             |}
           | {|
-              name: DestinationRouteName,
-              key?: string,
-              params?: $ElementType<ParamList, DestinationRouteName>,
+              +name: DestinationRouteName,
+              +key?: string,
+              +params?: $ElementType<ParamList, DestinationRouteName>,
             |},
       ) => void;
 

--- a/definitions/npm/@react-navigation/material-top-tabs_v5.x.x/flow_v0.104.x-/material-top-tabs_v5.x.x.js
+++ b/definitions/npm/@react-navigation/material-top-tabs_v5.x.x/flow_v0.104.x-/material-top-tabs_v5.x.x.js
@@ -787,13 +787,13 @@ declare module '@react-navigation/material-top-tabs' {
     & <DestinationRouteName: $Keys<ParamList>>(
         route:
           | {|
-              key: string,
-              params?: $ElementType<ParamList, DestinationRouteName>,
+              +key: string,
+              +params?: $ElementType<ParamList, DestinationRouteName>,
             |}
           | {|
-              name: DestinationRouteName,
-              key?: string,
-              params?: $ElementType<ParamList, DestinationRouteName>,
+              +name: DestinationRouteName,
+              +key?: string,
+              +params?: $ElementType<ParamList, DestinationRouteName>,
             |},
       ) => void;
 

--- a/definitions/npm/@react-navigation/native_v5.x.x/flow_v0.104.x-/native_v5.x.x.js
+++ b/definitions/npm/@react-navigation/native_v5.x.x/flow_v0.104.x-/native_v5.x.x.js
@@ -787,13 +787,13 @@ declare module '@react-navigation/native' {
     & <DestinationRouteName: $Keys<ParamList>>(
         route:
           | {|
-              key: string,
-              params?: $ElementType<ParamList, DestinationRouteName>,
+              +key: string,
+              +params?: $ElementType<ParamList, DestinationRouteName>,
             |}
           | {|
-              name: DestinationRouteName,
-              key?: string,
-              params?: $ElementType<ParamList, DestinationRouteName>,
+              +name: DestinationRouteName,
+              +key?: string,
+              +params?: $ElementType<ParamList, DestinationRouteName>,
             |},
       ) => void;
 

--- a/definitions/npm/@react-navigation/stack_v5.x.x/flow_v0.104.x-/stack_v5.x.x.js
+++ b/definitions/npm/@react-navigation/stack_v5.x.x/flow_v0.104.x-/stack_v5.x.x.js
@@ -787,13 +787,13 @@ declare module '@react-navigation/stack' {
     & <DestinationRouteName: $Keys<ParamList>>(
         route:
           | {|
-              key: string,
-              params?: $ElementType<ParamList, DestinationRouteName>,
+              +key: string,
+              +params?: $ElementType<ParamList, DestinationRouteName>,
             |}
           | {|
-              name: DestinationRouteName,
-              key?: string,
-              params?: $ElementType<ParamList, DestinationRouteName>,
+              +name: DestinationRouteName,
+              +key?: string,
+              +params?: $ElementType<ParamList, DestinationRouteName>,
             |},
       ) => void;
 


### PR DESCRIPTION
This should be `$ReadOnly` – it's a parameter that's passed in and not mutated.

Note: there are currently issues with the tests that should be solved in #4103, so they will be failing on this PR. I can rebase it after #4103 is merged, or you can take my word that I ran the tests locally :)