### PR TITLE
[docs] Add missing flag in run-tests docs

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -16,3 +16,4 @@ flow-typed run-tests axios_v0.16.x
 |---------|--------|-----------|----|
 ||--onlyChanged|Only runs tests on changed definitions|boolean||
 ||--path|Override default path for libdef root (Mainly for testing purposes)|string||
+||--numberOfFlowVersions|Only run against the latest X versions of flow|number||


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Ref: https://github.com/flow-typed/flow-typed/blob/master/cli/src/commands/runTests.js#L701

