### PR TITLE
[@testing-library/react] Add HTMLLabelElement to intersection type

### DIFF
--- a/definitions/npm/@testing-library/react_v12.x.x/flow_v0.104.x-/react_v12.x.x.js
+++ b/definitions/npm/@testing-library/react_v12.x.x/flow_v0.104.x-/react_v12.x.x.js
@@ -264,6 +264,7 @@ declare module '@testing-library/react' {
     | HTMLInputElement
     | HTMLAnchorElement
     | HTMLButtonElement
+    | HTMLLabelElement
     | HTMLSelectElement;
 
   declare export type IntersectionHTMLElement =
@@ -271,6 +272,7 @@ declare module '@testing-library/react' {
     & HTMLInputElement
     & HTMLAnchorElement
     & HTMLButtonElement
+    & HTMLLabelElement
     & HTMLSelectElement;
   // End mixed html types
 


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

Adding to `UnionHTMLElement` and `IntersectionHTMLElement` to allow usage with `<label />` elements for the use case of checking for the value of `htmlFor`

- Links to documentation: https://www.npmjs.com/package/@testing-library/react
- Link to GitHub or NPM: https://www.npmjs.com/package/@testing-library/react
- Type of contribution: addition

Other notes:

