### PR TITLE
Create def script for easier lib def creation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,8 @@ version 4.1.0. **[You've followed all of the
 best practices for writing high quality definitions,](https://github.com/flow-typed/flow-typed/issues/13#issuecomment-214892914)**
 and now you'd like to contribute it:
 
+> Flow-typed comes with a handy script to simplify the file creation process `./create_def.sh` which takes two args, the library name and the version you'd like to type. In the :point_down: example that would be `./create_def.sh left-pad 4.x.x`.
+
 #### 1) Create a new directory called `definitions/npm/left-pad_v4.1.0/`.
 
 ***We call this the "package version directory".***
@@ -245,7 +247,7 @@ When you export a module, you have a choice to use CommonJS or ES6 syntax. We ge
 
 ### Avoid global types
 
-Sometimes you see global definitions like `$npm$ModuleName$`. This is due to the fact that in the past Flow didn't support private types. **Global types should not be used anymore**. Since then Flow has added support for `declare export` which means that every type which doesn't have it are defined as private and can't be imported, see https://flow.org/en/docs/libdefs/creation/#toc-declaring-an-es-module for details. 
+Sometimes you see global definitions like `$npm$ModuleName$`. This is due to the fact that in the past Flow didn't support private types. **Global types should not be used anymore**. Since then Flow has added support for `declare export` which means that every type which doesn't have it are defined as private and can't be imported, see https://flow.org/en/docs/libdefs/creation/#toc-declaring-an-es-module for details.
 
 ### Prefer immutability
 

--- a/cli/src/cli.js
+++ b/cli/src/cli.js
@@ -5,6 +5,7 @@ import yargs from 'yargs';
 import {fs, path} from './lib/node.js';
 
 import * as Install from './commands/install.js';
+import * as CreateDef from './commands/create-def';
 import * as CreateStub from './commands/create-stub.js';
 import * as RunTests from './commands/runTests.js';
 import * as Search from './commands/search.js';
@@ -22,10 +23,10 @@ export function runCLI() {
     name: string,
     description: string,
     setup?: (yargs: Yargs) => Yargs,
-    // $FlowFixMe
     run: (argv: Argv) => Promise<number>,
   };
   const commands: Array<CommandModule> = [
+    CreateDef,
     CreateStub,
     Install,
     RunTests,

--- a/cli/src/commands/create-def.js
+++ b/cli/src/commands/create-def.js
@@ -1,0 +1,65 @@
+// @flow
+import path from 'path';
+import fs from 'fs';
+import typeof Yargs from 'yargs';
+
+const flowVersion = '0.83.x';
+
+export const name = 'create-def <libName> <ver>';
+export const description = 'Create template library definitions in flow-typed';
+
+export function setup(yargs: Yargs): Yargs {
+  return yargs
+    .usage(`$0 ${name}`)
+    .positional('libName', {
+      describe: 'Please provide the names of library',
+      type: 'string',
+    })
+    .positional('ver', {
+      describe: 'Please provide the version range you want to add',
+      type: 'string',
+    })
+    .example('$0 create-def foo 1.x.x', '')
+    .help('h')
+    .alias('h', 'help');
+}
+
+type Args = {
+  libName: mixed, // string
+  ver: mixed, // string
+};
+
+export async function run({libName, ver}: Args): Promise<number> {
+  if (typeof libName !== 'string' || typeof ver !== 'string') {
+    return 1;
+  }
+
+  const definitionsPath = path.join(process.cwd(), '/definitions/npm');
+  const rootDefDir = `${definitionsPath}/${libName}_v${ver}`;
+  const defDir = `${rootDefDir}/flow_v${flowVersion}-`;
+
+  fs.mkdirSync(rootDefDir);
+  fs.mkdirSync(defDir);
+
+  fs.writeFileSync(
+    `${defDir}/${libName}_v${ver}.js`,
+    `declare module '${libName}' {
+  declare module.exports: any;
+}`,
+  );
+
+  fs.writeFileSync(
+    `${defDir}/test_${libName}_v${ver}.js`,
+    `// @flow
+import { describe, it } from 'flow-typed-test';
+// import library from '${libName}';
+
+describe('${libName}', () => {
+  it('', () => {
+
+  });
+});`,
+  );
+
+  return 0;
+}

--- a/create_def.sh
+++ b/create_def.sh
@@ -1,41 +1,4 @@
 #!/bin/sh
 set -e
 
-LIB_NAME=$1
-VERSION=$2
-
-FLOW_VERSION="0.83.x"
-INFO_MESSAGE="Please try again in the format of \"./create_def.sh lib-name 1.x.x\""
-
-if [ $# -eq 0 ]; then
-    echo "ERROR: No arguments provided, expected first arg as library name and second as version. ${INFO_MESSAGE}"
-    exit 1
-fi
-if [ -z "$VERSION" ]; then
-    echo "ERROR: No version provided. ${INFO_MESSAGE}"
-    exit 1
-fi
-
-ROOT_DEF_DIR="definitions/npm/${LIB_NAME}_v${VERSION}"
-DEF_DIR="${ROOT_DEF_DIR}/flow_v${FLOW_VERSION}-"
-
-mkdir ${ROOT_DEF_DIR}
-mkdir ${DEF_DIR}
-
-cat > "${DEF_DIR}/${LIB_NAME}_v${VERSION}.js" <<- EOM
-declare module '$LIB_NAME' {
-  declare module.exports: any;
-}
-EOM
-
-cat > "${DEF_DIR}/test_${LIB_NAME}_v${VERSION}.js" <<- EOM
-// @flow
-import { describe, it } from 'flow-typed-test';
-// import library from '$LIB_NAME';
-
-describe('$LIB_NAME', () => {
-  it('', () => {
-
-  });
-});
-EOM
+node cli/dist/cli.js create-def "$@"

--- a/create_def.sh
+++ b/create_def.sh
@@ -3,7 +3,18 @@ set -e
 
 LIB_NAME=$1
 VERSION=$2
+
 FLOW_VERSION="0.83.x"
+INFO_MESSAGE="Please try again in the format of \"./create_def.sh lib-name 1.x.x\""
+
+if [ $# -eq 0 ]; then
+    echo "ERROR: No arguments provided, expected first arg as library name and second as version. ${INFO_MESSAGE}"
+    exit 1
+fi
+if [ -z "$VERSION" ]; then
+    echo "ERROR: No version provided. ${INFO_MESSAGE}"
+    exit 1
+fi
 
 ROOT_DEF_DIR="definitions/npm/${LIB_NAME}_v${VERSION}"
 DEF_DIR="${ROOT_DEF_DIR}/flow_v${FLOW_VERSION}-"

--- a/create_def.sh
+++ b/create_def.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+LIB_NAME=$1
+VERSION=$2
+FLOW_VERSION="0.83.x"
+
+ROOT_DEF_DIR="definitions/npm/${LIB_NAME}_v${VERSION}"
+DEF_DIR="${ROOT_DEF_DIR}/flow_v${FLOW_VERSION}-"
+
+mkdir ${ROOT_DEF_DIR}
+mkdir ${DEF_DIR}
+
+cat > "${DEF_DIR}/${LIB_NAME}_v${VERSION}.js" <<- EOM
+declare module '$LIB_NAME' {
+  declare module.exports: any;
+}
+EOM
+
+cat > "${DEF_DIR}/test_${LIB_NAME}_v${VERSION}.js" <<- EOM
+// @flow
+import { describe, it } from 'flow-typed-test';
+// import library from '$LIB_NAME';
+EOM

--- a/create_def.sh
+++ b/create_def.sh
@@ -32,4 +32,10 @@ cat > "${DEF_DIR}/test_${LIB_NAME}_v${VERSION}.js" <<- EOM
 // @flow
 import { describe, it } from 'flow-typed-test';
 // import library from '$LIB_NAME';
+
+describe('$LIB_NAME', () => {
+  it('', () => {
+
+  });
+});
 EOM


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Create a handy script inspired from #4042 that will create a basic structure for new type def configured to an appropriate lowest supported version as recommended in contribution guide.

Comes built with a lib def file plus a test file with base structure

Usage: `./create_def.sh lib-name 1.x.x`

### Skeleton File/Folder Structure
*sample when running `./create_def.sh test 1.x.x`*
<img width="1629" alt="Screen Shot 2021-08-28 at 4 31 14 pm" src="https://user-images.githubusercontent.com/12436524/131208785-9e31c9d8-34fe-42bc-afe1-ccb3d2beb94d.png">

### Script Error Handling
<img width="1731" alt="Screen Shot 2021-08-23 at 11 55 58 pm" src="https://user-images.githubusercontent.com/12436524/130460565-6b2fef66-70df-498b-bfdc-ec8672b87551.png">

