### PR TITLE
[chalk] Export list of modifier and color types

### DIFF
--- a/definitions/npm/chalk_v4.x.x/flow_v0.104.x-/chalk_v4.x.x.js
+++ b/definitions/npm/chalk_v4.x.x/flow_v0.104.x-/chalk_v4.x.x.js
@@ -1,6 +1,48 @@
 // From: https://github.com/chalk/chalk/blob/master/index.d.ts
 
 declare module "chalk" {
+  declare type ForegroundColor =
+    | 'black'
+    | 'red'
+    | 'green'
+    | 'yellow'
+    | 'blue'
+    | 'magenta'
+    | 'cyan'
+    | 'white'
+    | 'gray'
+    | 'grey'
+    | 'blackBright'
+    | 'redBright'
+    | 'greenBright'
+    | 'yellowBright'
+    | 'blueBright'
+    | 'magentaBright'
+    | 'cyanBright'
+    | 'whiteBright';
+
+  declare type BackgroundColor =
+    | 'bgBlack'
+    | 'bgRed'
+    | 'bgGreen'
+    | 'bgYellow'
+    | 'bgBlue'
+    | 'bgMagenta'
+    | 'bgCyan'
+    | 'bgWhite'
+    | 'bgGray'
+    | 'bgGrey'
+    | 'bgBlackBright'
+    | 'bgRedBright'
+    | 'bgGreenBright'
+    | 'bgYellowBright'
+    | 'bgBlueBright'
+    | 'bgMagentaBright'
+    | 'bgCyanBright'
+    | 'bgWhiteBright';
+
+  declare type Color = ForegroundColor | BackgroundColor;
+
   declare type TemplateStringsArray = $ReadOnlyArray<string>;
 
   declare type Level = $Values<{

--- a/definitions/npm/chalk_v4.x.x/flow_v0.104.x-/chalk_v4.x.x.js
+++ b/definitions/npm/chalk_v4.x.x/flow_v0.104.x-/chalk_v4.x.x.js
@@ -43,6 +43,17 @@ declare module "chalk" {
 
   declare type Color = ForegroundColor | BackgroundColor;
 
+  declare type Modifiers =
+    | 'reset'
+    | 'bold'
+    | 'dim'
+    | 'italic'
+    | 'underline'
+    | 'inverse'
+    | 'hidden'
+    | 'strikethrough'
+    | 'visible';
+
   declare type TemplateStringsArray = $ReadOnlyArray<string>;
 
   declare type Level = $Values<{

--- a/definitions/npm/chalk_v4.x.x/flow_v0.104.x-/test_chalk_v4.x.x.js
+++ b/definitions/npm/chalk_v4.x.x/flow_v0.104.x-/test_chalk_v4.x.x.js
@@ -1,6 +1,6 @@
 // @flow
 
-import chalk, { bold, type Chalk } from 'chalk';
+import chalk, { bold, type Chalk, type Color } from 'chalk';
 
 const requiredChalk = require('chalk');
 
@@ -28,3 +28,7 @@ const supportsStringTemplate: string = chalk`{red string template} done`;
 const useRequiredChalk: string = requiredChalk.bold("required chalk");
 
 const ctx: Chalk = new chalk.Instance({level: 0});
+
+// $FlowExpectedError[incompatible-type] Color must be one of supported colors
+const a: Color = 'random';
+const b: Color = 'black';

--- a/definitions/npm/chalk_v4.x.x/flow_v0.104.x-/test_chalk_v4.x.x.js
+++ b/definitions/npm/chalk_v4.x.x/flow_v0.104.x-/test_chalk_v4.x.x.js
@@ -1,6 +1,6 @@
 // @flow
 
-import chalk, { bold, type Chalk, type Color } from 'chalk';
+import chalk, { bold, type Chalk, type Color, type Modifiers } from 'chalk';
 
 const requiredChalk = require('chalk');
 
@@ -30,5 +30,9 @@ const useRequiredChalk: string = requiredChalk.bold("required chalk");
 const ctx: Chalk = new chalk.Instance({level: 0});
 
 // $FlowExpectedError[incompatible-type] Color must be one of supported colors
-const a: Color = 'random';
-const b: Color = 'black';
+const color1: Color = 'random';
+const color2: Color = 'black';
+
+// $FlowExpectedError[incompatible-type] Modifier must be one of supported modifiers
+const modifier1: Modifiers = 'random';
+const modifier2: Modifiers = 'underline';


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Follow patterns from TS definition to expose list of possible colors and modifiers so that consumers can build appropriate wrapper functions that accept only a subset of values instead of `string` which is unsafe.

- Links to documentation: https://github.com/chalk/chalk/blob/v4.1.2/index.d.ts#L6
- Link to GitHub or NPM: https://www.npmjs.com/package/chalk
- Type of contribution: addition

Other notes:

