### PR TITLE
[jest] Add tests against it.each

### DIFF
--- a/definitions/npm/jest_v23.x.x/flow_v0.134.x-/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.134.x-/test_jest-v23.x.x.js
@@ -692,3 +692,15 @@ expect(wrapper).toHaveDisplayName(true);
   // No type hint means we return any
   const FooModule3: boolean = jest.requireActual('FooModule');
 }
+
+it.each`
+  x    | y    | z
+  ${1} | ${2} | ${3}
+  ${2} | ${3} | ${5}
+  ${3} | ${4} | ${7}
+`(
+  'x=$x, y=$y, and z=$z',
+  ({ x, y, z }) => {
+      // perform tests
+  }
+);

--- a/definitions/npm/jest_v24.x.x/flow_v0.134.x-/test_jest-v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.134.x-/test_jest-v24.x.x.js
@@ -740,3 +740,15 @@ expect(wrapper).toHaveDisplayName(true);
   // No type hint means we return any
   const FooModule3: boolean = jest.requireActual('FooModule');
 }
+
+it.each`
+  x    | y    | z
+  ${1} | ${2} | ${3}
+  ${2} | ${3} | ${5}
+  ${3} | ${4} | ${7}
+`(
+  'x=$x, y=$y, and z=$z',
+  ({ x, y, z }) => {
+      // perform tests
+  }
+);

--- a/definitions/npm/jest_v25.x.x/flow_v0.134.x-/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.134.x-/test_jest-v25.x.x.js
@@ -746,3 +746,15 @@ expect(wrapper).toHaveDisplayName(true);
   // No type hint means we return any
   const FooModule3: boolean = jest.requireActual('FooModule');
 }
+
+it.each`
+  x    | y    | z
+  ${1} | ${2} | ${3}
+  ${2} | ${3} | ${5}
+  ${3} | ${4} | ${7}
+`(
+  'x=$x, y=$y, and z=$z',
+  ({ x, y, z }) => {
+      // perform tests
+  }
+);

--- a/definitions/npm/jest_v26.x.x/flow_v0.134.x-/test_jest-v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.134.x-/test_jest-v26.x.x.js
@@ -788,3 +788,15 @@ expect(wrapper).toHaveDisplayName(true);
   // No type hint means we return any
   const FooModule3: boolean = jest.requireActual('FooModule');
 }
+
+it.each`
+  x    | y    | z
+  ${1} | ${2} | ${3}
+  ${2} | ${3} | ${5}
+  ${3} | ${4} | ${7}
+`(
+  'x=$x, y=$y, and z=$z',
+  ({ x, y, z }) => {
+      // perform tests
+  }
+);

--- a/definitions/npm/jest_v27.x.x/flow_v0.134.x-/test_jest-v27.x.x.js
+++ b/definitions/npm/jest_v27.x.x/flow_v0.134.x-/test_jest-v27.x.x.js
@@ -786,3 +786,15 @@ expect(wrapper).toHaveDisplayName(true);
   // No type hint means we return any
   const FooModule3: boolean = jest.requireActual('FooModule');
 }
+
+it.each`
+  x    | y    | z
+  ${1} | ${2} | ${3}
+  ${2} | ${3} | ${5}
+  ${3} | ${4} | ${7}
+`(
+  'x=$x, y=$y, and z=$z',
+  ({ x, y, z }) => {
+      // perform tests
+  }
+);


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Closes #3836. Adding tests against `it` jest global opbject.

- Links to documentation: https://jestjs.io/docs/api#2-describeeachtablename-fn-timeout
- Link to GitHub or NPM: https://npmjs.com/package/jest
- Type of contribution: addition

Other notes: @hadron-mhchu looks like this has worked for a while on versions 23+ but I'm adding some tests since there are zero tests on `it` in general. 

