### PR TITLE
[cli] Turn off validate-def checks against npm

### DIFF
--- a/cli/src/lib/npm/npmLibDefs.js
+++ b/cli/src/lib/npm/npmLibDefs.js
@@ -1,5 +1,4 @@
 // @flow
-
 import {
   ensureCacheRepo,
   getCacheRepoDir,
@@ -31,7 +30,7 @@ import {
 
 import semver from 'semver';
 
-import got from 'got';
+// import got from 'got';
 
 import {ValidationError} from '../ValidationError';
 import {TEST_FILE_NAME_RE} from '../libDefs';
@@ -58,6 +57,8 @@ async function extractLibDefsFromNpmPkgDir(
   pkgDirPath: string,
   scope: null | string,
   pkgNameVer: string,
+  // Remove eslint error after `core.es5` change
+  // eslint-disable-next-line no-unused-vars
   validating?: boolean,
 ): Promise<Array<NpmLibDef>> {
   const parsedPkgNameVer = parsePkgNameVer(pkgNameVer);
@@ -70,31 +71,36 @@ async function extractLibDefsFromNpmPkgDir(
   const libDefFileName = `${pkgName}_${pkgVersionStr}.js`;
   const pkgDirItems = await fs.readdir(pkgDirPath);
 
-  if (validating) {
-    const fullPkgName = `${scope === null ? '' : scope + '/'}${pkgName}`;
-    await _npmExists(fullPkgName)
-      .then()
-      .catch(error => {
-        if (error.HTTPError && error.HTTPError.response.statusCode === 404) {
-          // Some times NPM returns 404 even though the package exists.
-          // Try to avoid false negatives by retrying
-          return new Promise((resolve, reject) =>
-            setTimeout(() => {
-              _npmExists(fullPkgName)
-                .then(resolve)
-                .catch(reject);
-            }, 1000),
-          );
-        }
-      })
-      .then()
-      .catch(error => {
-        // Only fail on 404, not on timeout
-        if (error.HTTPError && error.HTTPError.statusCode === 404) {
-          throw new ValidationError(`Package does not exist on npm!`);
-        }
-      });
-  }
+  /**
+   * TODO:
+   * The following block is commented out until `core.es5` has been moved to
+   * somewhere else such as core
+   */
+  // if (validating) {
+  //   const fullPkgName = `${scope === null ? '' : scope + '/'}${pkgName}`;
+  //   await _npmExists(fullPkgName)
+  //     .then()
+  //     .catch(error => {
+  //       if (error.HTTPError && error.HTTPError.response.statusCode === 404) {
+  //         // Some times NPM returns 404 even though the package exists.
+  //         // Try to avoid false negatives by retrying
+  //         return new Promise((resolve, reject) =>
+  //           setTimeout(() => {
+  //             _npmExists(fullPkgName)
+  //               .then(resolve)
+  //               .catch(reject);
+  //           }, 1000),
+  //         );
+  //       }
+  //     })
+  //     .then()
+  //     .catch(error => {
+  //       // Only fail on 404, not on timeout
+  //       if (error.HTTPError && error.HTTPError.statusCode === 404) {
+  //         throw new ValidationError(`Package does not exist on npm!`);
+  //       }
+  //     });
+  // }
 
   const commonTestFiles = [];
   const parsedFlowDirs: Array<[string, FlowVersion]> = [];
@@ -360,10 +366,13 @@ function filterLibDefs(
     });
 }
 
-async function _npmExists(pkgName: string): Promise<Function> {
-  const pkgUrl = `https://www.npmjs.com/package/${pkgName}`;
-  return got(pkgUrl, {method: 'HEAD'});
-}
+// TODO Unused until `core.es5`
+// async function _npmExists(pkgName: string): Promise<Function> {
+//   const pkgUrl = `https://api.npms.io/v2/package/${encodeURIComponent(
+//     pkgName,
+//   )}`;
+//   return got(pkgUrl, {method: 'HEAD'});
+// }
 
 export async function findNpmLibDef(
   pkgName: string,

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -1,11 +1,13 @@
 # validate-defs
 
-Validate the structure of the `/definitions` directory.
+Validate the structure of the `/definitions` directory given a path that contains an `npm` dir.
 
 ### Examples
 
 ```
-flow-typed validate-defs
+flow-typed validate-defs definitions
+flow-typed validate-defs ../definitions
+flow-typed validate-defs ~/projects/flow-typed/definitions
 ```
 
 ## Flags


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Hear me out, this is the beginning of a series of changes. After having a read of #87 and then testing `validate-def` I found that the testing against npmjs doesn't actually work. It uses `got` to ping npmjs.com but because it's hitting a website even if the website says 404 the website itself it a 200 response. Furthermore hitting a website like crazy reaches a `HTTPError: Response code 429 (Too Many Requests)` error. I've changed this to use `api.npms.io/v2/` instead which can support the load and will reliably return with whether the request succeeds or fails.

But the code using a mix of then/catch + async/await doesn't actually work properly, even if the `got` reaches a 404 it still ends saying `All libdefs are named and structured correctly`.

Finally there is one library called `core.es5` that was added 2 years ago and isn't actually an npm library, because of this it is meant to fail but it's perfectly valid given the reason it's there but it's not in the right place (`definitions/npm`) and as a result I cannot have the npmjs check working until we've shifted the definition somewhere else (I'm thinking `definitions/core` but I'll raise a discussion around this first). 

## What this PR does
Turn off the npmjs part of the validation to improve speed as we improve other areas to allow it turn back on. 