### PR TITLE
[react] Add new environment to override react definitions

### DIFF
--- a/definitions/environments/react/flow_v0.83.x-/react.js
+++ b/definitions/environments/react/flow_v0.83.x-/react.js
@@ -1,0 +1,9 @@
+declare type React$AbstractComponentStatics = {
+  displayName?: ?string,
+  // This is only on function components, but trying to access name when
+  // displayName is undefined is a common pattern.
+  name?: ?string,
+  propTypes?: {[string] : any, ...},
+  [key: string]: any,
+  ...
+};

--- a/definitions/environments/react/flow_v0.83.x-/test_react.js
+++ b/definitions/environments/react/flow_v0.83.x-/test_react.js
@@ -1,0 +1,21 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import * as React from 'react';
+
+describe('react', () => {
+  describe('React$AbstractComponentStatics override', () => {
+    it('can have any property attached to the component', () => {
+      declare var Comp: React$AbstractComponent<{ ... }, HTMLElement>;
+
+      Comp.random = 'test';
+    });
+
+    it('has other props still typed correctly', () => {
+      declare var Comp: React$AbstractComponent<{ ... }, HTMLElement>;
+
+      Comp.displayName = 'test';
+      // $FlowExpectedError[incompatible-type]
+      Comp.displayName = 123;
+    });
+  });
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
React components actually allow for extra properties in the react component once defined, there are many real world cases where this occurs but flow libs don't allow for this.

I'm adding a new flow-typed `environment` that overrides right now a single piece of the react definitions that doesn't require users to upgrade to the latest flow version to take advantage of this. I believe def can have future use cases where commonly flow libs are not backwards compatible.

- Links to documentation: N/A
- Link to GitHub or NPM: https://www.npmjs.com/package/react
- Type of contribution: new definition

Other notes: This use case came from @meandmax when we were pairing and found that flow blocked adding extra properties to a higher order component.

