### PR TITLE
[react-router-dom] Replace `Redirect` with `Navigate`

### DIFF
--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
@@ -142,13 +142,21 @@ declare module "react-router-dom" {
     context?: mixed;
   |}>
 
-  declare export var Redirect: React$ComponentType<{|
-    to: string | LocationShape,
-    push?: boolean,
-    from?: string,
-    exact?: boolean,
-    strict?: boolean
-  |}>
+  declare export var useNavigate: () => (
+    & ((
+      to: To,
+      options?: {|
+        replace?: boolean, state?: any,
+      |},
+    ) => void)
+    & ((delta: number) => void)
+  );
+
+  declare export var Navigate: (props: {|
+    to: To;
+    replace?: boolean;
+    state?: any;
+  |}) => null;
 
   declare export var Route: React$ComponentType<{|
     caseSensitive?: boolean,

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
@@ -7,12 +7,13 @@ import {
   NavLink,
   matchPath,
   withRouter,
+  Navigate,
   Outlet,
-  Redirect,
   Route,
   Routes,
   useHistory,
   useLocation,
+  useNavigate,
   useOutletContext,
   useParams,
   useRouteMatch,
@@ -339,33 +340,50 @@ describe("react-router-dom", () => {
     });
   });
 
-  describe("Redirect", () => {
+  describe("Navigate", () => {
     it("works", () => {
-      <Redirect to="/login" />;
+      <Navigate to="/login" />;
 
-      <Redirect exact strict to="/new-path" from="/old-Path" />;
+      <Navigate to="/new-path" replace />;
 
-      <Redirect
+      <Navigate
         to={{
           pathname: "/courses",
           search: "?sort=name",
           hash: "#the-hash",
           state: { fromDashboard: true }
         }}
-        from="/x"
-        push
+        state={{}}
       />;
     });
 
     it("raises error if passed incorrect props", () => {
       // $FlowExpectedError[prop-missing] - to prop is required
-      <Redirect />;
+      <Navigate />;
 
       // $FlowExpectedError[incompatible-type] - to prop must be a string or LocationShape
-      <Redirect to={[]} />;
+      <Navigate to={[]} />;
 
       // $FlowExpectedError[prop-missing] - unexpected prop xxx
-      <Redirect to='/x' xxx="1"/>;
+      <Navigate to='/x' xxx="1"/>;
+    });
+  });
+
+  describe('useNavigate', () => {
+    it('works', () => {
+      const navigate = useNavigate();
+
+      navigate("../success");
+      navigate("../success", { replace: true });
+      navigate(-1);
+    });
+
+    it('raises errors if used incorrectly', () => {
+      // $FlowExpectedError[extra-arg] takes no args
+      const navigate = useNavigate('test');
+
+      // $FlowExpectedError[incompatible-call]
+      navigate(true);
     });
   });
 


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation:
  - https://gist.github.com/mjackson/b5748add2795ce7448a366ae8f8ae3bb#notes-on-the-navigate-api
  - https://reactrouter.com/docs/en/v6/api#usenavigate
  - https://reactrouter.com/docs/en/v6/api#navigate
- Link to GitHub or NPM: https://www.npmjs.com/package/react-router
- Type of contribution: fix

Other notes:

