### PR TITLE
[react-testing-library] Fix `RenderResult` type to spread it's parent

### DIFF
--- a/definitions/npm/react-testing-library_v5.x.x/flow_v0.104.x-/react-testing-library_v5.x.x.js
+++ b/definitions/npm/react-testing-library_v5.x.x/flow_v0.104.x-/react-testing-library_v5.x.x.js
@@ -96,13 +96,14 @@ declare module 'react-testing-library' {
   |};
 
   declare type RenderResult = {|
+    ...GetsAndQueries,
     container: HTMLDivElement,
     unmount: () => void,
     baseElement: HTMLElement,
     asFragment: () => DocumentFragment,
     debug: (baseElement?: HTMLElement) => void,
     rerender: (ui: React$Element<*>) => void,
-  |} & GetsAndQueries;
+  |};
 
   declare type FireEvent<TInit> = (
     element: HTMLElement,

--- a/definitions/npm/react-testing-library_v5.x.x/flow_v0.104.x-/test_react-testing-library_v5.x.x.js
+++ b/definitions/npm/react-testing-library_v5.x.x/flow_v0.104.x-/test_react-testing-library_v5.x.x.js
@@ -14,9 +14,9 @@ import { describe, it } from 'flow-typed-test';
 
 describe('wait', () => {
   it('should fail on invalid inputs', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     wait(1);
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     wait(() => {}, 1);
   });
 
@@ -28,9 +28,9 @@ describe('wait', () => {
 
 describe('waitForDomChange', () => {
   it('should fail on invalid inputs', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     waitForDomChange(1);
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     waitForDomChange('1');
   });
 
@@ -42,9 +42,9 @@ describe('waitForDomChange', () => {
 
 describe('waitForElement', () => {
   it('should fail on invalid inputs', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     waitForElement(1);
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     waitForElement(() => {}, 1);
   });
 
@@ -118,36 +118,36 @@ describe('render', () => {
 
   it('unmount should has 0 arguments', () => {
     unmount();
-    // $FlowExpectedError
+    // $FlowExpectedError[extra-arg]
     unmount(1);
   });
 
   it('container should be an html element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: number = container;
     const b: HTMLElement = container;
   });
 
   it('baseElement should be an html element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: number = baseElement;
     const b: HTMLElement = baseElement;
   });
 
   it('asFragment should return a document fragment', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = asFragment();
     const b: DocumentFragment = asFragment();
   })
 
   it('debug maybe has 1 argument an html element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     debug(1);
     debug(container);
   });
 
   it('rerender should has 1 argument an react element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     rerender();
     rerender(<Component />);
   });
@@ -157,19 +157,19 @@ describe('render', () => {
   });
 
   it('getAllByAltText should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = getAllByAltText('1');
     const b: Array<HTMLElement> = getAllByAltText('2');
   });
 
   it('queryByAltText should return maybe HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryByAltText('1');
     const b: ?HTMLElement = queryByAltText('2');
   });
 
   it('queryAllByAltText should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryAllByAltText('1');
     const b: Array<HTMLElement> = queryAllByAltText('2');
   });
@@ -179,19 +179,19 @@ describe('render', () => {
   });
 
   it('getAllByDisplayValue should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = getAllByDisplayValue('1');
     const b: Array<HTMLElement> = getAllByDisplayValue('2');
   });
 
   it('queryByDisplayValue should return maybe HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryByDisplayValue('1');
     const b: ?HTMLElement = queryByDisplayValue('2');
   });
 
   it('queryAllByDisplayValue should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryAllByDisplayValue('1');
     const b: Array<HTMLElement> = queryAllByDisplayValue('2');
   });
@@ -201,19 +201,19 @@ describe('render', () => {
   });
 
   it('getAllByLabelText should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = getAllByLabelText('1');
     const b: Array<HTMLElement> = getAllByLabelText('2');
   });
 
   it('queryByLabelText should return maybe HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryByLabelText('1');
     const b: ?HTMLElement = queryByLabelText('2');
   });
 
   it('queryAllByLabelText should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryAllByLabelText('1');
     const b: Array<HTMLElement> = queryAllByLabelText('2');
   });
@@ -223,19 +223,19 @@ describe('render', () => {
   });
 
   it('getAllByPlaceholderText should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = getAllByPlaceholderText('1');
     const b: Array<HTMLElement> = getAllByPlaceholderText('2');
   });
 
   it('queryByPlaceholderText should return maybe HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryByPlaceholderText('1');
     const b: ?HTMLElement = queryByPlaceholderText('2');
   });
 
   it('queryAllByPlaceholderText should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryAllByPlaceholderText('1');
     const b: Array<HTMLElement> = queryAllByPlaceholderText('2');
   });
@@ -245,19 +245,19 @@ describe('render', () => {
   });
 
   it('getAllByRole should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = getAllByRole('1');
     const b: Array<HTMLElement> = getAllByRole('2');
   });
 
   it('queryByRole should return maybe HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryByRole('1');
     const b: ?HTMLElement = queryByRole('2');
   });
 
   it('queryAllByRole should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryAllByRole('1');
     const b: Array<HTMLElement> = queryAllByRole('2');
   });
@@ -267,19 +267,19 @@ describe('render', () => {
   });
 
   it('getAllBySelectText should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = getAllBySelectText('1');
     const b: Array<HTMLElement> = getAllBySelectText('2');
   });
 
   it('queryBySelectText should return maybe HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryBySelectText('1');
     const b: ?HTMLElement = queryBySelectText('2');
   });
 
   it('queryAllBySelectText should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryAllBySelectText('1');
     const b: Array<HTMLElement> = queryAllBySelectText('2');
   });
@@ -289,19 +289,19 @@ describe('render', () => {
   });
 
   it('getAllByTestId should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = getAllByTestId('1');
     const b: Array<HTMLElement> = getAllByTestId('2');
   });
 
   it('queryByTestId should return maybe HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryByTestId('1');
     const b: ?HTMLElement = queryByTestId('2');
   });
 
   it('queryAllByTestId should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryAllByTestId('1');
     const b: Array<HTMLElement> = queryAllByTestId('2');
   });
@@ -311,19 +311,19 @@ describe('render', () => {
   });
 
   it('getAllByText should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = getAllByText('1');
     const b: Array<HTMLElement> = getAllByText('2');
   });
 
   it('queryByText should return maybe HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryByText('1');
     const b: ?HTMLElement = queryByText('2');
   });
 
   it('queryAllByText should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryAllByText('1');
     const b: Array<HTMLElement> = queryAllByText('2');
   });
@@ -333,19 +333,19 @@ describe('render', () => {
   });
 
   it('getAllByTitle should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = getAllByTitle('1');
     const b: Array<HTMLElement> = getAllByTitle('2');
   });
 
   it('queryByTitle should return maybe HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryByTitle('1');
     const b: ?HTMLElement = queryByTitle('2');
   });
 
   it('queryAllByTitle should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryAllByTitle('1');
     const b: Array<HTMLElement> = queryAllByTitle('2');
   });
@@ -355,19 +355,19 @@ describe('render', () => {
   });
 
   it('getAllByValue should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = getAllByValue('1');
     const b: Array<HTMLElement> = getAllByValue('2');
   });
 
   it('queryByValue should return maybe HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryByValue('1');
     const b: ?HTMLElement = queryByValue('2');
   });
 
   it('queryAllByValue should return array of HTML element', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-type]
     const a: HTMLElement = queryAllByValue('1');
     const b: Array<HTMLElement> = queryAllByValue('2');
   });
@@ -376,7 +376,7 @@ describe('render', () => {
 describe('cleanup', () => {
   it('should be a function w/o arguments', () => {
     cleanup();
-    // $FlowExpectedError
+    // $FlowExpectedError[extra-arg]
     cleanup(1);
   });
 });
@@ -386,7 +386,7 @@ describe('within', () => {
   const { container } = render(<Component />);
 
   it('should has html element as argument', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     within();
     within(container);
   });
@@ -566,9 +566,9 @@ describe('fireEvent', () => {
   });
 
   it('should throw on invalid arguments', () => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     fireEvent(1);
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     fireEvent(htmlEl, 1);
   });
 


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Closes #3692

- Links to documentation: https://www.npmjs.com/package/react-testing-library
- Link to GitHub or NPM: https://www.npmjs.com/package/react-testing-library
- Type of contribution: fix

Other notes: Following the spread syntax from latest version of [@testing-library/react](https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/%40testing-library/react_v12.x.x/flow_v0.104.x-/react_v12.x.x.js#L444) which is shown to be the correct implementation. Although this library is deprecated.

