### PR TITLE
typescript: unbreak unbinding checks for LanguageServiceHost

### DIFF
--- a/definitions/npm/typescript_v3.3.x/flow_v0.104.x-/typescript_v3.3.x.js
+++ b/definitions/npm/typescript_v3.3.x/flow_v0.104.x-/typescript_v3.3.x.js
@@ -8441,7 +8441,7 @@ declare module "typescript" {
     +getProjectReferences?: () => $ReadOnlyArray<ProjectReference> | void,
     +getLocalizedDiagnosticMessages?: () => any,
     +getCancellationToken?: () => HostCancellationToken,
-    getCurrentDirectory(): string,
+    +getCurrentDirectory: () => string,
     getDefaultLibFileName(options: CompilerOptions): string,
     +log?: (s: string) => void,
     +trace?: (s: string) => void,

--- a/definitions/npm/typescript_v3.3.x/test_typescript_v3.3.x.js
+++ b/definitions/npm/typescript_v3.3.x/test_typescript_v3.3.x.js
@@ -1,0 +1,3 @@
+// @flow
+
+import type { LanguageServiceHost } from 'typescript';


### PR DESCRIPTION
The definitions for the typescript package don't seem to have any tests, so this broke silently with Flow's addition of unbinding checks.

From https://github.com/parcel-bundler/parcel/pull/6718#discussion_r688793140:

> The "methods" for this interface are a mix of methods and properties whose values are arrow functions. Methods cannot be unbound, but properties can, making them incompatible — unfortunately this means that our subclass can't use entirely methods nor properties.
> 
> I think the reasoning for this is the interfaces these inherit from have optional properties, something that can't be done with methods, and since they're incompatible, they must stay consistent. That's the case with getCurrentDirectory, which is a property in the parent interface but was a method here.

@gkz @jbrown215 How can we best express "optional" methods in an interface? 

cc @matthewwithanm @mischnic @devongovett

Test Plan: Added a very simple test only importing `LanguageServiceHost` and verified it failed before applying this change.