### PR TITLE
[base64-arraybuffer] Add base64-arraybuffer v1

### DIFF
--- a/definitions/npm/base64-arraybuffer_v1.x.x/flow_v0.83.x-/base64-arraybuffer_v1.x.x.js
+++ b/definitions/npm/base64-arraybuffer_v1.x.x/flow_v0.83.x-/base64-arraybuffer_v1.x.x.js
@@ -1,0 +1,5 @@
+declare module 'base64-arraybuffer' {
+  declare function encode(arraybuffer: ArrayBuffer): string;
+
+  declare function decode(base64: string): ArrayBuffer;
+}

--- a/definitions/npm/base64-arraybuffer_v1.x.x/flow_v0.83.x-/test_base64-arraybuffer_v1.x.x.js
+++ b/definitions/npm/base64-arraybuffer_v1.x.x/flow_v0.83.x-/test_base64-arraybuffer_v1.x.x.js
@@ -1,0 +1,20 @@
+import { describe, it } from 'flow-typed-test';
+
+import { encode, decode } from 'base64-arraybuffer';
+
+describe('encode', () => {
+  it('basic usage', () => {
+    encode(new ArrayBuffer(10));
+
+    // $FlowExpectedError[incompatible-call]
+    encode('lang');
+  });
+});
+
+describe('decode', () => {
+  it('basic usage', () => {
+    decode('test');
+    // $FlowExpectedError[incompatible-call]
+    decode(123);
+  });
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/niklasvh/base64-arraybuffer/blob/5339d8f0abed59c893e87116a785bf52acdc17aa/src/index.ts
- Link to GitHub or NPM: https://github.com/niklasvh/base64-arraybuffer
- Type of contribution: new definition