### PR TITLE
Add missing trailing comma from VerifyOptions type in jsonwebtoken definition

### DIFF
--- a/definitions/npm/jsonwebtoken_v8.4.x/flow_v0.56.x-v0.103.x/jsonwebtoken_v8.4.x.js
+++ b/definitions/npm/jsonwebtoken_v8.4.x/flow_v0.56.x-v0.103.x/jsonwebtoken_v8.4.x.js
@@ -59,7 +59,7 @@ declare module "jsonwebtoken" {
     subject: string | string[],
     clockTolerance: number,
     maxAge: string | number,
-    clockTimestamp: number
+    clockTimestamp: number,
     nonce?: string,
   }>;
 

--- a/definitions/npm/jsonwebtoken_v8.5.x/flow_v0.56.x-v0.103.x/jsonwebtoken_v8.5.x.js
+++ b/definitions/npm/jsonwebtoken_v8.5.x/flow_v0.56.x-v0.103.x/jsonwebtoken_v8.5.x.js
@@ -59,7 +59,7 @@ declare module "jsonwebtoken" {
     subject: string | string[],
     clockTolerance: number,
     maxAge: string | number,
-    clockTimestamp: number
+    clockTimestamp: number,
     nonce?: string,
     /** return an object with the decoded `{ payload, header, signature }` instead of only the usual content of the payload. */
     complete?: boolean,


### PR DESCRIPTION
This fix is for a definition that was added earlier today and breaks our production builds as we are using flow-bin < 0.103.

Your automated tests only cover the last 15 flow-bin versions published to npm.
