### PR TITLE
[react-router-dom] Update type for useParams to allow for generics

### DIFF
--- a/definitions/npm/react-router-dom_v5.x.x/flow_v0.104.x-/react-router-dom_v5.x.x.js
+++ b/definitions/npm/react-router-dom_v5.x.x/flow_v0.104.x-/react-router-dom_v5.x.x.js
@@ -174,7 +174,7 @@ declare module "react-router-dom" {
 
   declare export function useHistory(): $PropertyType<ContextRouter, 'history'>;
   declare export function useLocation(): $PropertyType<ContextRouter, 'location'>;
-  declare export function useParams(): $PropertyType<$PropertyType<ContextRouter, 'match'>, 'params'>;
+  declare export function useParams<Params = $PropertyType<$PropertyType<ContextRouter, 'match'>, 'params'>>(): Params;
   declare export function useRouteMatch(path?: MatchPathOptions | string | string[]): $PropertyType<ContextRouter, 'match'>;
 
   declare export function generatePath(pattern?: string, params?: { +[string]: mixed, ... }): string;

--- a/definitions/npm/react-router-dom_v5.x.x/flow_v0.104.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v5.x.x/flow_v0.104.x-/test_react-router-dom.js
@@ -413,6 +413,14 @@ describe("react-router-dom", () => {
       const params: { [key: string]: ?string, ... } = useParams();
     });
 
+    it('useParams with generic', () => {
+      type ParamsType = {|
+        +slug: string,
+      |};
+
+      const params: ParamsType = useParams<ParamsType>();
+    });
+
     it('useRouteMatch', () => {
       const match: Match = useRouteMatch();
       const matchPath: Match = useRouteMatch('/path');


### PR DESCRIPTION
Hello, sorry for the near duplicate PR. I realized this morning I only updated the type in `react-router` but forgot `react-router-dom` 😅. This is the same changes from #4273 applied to the `react-router-dom` types.
