### PR TITLE
Fix history.listen to have an object as a parameter

### DIFF
--- a/definitions/npm/history_v5.x.x/flow_v0.104.x-/history_v5.x.x.js
+++ b/definitions/npm/history_v5.x.x/flow_v0.104.x-/history_v5.x.x.js
@@ -22,7 +22,7 @@ declare module 'history' {
     go(n: number): void,
     goBack(): void,
     goForward(): void,
-    listen(({ location: HistoryLocation, action: Action }) => void): Unregister,
+    listen(({| location: HistoryLocation, action: Action |}) => void): Unregister,
     block(
       blocker: (transition: {|
         action: Action,

--- a/definitions/npm/history_v5.x.x/flow_v0.104.x-/history_v5.x.x.js
+++ b/definitions/npm/history_v5.x.x/flow_v0.104.x-/history_v5.x.x.js
@@ -22,7 +22,7 @@ declare module 'history' {
     go(n: number): void,
     goBack(): void,
     goForward(): void,
-    listen((location: HistoryLocation, action: Action) => void): Unregister,
+    listen(({ location: HistoryLocation, action: Action }) => void): Unregister,
     block(
       blocker: (transition: {|
         action: Action,


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: 
https://github.com/remix-run/history/blob/8bef6f4d50548f46ab7c97e171b3d8634093e7a7/packages/history/index.ts#L131
- Link to GitHub or NPM: 
- Type of contribution: fix

Other notes:

