### PR TITLE
rxjs: Fix faulty test for retryWhen.

### DIFF
--- a/definitions/npm/rxjs_v6.x.x/flow_v0.104.x-/test_operator_retryWhen.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.104.x-/test_operator_retryWhen.js
@@ -9,7 +9,7 @@ it("should infer correctly", () => {
 });
 
 it("should infer correctly when the error observable has a different type", () => {
-  const o = of(1, 2, 3).pipe(retryWhen(retryWhen(errors => of("a", "b", "c"))));
+  const o = of(1, 2, 3).pipe(retryWhen(errors => of("a", "b", "c")));
 });
 
 it("should enforce types", () => {

--- a/definitions/npm/rxjs_v6.x.x/flow_v0.72.x-v0.103.x/test_operator_retryWhen.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.72.x-v0.103.x/test_operator_retryWhen.js
@@ -9,7 +9,7 @@ it("should infer correctly", () => {
 });
 
 it("should infer correctly when the error observable has a different type", () => {
-  const o = of(1, 2, 3).pipe(retryWhen(retryWhen(errors => of("a", "b", "c"))));
+  const o = of(1, 2, 3).pipe(retryWhen(errors => of("a", "b", "c")));
 });
 
 it("should enforce types", () => {


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: 
- Link to GitHub or NPM: 
- Type of contribution: fix

Other notes:

This fixes a failing test.

It looks like someone typoed a duplicate `retryWhen` nested inside another `retryWhen`, but it's also possible they did it deliberately for some reason. Nevertheless it causes the test to fail.