### PR TITLE
[koa] Add body into request object

### DIFF
--- a/definitions/npm/koa_v2.0.x/flow_v0.104.x-v0.152.0/koa_v2.0.x.js
+++ b/definitions/npm/koa_v2.0.x/flow_v0.104.x-v0.152.0/koa_v2.0.x.js
@@ -24,6 +24,7 @@ declare module 'koa' {
     // props added by middlewares.
     [key: string]: mixed,
     app: Application,
+    body: { [key: string]: any },
     req: http$IncomingMessage<>,
     res: http$ServerResponse,
     ctx: Context,

--- a/definitions/npm/koa_v2.0.x/flow_v0.104.x-v0.152.0/koa_v2.0.x.js
+++ b/definitions/npm/koa_v2.0.x/flow_v0.104.x-v0.152.0/koa_v2.0.x.js
@@ -24,7 +24,7 @@ declare module 'koa' {
     // props added by middlewares.
     [key: string]: mixed,
     app: Application,
-    body: { [key: string]: any },
+    body: { [key: string]: any, ... },
     req: http$IncomingMessage<>,
     res: http$ServerResponse,
     ctx: Context,

--- a/definitions/npm/koa_v2.0.x/flow_v0.104.x-v0.152.0/test_koa_v2.0.x.js
+++ b/definitions/npm/koa_v2.0.x/flow_v0.104.x-v0.152.0/test_koa_v2.0.x.js
@@ -176,6 +176,10 @@ function test_response() {
 
 function test_request() {
   declare var request:Request;
+  const body = request.body;
+  body.someValue;
+  // $FlowExpectedError[incompatible-cast] is an object
+  (request.body: string)
   const req: http$IncomingMessage<> = request.req;
   // $FlowExpectedError[incompatible-type]
   const _req: number = request.req;

--- a/definitions/npm/koa_v2.0.x/flow_v0.153.x-/koa_v2.0.x.js
+++ b/definitions/npm/koa_v2.0.x/flow_v0.153.x-/koa_v2.0.x.js
@@ -24,6 +24,7 @@ declare module 'koa' {
     // props added by middlewares.
     [key: string]: mixed,
     app: Application,
+    body: { [key: string]: any },
     req: http$IncomingMessage<>,
     res: http$ServerResponse,
     ctx: Context,

--- a/definitions/npm/koa_v2.0.x/flow_v0.153.x-/koa_v2.0.x.js
+++ b/definitions/npm/koa_v2.0.x/flow_v0.153.x-/koa_v2.0.x.js
@@ -24,7 +24,7 @@ declare module 'koa' {
     // props added by middlewares.
     [key: string]: mixed,
     app: Application,
-    body: { [key: string]: any },
+    body: { [key: string]: any, ... },
     req: http$IncomingMessage<>,
     res: http$ServerResponse,
     ctx: Context,

--- a/definitions/npm/koa_v2.0.x/flow_v0.153.x-/test_koa_v2.0.x.js
+++ b/definitions/npm/koa_v2.0.x/flow_v0.153.x-/test_koa_v2.0.x.js
@@ -182,6 +182,10 @@ function test_response() {
 
 function test_request() {
   declare var request:Request;
+  const body = request.body;
+  body.someValue;
+  // $FlowExpectedError[incompatible-cast] is an object
+  (request.body: string)
   const req: http$IncomingMessage<> = request.req;
   // $FlowExpectedError[incompatible-type]
   const _req: number = request.req;


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
When using `koa` with `koa-body` you can access the request body through the ctx, in koa-body docs you can look for `ctx.request.body` for reference.

- Links to documentation: https://www.npmjs.com/package/koa-body
- Link to GitHub or NPM: https://www.npmjs.com/package/koa
- Type of contribution: addition

Other notes:

