### PR TITLE
[cli] .ignore file support

### DIFF
--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -796,5 +796,101 @@ describe('install (command)', () => {
         ).toEqual(true);
       });
     });
+
+    it("doesn't install definitions that are ignored", () => {
+      return fakeProjectEnv(async FLOWPROJ_DIR => {
+        // Create some dependencies
+        await Promise.all([
+          mkdirp(path.join(FLOWPROJ_DIR, 'src')),
+          writePkgJson(path.join(FLOWPROJ_DIR, 'package.json'), {
+            name: 'test',
+            devDependencies: {
+              'flow-bin': '^0.43.0',
+            },
+            dependencies: {
+              foo: '1.2.3',
+            },
+          }),
+          mkdirp(path.join(FLOWPROJ_DIR, 'node_modules', 'foo')),
+          mkdirp(path.join(FLOWPROJ_DIR, 'node_modules', 'flow-bin')),
+        ]);
+
+        await touchFile(path.join(FLOWPROJ_DIR, 'src', '.flowconfig'));
+        await mkdirp(path.join(FLOWPROJ_DIR, 'src', 'flow-typed'));
+        await touchFile(
+          path.join(FLOWPROJ_DIR, 'src', 'flow-typed', '.ignore'),
+        );
+        await fs.writeJson(
+          path.join(FLOWPROJ_DIR, 'src', 'flow-typed', '.ignore'),
+          'foo',
+        );
+
+        // Run the install command
+        await run({
+          overwrite: false,
+          verbose: false,
+          skip: false,
+          rootDir: path.join(FLOWPROJ_DIR, 'src'),
+          explicitLibDefs: [],
+        });
+
+        // Installs libdef
+        expect(
+          await fs.exists(
+            path.join(
+              FLOWPROJ_DIR,
+              'src',
+              'flow-typed',
+              'npm',
+              'foo_v1.x.x.js',
+            ),
+          ),
+        ).toEqual(false);
+      });
+    });
+
+    // it('doesn\'t install definitions under an ignored scope', () => {
+    //   return fakeProjectEnv(async FLOWPROJ_DIR => {
+    //     // Create some dependencies
+    //     await Promise.all([
+    //       mkdirp(path.join(FLOWPROJ_DIR, 'src')),
+    //       writePkgJson(path.join(FLOWPROJ_DIR, 'package.json'), {
+    //         name: 'test',
+    //         devDependencies: {
+    //           'flow-bin': '^0.43.0',
+    //         },
+    //         dependencies: {
+    //           foo: '1.2.3',
+    //         },
+    //       }),
+    //       mkdirp(path.join(FLOWPROJ_DIR, 'node_modules', 'foo')),
+    //       mkdirp(path.join(FLOWPROJ_DIR, 'node_modules', 'flow-bin')),
+    //     ]);
+
+    //     await touchFile(path.join(FLOWPROJ_DIR, 'src', '.flowconfig'));
+
+    //     // Run the install command
+    //     await run({
+    //       overwrite: false,
+    //       verbose: false,
+    //       skip: false,
+    //       rootDir: path.join(FLOWPROJ_DIR, 'src'),
+    //       explicitLibDefs: [],
+    //     });
+
+    //     // Installs libdef
+    //     expect(
+    //       await fs.exists(
+    //         path.join(
+    //           FLOWPROJ_DIR,
+    //           'src',
+    //           'flow-typed',
+    //           'npm',
+    //           'foo_v1.x.x.js',
+    //         ),
+    //       ),
+    //     ).toEqual(true);
+    //   });
+    // });
   });
 });

--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -849,48 +849,58 @@ describe('install (command)', () => {
       });
     });
 
