### PR TITLE
Update humps v2.x.x camelizeKeys function definition

### DIFF
--- a/definitions/npm/humps_v2.x.x/flow_v0.104.x-/humps_v2.x.x.js
+++ b/definitions/npm/humps_v2.x.x/flow_v0.104.x-/humps_v2.x.x.js
@@ -18,9 +18,9 @@ declare module "humps" {
   declare export function depascalize(string, options?: Options): string;
 
   declare export function camelizeKeys(
-    Object | Array<Object>,
+    { +[string]: mixed, ... },
     options?: Options
-  ): Object;
+  ): { [string]: mixed, ... };
   declare export function pascalizeKeys(
     { +[string]: mixed, ... },
     options?: Options
@@ -33,6 +33,11 @@ declare module "humps" {
     { +[string]: mixed, ... },
     options?: Options
   ): { [string]: mixed, ... };
+
+  declare export function camelizeKeys(
+    Array<{ +[string]: mixed, ... }>,
+    options?: Options
+  ): Array<{ [string]: mixed, ... }>;
 
   declare export default {|
     camelize: typeof camelize,

--- a/definitions/npm/humps_v2.x.x/flow_v0.104.x-/humps_v2.x.x.js
+++ b/definitions/npm/humps_v2.x.x/flow_v0.104.x-/humps_v2.x.x.js
@@ -18,9 +18,9 @@ declare module "humps" {
   declare export function depascalize(string, options?: Options): string;
 
   declare export function camelizeKeys(
-    { +[string]: mixed, ... },
+    Object | Array<Object>,
     options?: Options
-  ): { [string]: mixed, ... };
+  ): Object;
   declare export function pascalizeKeys(
     { +[string]: mixed, ... },
     options?: Options

--- a/definitions/npm/humps_v2.x.x/flow_v0.104.x-/test_humps_v2.x.x.js
+++ b/definitions/npm/humps_v2.x.x/flow_v0.104.x-/test_humps_v2.x.x.js
@@ -31,5 +31,8 @@ describe("tests", () => {
     (pascalizeKeys({ foo: 1 }): { [string]: mixed, ... });
     (decamelizeKeys({ foo: 1 }): { [string]: mixed, ... });
     (depascalizeKeys({ foo: 1 }): { [string]: mixed, ... });
+
+    (camelizeKeys([{ foo: 1 }]): Array<{ [string]: mixed, ... }>);
+    (camelizeKeys([{ foo: "bar" }]): Array<{ [string]: mixed, ... }>);
   });
 });


### PR DESCRIPTION
Co-authored-by: David Coelho <davidcoelho02@outlook.com>

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/domchristie/humps/tree/050b1fd852cf0847bed9513655b2afbb20d89859#converting-object-keys
- Link to GitHub or NPM: https://github.com/domchristie/humps
- Type of contribution: fix

Other notes:

We were working with hump's `camelizeKeys` and hitting an error due to its definition.
We got it to work properly with this change, but feel free to tell us if we should have done this differently.

Thanks for your review 🙇 