### PR TITLE
[react-router] Update type for useParams to allow for generics

### DIFF
--- a/definitions/npm/react-router_v5.x.x/flow_v0.104.x-/react-router_v5.x.x.js
+++ b/definitions/npm/react-router_v5.x.x/flow_v0.104.x-/react-router_v5.x.x.js
@@ -135,7 +135,7 @@ declare module "react-router" {
 
   declare export function useHistory(): $PropertyType<ContextRouter, 'history'>;
   declare export function useLocation(): $PropertyType<ContextRouter, 'location'>;
-  declare export function useParams(): $PropertyType<$PropertyType<ContextRouter, 'match'>, 'params'>;
+  declare export function useParams<Params = $PropertyType<$PropertyType<ContextRouter, 'match'>, 'params'>>(): Params;
   declare export function useRouteMatch(path?: MatchPathOptions | string | string[]): $PropertyType<ContextRouter, 'match'>;
 
   declare export function generatePath(pattern?: string, params?: {...}): string;

--- a/definitions/npm/react-router_v5.x.x/flow_v0.104.x-/test_react-router.js
+++ b/definitions/npm/react-router_v5.x.x/flow_v0.104.x-/test_react-router.js
@@ -229,6 +229,14 @@ describe('react hook', () => {
     const params: { [key: string]: ?string, ... } = useParams();
   });
 
+  it('useParams with generic', () => {
+    type ParamsType = {|
+      +slug: string,
+    |};
+
+    const params: ParamsType = useParams<ParamsType>();
+  });
+
   it('useRouteMatch', () => {
     const match: Match = useRouteMatch();
     const matchPath: Match = useRouteMatch('/path');


### PR DESCRIPTION
I made an update to the `useParams` types after opening #4272. I tried to add a bound to the type to require that the provided type has string values only, but ran into issues with making that work with the default type that is provided since it has the values as `?string`. If there is a quick fix for this I'd love to add it, but these types would work for me!