-    // it('doesn\'t install definitions under an ignored scope', () => {
-    //   return fakeProjectEnv(async FLOWPROJ_DIR => {
-    //     // Create some dependencies
-    //     await Promise.all([
-    //       mkdirp(path.join(FLOWPROJ_DIR, 'src')),
-    //       writePkgJson(path.join(FLOWPROJ_DIR, 'package.json'), {
-    //         name: 'test',
-    //         devDependencies: {
-    //           'flow-bin': '^0.43.0',
-    //         },
-    //         dependencies: {
-    //           foo: '1.2.3',
-    //         },
-    //       }),
-    //       mkdirp(path.join(FLOWPROJ_DIR, 'node_modules', 'foo')),
-    //       mkdirp(path.join(FLOWPROJ_DIR, 'node_modules', 'flow-bin')),
-    //     ]);
+    it("doesn't install definitions under an ignored scope", () => {
+      return fakeProjectEnv(async FLOWPROJ_DIR => {
+        // Create some dependencies
+        await Promise.all([
+          mkdirp(path.join(FLOWPROJ_DIR, 'src')),
+          writePkgJson(path.join(FLOWPROJ_DIR, 'package.json'), {
+            name: 'test',
+            devDependencies: {
+              'flow-bin': '^0.43.0',
+            },
+            dependencies: {
+              '@scoped/package': '1.2.3',
+              foo: '1.2.3',
+            },
+          }),
+          mkdirp(path.join(FLOWPROJ_DIR, 'node_modules', 'foo')),
+          mkdirp(path.join(FLOWPROJ_DIR, 'node_modules', 'flow-bin')),
+        ]);
 
-    //     await touchFile(path.join(FLOWPROJ_DIR, 'src', '.flowconfig'));
+        await touchFile(path.join(FLOWPROJ_DIR, 'src', '.flowconfig'));
+        await mkdirp(path.join(FLOWPROJ_DIR, 'src', 'flow-typed'));
+        await touchFile(
+          path.join(FLOWPROJ_DIR, 'src', 'flow-typed', '.ignore'),
+        );
+        await fs.writeJson(
+          path.join(FLOWPROJ_DIR, 'src', 'flow-typed', '.ignore'),
+          '@scoped',
+        );
 
-    //     // Run the install command
-    //     await run({
-    //       overwrite: false,
-    //       verbose: false,
-    //       skip: false,
-    //       rootDir: path.join(FLOWPROJ_DIR, 'src'),
-    //       explicitLibDefs: [],
-    //     });
+        // Run the install command
+        await run({
+          overwrite: false,
+          verbose: false,
+          skip: false,
+          rootDir: path.join(FLOWPROJ_DIR, 'src'),
+          explicitLibDefs: [],
+        });
 
-    //     // Installs libdef
-    //     expect(
-    //       await fs.exists(
-    //         path.join(
-    //           FLOWPROJ_DIR,
-    //           'src',
-    //           'flow-typed',
-    //           'npm',
-    //           'foo_v1.x.x.js',
-    //         ),
-    //       ),
-    //     ).toEqual(true);
-    //   });
-    // });
+        // Installs libdef
+        expect(
+          await fs.exists(
+            path.join(
+              FLOWPROJ_DIR,
+              'src',
+              'flow-typed',
+              'npm',
+              '@scoped',
+              'package_vx.x.x.js',
+            ),
+          ),
+        ).toEqual(false);
+      });
+    });
   });
 });

--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -969,5 +969,59 @@ describe('install (command)', () => {
         ).toEqual(false);
       });
     });
