### PR TITLE
[react-test-renderer] fix getMountedInstance type

### DIFF
--- a/definitions/npm/react-test-renderer_v16.x.x/flow_v0.104.x-/react-test-renderer_v16.x.x.js
+++ b/definitions/npm/react-test-renderer_v16.x.x/flow_v0.104.x-/react-test-renderer_v16.x.x.js
@@ -3,6 +3,8 @@
 
 type ReactComponentInstance = React$Component<any>;
 
+type ReactInstance = React$Component<any, any> | React$Element<any>;
+
 type ReactTestRendererJSON = {
   type: string,
   props: { [propName: string]: any, ... },
@@ -67,7 +69,7 @@ declare module "react-test-renderer" {
 declare module "react-test-renderer/shallow" {
   declare export default class ShallowRenderer {
     static createRenderer(): ShallowRenderer;
-    getMountedInstance(): ReactTestInstance;
+    getMountedInstance<I: ReactInstance>(): I;
     getRenderOutput<E: React$Element<any>>(): E;
     getRenderOutput(): React$Element<any>;
     render(element: React$Element<any>, context?: any): void;


### PR DESCRIPTION
Fix return type of `getMountedInstance()` (see [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f7ec78508c6797e42f87a4390735bc2c650a1bfd/types/react-test-renderer/v16/shallow/index.d.ts) and [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/afd309b4193c1f448386bf8fe09e512e4422e69e/types/react/index.d.ts#L435))