### PR TITLE
fix: pin colors@1.4.0 to fix security vuln

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^18.12.0",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "flowgen": "^1.10.0",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.6",


### PR DESCRIPTION
A Security Vuln was identified in the Colors package for >1.4.0, offending packages being `1.4.1`, `1.4.44-liberty`
- [source1](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source2](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source3](https://security.snyk.io/vuln/SNYK-JS-COLORS-2331906)

This PR pins the color package to `1.4.0` as advised on the [snyk page](https://snyk.io/blog/open-source-maintainer-pulls-the-plug-on-npm-packages-colors-and-faker-now-what/)

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: 
- Link to GitHub or NPM: 
- Type of contribution: new definition | addition | fix | refactor

Other notes:

