### PR TITLE
Fix history@5 back() and forward() type definitions

### DIFF
--- a/definitions/npm/history_v5.x.x/flow_v0.104.x-/history_v5.x.x.js
+++ b/definitions/npm/history_v5.x.x/flow_v0.104.x-/history_v5.x.x.js
@@ -20,8 +20,8 @@ declare module 'history' {
     replace: ((path: string, state?: { ... }) => void) &
       ((location: $Shape<HistoryLocation>) => void),
     go(n: number): void,
-    goBack(): void,
-    goForward(): void,
+    back(): void,
+    forward(): void,
     listen(({| location: HistoryLocation, action: Action |}) => void): Unregister,
     block(
       blocker: (transition: {|


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: 
- https://github.com/remix-run/history/blob/main/docs/api-reference.md#historyforward
https://github.com/remix-run/history/blob/main/docs/api-reference.md#historyforward
- Link to GitHub or NPM: 
https://github.com/remix-run/history
- Type of contribution: fix

Other notes:
`goBack` -> `back` in V5
`goForward` -> `forward` in V5
Maybe V4 types were copied over by accident

