### PR TITLE
[cli] Install can match with alpha versions now

### DIFF
--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -364,6 +364,49 @@ describe('install (command)', () => {
       });
     });
 
+    it('installs version matched libdef for alpha versions', () => {
+      return fakeProjectEnv(async FLOWPROJ_DIR => {
+        // Create some dependencies
+        await Promise.all([
+          touchFile(path.join(FLOWPROJ_DIR, '.flowconfig')),
+          writePkgJson(path.join(FLOWPROJ_DIR, 'package.json'), {
+            name: 'test',
+            devDependencies: {
+              'flow-bin': '^0.43.0',
+            },
+            dependencies: {
+              foo: '1.2.3-alpha.5',
+            },
+          }),
+          mkdirp(path.join(FLOWPROJ_DIR, 'node_modules', 'foo')),
+          mkdirp(path.join(FLOWPROJ_DIR, 'node_modules', 'flow-bin')),
+        ]);
+
+        // Run the install command
+        await run({
+          ...defaultRunProps,
+          ignoreDeps: [],
+        });
+
+        // Installs libdefs
+        expect(
+          await Promise.all([
+            fs.exists(
+              path.join(
+                FLOWPROJ_DIR,
+                'flow-typed',
+                'npm',
+                'flow-bin_v0.x.x.js',
+              ),
+            ),
+            fs.exists(
+              path.join(FLOWPROJ_DIR, 'flow-typed', 'npm', 'foo_v1.x.x.js'),
+            ),
+          ]),
+        ).toEqual([true, true]);
+      });
+    });
+
     it('installs available libdefs using PnP', () => {
       return fakeProjectEnv(async FLOWPROJ_DIR => {
         // Create some dependencies

--- a/cli/src/lib/npm/__tests__/npmLibDefs-test.js
+++ b/cli/src/lib/npm/__tests__/npmLibDefs-test.js
@@ -340,12 +340,21 @@ describe('npmLibDefs', () => {
       expect(pkgVersionMatch('>=8.5.1', '9.x.x')).toBe(false);
     });
 
-    it('matches explicit libdef with major range libdef', () => {
+    it('matches explicit version with major range libdef', () => {
       expect(pkgVersionMatch('8.5.1', '8.x.x')).toBe(true);
     });
 
-    it('matches explicit libdef with minor range libdef', () => {
+    it('matches explicit version with minor range libdef', () => {
       expect(pkgVersionMatch('8.5.1', '8.5.x')).toBe(true);
+    });
+
+    it('matches alpha version with libdef', () => {
+      expect(pkgVersionMatch('8.5.1-alpha.0', '8.5.x')).toBe(true);
+      expect(pkgVersionMatch('8.5.1-alpha.0', '8.x.x')).toBe(true);
+    });
+
+    it('matches non-semantic version alpha version with libdef', () => {
+      expect(pkgVersionMatch('42.6.7.9.3-alpha', '42.6.x')).toBe(true);
     });
   });
 


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Closes #4245. Previously there was no way for alpha versions of a library to match a libdef.