### PR TITLE
[cli] fix create def with scopes 

### DIFF
--- a/cli/src/commands/create-def.js
+++ b/cli/src/commands/create-def.js
@@ -35,22 +35,37 @@ export async function run({libName, ver}: Args): Promise<number> {
     return 1;
   }
 
-  const definitionsPath = path.join(process.cwd(), '/definitions/npm');
-  const rootDefDir = `${definitionsPath}/${libName}_v${ver}`;
+  const scope = libName.startsWith('@') ? libName.split('/')[0] : '';
+  const packageName = scope ? libName.split('/')[1] : libName;
+  const definitionsPath = path.join(
+    process.cwd(),
+    '/definitions/npm',
+    scope ?? '',
+  );
+  const rootDefDir = `${definitionsPath}/${packageName}_v${ver}`;
   const defDir = `${rootDefDir}/flow_v${flowVersion}-`;
 
+  if (scope) {
+    try {
+      fs.mkdirSync(definitionsPath);
+    } catch (err) {
+      if (err.code !== 'EEXIST') {
+        throw err;
+      }
+    }
+  }
   fs.mkdirSync(rootDefDir);
   fs.mkdirSync(defDir);
 
   fs.writeFileSync(
-    `${defDir}/${libName}_v${ver}.js`,
+    `${defDir}/${packageName}_v${ver}.js`,
     `declare module '${libName}' {
   declare module.exports: any;
 }`,
   );
 
   fs.writeFileSync(
-    `${defDir}/test_${libName}_v${ver}.js`,
+    `${defDir}/test_${packageName}_v${ver}.js`,
     `// @flow
 import { describe, it } from 'flow-typed-test';
 // import library from '${libName}';


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
When using `./create_def.sh` with a scoped package such as `@octokit/rest` it didn't work because the command wasn't configured to handle this and would try to created nested directories immediately.

<img width="396" alt="Screen Shot 2022-01-14 at 5 23 29 am" src="https://user-images.githubusercontent.com/12436524/149387860-fdbc10d1-1f73-407d-b09e-43a6aebb7659.png">

