### PR TITLE
[redux-devtools-extension] fix toplevel-library-import errors

### DIFF
--- a/definitions/npm/redux-devtools-extension_v2.x.x/flow_v0.104.x-/redux-devtools-extension_v2.x.x.js
+++ b/definitions/npm/redux-devtools-extension_v2.x.x/flow_v0.104.x-/redux-devtools-extension_v2.x.x.js
@@ -1,5 +1,32 @@
-import type { ActionCreator, StoreEnhancer } from 'redux';
-import typeof { compose } from 'redux';
+declare type DispatchAPI<A> = (action: A) => A;
+
+declare type Dispatch<A: { type: *, ... }> = DispatchAPI<A>;
+
+declare type Store<S, A, D = Dispatch<A>> = {
+  dispatch: D,
+  getState(): S,
+  subscribe(listener: () => void): () => void,
+  replaceReducer(nextReducer: Reducer<S, A>): void,
+  ...
+};
+
+declare type Reducer<S, A> = (state: S | void, action: A) => S;
+
+declare type StoreCreator<S, A, D = Dispatch<A>> = {
+  (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>,
+  (
+    reducer: Reducer<S, A>,
+    preloadedState: S,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>,
+  ...
+};
+
+declare type StoreEnhancer<S, A, D = Dispatch<A>> = (
+  next: StoreCreator<S, A, D>
+) => StoreCreator<S, A, D>;
+
+declare type ActionCreator<A, B> = (...args: Array<B>) => A;
 
 declare type $npm$ReduxDevtoolsExtension$DevToolsOptions = {
   name?: string,
@@ -45,7 +72,7 @@ declare type $npm$ReduxDevtoolsExtension$DevToolsOptions = {
 };
 
 declare function $npm$ReduxDevtoolsExtension$composeWithDevTools<A, B>(ab: A => B): A => B;
-declare function $npm$ReduxDevtoolsExtension$composeWithDevTools(options: $npm$ReduxDevtoolsExtension$DevToolsOptions): compose;
+declare function $npm$ReduxDevtoolsExtension$composeWithDevTools(options: $npm$ReduxDevtoolsExtension$DevToolsOptions): (...args: Array<any>) => any;
 declare function $npm$ReduxDevtoolsExtension$composeWithDevTools<A, B, C>(
   bc: B => C,
   ab: A => B

--- a/definitions/npm/redux-devtools-extension_v2.x.x/test_redux-devtools-extension_v2.x.x.js
+++ b/definitions/npm/redux-devtools-extension_v2.x.x/test_redux-devtools-extension_v2.x.x.js
@@ -41,20 +41,20 @@ const options1: Options = {
 (options1: OptionsLog);
 (options1: OptionsLogProd);
 
-// $FlowExpectedError
 const options2: Options = {
+  // $FlowExpectedError[incompatible-type]
   name: 54
 };
-// $FlowExpectedError
 const options3: OptionsDev = {
+  // $FlowExpectedError[incompatible-type]
   name: 54
 };
-// $FlowExpectedError
 const options4: OptionsLog = {
+  // $FlowExpectedError[incompatible-type]
   name: 54
 };
-// $FlowExpectedError
 const options5: OptionsLogProd = {
+  // $FlowExpectedError[incompatible-type]
   name: 54
 };
 
@@ -70,9 +70,9 @@ const options5: OptionsLogProd = {
 (compose(options1): * => Function);
 (compose((x: number): boolean => x === 0): number => boolean);
 (compose((b: boolean): Array<number> => b?[0]:[], (x: number): boolean => x === 0): number => Array<number>);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-cast]
 (compose((b: boolean): Array<number> => b?[0]:[], (x: number): boolean => x === 0): Array<number> => number);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-cast]
 (compose((s: string): number => parseInt(s), (n: number): string => String(n)): string => string);
 (compose((s: string): number => parseInt(s), (n: number): string => String(n)): number => number);
 


### PR DESCRIPTION
Move the imports and type declarations into the `declare module 'redux-devtools-extension'` block, and duplicate the type declarations into the other module blocks.