### PR TITLE
[remarkable_v2.x.x] Fix and update linkify plugin

### DIFF
--- a/definitions/npm/remarkable_v1.x.x/test_remarkable_v1.x.x.js
+++ b/definitions/npm/remarkable_v1.x.x/test_remarkable_v1.x.x.js
@@ -4,27 +4,26 @@ import Remarkable from 'remarkable';
 
 /* Trivial case */
 
-// $FlowExpectedError
+// $FlowExpectedError[cannot-resolve-name]
 remarkable.foo();
 
 const rmk = new Remarkable();
 
-// $FlowExpectedError
+// $FlowExpectedError[prop-missing]
 rmk.foo();
-
 
 /* Remarkable#parse() */
 rmk.parse('');
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 rmk.parse(true);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 rmk.parse(1);
 
 /* Remarkable#parseInline() */
 rmk.parseInline('');
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 rmk.parseInline(true);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 rmk.parseInline(1);
 
 /* Remarkable#set() */
@@ -39,10 +38,10 @@ rmk.set({ highlight: (str: string, lang: string) => '' });
 
 /* Remarkable#render() */
 rmk.render('');
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 rmk.render(true);
 
 /* Remarkable#renderInline() */
 rmk.renderInline('');
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 rmk.renderInline(true);

--- a/definitions/npm/remarkable_v2.x.x/flow_v0.104.x-/remarkable_v2.x.x.js
+++ b/definitions/npm/remarkable_v2.x.x/flow_v0.104.x-/remarkable_v2.x.x.js
@@ -5,7 +5,7 @@ declare module 'remarkable' {
 
   declare type State = any;
 
-  declare type RemarkablePlugin<Option> = (
+  declare export type RemarkablePlugin<Option> = (
     md: Remarkable,
     option: Option
   ) => void;
@@ -112,5 +112,5 @@ declare module 'remarkable' {
 declare module 'remarkable/linkify' {
   import type { RemarkablePlugin } from 'remarkable';
 
-  declare export var linkify: RemarkablePlugin;
+  declare export var linkify: RemarkablePlugin<void>;
 }

--- a/definitions/npm/remarkable_v2.x.x/test_remarkable_v2.x.x.js
+++ b/definitions/npm/remarkable_v2.x.x/test_remarkable_v2.x.x.js
@@ -24,11 +24,11 @@ describe('the Remarkable constructor', () => {
       },
     });
 
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     new Remarkable('');
 
     md.render('# Remarkable rulezz!');
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     md.render(true);
   });
 });
@@ -36,9 +36,9 @@ describe('the Remarkable constructor', () => {
 describe('the parse method', () => {
   it('should accept strings as first param', () => {
     md.parse('');
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     md.parse(true);
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     md.parse(1);
   });
 });
@@ -46,9 +46,9 @@ describe('the parse method', () => {
 describe('the parseInline method', () => {
   it('should accept strings as first param', () => {
     md.parseInline('');
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     md.parseInline(true);
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     md.parseInline(1);
   });
 });
@@ -69,7 +69,7 @@ describe('the set method', () => {
 describe('the renderInline method', () => {
   it('should accept strings as first param', () => {
     md.renderInline('');
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     md.renderInline(true);
   });
 });
@@ -105,5 +105,10 @@ describe('the utils helpers', () => {
 describe('the linkify plugin', () => {
   it('should validate on default usage', () => {
     md = new Remarkable().use(linkify);
+  });
+
+  it('should not accept options', () => {
+    // $FlowExpectedError[incompatible-call]
+    md = new Remarkable().use(linkify, {});
   });
 });


### PR DESCRIPTION
- Links to documentation: https://github.com/jonschlinkert/remarkable
- Link to GitHub or NPM: https://github.com/jonschlinkert/remarkable
- Type of contribution: fix

Other notes:
- The `RemarkablePlugin` type was not exported and as used by the `linkify` plugin produced an error
- The `linkify` pllugin does not accept options https://github.com/jonschlinkert/remarkable/blob/58b6945f203ca7a0bb5a0785df90a3a6a8b9e59c/lib/linkify.js#L157
- Added suppression codes to 1.x as well
