### PR TITLE
[cli] Only run changed version on only-changed option

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -621,7 +621,6 @@ async function runTests(
   numberOfFlowVersions?: number,
 ): Promise<Map<string, Array<string>>> {
   const testPatternRes = testPatterns.map(patt => new RegExp(patt, 'g'));
-  console.log(testPatternRes);
   const testGroups = (await getTestGroups(repoDirPath, onlyChanged)).filter(
     testGroup => {
       if (testPatternRes.length === 0) {

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -61,7 +61,6 @@ async function getTestGroups(
   let libDefs = await getLibDefs(repoDirPath);
   if (onlyChanged) {
     const diff = await getDiff();
-    let changedDefs;
     const baseDiff: string[] = diff
       .map(d => {
         const match = d.match(basePathRegex);
@@ -72,8 +71,20 @@ async function getTestGroups(
       })
       .filter(d => d !== '');
 
-    changedDefs = baseDiff.map(d => parseRepoDirItem(d).pkgName);
-    libDefs = libDefs.filter(def => changedDefs.includes(def.pkgName));
+    const changedDefs = baseDiff.map(d => {
+      const { pkgName, pkgVersion } = parseRepoDirItem(d);
+      const { major, minor, patch } = pkgVersion;
+      return {
+        name: pkgName,
+        version: `v${major}.${minor}.${patch}`,
+      };
+    });
+    libDefs = libDefs.filter(def => (
+      changedDefs.some((d) => (
+        d.name === def.pkgName
+        && d.version === def.pkgVersionStr
+      ))
+    ));
   }
   return libDefs.map(libDef => {
     const groupID = `${libDef.pkgName}_${libDef.pkgVersionStr}/${libDef.flowVersionStr}`;
@@ -610,6 +621,7 @@ async function runTests(
   numberOfFlowVersions?: number,
 ): Promise<Map<string, Array<string>>> {
   const testPatternRes = testPatterns.map(patt => new RegExp(patt, 'g'));
+  console.log(testPatternRes);
   const testGroups = (await getTestGroups(repoDirPath, onlyChanged)).filter(
     testGroup => {
       if (testPatternRes.length === 0) {

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -72,19 +72,18 @@ async function getTestGroups(
       .filter(d => d !== '');
 
     const changedDefs = baseDiff.map(d => {
-      const { pkgName, pkgVersion } = parseRepoDirItem(d);
-      const { major, minor, patch } = pkgVersion;
+      const {pkgName, pkgVersion} = parseRepoDirItem(d);
+      const {major, minor, patch} = pkgVersion;
       return {
         name: pkgName,
         version: `v${major}.${minor}.${patch}`,
       };
     });
-    libDefs = libDefs.filter(def => (
-      changedDefs.some((d) => (
-        d.name === def.pkgName
-        && d.version === def.pkgVersionStr
-      ))
-    ));
+    libDefs = libDefs.filter(def =>
+      changedDefs.some(
+        d => d.name === def.pkgName && d.version === def.pkgVersionStr,
+      ),
+    );
   }
   return libDefs.map(libDef => {
     const groupID = `${libDef.pkgName}_${libDef.pkgVersionStr}/${libDef.flowVersionStr}`;


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Closes #2752. When making a change to a libdef of a particular version it sometimes becomes overwhelming when a single change on one library version requires changes to all versions of the same library name.

This change will target the particular version changes only.

Example:
Tests only run on a single version of redux-saga that was modified
<img width="887" alt="Screen Shot 2021-11-23 at 9 02 13 pm" src="https://user-images.githubusercontent.com/12436524/143005367-6f4cc406-a4f7-4311-8cd3-e0281cdf3a4f.png">

Other notes: I don't mind it most of the time, but I can see the struggle when trying to maintain `styled-component` for example and the older versions are completely broken so your tests will never pass.

cc @villesau

