### PR TITLE
Fix the definitions of old versions of mocha

### DIFF
--- a/definitions/npm/mocha_v3.1.x/flow_v0.104.x-/mocha_v3.1.x.js
+++ b/definitions/npm/mocha_v3.1.x/flow_v0.104.x-/mocha_v3.1.x.js
@@ -202,7 +202,7 @@ type AfterEach =
 declare var setup: Setup;
 declare var teardown: Teardown;
 declare var suiteSetup: SuiteSetup;
-declare var suiteTeardown;
+declare var suiteTeardown: SuiteTeardown;
 declare var before: Before
 declare var after: After;
 declare var beforeEach: BeforeEach;

--- a/definitions/npm/mocha_v4.x.x/flow_v0.104.x-/mocha_v4.x.x.js
+++ b/definitions/npm/mocha_v4.x.x/flow_v0.104.x-/mocha_v4.x.x.js
@@ -202,7 +202,7 @@ type AfterEach =
 declare var setup: Setup;
 declare var teardown: Teardown;
 declare var suiteSetup: SuiteSetup;
-declare var suiteTeardown;
+declare var suiteTeardown: SuiteTeardown;
 declare var before: Before
 declare var after: After;
 declare var beforeEach: BeforeEach;

--- a/definitions/npm/mocha_v5.x.x/flow_v0.104.x-/mocha_v5.x.x.js
+++ b/definitions/npm/mocha_v5.x.x/flow_v0.104.x-/mocha_v5.x.x.js
@@ -203,7 +203,7 @@ type AfterEach =
 declare var setup: Setup;
 declare var teardown: Teardown;
 declare var suiteSetup: SuiteSetup;
-declare var suiteTeardown;
+declare var suiteTeardown: SuiteTeardown;
 declare var before: Before
 declare var after: After;
 declare var beforeEach: BeforeEach;

--- a/definitions/npm/mocha_v6.x.x/flow_v0.104.x-/mocha_v6.x.x.js
+++ b/definitions/npm/mocha_v6.x.x/flow_v0.104.x-/mocha_v6.x.x.js
@@ -203,7 +203,7 @@ type AfterEach =
 declare var setup: Setup;
 declare var teardown: Teardown;
 declare var suiteSetup: SuiteSetup;
-declare var suiteTeardown;
+declare var suiteTeardown: SuiteTeardown;
 declare var before: Before
 declare var after: After;
 declare var beforeEach: BeforeEach;

--- a/definitions/npm/mocha_v7.x.x/flow_v0.104.x-/mocha_v7.x.x.js
+++ b/definitions/npm/mocha_v7.x.x/flow_v0.104.x-/mocha_v7.x.x.js
@@ -203,7 +203,7 @@ type AfterEach =
 declare var setup: Setup;
 declare var teardown: Teardown;
 declare var suiteSetup: SuiteSetup;
-declare var suiteTeardown;
+declare var suiteTeardown: SuiteTeardown;
 declare var before: Before
 declare var after: After;
 declare var beforeEach: BeforeEach;


### PR DESCRIPTION
The definitions of mocha v4-7 contains a line that the latest version of flow cannot process.

```
Error ---------------------------------------------------------------------------- flow-typed/npm/mocha_v4.x.x.js:208:26

Unexpected token `;`, expected the token `:`

   208| declare var suiteTeardown;
                                 ^
```

- Links to documentation: 
- Link to GitHub or NPM: 
- Type of contribution: fix

