### PR TITLE
Coerce cli version with semver to allow for prerelease tags

### DIFF
--- a/cli/src/lib/cacheRepoUtils.js
+++ b/cli/src/lib/cacheRepoUtils.js
@@ -141,7 +141,12 @@ export async function verifyCLIVersion(): Promise<void> {
   const thisCLIPkgJsonPath = path.join(__dirname, '..', '..', 'package.json');
   const thisCLIPkgJson = await fs.readJson(thisCLIPkgJsonPath);
   const thisCLIVersion = thisCLIPkgJson.version;
-  if (!semver.satisfies(thisCLIVersion, compatibleCLIRange)) {
+  if (
+    !semver.satisfies(
+      semver.coerce(thisCLIVersion) ?? thisCLIVersion,
+      compatibleCLIRange,
+    )
+  ) {
     throw new Error(
       `Please upgrade your flow-typed CLI! This CLI is version ` +
         `${thisCLIVersion}, but the latest flow-typed definitions are only ` +

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -419,7 +419,12 @@ async function verifyCLIVersion(defsDirPath) {
   }
   const minCLIVersion = metadata.compatibleCLIRange;
   const thisCLIVersion = require('../../package.json').version;
-  if (!semver.satisfies(thisCLIVersion, minCLIVersion)) {
+  if (
+    !semver.satisfies(
+      semver.coerce(thisCLIVersion) ?? thisCLIVersion,
+      minCLIVersion,
+    )
+  ) {
     throw new Error(
       `Please upgrade your CLI version! This CLI is version ` +
         `${thisCLIVersion}, but the latest flow-typed definitions are only ` +


### PR DESCRIPTION
- Type of contribution: fix

Other notes:

Trying to get a prerelease ready @ `3.8.0-0`, I encounter this error: `Please upgrade your flow-typed CLI! This CLI is version 3.8.0-0, but the latest flow-typed definitions are only compatible with flow-typed@>=*.*.*`. This fix coerces that version to `3.8.0`, allowing it to pass the tests.