+
+    it("doesn't install definitions under an ignored scope with trailing slash", () => {
+      return fakeProjectEnv(async FLOWPROJ_DIR => {
+        // Create some dependencies
+        await Promise.all([
+          mkdirp(path.join(FLOWPROJ_DIR, 'src')),
+          writePkgJson(path.join(FLOWPROJ_DIR, 'package.json'), {
+            name: 'test',
+            devDependencies: {
+              'flow-bin': '^0.43.0',
+            },
+            dependencies: {
+              '@scoped/package': '1.2.3',
+              foo: '1.2.3',
+            },
+          }),
+          mkdirp(path.join(FLOWPROJ_DIR, 'node_modules', 'foo')),
+          mkdirp(path.join(FLOWPROJ_DIR, 'node_modules', 'flow-bin')),
+        ]);
+
+        await touchFile(path.join(FLOWPROJ_DIR, 'src', '.flowconfig'));
+        await mkdirp(path.join(FLOWPROJ_DIR, 'src', 'flow-typed'));
+        await touchFile(
+          path.join(FLOWPROJ_DIR, 'src', 'flow-typed', '.ignore'),
+        );
+        await fs.writeJson(
+          path.join(FLOWPROJ_DIR, 'src', 'flow-typed', '.ignore'),
+          '@scoped/',
+        );
+
+        // Run the install command
+        await run({
+          overwrite: false,
+          verbose: false,
+          skip: false,
+          rootDir: path.join(FLOWPROJ_DIR, 'src'),
+          explicitLibDefs: [],
+        });
+
+        // Installs libdef
+        expect(
+          await fs.exists(
+            path.join(
+              FLOWPROJ_DIR,
+              'src',
+              'flow-typed',
+              'npm',
+              '@scoped',
+              'package_vx.x.x.js',
+            ),
+          ),
+        ).toEqual(false);
+      });
+    });
   });
 });

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -290,7 +290,11 @@ async function installNpmLibDefs({
         .readFileSync(path.join(cwd, libdefDir, '.ignore'), 'utf-8')
         .replace(/"/g, '')
         .split('\n');
-    } catch (e) {
+    } catch (err) {
+      // If the error is unrelated to file not existing we should continue throwing
+      if (err.code !== 'ENOENT') {
+        throw err;
+      }
       ignoreDefs = [];
     }
 

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -265,7 +265,7 @@ async function installNpmLibDefs({
       const termMatches = term.match(/(@[^@\/]+\/)?([^@]+)@(.+)/);
       if (termMatches == null) {
         const pkgJsonData = await getPackageJsonData(cwd);
-        const pkgJsonDeps = getPackageJsonDependencies(pkgJsonData, []);
+        const pkgJsonDeps = getPackageJsonDependencies(pkgJsonData, [], []);
         const packageVersion = pkgJsonDeps[term];
         if (packageVersion) {
           libdefsToSearchFor.set(term, packageVersion);
@@ -284,8 +284,19 @@ async function installNpmLibDefs({
     }
     console.log(`• Searching for ${libdefsToSearchFor.size} libdefs...`);
   } else {
+    let ignoreDefs;
+    try {
+      ignoreDefs = fs.readFileSync(path.join(cwd, libdefDir, '.ignore'));
+    } catch (e) {
+      ignoreDefs = [];
+    }
+
     const pkgJsonData = await getPackageJsonData(cwd);
-    const pkgJsonDeps = getPackageJsonDependencies(pkgJsonData, ignoreDeps);
+    const pkgJsonDeps = getPackageJsonDependencies(
+      pkgJsonData,
+      ignoreDeps,
+      ignoreDefs,
+    );
     for (const pkgName in pkgJsonDeps) {
       libdefsToSearchFor.set(pkgName, pkgJsonDeps[pkgName]);
     }

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -286,7 +286,9 @@ async function installNpmLibDefs({
   } else {
     let ignoreDefs;
     try {
-      ignoreDefs = fs.readFileSync(path.join(cwd, libdefDir, '.ignore'));
+      ignoreDefs = fs
+        .readFileSync(path.join(cwd, libdefDir, '.ignore'), 'utf-8')
+        .split('\n');
     } catch (e) {
       ignoreDefs = [];
     }

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -288,6 +288,7 @@ async function installNpmLibDefs({
     try {
       ignoreDefs = fs
         .readFileSync(path.join(cwd, libdefDir, '.ignore'), 'utf-8')
+        .replace(/"/g, '')
         .split('\n');
     } catch (e) {
       ignoreDefs = [];

--- a/cli/src/lib/npm/npmProjectUtils.js
+++ b/cli/src/lib/npm/npmProjectUtils.js
@@ -99,8 +99,13 @@ export function getPackageJsonDependencies(
         }
         const pkgIgnored = ignoreDefs.reduce((acc, cur) => {
           if (acc) return acc;
-          if (cur === '') return acc;
-          return pkgName.startsWith(cur);
+          const ignoreDef = cur.trim();
+          if (ignoreDef === '') return acc;
+          // if we are looking to ignore a scope dir
+          if (ignoreDef.charAt(0) === '@' && ignoreDef.indexOf('/') === -1) {
+            return pkgName.startsWith(ignoreDef);
+          }
+          return pkgName === ignoreDef;
         }, false);
         if (pkgIgnored) return;
 

--- a/cli/src/lib/npm/npmProjectUtils.js
+++ b/cli/src/lib/npm/npmProjectUtils.js
@@ -77,7 +77,14 @@ export async function findPackageJsonPath(pathStr: string): Promise<string> {
 // TODO: Write tests for this
 export function getPackageJsonDependencies(
   pkgJson: PkgJson,
+  /**
+   * dependency groups to ignore
+   */
   ignoreDeps: Array<string>,
+  /**
+   * dependencies or scopes of dependencies to be ignored
+   */
+  ignoreDefs: Array<string>,
 ): {[depName: string]: string} {
   const depFields = PKG_JSON_DEP_FIELDS.filter(field => {
     return ignoreDeps.indexOf(field.slice(0, -12)) === -1;
@@ -90,6 +97,7 @@ export function getPackageJsonDependencies(
         if (deps[pkgName]) {
           console.warn(`Found ${pkgName} listed twice in package.json!`);
         }
+        if (ignoreDefs.includes(pkgName)) return;
         deps[pkgName] = contentSection[pkgName];
       });
     }

--- a/cli/src/lib/npm/npmProjectUtils.js
+++ b/cli/src/lib/npm/npmProjectUtils.js
@@ -97,16 +97,19 @@ export function getPackageJsonDependencies(
         if (deps[pkgName]) {
           console.warn(`Found ${pkgName} listed twice in package.json!`);
         }
-        const pkgIgnored = ignoreDefs.reduce((acc, cur) => {
-          if (acc) return acc;
+        const pkgIgnored = ignoreDefs.some(cur => {
           const ignoreDef = cur.trim();
-          if (ignoreDef === '') return acc;
+          if (ignoreDef === '') return false;
           // if we are looking to ignore a scope dir
-          if (ignoreDef.charAt(0) === '@' && ignoreDef.indexOf('/') === -1) {
+          if (
+            ignoreDef.charAt(0) === '@' &&
+            (ignoreDef.indexOf('/') === -1 ||
+              ignoreDef.indexOf('/') === ignoreDef.length - 1)
+          ) {
             return pkgName.startsWith(ignoreDef);
           }
           return pkgName === ignoreDef;
-        }, false);
+        });
         if (pkgIgnored) return;
 
         deps[pkgName] = contentSection[pkgName];

--- a/cli/src/lib/npm/npmProjectUtils.js
+++ b/cli/src/lib/npm/npmProjectUtils.js
@@ -99,6 +99,7 @@ export function getPackageJsonDependencies(
         }
         const pkgIgnored = ignoreDefs.reduce((acc, cur) => {
           if (acc) return acc;
+          if (cur === '') return acc;
           return pkgName.startsWith(cur);
         }, false);
         if (pkgIgnored) return;

--- a/cli/src/lib/npm/npmProjectUtils.js
+++ b/cli/src/lib/npm/npmProjectUtils.js
@@ -97,7 +97,12 @@ export function getPackageJsonDependencies(
         if (deps[pkgName]) {
           console.warn(`Found ${pkgName} listed twice in package.json!`);
         }
-        if (ignoreDefs.includes(pkgName)) return;
+        const pkgIgnored = ignoreDefs.reduce((acc, cur) => {
+          if (acc) return acc;
+          return pkgName.startsWith(cur);
+        }, false);
+        if (pkgIgnored) return;
+
         deps[pkgName] = contentSection[pkgName];
       });
     }

--- a/cli/src/lib/stubUtils.js
+++ b/cli/src/lib/stubUtils.js
@@ -498,6 +498,7 @@ export async function createStub(
       const rootDependencies = await getPackageJsonDependencies(
         pkgJsonData,
         [],
+        [],
       );
       version = rootDependencies[packageName] || null;
     } catch (e) {}


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Closes #4127.

This PR supports a new `.ignore` file that can be added to the root `flow-typed` dir of a project where your lib defs currently live. ie: `./flow-typed/.ignore`

Here you can add lines of exclusions separated by new lines supporting explicit dependencies or scopes
eg the file may look like
```
@babel
@babel/
@testing-library/react
eslint

```

Other notes: Tested locally and works pretty well