### PR TITLE
@sentry/browser root captureException & captureMessage arg types update

### DIFF
--- a/definitions/npm/@sentry/browser_v5.x.x/flow_v0.90.x-/browser_v5.x.x.js
+++ b/definitions/npm/@sentry/browser_v5.x.x/flow_v0.90.x-/browser_v5.x.x.js
@@ -5,15 +5,27 @@ declare module '@sentry/browser' {
     declare export function addBreadcrumb(breadcrumb: Breadcrumb): void;
     declare export function captureException(
         message: mixed,
-        severity?: $Values<typeof Severity>,
+        captureContext?: CaptureContext,
     ): void;
     declare export function captureMessage(
         message: mixed,
-        severity?: $Values<typeof Severity>,
+        captureContext?: CaptureContext | $Values<typeof Severity>,
     ): void;
     declare export function configureScope((Scope) => void): void;
     declare export function getCurrentHub(): Hub;
     declare export function getHubFromCarrier(carrier: Carrier): Hub;
+
+    declare export type CaptureContext = Scope | $Shape<ScopeContext> | ((scope: Scope) => Scope)
+    
+    declare export type ScopeContext = {
+        user?: User;
+        level: $Values<typeof Severity>;
+        extra:  { [key: string]: any, ... };
+        contexts: {| [key: string]: { ... } |};
+        tags: { [key: string]: string, ... };
+        fingerprint?: $ReadOnlyArray<string>;
+        requestSession: RequestSession;
+    }
 
     declare export class Hub {
         constructor(client: BrowserClient<Options>): Hub;


### PR DESCRIPTION
captureMessage & captureException exist on the root of Sentry and also at the Hub & Scope level. We currently type all instances as if they were Hub.captureException instead of Sentry.captureException.

Hub captureException docs:
https://getsentry.github.io/sentry-javascript/interfaces/types.hub-1.html#captureexception

root captureException docs:
https://getsentry.github.io/sentry-javascript/modules/minimal.html#captureexception

This updates the root captureMessage/Exception arguments:

