### PR TITLE
[cypress] Update invoke function to return chainable

### DIFF
--- a/definitions/npm/cypress_v5.x.x/flow_v0.25.x-/cypress_v5.x.x.js
+++ b/definitions/npm/cypress_v5.x.x/flow_v0.25.x-/cypress_v5.x.x.js
@@ -658,10 +658,11 @@ declare type Cypress$BlurOptions = {|
   force?: boolean
 |} & Cypress$Loggable & Cypress$Timeoutable
 
-declare type Cypress$CheckOptions = {|
+declare type Cypress$CheckOptions = {
   interval?: number,
-  force?: boolean
-|} & Cypress$Loggable & Cypress$Timeoutable
+  force?: boolean,
+  ...
+} & Cypress$Loggable & Cypress$Timeoutable
 
 declare type Cypress$ClearOptions = {|
   force?: boolean,

--- a/definitions/npm/cypress_v6.x.x/flow_v0.25.x-/cypress_v6.x.x.js
+++ b/definitions/npm/cypress_v6.x.x/flow_v0.25.x-/cypress_v6.x.x.js
@@ -371,8 +371,8 @@ declare interface Cypress$Chainable {
   /**
    * @see https://docs.cypress.io/api/commands/invoke.html
    */
-  invoke(functionName: string | number): void,
-  invoke(functionName: string | number, ...args: Array<any>): void,
+  invoke(functionName: string | number): Cypress$Global,
+  invoke(functionName: string | number, ...args: Array<any>): Cypress$Global,
 
   /**
    * @see https://docs.cypress.io/api/commands/its.html

--- a/definitions/npm/cypress_v6.x.x/test_cypress_v6.x.x.js
+++ b/definitions/npm/cypress_v6.x.x/test_cypress_v6.x.x.js
@@ -102,10 +102,10 @@ cy.go('test');
 
 cy.hash().click();
 
-(cy.invoke('test'): void);
-(cy.invoke(0): void);
-(cy.invoke('test', 1, 2, 3): void);
-(cy.invoke(1, () => {}, true): void);
+cy.invoke('test').click();
+cy.invoke(0).click();
+cy.invoke('test', 1, 2, 3).click();
+cy.invoke(1, () => {}, true).click();
 
 cy.its('test').click();
 


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
In our own use case we've found that cypress invoke function actually returns a chainable object as opposed to void. This fixes that.

- Links to documentation: https://docs.cypress.io/api/commands/invoke#Arguments
- Link to GitHub or NPM: https://www.npmjs.com/package/cypress
- Type of contribution: fix

Other notes:

