### PR TITLE
[cli] Install will restart flow bin

### DIFF
--- a/cli/flow-typed/npm/lodash_v4.x.x.js
+++ b/cli/flow-typed/npm/lodash_v4.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: bda9729ed82a5e508dab97c2976a44c6
-// flow-typed version: ae5138a380/lodash_v4.x.x/flow_>=v0.155.x
+// flow-typed signature: fd88436625196dbb8bf813a1f1684e58
+// flow-typed version: 179ae71d58/lodash_v4.x.x/flow_>=v0.155.x
 
 declare module "lodash" {
   declare type Path = $ReadOnlyArray<string | number> | string | number;
@@ -177,7 +177,7 @@ declare module "lodash" {
   declare type NestedArray<V> = Array<Array<V>>;
   declare type Collection<V, K = Key> = $ReadOnlyArray<V> | ReadOnlyIndexerObject<V, K>;
 
-  declare type matchesIterateeShorthand = { [Key]: any, ... };
+  declare type matchesIterateeShorthand = { [key: string]: any, ... };
   declare type matchesPropertyIterateeShorthand = [string, any];
   declare type propertyIterateeShorthand = string;
 
@@ -579,10 +579,10 @@ declare module "lodash" {
 
     // Collection
     countBy:
-      & (<T>(array: $ReadOnlyArray<T>, iteratee?: ?ValueOnlyIteratee<T>) => { [string]: number, ... })
-      & (<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>) => {...})
-      & ((string: string, iteratee?: ?ValueOnlyIteratee<string>) => { [string]: number, ... })
-      & (<T>(object: ReadOnlyIndexerObject<T>, iteratee?: ?ValueOnlyIteratee<T>) => { [string]: number, ... });
+      & (<T>(array: $ReadOnlyArray<T>, iteratee?: ?ValueOnlyIteratee<T>) => { [key: string]: number, ... })
+      & (<T>(array: void | null, iteratee?: ?ValueOnlyIteratee<T>) => { [key: string]: number, ... })
+      & ((string: string, iteratee?: ?ValueOnlyIteratee<string>) => { [key: string]: number, ... })
+      & (<T>(object: ReadOnlyIndexerObject<T>, iteratee?: ?ValueOnlyIteratee<T>) => { [key: string]: number, ... });
     // alias of _.forEach
     each<A, K, T: ReadOnlyIndexerObject<A, K> | $ReadOnlyArray<A> | string | void | null>(collection: T, iteratee?: ?IterateeWithResult<A, K, T, boolean | void>): T;
     // alias of _.forEachRight
@@ -3385,12 +3385,6 @@ declare module "lodash/fp" {
     unset:
       & ((path: Path) => ((object: Object) => Object))
       & ((path: Path, object: Object) => Object);
-    dissoc:
-      & ((path: Path) => ((object: Object) => Object))
-      & ((path: Path, object: Object) => Object);
-    dissocPath:
-      & ((path: Path) => ((object: Object) => Object))
-      & ((path: Path, object: Object) => Object);
     update:
       & ((
         path: Path
@@ -6062,14 +6056,6 @@ declare module "lodash/fp/transform" {
 
 declare module "lodash/fp/unset" {
   declare module.exports: $Exports<"lodash/fp">["unset"];
-}
-
-declare module "lodash/fp/dissoc" {
-  declare module.exports: $Exports<"lodash/fp">["dissoc"];
-}
-
-declare module "lodash/fp/dissocPath" {
-  declare module.exports: $Exports<"lodash/fp">["dissocPath"];
 }
 
 declare module "lodash/fp/update" {

--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -35,7 +35,7 @@ import {
 const BASE_FIXTURE_ROOT = path.join(__dirname, '__install-fixtures__');
 
 function _mock(mockFn) {
-  return ((mockFn: any): JestMockFn<*, *>);
+  return ((mockFn: any): JestMockFn<any, any>);
 }
 
 async function touchFile(filePath) {
@@ -45,6 +45,14 @@ async function touchFile(filePath) {
 async function writePkgJson(filePath, pkgJson) {
   await fs.writeJson(filePath, pkgJson);
 }
+
+const defaultRunProps = {
+  overwrite: false,
+  verbose: false,
+  skip: false,
+  skipFlowRestart: true,
+  explicitLibDefs: [],
+};
 
 describe('install (command)', () => {
   describe('determineFlowVersion', () => {
@@ -262,6 +270,7 @@ describe('install (command)', () => {
 
     const origConsoleLog = console.log;
     const origConsoleError = console.error;
+
     beforeEach(() => {
       (console: any).log = jest.fn();
       (console: any).error = jest.fn();
@@ -324,11 +333,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           ignoreDeps: [],
-          explicitLibDefs: [],
         });
 
         // Installs libdefs
@@ -403,11 +409,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           ignoreDeps: [],
-          explicitLibDefs: [],
         });
 
         // Installs libdefs
@@ -467,11 +470,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           ignoreDeps: ['dev', 'optional', 'bundled'],
-          explicitLibDefs: [],
         });
 
         // Installs libdefs
@@ -515,12 +515,7 @@ describe('install (command)', () => {
         ]);
 
         // Run the install command
-        await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
-          explicitLibDefs: [],
-        });
+        await run(defaultRunProps);
 
         // Installs a stub for someUntypedDep
         expect(
@@ -555,12 +550,7 @@ describe('install (command)', () => {
         ]);
 
         // Run the install command
-        await run({
-          overwrite: false,
-          verbose: false,
-          skip: true,
-          explicitLibDefs: [],
-        });
+        await run(defaultRunProps);
 
         // Installs a stub for someUntypedDep
         expect(
@@ -594,10 +584,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
+          ...defaultRunProps,
           overwrite: true,
-          verbose: false,
-          skip: false,
-          explicitLibDefs: [],
         });
 
         // Replaces the stub with the real typedef
@@ -633,12 +621,7 @@ describe('install (command)', () => {
         ]);
 
         // Run the install command
-        await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
-          explicitLibDefs: [],
-        });
+        await run(defaultRunProps);
 
         const libdefFilePath = path.join(
           FLOWPROJ_DIR,
@@ -653,12 +636,7 @@ describe('install (command)', () => {
         await fs.writeFile(libdefFilePath, libdefFileContent);
 
         // Run install command again
-        await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
-          explicitLibDefs: [],
-        });
+        await run(defaultRunProps);
 
         // Verify that the tweaked libdef file wasn't overwritten
         expect(await fs.readFile(libdefFilePath, 'utf8')).toBe(
@@ -686,12 +664,7 @@ describe('install (command)', () => {
         ]);
 
         // Run the install command
-        await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
-          explicitLibDefs: [],
-        });
+        await run(defaultRunProps);
 
         const libdefFilePath = path.join(
           FLOWPROJ_DIR,
@@ -706,10 +679,8 @@ describe('install (command)', () => {
 
         // Run install command again
         await run({
+          ...defaultRunProps,
           overwrite: true,
-          skip: false,
-          verbose: false,
-          explicitLibDefs: [],
         });
 
         // Verify that the tweaked libdef file wasn't overwritten
@@ -742,11 +713,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           packageDir: path.join(FLOWPROJ_DIR, '..'),
-          explicitLibDefs: [],
         });
 
         // Installs libdef
@@ -780,11 +748,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           rootDir: path.join(FLOWPROJ_DIR, 'src'),
-          explicitLibDefs: [],
         });
 
         // Installs libdef
@@ -832,11 +797,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           rootDir: path.join(FLOWPROJ_DIR, 'src'),
-          explicitLibDefs: [],
         });
 
         // Installs libdef
@@ -886,11 +848,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           rootDir: path.join(FLOWPROJ_DIR, 'src'),
-          explicitLibDefs: [],
         });
 
         // Installs libdef
@@ -952,11 +911,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           rootDir: path.join(FLOWPROJ_DIR, 'src'),
-          explicitLibDefs: [],
         });
 
         // Installs libdef
@@ -1006,11 +962,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           rootDir: path.join(FLOWPROJ_DIR, 'src'),
-          explicitLibDefs: [],
         });
 
         // Installs libdef
@@ -1049,11 +1002,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           rootDir: path.join(FLOWPROJ_DIR, 'src'),
-          explicitLibDefs: [],
         });
 
         // Installs libdef
@@ -1110,11 +1060,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           rootDir: path.join(FLOWPROJ_DIR, 'src'),
-          explicitLibDefs: [],
         });
 
         // Installs libdef
@@ -1172,11 +1119,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           rootDir: path.join(FLOWPROJ_DIR, 'src'),
-          explicitLibDefs: [],
         });
 
         // Installs libdef
@@ -1230,11 +1174,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           rootDir: path.join(FLOWPROJ_DIR, 'src'),
-          explicitLibDefs: [],
         });
 
         // Installs libdef
@@ -1286,11 +1227,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           rootDir: path.join(FLOWPROJ_DIR, 'src'),
-          explicitLibDefs: [],
         });
 
         // Installs libdef
@@ -1370,11 +1308,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           ignoreDeps: [],
-          explicitLibDefs: [],
         });
 
         // Installs libdefs
@@ -1407,11 +1342,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           ignoreDeps: [],
-          explicitLibDefs: [],
         });
 
         // Installs libdefs
@@ -1441,11 +1373,8 @@ describe('install (command)', () => {
 
         // Run the install command
         await run({
-          overwrite: false,
-          verbose: false,
-          skip: false,
+          ...defaultRunProps,
           ignoreDeps: [],
-          explicitLibDefs: [],
         });
 
         // Installs libdefs

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -3,6 +3,7 @@
 import type {FlowSpecificVer} from '../lib/flowVersion';
 import {signCodeStream} from '../lib/codeSign';
 import {copyFile, mkdirp} from '../lib/fileUtils';
+import {child_process} from '../lib/node';
 
 import {findFlowRoot} from '../lib/flowProjectUtils';
 
@@ -196,6 +197,15 @@ export async function run(args: Args): Promise<number> {
   if (npmLibDefResult !== 0) {
     return npmLibDefResult;
   }
+
+  // Once complete restart flow to solve flow issues when scanning large diffs
+  try {
+    await child_process.execP('npx flow stop');
+    await child_process.execP('npx flow');
+  } catch (e) {
+    console.log(colors.red('!! Flow restarted with some errors'));
+  }
+
   return 0;
 }
 

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -55,6 +55,7 @@ export type Args = {
   overwrite: mixed, // boolean
   skip: mixed, // boolean
   skipCache?: mixed, // boolean
+  skipFlowRestart?: mixed, // boolean
   verbose: mixed, // boolean
   libdefDir?: mixed, // string
   cacheDir?: mixed, // string
@@ -93,6 +94,11 @@ export function setup(yargs: Yargs): Yargs {
       },
       skipCache: {
         describe: 'Do not update cache prior to installing libdefs',
+        type: 'boolean',
+        demandOption: false,
+      },
+      skipFlowRestart: {
+        describe: 'Do not restart flow after installing libdefs',
         type: 'boolean',
         demandOption: false,
       },
@@ -199,11 +205,13 @@ export async function run(args: Args): Promise<number> {
   }
 
   // Once complete restart flow to solve flow issues when scanning large diffs
-  try {
-    await child_process.execP('npx flow stop');
-    await child_process.execP('npx flow');
-  } catch (e) {
-    console.log(colors.red('!! Flow restarted with some errors'));
+  if (!args.skipFlowRestart) {
+    try {
+      await child_process.execP('npx flow stop');
+      await child_process.execP('npx flow');
+    } catch (e) {
+      console.log(colors.red('!! Flow restarted with some errors'));
+    }
   }
 
   return 0;


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Closes #4184.

User when running `flow-typed install` will now also have flow stop and start which will have more guarantee of a stable install process.

Added an option `skipFlowRestart` that will tell flow-typed to not run this post install process but it being false by default seems better for every day user.

This does slow down install by a bit, so will need to look into performance of flow-typed install later anyways as mentioned here #2881

<img width="926" alt="Screen Shot 2021-12-01 at 7 25 01 pm" src="https://user-images.githubusercontent.com/12436524/144212540-b1ce4ca0-05bc-4c55-b2b1-d745aa56398a.png">
