### PR TITLE
[@testing-library/user-event] Add definitions for v13

### DIFF
--- a/definitions/npm/@testing-library/user-event_v13.x.x/flow_v0.104.x-/test_user-event_v13.x.x.js
+++ b/definitions/npm/@testing-library/user-event_v13.x.x/flow_v0.104.x-/test_user-event_v13.x.x.js
@@ -1,0 +1,261 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import userEvent from '@testing-library/user-event';
+
+// Mock @testing-lib/react
+declare function getByTestId(string): HTMLElement;
+declare function getByText(string): HTMLElement;
+declare function getByRole(string): HTMLElement;
+declare function getByLabelText(string): HTMLElement;
+declare function getByTestId(string): HTMLElement;
+declare function queryByText(string): ?HTMLElement;
+declare function queryByRole(string): HTMLElement | null;
+
+describe('click', () => {
+  const label = getByText('');
+
+  it('should validate on default usage', () => {
+    userEvent.click(label);
+  });
+  it('should validate on extra params', () => {
+    userEvent.click(label, { ctrlKey: true, shiftKey: true });
+    userEvent.click(label, {}, { skipHover: true, clickCount: 3 });
+  });
+  it('should error on invalid params', () => {
+    // $FlowExpectedError[incompatible-call]
+    userEvent.click(queryByText(''));
+    // $FlowExpectedError[prop-missing]
+    userEvent.click(label, {}, { fail: true });
+  });
+});
+
+describe('dblClick', () => {
+  const checkbox = getByTestId('');
+
+  it('should validate on default usage', () => {
+    userEvent.dblClick(checkbox);
+  });
+  it('should validate on extra params', () => {
+    userEvent.dblClick(checkbox, { ctrlKey: true, shiftKey: true });
+    userEvent.dblClick(checkbox, {}, { skipHover: true, clickCount: 3 });
+  });
+  it('should error on invalid params', () => {
+    // $FlowExpectedError[incompatible-call]
+    userEvent.dblClick(queryByText(''));
+    // $FlowExpectedError[prop-missing]
+    userEvent.dblClick(checkbox, {}, { fail: true });
+  });
+});
+
+describe('type', () => {
+  const input = getByRole('');
+
+  it('should validate on default usage', () => {
+    userEvent.type(input, '');
+  });
+  it('should validate on extra params', () => {
+    userEvent.type(input, '', { skipClick: true });
+  });
+  it('should validate on extra params being delay', () => {
+    userEvent.type(input, '', { delay: 123 }).then(() => {});
+  });
+  it('should error on invalid promise', () => {
+    // $FlowExpectedError[incompatible-use]
+    userEvent.type(input, '').then(() => {});
+  });
+  it('should error on invalid params', () => {
+    // $FlowExpectedError[incompatible-call]
+    userEvent.type(queryByText(''), '');
+    // $FlowExpectedError[incompatible-call]
+    userEvent.type(input, { skipClick: true });
+    // $FlowExpectedError[incompatible-call]
+    userEvent.type(input, '', { fail: true });
+  });
+});
+
+describe('keyboard', () => {
+  it('should validate on default usage', () => {
+    userEvent.keyboard('');
+  });
+  it('should validate on extra params', () => {
+    userEvent.keyboard('', { autoModify: false });
+  });
+  it('should validate on extra params being delay', () => {
+    userEvent.keyboard('', { delay: 123 }).then(() => {});
+  });
+  it('should validate returned keyboard state', () => {
+    const state: KeyboardState = userEvent.keyboard('');
+  });
+  it('should error on invalid promise', () => {
+    // $FlowExpectedError[prop-missing]
+    userEvent.keyboard('').then(() => {});
+  });
+  it('should error on invalid params', () => {
+    // $FlowExpectedError[incompatible-call]
+    userEvent.keyboard(queryByText(''), '');
+    // $FlowExpectedError[incompatible-call]
+    userEvent.keyboard('', { fail: true });
+  });
+});
+
+describe('upload', () => {
+  const input = getByLabelText('');
+  const file = new File([''], '', { type: 'image/png' });
+  const files = [
+    new File([''], '', { type: 'image/png' }),
+    new File([''], '', { type: 'image/png' }),
+  ];
+
+  it('should validate on default usage', () => {
+    userEvent.upload(input, file);
+    userEvent.upload(input, files);
+  });
+  it('should validate on extra params', () => {
+    userEvent.upload(input, file, { clickInit: { ctrlKey: true } });
+  });
+  it('should error on invalid params', () => {
+    // $FlowExpectedError[incompatible-call]
+    userEvent.upload(queryByText(''), file);
+    // $FlowExpectedError[incompatible-call]
+    userEvent.upload(input, '');
+    // $FlowExpectedError[prop-missing]
+    userEvent.upload(input, file, { fail: true });
+  });
+});
+
+describe('clear', () => {
+  it('should validate on default usage', () => {
+    userEvent.clear(getByRole(''));
+  });
+  it('should error on invalid params', () => {
+    // $FlowExpectedError[incompatible-call]
+    userEvent.clear(queryByRole(''));
+  });
+});
+
+describe('selectOptions', () => {
+  const select = getByTestId('');
+
+  it('should validate on default usage', () => {
+    userEvent.selectOptions(
+      select,
+      ([getByText(''), getByText('')]: HTMLElement[])
+    );
+  });
+  it('should validate on extra params', () => {
+    userEvent.selectOptions(select, (['1', '3']: string[]), { ctrlKey: true });
+  });
+  it('should error on invalid params', () => {
+    // $FlowExpectedError[incompatible-call]
+    userEvent.selectOptions(queryByText(''), (['1', '3']: string[]));
+    // $FlowExpectedError[incompatible-call]
+    userEvent.selectOptions(select, {});
+    userEvent.selectOptions(
+      select,
+      // $FlowExpectedError[incompatible-call]
+      ([queryByText(''), queryByText('')]: Array<?HTMLElement>)
+    );
+    // $FlowExpectedError[incompatible-call]
+    userEvent.selectOptions(select, (['1', '3']: string[]), true);
+  });
+});
+
+describe('deselectOptions', () => {
+  const select = getByTestId('');
+
+  it('should validate on default usage', () => {
+    userEvent.deselectOptions(
+      select,
+      ([getByText(''), getByText('')]: HTMLElement[])
+    );
+  });
+  it('should validate on extra params', () => {
+    userEvent.deselectOptions(select, (['1', '3']: string[]), {
+      ctrlKey: true,
+    });
+  });
+  it('should error on invalid params', () => {
+    // $FlowExpectedError[incompatible-call]
+    userEvent.deselectOptions(queryByText(''), (['1', '3']: string[]));
+    // $FlowExpectedError[incompatible-call]
+    userEvent.deselectOptions(select, {});
+    userEvent.deselectOptions(
+      select,
+      // $FlowExpectedError[incompatible-call]
+      ([queryByText(''), queryByText('')]: Array<?HTMLElement>)
+    );
+    // $FlowExpectedError[incompatible-call]
+    userEvent.deselectOptions(select, (['1', '3']: string[]), true);
+  });
+});
+
+describe('tab', () => {
+  it('should validate on default usage', () => {
+    userEvent.tab();
+  });
+  it('should validate on extra params', () => {
+    userEvent.tab({ shift: true });
+    userEvent.tab({ focusTrap: document });
+  });
+  it('should error on invalid params', () => {
+    // $FlowExpectedError[incompatible-exact]
+    userEvent.tab(getByText(''));
+    // $FlowExpectedError[prop-missing]
+    userEvent.tab({ fail: true });
+  });
+});
+
+describe('hover', () => {
+  const button = getByRole('');
+
+  it('should validate on default usage', () => {
+    userEvent.hover(button);
+  });
+  it('should validate on extra params', () => {
+    userEvent.hover(button, { ctrlKey: true });
+  });
+  it('should error on invalid params', () => {
+    // $FlowExpectedError[incompatible-call]
+    userEvent.hover(queryByText(''));
+    // $FlowExpectedError[incompatible-call]
+    userEvent.hover(button, true);
+  });
+});
+
+describe('unhover', () => {
+  const button = getByRole('');
+
+  it('should validate on default usage', () => {
+    userEvent.unhover(button);
+  });
+  it('should validate on extra params', () => {
+    userEvent.unhover(button, { ctrlKey: true });
+  });
+  it('should error on invalid params', () => {
+    // $FlowExpectedError[incompatible-call]
+    userEvent.unhover(queryByText(''));
+    // $FlowExpectedError[incompatible-call]
+    userEvent.unhover(button, true);
+  });
+});
+
+describe('paste', () => {
+  const textbox = getByRole('');
+
+  it('should validate on default usage', () => {
+    userEvent.paste(textbox, '');
+  });
+  it('should validate on extra params', () => {
+    userEvent.paste(textbox, '', { ctrlKey: true });
+    userEvent.paste(textbox, '', {}, { initialSelectionStart: 123 });
+  });
+  it('should error on invalid params', () => {
+    // $FlowExpectedError[incompatible-call]
+    userEvent.paste(queryByRole(''), '');
+    // $FlowExpectedError[incompatible-call]
+    userEvent.paste(textbox, {});
+    // $FlowExpectedError[prop-missing]
+    userEvent.paste(textbox, '', {}, { fail: true });
+  });
+});

