### PR TITLE
[cli] Install will create eslintrc

### DIFF
--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -1381,6 +1381,7 @@ describe('install (command)', () => {
         expect(
           await fs.readdir(path.join(FLOWPROJ_DIR, 'flow-typed', 'npm')),
         ).toEqual([
+          '.eslintrc.js',
           'a_vx.x.x.js',
           'bar_v1.x.x.js',
           'c_vx.x.x.js',
@@ -1418,6 +1419,7 @@ describe('install (command)', () => {
         expect(
           await fs.readdir(path.join(FLOWPROJ_DIR, 'flow-typed', 'npm')),
         ).toEqual([
+          '.eslintrc.js',
           'a_vx.x.x.js',
           'bar_v1.x.x.js',
           'c_vx.x.x.js',
@@ -1452,6 +1454,7 @@ describe('install (command)', () => {
         expect(
           await fs.readdir(path.join(FLOWPROJ_DIR, 'flow-typed', 'npm')),
         ).toEqual([
+          '.eslintrc.js',
           'a_vx.x.x.js',
           'c_vx.x.x.js',
           'flow-bin_v0.x.x.js',

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -580,6 +580,10 @@ async function installNpmLibDef(
   npmDir: string,
   overwrite: boolean,
 ): Promise<boolean> {
+  // When installing a lib def also check if there is an `eslintrc.js`
+  // If it doesn't exist create one, otherwise use existing which may
+  // have been modified
+
   const scopedDir =
     npmLibDef.scope === null ? npmDir : path.join(npmDir, npmLibDef.scope);
   mkdirp(scopedDir);

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -2,7 +2,7 @@
 
 import type {FlowSpecificVer} from '../lib/flowVersion';
 import {signCodeStream} from '../lib/codeSign';
-import {copyFile, mkdirp} from '../lib/fileUtils';
+import {copyFile, writeFile, mkdirp} from '../lib/fileUtils';
 
 import {findFlowRoot} from '../lib/flowProjectUtils';
 
@@ -583,6 +583,13 @@ async function installNpmLibDef(
   // When installing a lib def also check if there is an `eslintrc.js`
   // If it doesn't exist create one, otherwise use existing which may
   // have been modified
+  const eslintPath = path.join(npmDir, '.eslintrc.js');
+  if (!(await fs.exists(eslintPath))) {
+    const content = `module.exports = {
+  ignorePatterns: ['**/*.js'],
+};`;
+    await writeFile(eslintPath, content);
+  }
 
   const scopedDir =
     npmLibDef.scope === null ? npmDir : path.join(npmDir, npmLibDef.scope);

--- a/cli/src/lib/fileUtils.js
+++ b/cli/src/lib/fileUtils.js
@@ -18,6 +18,18 @@ export function copyDir(srcPath: string, destPath: string): Promise<void> {
   });
 }
 
+export function writeFile(destPath: string, content: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    fs.writeFile(destPath, content, (err: Error) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
 export function copyFile(
   srcPath: string,
   destPath: string,
@@ -27,13 +39,13 @@ export function copyFile(
     if (preProcessor) {
       const content = fs.readFileSync(srcPath, 'utf-8');
 
-      fs.writeFile(destPath, preProcessor(content), (err: Error) => {
-        if (err) {
-          rej(err);
-        } else {
+      writeFile(destPath, preProcessor(content))
+        .then(() => {
           res();
-        }
-      });
+        })
+        .catch((err: Error) => {
+          rej(err);
+        });
     } else {
       fs.copyFile(srcPath, destPath, err => {
         if (err) {


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Closes #779, #929

When starting a new project `flow-typed install` should be seamless and with zero config. With eslint it's not really the case and at least for me I'd add `flow-typed` into `.eslintignore`. There's basically no reason to run eslint rules at all in libdefs coming from `flow-typed` so this change adds an automatic `.eslintrc.js` that disables rules.

It can be overridden though for some unique use cases.