### PR TITLE
[redux-saga] Add done to runSaga

### DIFF
--- a/definitions/npm/redux-saga_v1.x.x/flow_v0.104.x-/redux-saga_v1.x.x.js
+++ b/definitions/npm/redux-saga_v1.x.x/flow_v0.104.x-/redux-saga_v1.x.x.js
@@ -56,6 +56,7 @@ declare module "redux-saga" {
     cancel: () => void;
     toPromise(): Promise<RT>;
     setContext<C: {...}>(props: $Shape<C>): void;
+    done: Promise<any>;
   }
 
   declare export interface SagaMonitor {


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Adding a property `done` to the `Task` interface used in `runSaga`. After flow typing some more of my codebase I found this threw an error. The strange thing is there is hardly any documentation on this property and also doesn't appear in TS types but it's 100% usable, docs attached and I use it in my test like so,

```
  it('clears unauth route if it was previously populated', async () => {
    // ... arrange

    await runSaga(
      // ... implementation detail
    ).done;

    // ... assertion 
  });
```

- Links to documentation: http://cef62.github.io/redux-saga/docs/advanced/UsingRunSaga.html
- Link to GitHub or NPM: https://www.npmjs.com/package/redux-saga
- Type of contribution: addition

Other notes:

