### PR TITLE
rxjs: Fix incorrect type for retryWhen.

### DIFF
--- a/definitions/npm/rxjs_v6.x.x/flow_v0.104.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.104.x-/rxjs_v6.x.x.js
@@ -2735,7 +2735,7 @@ declare module "rxjs/operators" {
 
   declare export function retryWhen<T>(
     notifier: (errors: rxjs$Observable<any>) => rxjs$Observable<mixed>
-  ): (rxjs$Observable<T>) => rxjs$Observable<T>;
+  ): rxjs$MonoTypeOperatorFunction<T>;
 
   declare export function refCount<T>(): rxjs$MonoTypeOperatorFunction<T>;
 

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.72.x-v0.103.x/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.72.x-v0.103.x/rxjs_v6.x.x.js
@@ -2735,7 +2735,7 @@ declare module "rxjs/operators" {
 
   declare export function retryWhen<T>(
     notifier: (errors: rxjs$Observable<any>) => rxjs$Observable<mixed>
-  ): (rxjs$Observable<T>) => rxjs$Observable<T>;
+  ): rxjs$MonoTypeOperatorFunction<T>;
 
   declare export function refCount<T>(): rxjs$MonoTypeOperatorFunction<T>;
 


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: 
- Link to GitHub or NPM: 
- Type of contribution:  fix

Other notes:

Fix inconsistent/incorrect type for `retryWhen`.

I'm not sure why but flow treats `(rxjs$Observable<T>) => rxjs$Observable<T>` as a different type to `rxjs$MonoTypeOperatorFunction<T>` although they look like they should be compatible to me. As a consequence without this change it is a type error to use `retryWhen` in a `.pipe(...)`, which is how it is intended to be used. For this reason, this change fixes three failing tests.