### PR TITLE
[cli] Provide better logs related to dir structure when running tests

### DIFF
--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -168,6 +168,8 @@ export async function getLibDefs(defsDir: string): Promise<Array<LibDef>> {
   const defsDirItems = await fs.readdir(defsDir);
   await P.all(
     defsDirItems.map(async item => {
+      if (item === '.DS_Store') return;
+
       const itemPath = path.join(defsDir, item);
       const itemStat = await fs.stat(itemPath);
       if (itemStat.isDirectory()) {
@@ -177,13 +179,15 @@ export async function getLibDefs(defsDir: string): Promise<Array<LibDef>> {
           const defsDirItems = await fs.readdir(itemPath);
           await P.all(
             defsDirItems.map(async item => {
+              if (item === '.DS_Store') return;
+
               const itemPath = path.join(defsDir, scope, item);
               const itemStat = await fs.stat(itemPath);
               if (itemStat.isDirectory()) {
                 // itemPath is a lib dir
                 await addLibDefs(itemPath, libDefs);
               } else {
-                const error = `Expected only directories in the 'definitions/npm/@<scope>' directory!`;
+                const error = `Expected only directories in the 'definitions/npm/@<scope>' directory! Please remove or change ${itemPath}`;
                 throw new ValidationError(error);
               }
             }),
@@ -193,7 +197,7 @@ export async function getLibDefs(defsDir: string): Promise<Array<LibDef>> {
           await addLibDefs(itemPath, libDefs);
         }
       } else {
-        const error = `Expected only directories in the 'definitions/npm' directory!`;
+        const error = `Expected only directories in the 'definitions/npm' directory! Please remove or change ${itemPath}`;
         throw new ValidationError(error);
       }
     }),
@@ -246,7 +250,7 @@ async function parseLibDefsFromPkgDir(
   }
 
   if (flowDirs.length === 0) {
-    throw new ValidationError(`No libdef files found for ${pkgDirPath}!`);
+    throw new ValidationError(`No libdef files found in ${pkgDirPath}!`);
   }
 
   const libDefs = [];
@@ -290,7 +294,7 @@ async function parseLibDefsFromPkgDir(
       if (libDefFilePath == null) {
         libDefFilePath = path.join(flowDirPath, libDefFileName);
         if (pkgName !== 'ERROR') {
-          const error = 'No libdef file found!';
+          const error = `No libdef file found in ${flowDirPath}`;
           throw new ValidationError(error);
         }
         return;

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -168,6 +168,8 @@ export async function getLibDefs(defsDir: string): Promise<Array<LibDef>> {
   const defsDirItems = await fs.readdir(defsDir);
   await P.all(
     defsDirItems.map(async item => {
+      // If a user opens definitions dir in finder it will create `.DS_Store`
+      // which will need to be excluded while parsing
       if (item === '.DS_Store') return;
 
       const itemPath = path.join(defsDir, item);


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
In https://github.com/flow-typed/flow-typed/pull/4210 a contributor was unable to run tests when create a new lib def because they may have made a mistake when initially trying to create the dir structure. This throws an error but it's not one that's descriptive enough to help them pinpoint where to go to solve the issue.

Other notes, when I was building this fix I opened the `definitions/npm` dir in my finder and then it started throwing a lot of errors related to `DS_Store` I think instead of throwing we should just exit in that case so I've added that also. 