### PR TITLE
Add missing type for mocha global variable

### DIFF
--- a/definitions/npm/mocha_v8.x.x/flow_v0.104.x-/mocha_v8.x.x.js
+++ b/definitions/npm/mocha_v8.x.x/flow_v0.104.x-/mocha_v8.x.x.js
@@ -203,7 +203,7 @@ type AfterEach =
 declare var setup: Setup;
 declare var teardown: Teardown;
 declare var suiteSetup: SuiteSetup;
-declare var suiteTeardown;
+declare var suiteTeardown: SuiteTeardown;
 declare var before: Before
 declare var after: After;
 declare var beforeEach: BeforeEach;


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: 
- Link to GitHub or NPM: 
- Type of contribution: fix

Other notes:

This seems like a typo, with Flow 0.168 this actually throws an error:
```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ flow-typed/npm/mocha_v8.x.x.js:209:26

Unexpected token ;, expected the token :

     206│ declare var setup: Setup;
     207│ declare var teardown: Teardown;
     208│ declare var suiteSetup: SuiteSetup;
     209│ declare var suiteTeardown;
                                   ^
     210│ declare var before: Before
     211│ declare var after: After;
     212│ declare var beforeEach: BeforeEach;
```
