### PR TITLE
[redux-saga_v1.x.x] Allow for any return value on Subpattern functions

### DIFF
--- a/definitions/npm/redux-saga_v1.x.x/flow_v0.104.x-/redux-saga_v1.x.x.js
+++ b/definitions/npm/redux-saga_v1.x.x/flow_v0.104.x-/redux-saga_v1.x.x.js
@@ -282,7 +282,7 @@ declare module "redux-saga" {
   declare export default typeof sagaMiddlewareFactory;
 
   // Effect types
-  declare export type SubPattern = string | (any => boolean);
+  declare export type SubPattern = string | (any => any);
 
   declare export type Pattern = SubPattern | Array<SubPattern>;
 

--- a/definitions/npm/redux-saga_v1.x.x/flow_v0.104.x-/test_redux-saga_1.x.x_take.js
+++ b/definitions/npm/redux-saga_v1.x.x/flow_v0.104.x-/test_redux-saga_1.x.x_take.js
@@ -45,6 +45,7 @@ describe("take effect", () => {
   describe("take(pattern)", () => {
     it("must passes when used properly", () => {
       take(action => action.type === "foo");
+      take(action => action.type);
       take([action => action.type === "foo", action => action.type === "foo"]);
 
       take("ACTION_1");
@@ -52,9 +53,6 @@ describe("take effect", () => {
     });
 
     it("must raises an error when passed invalid pattern", () => {
-      // $FlowExpectedError[incompatible-call]: PatternFn returns a boolean
-      take(action => null);
-
       // $FlowExpectedError[incompatible-call]: Only string patterns for arrays
       take(["FOO", "BAR", 1]);
     });

--- a/definitions/npm/redux-saga_v1.x.x/flow_v0.104.x-/test_redux-saga_1.x.x_takeMaybe.js
+++ b/definitions/npm/redux-saga_v1.x.x/flow_v0.104.x-/test_redux-saga_1.x.x_takeMaybe.js
@@ -44,6 +44,7 @@ describe("takeMaybe effect", () => {
   describe("takeMaybe(pattern)", () => {
     it("must passes when used properly", () => {
       takeMaybe(action => action.type === "foo");
+      takeMaybe(action => action.type);
       takeMaybe([
         action => action.type === "foo",
         action => action.type === "foo",
@@ -54,9 +55,6 @@ describe("takeMaybe effect", () => {
     });
 
     it("must raises an error when passed invalid pattern", () => {
-      // $FlowExpectedError[incompatible-call]: PatternFn returns a boolean
-      takeMaybe(action => null);
-
       // $FlowExpectedError[incompatible-call]: Only string patterns for arrays
       takeMaybe(["FOO", "BAR", 1]);
     });

--- a/definitions/npm/redux-saga_v1.x.x/flow_v0.76.0-v0.103.x/redux-saga_v1.x.x.js
+++ b/definitions/npm/redux-saga_v1.x.x/flow_v0.76.0-v0.103.x/redux-saga_v1.x.x.js
@@ -276,7 +276,7 @@ declare module "redux-saga" {
   declare export default typeof sagaMiddlewareFactory;
 
   // Effect types
-  declare export type SubPattern = string | (any => boolean);
+  declare export type SubPattern = string | (any => any);
 
   declare export type Pattern = SubPattern | Array<SubPattern>;
 

--- a/definitions/npm/redux-saga_v1.x.x/flow_v0.76.0-v0.103.x/test_redux-saga_1.x.x_take.js
+++ b/definitions/npm/redux-saga_v1.x.x/flow_v0.76.0-v0.103.x/test_redux-saga_1.x.x_take.js
@@ -45,6 +45,7 @@ describe("take effect", () => {
   describe("take(pattern)", () => {
     it("must passes when used properly", () => {
       take(action => action.type === "foo");
+      take(action => action.type);
       take([action => action.type === "foo", action => action.type === "foo"]);
 
       take("ACTION_1");
@@ -52,9 +53,6 @@ describe("take effect", () => {
     });
 
     it("must raises an error when passed invalid pattern", () => {
-      // $FlowExpectedError: PatternFn returns a boolean
-      take(action => null);
-
       // $FlowExpectedError: Only string patterns for arrays
       take(["FOO", "BAR", 1]);
     });

--- a/definitions/npm/redux-saga_v1.x.x/flow_v0.76.0-v0.103.x/test_redux-saga_1.x.x_takeMaybe.js
+++ b/definitions/npm/redux-saga_v1.x.x/flow_v0.76.0-v0.103.x/test_redux-saga_1.x.x_takeMaybe.js
@@ -44,6 +44,7 @@ describe("takeMaybe effect", () => {
   describe("takeMaybe(pattern)", () => {
     it("must passes when used properly", () => {
       takeMaybe(action => action.type === "foo");
+      takeMaybe(action => action.type);
       takeMaybe([
         action => action.type === "foo",
         action => action.type === "foo",
@@ -54,9 +55,6 @@ describe("takeMaybe effect", () => {
     });
 
     it("must raises an error when passed invalid pattern", () => {
-      // $FlowExpectedError: PatternFn returns a boolean
-      takeMaybe(action => null);
-
       // $FlowExpectedError: Only string patterns for arrays
       takeMaybe(["FOO", "BAR", 1]);
     });


### PR DESCRIPTION
- Links to documentation: https://redux-saga.js.org/docs/api/#takepattern
- Link to GitHub or NPM: https://github.com/redux-saga/redux-saga/blob/1ecb1bed867eeafc69757df8acf1024b438a79e0/packages/types/types/index.d.ts#L12
- Type of contribution: fix

Other notes:

Function patterns don't require returning a boolean, but instead just returning _any_ value, which is checked for "thruthiness" or "falsiness."

> If `pattern` is a function, the action is matched if `pattern(action)` is true (e.g. `take(action => action.entities)` will match all actions having a (truthy) `entities` field.)