### PR TITLE
[cli]: Consistent list logging

### DIFF
--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -36,6 +36,7 @@ import {
 } from '../lib/npm/npmProjectUtils';
 import {getRangeLowerBound} from '../lib/semver';
 import {createStub, pkgHasFlowFiles} from '../lib/stubUtils';
+import {listItem} from '../lib/logger';
 
 export const name = 'install [explicitLibDefs...]';
 export const description = 'Installs libdefs into the ./flow-typed directory';
@@ -273,15 +274,7 @@ async function installEnvLibDefs(
               const localFile = fs.readFileSync(defLocalPath, 'utf-8');
 
               if (!verifySignedCode(localFile) && !overwrite) {
-                console.log(
-                  colors.bold(
-                    '  • %s\n' +
-                      '    └> %s\n' +
-                      '       %s\n' +
-                      '       %s\n' +
-                      '       %s\n' +
-                      '       %s',
-                  ),
+                listItem(
                   en,
                   colors.red(
                     `${en} already exists and appears to have been manually written or changed!`,
@@ -312,16 +305,14 @@ async function installEnvLibDefs(
             const codeSignPreprocessor = signCodeStream(repoVersion);
             await copyFile(def.path, defLocalPath, codeSignPreprocessor);
 
-            console.log(
-              colors.bold('  • %s\n' + '    └> %s'),
+            listItem(
               en,
               colors.green(
                 `.${path.sep}${path.relative(flowProjectRoot, defLocalPath)}`,
               ),
             );
           } else {
-            console.log(
-              colors.bold('  • %s\n' + '    └> %s'),
+            listItem(
               en,
               colors.yellow(
                 `Was unable to install ${en}. The env might not exist or there is not a version compatible with your version of flow`,
@@ -703,8 +694,7 @@ async function installNpmLibDef(
     );
 
     if (!overwrite && (await fs.exists(filePath))) {
-      console.error(
-        '  • %s\n' + '    %s\n    %s\n    └> %s',
+      listItem(
         colors.bold(
           colors.red(
             `${terseFilePath} already exists and appears to have been manually ` +
@@ -727,11 +717,7 @@ async function installNpmLibDef(
     const codeSignPreprocessor = signCodeStream(repoVersion);
     await copyFile(npmLibDef.path, filePath, codeSignPreprocessor);
 
-    console.log(
-      colors.bold('  • %s\n' + '    └> %s'),
-      fileName,
-      colors.green(`.${path.sep}${terseFilePath}`),
-    );
+    listItem(fileName, colors.green(`.${path.sep}${terseFilePath}`));
 
     // Remove any lingering stubs
     console.log(npmLibDef.name);

--- a/cli/src/lib/__tests__/logger.js
+++ b/cli/src/lib/__tests__/logger.js
@@ -1,0 +1,27 @@
+// @flow
+import colors from 'colors';
+
+import {listItem} from '../logger';
+
+describe('logger', () => {
+  const consoleLog = jest.fn();
+  jest.spyOn(console, 'log').mockImplementation(consoleLog);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('listItem', () => {
+    it('returns expected result', () => {
+      listItem('test', 'a', 'b');
+
+      expect(consoleLog).toHaveBeenCalledWith(
+        colors.bold(`  • test
+    └> a
+       b`),
+      );
+    });
+  });
+
+  describe('list', () => {});
+});

--- a/cli/src/lib/__tests__/logger.js
+++ b/cli/src/lib/__tests__/logger.js
@@ -12,7 +12,22 @@ describe('logger', () => {
   });
 
   describe('listItem', () => {
-    it('returns expected result', () => {
+    it('logs single value', () => {
+      listItem('test');
+
+      expect(consoleLog).toHaveBeenCalledWith(colors.bold(`  • test`));
+    });
+
+    it('logs two values', () => {
+      listItem('test', 'a');
+
+      expect(consoleLog).toHaveBeenCalledWith(
+        colors.bold(`  • test
+    └> a`),
+      );
+    });
+
+    it('logs multiple values', () => {
       listItem('test', 'a', 'b');
 
       expect(consoleLog).toHaveBeenCalledWith(
@@ -21,7 +36,23 @@ describe('logger', () => {
        b`),
       );
     });
-  });
 
-  describe('list', () => {});
+    it('ignores undefined values', () => {
+      listItem(undefined, 'a', 'b');
+
+      expect(consoleLog).toHaveBeenCalledWith(
+        colors.bold(`  • a
+    └> b`),
+      );
+    });
+
+    it('ignores empty strings', () => {
+      listItem('test', '', 'b');
+
+      expect(consoleLog).toHaveBeenCalledWith(
+        colors.bold(`  • test
+    └> b`),
+      );
+    });
+  });
 });

--- a/cli/src/lib/logger.js
+++ b/cli/src/lib/logger.js
@@ -5,20 +5,28 @@ const bulletPoint = `  • `;
 const arrow = `    └> `;
 const genericRowPad = `       `;
 
+const shouldNewLine = (condition: boolean) => (condition ? '\n' : '');
+
 const createListItem = (values: Array<string>): string => {
   const [first, second, ...rest] = values;
-  let value = `${bulletPoint}${first}\n`;
+  let value = `${bulletPoint}${first}${shouldNewLine(!!second)}`;
   if (second) {
-    value += `${arrow}${second}\n`;
+    value += `${arrow}${second}${shouldNewLine(rest.length > 0)}`;
   }
   if (rest.length > 0) {
     rest.forEach((r, i) => {
-      value += `${genericRowPad}${r}${i === rest.length - 1 ? '' : '\n'}`;
+      value += `${genericRowPad}${r}${shouldNewLine(i !== rest.length - 1)}`;
     });
   }
   return colors.bold(value);
 };
 
-export const listItem = (...values: Array<string>): void => {
-  console.log(createListItem(values));
+export const listItem = (...values: Array<string | void>): void => {
+  const validItems: Array<string> = values
+    .map(o => {
+      if (!o) return '';
+      return o;
+    })
+    .filter(o => !!o);
+  console.log(createListItem(validItems));
 };

--- a/cli/src/lib/logger.js
+++ b/cli/src/lib/logger.js
@@ -1,0 +1,24 @@
+// @flow
+import colors from 'colors';
+
+const bulletPoint = `  • `;
+const arrow = `    └> `;
+const genericRowPad = `       `;
+
+const createListItem = (values: Array<string>): string => {
+  const [first, second, ...rest] = values;
+  let value = `${bulletPoint}${first}\n`;
+  if (second) {
+    value += `${arrow}${second}\n`;
+  }
+  if (rest.length > 0) {
+    rest.forEach((r, i) => {
+      value += `${genericRowPad}${r}${i === rest.length - 1 ? '' : '\n'}`;
+    });
+  }
+  return colors.bold(value);
+};
+
+export const listItem = (...values: Array<string>): void => {
+  console.log(createListItem(values));
+};

--- a/cli/src/lib/stubUtils.js
+++ b/cli/src/lib/stubUtils.js
@@ -533,17 +533,15 @@ export async function createStub(
       typescriptTypingsContent,
     );
     const terseFilename = path.relative(projectRoot, filename);
-    listItem(`${packageName}@${version}`, colors.red(terseFilename));
-    if (resolutionError) {
-      console.log(
-        colors.yellow(
-          "\t  Unable to stub all files in '%s', " +
-            'so only created a stub for the main module (%s)',
-        ),
-        packageName,
-        resolutionError.message,
-      );
-    }
+    listItem(
+      `${packageName}@${version}`,
+      colors.red(terseFilename),
+      resolutionError
+        ? colors.yellow(
+            `Unable to stub all files in ${packageName}, so only created a stub for the main module (${resolutionError.message})`,
+          )
+        : undefined,
+    );
     return true;
   } catch (e) {
     console.log(

--- a/cli/src/lib/stubUtils.js
+++ b/cli/src/lib/stubUtils.js
@@ -19,6 +19,7 @@ import {path} from './node';
 import {signCode} from './codeSign';
 import {verifySignedCode} from './codeSign';
 import {versionToString} from './semver';
+import {listItem} from './logger';
 
 export function glob(pattern: string, options: Object): Promise<Array<string>> {
   return new Promise((resolve, reject) =>
@@ -532,12 +533,7 @@ export async function createStub(
       typescriptTypingsContent,
     );
     const terseFilename = path.relative(projectRoot, filename);
-    console.log(
-      colors.bold('  • %s@%s\n' + '    └> %s'),
-      packageName,
-      version,
-      colors.red(terseFilename),
-    );
+    listItem(`${packageName}@${version}`, colors.red(terseFilename));
     if (resolutionError) {
       console.log(
         colors.yellow(


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Improving some of the console logs, particularly whenever there are usages of `└>` to display listed items to a reusable func to make the overall cli usage cleaner and make it easier for other areas to use the same format

## Installing
### Before
<img width="1293" alt="Screen Shot 2022-03-19 at 9 26 13 am" src="https://user-images.githubusercontent.com/12436524/159092657-6b8c7486-6216-46de-ae97-f03bf2c794d8.png">

### After
<img width="1262" alt="Screen Shot 2022-03-18 at 1 58 36 pm" src="https://user-images.githubusercontent.com/12436524/159092668-092f37cf-d874-4280-9d43-b02e67e5ef93.png">

## Installing stub
### Before
<img width="702" alt="Screen Shot 2022-03-19 at 9 26 01 am" src="https://user-images.githubusercontent.com/12436524/159092680-41b800b1-bd62-4eaa-aab5-726fbd5658f6.png">

### After
<img width="713" alt="Screen Shot 2022-03-18 at 1 58 48 pm" src="https://user-images.githubusercontent.com/12436524/159092687-f8171d58-a583-48d2-8bd6-d9f1718ce397.png">

## Creating stub
### Before
<img width="1431" alt="Screen Shot 2022-03-19 at 9 51 18 am" src="https://user-images.githubusercontent.com/12436524/159094447-79d4e326-99e1-4690-b2bd-7a272fe7e3d6.png">

### After
<img width="1440" alt="Screen Shot 2022-03-19 at 9 51 10 am" src="https://user-images.githubusercontent.com/12436524/159094455-38d1e5b0-ac6b-456d-aab4-30e1229421c1.png">

