### PR TITLE
[docs] Fix the documented pathing for an ignoring eslint

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -77,7 +77,7 @@ flow-typed/npm
 ```
 or
 ```
-// .eslintrc.js
+// flow-typed/.eslintrc.js
 module.exports = {
   ignorePatterns: ['**/*.js'],
 };


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Fix the docs I added in FAQ regarding where to add the `eslintrc.js` file.