--- a/definitions/npm/@testing-library/user-event_v13.x.x/flow_v0.104.x-/test_user-event_v13.x.x.js
+++ b/definitions/npm/@testing-library/user-event_v13.x.x/flow_v0.104.x-/test_user-event_v13.x.x.js
@@ -85,7 +85,14 @@ describe('keyboard', () => {
     userEvent.keyboard('', { delay: 123 }).then(() => {});
   });
   it('should validate returned keyboard state', () => {
-    const state: KeyboardState = userEvent.keyboard('');
+    // Basic check for shape of state
+    const {
+      pressed,
+      modifiers: { alt, caps, ctrl, meta, shift },
+      activeElement,
+      carryValue,
+      carryChar,
+    } = userEvent.keyboard('');
   });
   it('should error on invalid promise', () => {
     // $FlowExpectedError[prop-missing]

--- a/definitions/npm/@testing-library/user-event_v13.x.x/flow_v0.104.x-/user-event_v13.x.x.js
+++ b/definitions/npm/@testing-library/user-event_v13.x.x/flow_v0.104.x-/user-event_v13.x.x.js
@@ -1,82 +1,79 @@
-declare type TypeOpts = {|
-  skipClick?: boolean,
-  skipAutoClose?: boolean,
-  initialSelectionStart?: number,
-  initialSelectionEnd?: number,
-|};
-declare type TypeOptsDelay = {|
-  skipClick?: boolean,
-  skipAutoClose?: boolean,
-  delay: number,
-  initialSelectionStart?: number,
-  initialSelectionEnd?: number,
-|};
-
-/* Source for keyboard: https://github.com/testing-library/user-event/blob/main/src/keyboard/types.ts */
-declare type KeyboardKey = {|
-  code?: string,
-  key?: string,
-  /** Location on the keyboard for keys with multiple representation
-   * STANDARD = 0,
-   * LEFT = 1,
-   * RIGHT = 2,
-   * NUMPAD = 3
-   */
-  location?: 0 | 1 | 2 | 3,
-  keyCode?: number,
-  altGr?: boolean,
-  shift?: boolean,
-|};
-declare type BaseKeyboardOpts = {|
-  document?: Document,
-  autoModify?: boolean,
-  keyboardMap?: Array<KeyboardKey>,
-|};
-declare type KeyboardState = {|
-  pressed: Array<{|
-    keyDef: KeyboardKey,
-    unpreventedDefault: boolean,
-  |}>,
-  modifiers: {|
-    alt: boolean,
-    caps: boolean,
-    ctrl: boolean,
-    meta: boolean,
-    shift: boolean,
-  |},
-  activeElement: TargetElement | null,
-  carryValue?: string,
-  carryChar: string,
-|};
-
-declare type KeyboardOpts = BaseKeyboardOpts;
-declare type KeyboardOptsDelay = {|
-  ...BaseKeyboardOpts,
-  /** Delay between keystrokes */
-  delay: number,
-|};
-
-declare type TabUserOptions = {|
-  shift?: boolean,
-  focusTrap?: Document | Element,
-|};
-
-// As of Flow 0.134.x WindowProxy is any, which would annihilate all typechecking.
-declare type TargetElement = Element; /* | WindowProxy */
-
-declare type FilesArgument = File | File[];
-
-declare type UploadInitArgument = {|
-  clickInit?: MouseEvent$MouseEventInit,
-  changeInit?: Event,
-|};
-
-declare type ClickOptions = {|
-  skipHover?: boolean,
-  clickCount?: number,
-|};
-
 declare module '@testing-library/user-event' {
+  // As of Flow 0.134.x WindowProxy is any, which would annihilate all typechecking.
+  declare type TargetElement = Element; /* | WindowProxy */
+
+  declare type TypeOpts = {|
+    skipClick?: boolean,
+    skipAutoClose?: boolean,
+    initialSelectionStart?: number,
+    initialSelectionEnd?: number,
+  |};
+  declare type TypeOptsDelay = {|
+    ...TypeOpts,
+    delay: number,
+  |};
+
+  /* Source for keyboard: https://github.com/testing-library/user-event/blob/main/src/keyboard/types.ts */
+  declare type KeyboardKey = {|
+    code?: string,
+    key?: string,
+    /** Location on the keyboard for keys with multiple representation
+     * STANDARD = 0,
+     * LEFT = 1,
+     * RIGHT = 2,
+     * NUMPAD = 3
+     */
+    location?: 0 | 1 | 2 | 3,
+    keyCode?: number,
+    altGr?: boolean,
+    shift?: boolean,
+  |};
+  declare type BaseKeyboardOpts = {|
+    document?: Document,
+    autoModify?: boolean,
+    keyboardMap?: Array<KeyboardKey>,
+  |};
+  declare type KeyboardState = {|
+    pressed: Array<{|
+      keyDef: KeyboardKey,
+      unpreventedDefault: boolean,
+    |}>,
+    modifiers: {|
+      alt: boolean,
+      caps: boolean,
+      ctrl: boolean,
+      meta: boolean,
+      shift: boolean,
+    |},
+    activeElement: TargetElement | null,
+    carryValue?: string,
+    carryChar: string,
+  |};
+
+  declare type KeyboardOpts = BaseKeyboardOpts;
+  declare type KeyboardOptsDelay = {|
+    ...BaseKeyboardOpts,
+    /** Delay between keystrokes */
+    delay: number,
+  |};
+
+  declare type TabUserOptions = {|
+    shift?: boolean,
+    focusTrap?: Document | Element,
+  |};
+
+  declare type FilesArgument = File | File[];
+
+  declare type UploadInitArgument = {|
+    clickInit?: MouseEvent$MouseEventInit,
+    changeInit?: Event,
+  |};
+
+  declare type ClickOptions = {|
+    skipHover?: boolean,
+    clickCount?: number,
+  |};
+
   declare function clear(element: TargetElement): void;
 
   declare function click(

--- a/definitions/npm/@testing-library/user-event_v13.x.x/flow_v0.104.x-/user-event_v13.x.x.js
+++ b/definitions/npm/@testing-library/user-event_v13.x.x/flow_v0.104.x-/user-event_v13.x.x.js
@@ -1,0 +1,170 @@
+declare type TypeOpts = {|
+  skipClick?: boolean,
+  skipAutoClose?: boolean,
+  initialSelectionStart?: number,
+  initialSelectionEnd?: number,
+|};
+declare type TypeOptsDelay = {|
+  skipClick?: boolean,
+  skipAutoClose?: boolean,
+  delay: number,
+  initialSelectionStart?: number,
+  initialSelectionEnd?: number,
+|};
+
+/* Source for keyboard: https://github.com/testing-library/user-event/blob/main/src/keyboard/types.ts */
+declare type KeyboardKey = {|
+  code?: string,
+  key?: string,
+  /** Location on the keyboard for keys with multiple representation
+   * STANDARD = 0,
+   * LEFT = 1,
+   * RIGHT = 2,
+   * NUMPAD = 3
+   */
+  location?: 0 | 1 | 2 | 3,
+  keyCode?: number,
+  altGr?: boolean,
+  shift?: boolean,
+|};
+declare type BaseKeyboardOpts = {|
+  document?: Document,
+  autoModify?: boolean,
+  keyboardMap?: Array<KeyboardKey>,
+|};
+declare type KeyboardState = {|
+  pressed: Array<{|
+    keyDef: KeyboardKey,
+    unpreventedDefault: boolean,
+  |}>,
+  modifiers: {|
+    alt: boolean,
+    caps: boolean,
+    ctrl: boolean,
+    meta: boolean,
+    shift: boolean,
+  |},
+  activeElement: TargetElement | null,
+  carryValue?: string,
+  carryChar: string,
+|};
+
+declare type KeyboardOpts = BaseKeyboardOpts;
+declare type KeyboardOptsDelay = {|
+  ...BaseKeyboardOpts,
+  /** Delay between keystrokes */
+  delay: number,
+|};
+
+declare type TabUserOptions = {|
+  shift?: boolean,
+  focusTrap?: Document | Element,
+|};
+
+// As of Flow 0.134.x WindowProxy is any, which would annihilate all typechecking.
+declare type TargetElement = Element; /* | WindowProxy */
+
+declare type FilesArgument = File | File[];
+
+declare type UploadInitArgument = {|
+  clickInit?: MouseEvent$MouseEventInit,
+  changeInit?: Event,
+|};
+
+declare type ClickOptions = {|
+  skipHover?: boolean,
+  clickCount?: number,
+|};
+
+declare module '@testing-library/user-event' {
+  declare function clear(element: TargetElement): void;
+
+  declare function click(
+    element: TargetElement,
+    eventInit?: MouseEvent$MouseEventInit,
+    options?: ClickOptions
+  ): void;
+
+  declare function dblClick(
+    element: TargetElement,
+    eventInit?: MouseEvent$MouseEventInit,
+    options?: ClickOptions
+  ): void;
+
+  declare function selectOptions(
+    element: TargetElement,
+    values: string | string[] | HTMLElement | HTMLElement[],
+    eventInit?: MouseEvent$MouseEventInit
+  ): void;
+
+  declare function deselectOptions(
+    element: TargetElement,
+    values: string | string[] | HTMLElement | HTMLElement[],
+    eventInit?: MouseEvent$MouseEventInit
+  ): void;
+
+  declare function upload(
+    element: TargetElement,
+    files: FilesArgument,
+    init?: UploadInitArgument
+  ): void;
+
+  declare function type(
+    element: TargetElement,
+    text: string,
+    userOpts?: TypeOpts
+  ): void;
+  declare function type(
+    element: TargetElement,
+    text: string,
+    userOpts: TypeOptsDelay
+  ): Promise<void>;
+
+  declare function keyboard(
+    text: string,
+    options?: KeyboardOpts
+  ): KeyboardState;
+  declare function keyboard(
+    text: string,
+    options: KeyboardOptsDelay
+  ): Promise<KeyboardState>;
+
+  declare function tab(userOpts?: TabUserOptions): void;
+
+  declare function paste(
+    element: TargetElement,
+    text: string,
+    eventInit?: MouseEvent$MouseEventInit,
+    pasteOptions?: {|
+      initialSelectionStart?: number,
+      initialSelectionEnd?: number,
+    |}
+  ): void;
+
+  declare function hover(
+    element: TargetElement,
+    init?: MouseEvent$MouseEventInit
+  ): void;
+
+  declare function unhover(
+    element: TargetElement,
+    init?: MouseEvent$MouseEventInit
+  ): void;
+
+  declare type UserEvent = {|
+    clear: typeof clear,
+    click: typeof click,
+    dblClick: typeof dblClick,
+    deselectOptions: typeof deselectOptions,
+    hover: typeof hover,
+    paste: typeof paste,
+    selectOptions: typeof selectOptions,
+    tab: typeof tab,
+    type: typeof type,
+    keyboard: typeof keyboard,
+    unhover: typeof unhover,
+    upload: typeof upload,
+  |};
+
+  declare export default UserEvent;
+}


### PR DESCRIPTION
Update definitions for v13 of `@testing-library/user-event`.

Added: [`.keyboard()`](https://testing-library.com/docs/ecosystem-user-event/#keyboardtext-options) definition.
Modified: [`.type()`](https://testing-library.com/docs/ecosystem-user-event/#typeelement-text-options) returns an empty promise when the option `delay` is given with a value superior to `0`. Otherwise it returns immediately `void`.

NOTE: To do so, I had to rewrite the definition file using separate `declare function` instead of a object type.

- Links to documentation: https://testing-library.com/docs/ecosystem-user-event/
- Link to GitHub or NPM: https://github.com/testing-library/user-event
- Type of contribution:  addition & fix & refactor


