### PR TITLE
feat: add bn.js libdefs (v2, v3, v4, v5)

### DIFF
--- a/definitions/npm/bn.js_v2.x.x/flow_v0.83.x-/bn.js_v2.x.x.js
+++ b/definitions/npm/bn.js_v2.x.x/flow_v0.83.x-/bn.js_v2.x.x.js
@@ -1,0 +1,126 @@
+declare module 'bn.js' {
+  declare type Endianness = 'le' | 'be';
+  declare type Primes = 'k256' | 'p224' | 'p192' | 'p25519';
+  declare type ReductionContext = BN | Primes;
+  declare type Extended = {|
+    words: Array<number>,
+    length: number,
+  |};
+
+  declare class MPrime {
+    p: BN;
+
+    constructor(name: string, p: string): MPrime;
+
+    ireduce(b: BN): BN;
+    split(input: BN, out: BN): void;
+    imulK(b: BN): BN;
+  }
+
+  declare class Red {
+    prime: MPrime;
+
+    constructor(m: ReductionContext): Red;
+  }
+
+  declare class BN {
+    constructor(
+      number?: number | string,
+      base?: number | 'hex' | null,
+      endian?: Endianness
+    ): BN;
+    constructor(
+      number?: Array<number> | Uint8Array | Buffer | BN,
+      endian?: Endianness
+    ): BN;
+
+    negative: boolean;
+    words: Array<number> | null;
+    length: number;
+
+    static _prime(prime: Primes): MPrime;
+    static red(b: ReductionContext): Red;
+    static mont(b: BN): Red;
+
+    // Arithmetics
+    neg(): BN;
+    abs(): BN;
+    iabs(): BN;
+    add(b: BN): BN;
+    iadd(b: BN): BN;
+    addn(b: number): BN;
+    iaddn(b: number): BN;
+    sub(b: BN): BN;
+    isub(b: BN): BN;
+    subn(b: number): BN;
+    isubn(b: number): BN;
+    mul(b: BN): BN;
+    imul(b: BN): BN;
+    muln(b: number): BN;
+    imuln(b: number): BN;
+    sqr(): BN;
+    isqr(): BN;
+    pow(b: BN): BN;
+    div(b: BN): BN;
+    divn(b: number): BN;
+    idivn(b: number): BN;
+    mod(b: BN): BN;
+    modn(b: number): BN;
+    divRound(b: BN): BN;
+
+    // Bit operations
+    or(b: BN): BN;
+    ior(b: BN): BN;
+    and(b: BN): BN;
+    iand(b: BN): BN;
+    andln(b: number): number;
+    xor(b: BN): BN;
+    ixor(b: BN): BN;
+    setn(bit: number, val: boolean): BN;
+    shln(bits: number): BN;
+    ishln(bits: number): BN;
+    shrn(bits: number): BN;
+    ishrn(bits: number, hint?: number, extended?: Extended): BN;
+    testn(bit: number): boolean;
+    maskn(bits: number): BN;
+    imaskn(bits: number): BN;
+    bincn(bit: number): BN;
+
+    // Reduction
+    gcd(b: BN): BN;
+    egcd(b: BN): BN;
+    invm(b: BN): BN;
+
+    // Red instructions
+    redAdd(b: BN): BN;
+    redIAdd(b: BN): BN;
+    redSub(b: BN): BN;
+    redISub(b: BN): BN;
+    redShl(b: number): BN;
+    redMul(b: BN): BN;
+    redIMul(b: BN): BN;
+    redSqr(): BN;
+    redISqr(): BN;
+    redSqrt(): BN;
+    redInvm(): BN;
+    redNeg(): BN;
+    redPow(b: BN): BN;
+
+    // Utilities
+    clone(): BN;
+    toArray(endian?: Endianness): Array<number>; // check
+    toString(base?: number | 'hex', padding?: number): string;
+    bitLength(): number;
+    zeroBits(): number;
+    byteLength(): number;
+    isEven(): boolean;
+    isOdd(): boolean;
+    cmp(b: BN): number;
+    ucmp(b: BN): number;
+    cmpn(b: number): number;
+    toRed(red: Red): BN;
+    fromRed(): BN;
+  }
+
+  declare module.exports: typeof BN;
+}

--- a/definitions/npm/bn.js_v2.x.x/flow_v0.83.x-/test_bn.js_v2.x.x.js
+++ b/definitions/npm/bn.js_v2.x.x/flow_v0.83.x-/test_bn.js_v2.x.x.js
@@ -16,6 +16,17 @@ describe('BN main usages', () => {
     new BN(new BN('dead', 'hex'));
   });
 
+  it('prevents invalid constructors', () => {
+    // $FlowExpectedError[incompatible-call]
+    new BN({});
+
+    // $FlowExpectedError[incompatible-call]
+    new BN('dead', 'dec', 'le');
+
+    // $FlowExpectedError[incompatible-call]
+    new BN('dead', 'hex', 'le', {});
+  });
+
   it('handles arithmetics', () => {
     const a = new BN(21);
     const b = new BN(42);
@@ -75,6 +86,16 @@ describe('BN main usages', () => {
       .redNeg();
   });
 
+  it('prevents calling functions with wrong input types', () => {
+    const a = new BN(21);
+
+    // $FlowExpectedError[incompatible-call]
+    a.mul(2);
+
+    // $FlowExpectedError[incompatible-call]
+    a.muln(new BN(2));
+  });
+
   it('handles utilities', () => {
     const a = new BN();
 
@@ -85,5 +106,43 @@ describe('BN main usages', () => {
     a.byteLength();
     a.cmp(new BN(2));
     a.toRed(BN.red('p192')).fromRed();
+  });
+
+  it('prevents invalid utilities usage', () => {
+    const a = new BN();
+
+    // $FlowExpectedError[incompatible-call]
+    a.toString('dec');
+
+    // $FlowExpectedError[incompatible-call]
+    a.toArray('other');
+  });
+
+  it('prevents calling functions that were added in later versions', () => {
+    const a = new BN();
+
+    // $FlowExpectedError[prop-missing]
+    a.lt(2);
+
+    // $FlowExpectedError[prop-missing]
+    a.ltn(new BN(2));
+
+    // $FlowExpectedError[prop-missing]
+    a.toArrayLike(Buffer, 'le', 8);
+
+    // $FlowExpectedError[prop-missing]
+    a.toBuffer('be', 8);
+
+    // $FlowExpectedError[prop-missing]
+    a.toArrayLike(Buffer, 'le', 8);
+
+    // $FlowExpectedError[prop-missing]
+    a.umod(new BN(2));
+
+    // $FlowExpectedError[prop-missing]
+    a.uand(new BN(2));
+
+    // $FlowExpectedError[prop-missing]
+    a.iushrn(new BN(2));
   });
 });

--- a/definitions/npm/bn.js_v2.x.x/flow_v0.83.x-/test_bn.js_v2.x.x.js
+++ b/definitions/npm/bn.js_v2.x.x/flow_v0.83.x-/test_bn.js_v2.x.x.js
@@ -1,0 +1,89 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import BN from 'bn.js';
+
+describe('BN main usages', () => {
+  it('support different constructors', () => {
+    new BN(2);
+    new BN('2');
+    new BN('dead', 'hex');
+    new BN('dead', 16);
+    new BN('dead', 'hex', 'le');
+
+    new BN([1, 2, 3, 4]);
+    new BN([1, 2, 3, 4], 'le');
+    new BN(Buffer.from('dead', 'hex'));
+    new BN(new BN('dead', 'hex'));
+  });
+
+  it('handles arithmetics', () => {
+    const a = new BN(21);
+    const b = new BN(42);
+
+    new BN(21)
+      .neg()
+      .abs()
+      .iadd(a)
+      .sub(b)
+      .mul(a)
+      .sqr()
+      .pow(b)
+      .div(a)
+      .mod(b)
+      .addn(21);
+  });
+
+  it('handles bit operations', () => {
+    const a = new BN(21);
+    const b = new BN(42);
+
+    new BN(21)
+      .or(a)
+      .iand(b)
+      .xor(a)
+      .setn(2, true)
+      .shln(4)
+      .ishrn(4, 1, {
+        words: [],
+        length: 0,
+      })
+      .maskn(21);
+  });
+
+  it('handles reduction', () => {
+    const a = new BN(21);
+
+    new BN(21)
+      .gcd(a)
+      .egcd(a)
+      .invm(a);
+  });
+
+  it('handles fast reduction', () => {
+    BN.red(new BN(21));
+    BN.red('p224');
+    BN.mont(new BN(21));
+
+    const red = BN.red('p192');
+
+    const a = new BN(128).toRed(red);
+    const b = new BN(64).toRed(red);
+
+    a.redAdd(b)
+      .redSub(b)
+      .redInvm()
+      .redNeg();
+  });
+
+  it('handles utilities', () => {
+    const a = new BN();
+
+    a.clone().toString();
+    a.toString(16);
+    a.toArray('le');
+    a.zeroBits();
+    a.byteLength();
+    a.cmp(new BN(2));
+    a.toRed(BN.red('p192')).fromRed();
+  });
+});

--- a/definitions/npm/bn.js_v3.x.x/flow_v0.83.x-/bn.js_v3.x.x.js
+++ b/definitions/npm/bn.js_v3.x.x/flow_v0.83.x-/bn.js_v3.x.x.js
@@ -1,0 +1,140 @@
+declare module 'bn.js' {
+  declare type Endianness = 'le' | 'be';
+  declare type Primes = 'k256' | 'p224' | 'p192' | 'p25519';
+  declare type ReductionContext = BN | Primes;
+  declare type Extended = {|
+    words: Array<number>,
+    length: number,
+  |};
+
+  declare class MPrime {
+    p: BN;
+
+    constructor(name: string, p: string): MPrime;
+
+    ireduce(b: BN): BN;
+    split(input: BN, out: BN): void;
+    imulK(b: BN): BN;
+  }
+
+  declare class Red {
+    prime: MPrime;
+
+    constructor(m: ReductionContext): Red;
+  }
+
+  declare class BN {
+    constructor(
+      number?: number | string,
+      base?: number | 'hex' | null,
+      endian?: Endianness
+    ): BN;
+    constructor(
+      number?: Array<number> | Uint8Array | Buffer | BN,
+      endian?: Endianness
+    ): BN;
+
+    negative: boolean;
+    words: Array<number> | null;
+    length: number;
+
+    static min(a: BN, b: BN): BN;
+    static max(a: BN, b: BN): BN;
+    static _prime(prime: Primes): MPrime;
+    static red(b: ReductionContext): Red;
+    static mont(b: BN): Red;
+
+    // Arithmetics
+    neg(): BN;
+    ineg(): BN;
+    abs(): BN;
+    iabs(): BN;
+    add(b: BN): BN;
+    iadd(b: BN): BN;
+    addn(b: number): BN;
+    iaddn(b: number): BN;
+    sub(b: BN): BN;
+    isub(b: BN): BN;
+    subn(b: number): BN;
+    isubn(b: number): BN;
+    mul(b: BN): BN;
+    imul(b: BN): BN;
+    muln(b: number): BN;
+    imuln(b: number): BN;
+    sqr(): BN;
+    isqr(): BN;
+    pow(b: BN): BN;
+    div(b: BN): BN;
+    divn(b: number): BN;
+    idivn(b: number): BN;
+    mod(b: BN): BN;
+    umod(b: BN): BN;
+    modn(b: number): BN;
+    divRound(b: BN): BN;
+
+    // Bit operations
+    or(b: BN): BN;
+    ior(b: BN): BN;
+    uor(b: BN): BN;
+    iuor(b: BN): BN;
+    and(b: BN): BN;
+    iand(b: BN): BN;
+    uand(b: BN): BN;
+    iuand(b: BN): BN;
+    andln(b: number): number;
+    xor(b: BN): BN;
+    ixor(b: BN): BN;
+    uxor(b: BN): BN;
+    iuxor(b: BN): BN;
+    setn(bit: number, val: boolean): BN;
+    shln(bits: number): BN;
+    ishln(bits: number): BN;
+    ushln(bits: number): BN;
+    iushln(bits: number): BN;
+    shrn(bits: number): BN;
+    ishrn(bits: number, hint?: number, extended?: Extended): BN;
+    ushrn(bits: number): BN;
+    iushrn(bits: number, hint?: number, extended?: Extended): BN;
+    testn(bit: number): boolean;
+    maskn(bits: number): BN;
+    imaskn(bits: number): BN;
+    bincn(bit: number): BN;
+
+    // Reduction
+    gcd(b: BN): BN;
+    egcd(b: BN): BN;
+    invm(b: BN): BN;
+
+    // Red instructions
+    redAdd(b: BN): BN;
+    redIAdd(b: BN): BN;
+    redSub(b: BN): BN;
+    redISub(b: BN): BN;
+    redShl(b: number): BN;
+    redMul(b: BN): BN;
+    redIMul(b: BN): BN;
+    redSqr(): BN;
+    redISqr(): BN;
+    redSqrt(): BN;
+    redInvm(): BN;
+    redNeg(): BN;
+    redPow(b: BN): BN;
+
+    // Utilities
+    clone(): BN;
+    toArray(endian?: Endianness, length?: number): Array<number>;
+    toString(base?: number | 'hex', padding?: number): string;
+    bitLength(): number;
+    zeroBits(): number;
+    byteLength(): number;
+    isEven(): boolean;
+    isOdd(): boolean;
+    cmp(b: BN): number;
+    ucmp(b: BN): number;
+    cmpn(b: number): number;
+    toRed(red: Red): BN;
+    fromRed(): BN;
+  }
+
+  declare module.exports: typeof BN;
+}

--- a/definitions/npm/bn.js_v3.x.x/flow_v0.83.x-/test_bn.js_v3.x.x.js
+++ b/definitions/npm/bn.js_v3.x.x/flow_v0.83.x-/test_bn.js_v3.x.x.js
@@ -1,0 +1,91 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import BN from 'bn.js';
+
+describe('BN main usages', () => {
+  it('support different constructors', () => {
+    new BN(2);
+    new BN('2');
+    new BN('dead', 'hex');
+    new BN('dead', 16);
+    new BN('dead', 'hex', 'le');
+
+    new BN([1, 2, 3, 4]);
+    new BN([1, 2, 3, 4], 'le');
+    new BN(Buffer.from('dead', 'hex'));
+    new BN(new BN('dead', 'hex'));
+  });
+
+  it('handles arithmetics', () => {
+    const a = new BN(21);
+    const b = new BN(42);
+
+    new BN(21)
+      .neg()
+      .abs()
+      .iadd(a)
+      .sub(b)
+      .mul(a)
+      .muln(20)
+      .sqr()
+      .pow(b)
+      .div(a)
+      .mod(b)
+      .addn(21);
+  });
+
+  it('handles bit operations', () => {
+    const a = new BN(21);
+    const b = new BN(42);
+
+    new BN(21)
+      .or(a)
+      .iand(b)
+      .xor(a)
+      .setn(2, true)
+      .shln(4)
+      .maskn(21)
+      .ishrn(4, 1, {
+        words: [],
+        length: 0,
+      })
+      .ushln(128);
+  });
+
+  it('handles reduction', () => {
+    const a = new BN(21);
+
+    new BN(21)
+      .gcd(a)
+      .egcd(a)
+      .invm(a);
+  });
+
+  it('handles fast reduction', () => {
+    BN.red(new BN(21));
+    BN.red('p224');
+    BN.mont(new BN(21));
+
+    const red = BN.red('p192');
+
+    const a = new BN(128).toRed(red);
+    const b = new BN(64).toRed(red);
+
+    a.redAdd(b)
+      .redSub(b)
+      .redInvm()
+      .redNeg();
+  });
+
+  it('handles utilities', () => {
+    const a = new BN();
+
+    a.clone().toString();
+    a.toString(16);
+    a.toArray('le', 8);
+    a.zeroBits();
+    a.byteLength();
+    a.cmp(new BN(2));
+    a.toRed(BN.red('p192')).fromRed();
+  });
+});

--- a/definitions/npm/bn.js_v3.x.x/flow_v0.83.x-/test_bn.js_v3.x.x.js
+++ b/definitions/npm/bn.js_v3.x.x/flow_v0.83.x-/test_bn.js_v3.x.x.js
@@ -16,6 +16,17 @@ describe('BN main usages', () => {
     new BN(new BN('dead', 'hex'));
   });
 
+  it('prevents invalid constructors', () => {
+    // $FlowExpectedError[incompatible-call]
+    new BN({});
+
+    // $FlowExpectedError[incompatible-call]
+    new BN('dead', 'dec', 'le');
+
+    // $FlowExpectedError[incompatible-call]
+    new BN('dead', 'hex', 'le', {});
+  });
+
   it('handles arithmetics', () => {
     const a = new BN(21);
     const b = new BN(42);
@@ -77,6 +88,16 @@ describe('BN main usages', () => {
       .redNeg();
   });
 
+  it('prevents calling functions with wrong input types', () => {
+    const a = new BN(21);
+
+    // $FlowExpectedError[incompatible-call]
+    a.mul(2);
+
+    // $FlowExpectedError[incompatible-call]
+    a.muln(new BN(2));
+  });
+
   it('handles utilities', () => {
     const a = new BN();
 
@@ -87,5 +108,34 @@ describe('BN main usages', () => {
     a.byteLength();
     a.cmp(new BN(2));
     a.toRed(BN.red('p192')).fromRed();
+  });
+
+  it('prevents invalid utilities usage', () => {
+    const a = new BN();
+
+    // $FlowExpectedError[incompatible-call]
+    a.toString('dec');
+
+    // $FlowExpectedError[incompatible-call]
+    a.toArray('other');
+  });
+
+  it('prevents calling functions that were added in later versions', () => {
+    const a = new BN();
+
+    // $FlowExpectedError[prop-missing]
+    a.lt(2);
+
+    // $FlowExpectedError[prop-missing]
+    a.ltn(new BN(2));
+
+    // $FlowExpectedError[prop-missing]
+    a.toArrayLike(Buffer, 'le', 8);
+
+    // $FlowExpectedError[prop-missing]
+    a.toBuffer('be', 8);
+
+    // $FlowExpectedError[prop-missing]
+    a.toArrayLike(Buffer, 'le', 8);
   });
 });

--- a/definitions/npm/bn.js_v4.x.x/flow_v0.83.x-/bn.js_v4.x.x.js
+++ b/definitions/npm/bn.js_v4.x.x/flow_v0.83.x-/bn.js_v4.x.x.js
@@ -1,0 +1,168 @@
+declare module 'bn.js' {
+  declare type Endianness = 'le' | 'be';
+  declare type Primes = 'k256' | 'p224' | 'p192' | 'p25519';
+  declare type ReductionContext = BN | Primes;
+  declare type Extended = {|
+    words: Array<number>,
+    length: number,
+  |};
+
+  declare class MPrime {
+    p: BN;
+
+    constructor(name: string, p: string): MPrime;
+
+    ireduce(b: BN): BN;
+    split(input: BN, out: BN): void;
+    imulK(b: BN): BN;
+  }
+
+  declare class Red {
+    prime: MPrime;
+
+    constructor(m: ReductionContext): Red;
+  }
+
+  declare class BN {
+    constructor(
+      number?: number | string,
+      base?: number | 'hex' | null,
+      endian?: Endianness
+    ): BN;
+    constructor(
+      number?: Array<number> | Uint8Array | Buffer | BN,
+      endian?: Endianness
+    ): BN;
+
+    negative: boolean;
+    words: Array<number> | null;
+    length: number;
+
+    static isBN(obj: any): boolean;
+    static min(a: BN, b: BN): BN;
+    static max(a: BN, b: BN): BN;
+    static _prime(prime: Primes): MPrime;
+    static red(b: ReductionContext): Red;
+    static mont(b: BN): Red;
+
+    // Arithmetics
+    neg(): BN;
+    ineg(): BN;
+    abs(): BN;
+    iabs(): BN;
+    add(b: BN): BN;
+    iadd(b: BN): BN;
+    addn(b: number): BN;
+    iaddn(b: number): BN;
+    sub(b: BN): BN;
+    isub(b: BN): BN;
+    subn(b: number): BN;
+    isubn(b: number): BN;
+    mul(b: BN): BN;
+    imul(b: BN): BN;
+    muln(b: number): BN;
+    imuln(b: number): BN;
+    mulf(b: BN): BN;
+    sqr(): BN;
+    isqr(): BN;
+    pow(b: BN): BN;
+    div(b: BN): BN;
+    divn(b: number): BN;
+    idivn(b: number): BN;
+    mod(b: BN): BN;
+    umod(b: BN): BN;
+    modn(b: number): BN;
+    modrn(b: number): number;
+    divmod(b: BN): BN;
+    divRound(b: BN): BN;
+
+    // Bit operations
+    or(b: BN): BN;
+    ior(b: BN): BN;
+    uor(b: BN): BN;
+    iuor(b: BN): BN;
+    and(b: BN): BN;
+    iand(b: BN): BN;
+    uand(b: BN): BN;
+    iuand(b: BN): BN;
+    andln(b: number): number;
+    xor(b: BN): BN;
+    ixor(b: BN): BN;
+    uxor(b: BN): BN;
+    iuxor(b: BN): BN;
+    setn(bit: number, val: boolean): BN;
+    shln(bits: number): BN;
+    ishln(bits: number): BN;
+    ushln(bits: number): BN;
+    iushln(bits: number): BN;
+    shrn(bits: number): BN;
+    ishrn(bits: number, hint?: number, extended?: Extended): BN;
+    ushrn(bits: number): BN;
+    iushrn(bits: number, hint?: number, extended?: Extended): BN;
+    testn(bit: number): boolean;
+    maskn(bits: number): BN;
+    imaskn(bits: number): BN;
+    bincn(bit: number): BN;
+    notn(width: number): BN;
+    inotn(width: number): BN;
+
+    // Reduction
+    gcd(b: BN): BN;
+    egcd(b: BN): BN;
+    invm(b: BN): BN;
+
+    // Red instructions
+    redAdd(b: BN): BN;
+    redIAdd(b: BN): BN;
+    redSub(b: BN): BN;
+    redISub(b: BN): BN;
+    redShl(b: number): BN;
+    redMul(b: BN): BN;
+    redIMul(b: BN): BN;
+    redSqr(): BN;
+    redISqr(): BN;
+    redSqrt(): BN;
+    redInvm(): BN;
+    redNeg(): BN;
+    redPow(b: BN): BN;
+
+    // Utilities
+    clone(): BN;
+    toString(base?: number | 'hex', length?: number): string;
+    toNumber(): number;
+    toJSON(): string;
+    toArray(endian?: Endianness, length?: number): Array<number>;
+    toArrayLike(
+      ArrayType: typeof Buffer | typeof Array,
+      endian?: Endianness,
+      length?: number
+    ): Buffer | Array<number>;
+    toBuffer(endian?: Endianness, length?: number): Buffer;
+    bitLength(): number;
+    zeroBits(): number;
+    byteLength(): number;
+    isNeg(): boolean;
+    isEven(): boolean;
+    isOdd(): boolean;
+    isZero(): boolean;
+    cmp(b: BN): number;
+    ucmp(b: BN): number;
+    cmpn(b: number): number;
+    lt(b: BN): boolean;
+    ltn(b: number): boolean;
+    lte(b: BN): boolean;
+    lten(b: number): boolean;
+    gt(b: BN): boolean;
+    gtn(b: number): boolean;
+    gte(b: BN): boolean;
+    gten(b: number): boolean;
+    eq(b: BN): boolean;
+    eqn(b: number): boolean;
+    toTwos(width: number): BN;
+    fromTwos(width: number): BN;
+    toRed(red: Red): BN;
+    fromRed(): BN;
+  }
+
+  declare module.exports: typeof BN;
+}

--- a/definitions/npm/bn.js_v4.x.x/flow_v0.83.x-/test_bn.js_v4.x.x.js
+++ b/definitions/npm/bn.js_v4.x.x/flow_v0.83.x-/test_bn.js_v4.x.x.js
@@ -16,6 +16,17 @@ describe('BN main usages', () => {
     new BN(new BN('dead', 'hex'));
   });
 
+  it('prevents invalid constructors', () => {
+    // $FlowExpectedError[incompatible-call]
+    new BN({});
+
+    // $FlowExpectedError[incompatible-call]
+    new BN('dead', 'dec', 'le');
+
+    // $FlowExpectedError[incompatible-call]
+    new BN('dead', 'hex', 'le', {});
+  });
+
   it('handles arithmetics', () => {
     const a = new BN(21);
     const b = new BN(42);
@@ -77,6 +88,22 @@ describe('BN main usages', () => {
       .redNeg();
   });
 
+  it('prevents calling functions with wrong input types', () => {
+    const a = new BN(21);
+
+    // $FlowExpectedError[incompatible-call]
+    a.lt(2);
+
+    // $FlowExpectedError[incompatible-call]
+    a.ltn(new BN(2));
+
+    // $FlowExpectedError[incompatible-call]
+    a.mul(2);
+
+    // $FlowExpectedError[incompatible-call]
+    a.muln(new BN(2));
+  });
+
   it('handles utilities', () => {
     const a = new BN();
 
@@ -93,5 +120,21 @@ describe('BN main usages', () => {
     a.gte(new BN(2));
     a.toTwos(8);
     a.toRed(BN.red('p192')).fromRed();
+  });
+
+  it('prevents invalid utilities usage', () => {
+    const a = new BN();
+
+    // $FlowExpectedError[incompatible-call]
+    a.toString('dec');
+
+    // $FlowExpectedError[incompatible-call]
+    a.toArray('other');
+
+    // $FlowExpectedError[incompatible-call]
+    a.toArrayLike(Object, 'le', 8);
+
+    // $FlowExpectedError[incompatible-call]
+    a.cmp(0);
   });
 });

--- a/definitions/npm/bn.js_v4.x.x/flow_v0.83.x-/test_bn.js_v4.x.x.js
+++ b/definitions/npm/bn.js_v4.x.x/flow_v0.83.x-/test_bn.js_v4.x.x.js
@@ -1,0 +1,97 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import BN from 'bn.js';
+
+describe('BN main usages', () => {
+  it('support different constructors', () => {
+    new BN(2);
+    new BN('2');
+    new BN('dead', 'hex');
+    new BN('dead', 16);
+    new BN('dead', 'hex', 'le');
+
+    new BN([1, 2, 3, 4]);
+    new BN([1, 2, 3, 4], 'le');
+    new BN(Buffer.from('dead', 'hex'));
+    new BN(new BN('dead', 'hex'));
+  });
+
+  it('handles arithmetics', () => {
+    const a = new BN(21);
+    const b = new BN(42);
+
+    new BN(21)
+      .neg()
+      .abs()
+      .iadd(a)
+      .sub(b)
+      .mul(a)
+      .muln(20)
+      .sqr()
+      .pow(b)
+      .div(a)
+      .mod(b)
+      .addn(21);
+  });
+
+  it('handles bit operations', () => {
+    const a = new BN(21);
+    const b = new BN(42);
+
+    new BN(21)
+      .or(a)
+      .iand(b)
+      .xor(a)
+      .setn(2, true)
+      .shln(4)
+      .maskn(21)
+      .ishrn(4, 1, {
+        words: [],
+        length: 0,
+      })
+      .ushln(128);
+  });
+
+  it('handles reduction', () => {
+    const a = new BN(21);
+
+    new BN(21)
+      .gcd(a)
+      .egcd(a)
+      .invm(a);
+  });
+
+  it('handles fast reduction', () => {
+    BN.red(new BN(21));
+    BN.red('p224');
+    BN.mont(new BN(21));
+
+    const red = BN.red('p192');
+
+    const a = new BN(128).toRed(red);
+    const b = new BN(64).toRed(red);
+
+    a.redAdd(b)
+      .redSub(b)
+      .redInvm()
+      .redNeg();
+  });
+
+  it('handles utilities', () => {
+    const a = new BN();
+
+    a.clone().toString();
+    a.toString(16);
+    a.toNumber();
+    a.toArray('le', 8);
+    a.toBuffer('be', 8);
+    a.toArrayLike(Buffer, 'le', 8);
+    a.zeroBits();
+    a.byteLength();
+    a.cmp(new BN(2));
+    a.ltn(2);
+    a.gte(new BN(2));
+    a.toTwos(8);
+    a.toRed(BN.red('p192')).fromRed();
+  });
+});

--- a/definitions/npm/bn.js_v5.x.x/flow_v0.83.x-/bn.js_v5.x.x.js
+++ b/definitions/npm/bn.js_v5.x.x/flow_v0.83.x-/bn.js_v5.x.x.js
@@ -1,0 +1,168 @@
+declare module 'bn.js' {
+  declare type Endianness = 'le' | 'be';
+  declare type Primes = 'k256' | 'p224' | 'p192' | 'p25519';
+  declare type ReductionContext = BN | Primes;
+  declare type Extended = {|
+    words: Array<number>,
+    length: number,
+  |};
+
+  declare class MPrime {
+    p: BN;
+
+    constructor(name: string, p: string): MPrime;
+
+    ireduce(b: BN): BN;
+    split(input: BN, out: BN): void;
+    imulK(b: BN): BN;
+  }
+
+  declare class Red {
+    prime: MPrime;
+
+    constructor(m: ReductionContext): Red;
+  }
+
+  declare class BN {
+    constructor(
+      number?: number | string,
+      base?: number | 'hex' | null,
+      endian?: Endianness
+    ): BN;
+    constructor(
+      number?: Array<number> | Uint8Array | Buffer | BN,
+      endian?: Endianness
+    ): BN;
+
+    negative: boolean;
+    words: Array<number> | null;
+    length: number;
+
+    static isBN(obj: any): boolean;
+    static min(a: BN, b: BN): BN;
+    static max(a: BN, b: BN): BN;
+    static _prime(prime: Primes): MPrime;
+    static red(b: ReductionContext): Red;
+    static mont(b: BN): Red;
+
+    // Arithmetics
+    neg(): BN;
+    ineg(): BN;
+    abs(): BN;
+    iabs(): BN;
+    add(b: BN): BN;
+    iadd(b: BN): BN;
+    addn(b: number): BN;
+    iaddn(b: number): BN;
+    sub(b: BN): BN;
+    isub(b: BN): BN;
+    subn(b: number): BN;
+    isubn(b: number): BN;
+    mul(b: BN): BN;
+    imul(b: BN): BN;
+    muln(b: number): BN;
+    imuln(b: number): BN;
+    mulf(b: BN): BN;
+    sqr(): BN;
+    isqr(): BN;
+    pow(b: BN): BN;
+    div(b: BN): BN;
+    divn(b: number): BN;
+    idivn(b: number): BN;
+    mod(b: BN): BN;
+    umod(b: BN): BN;
+    modn(b: number): BN;
+    modrn(b: number): number;
+    divmod(b: BN): BN;
+    divRound(b: BN): BN;
+
+    // Bit operations
+    or(b: BN): BN;
+    ior(b: BN): BN;
+    uor(b: BN): BN;
+    iuor(b: BN): BN;
+    and(b: BN): BN;
+    iand(b: BN): BN;
+    uand(b: BN): BN;
+    iuand(b: BN): BN;
+    andln(b: number): number;
+    xor(b: BN): BN;
+    ixor(b: BN): BN;
+    uxor(b: BN): BN;
+    iuxor(b: BN): BN;
+    setn(bit: number, val: boolean): BN;
+    shln(bits: number): BN;
+    ishln(bits: number): BN;
+    ushln(bits: number): BN;
+    iushln(bits: number): BN;
+    shrn(bits: number): BN;
+    ishrn(bits: number, hint?: number, extended?: Extended): BN;
+    ushrn(bits: number): BN;
+    iushrn(bits: number, hint?: number, extended?: Extended): BN;
+    testn(bit: number): boolean;
+    maskn(bits: number): BN;
+    imaskn(bits: number): BN;
+    bincn(bit: number): BN;
+    notn(width: number): BN;
+    inotn(width: number): BN;
+
+    // Reduction
+    gcd(b: BN): BN;
+    egcd(b: BN): BN;
+    invm(b: BN): BN;
+
+    // Red instructions
+    redAdd(b: BN): BN;
+    redIAdd(b: BN): BN;
+    redSub(b: BN): BN;
+    redISub(b: BN): BN;
+    redShl(b: number): BN;
+    redMul(b: BN): BN;
+    redIMul(b: BN): BN;
+    redSqr(): BN;
+    redISqr(): BN;
+    redSqrt(): BN;
+    redInvm(): BN;
+    redNeg(): BN;
+    redPow(b: BN): BN;
+
+    // Utilities
+    clone(): BN;
+    toString(base?: number | 'hex', length?: number): string;
+    toNumber(): number;
+    toJSON(): string;
+    toArray(endian?: Endianness, length?: number): Array<number>;
+    toArrayLike(
+      ArrayType: typeof Buffer | typeof Array,
+      endian?: Endianness,
+      length?: number
+    ): Buffer | Array<number>;
+    toBuffer(endian?: Endianness, length?: number): Buffer;
+    bitLength(): number;
+    zeroBits(): number;
+    byteLength(): number;
+    isNeg(): boolean;
+    isEven(): boolean;
+    isOdd(): boolean;
+    isZero(): boolean;
+    cmp(b: BN): number;
+    ucmp(b: BN): number;
+    cmpn(b: number): number;
+    lt(b: BN): boolean;
+    ltn(b: number): boolean;
+    lte(b: BN): boolean;
+    lten(b: number): boolean;
+    gt(b: BN): boolean;
+    gtn(b: number): boolean;
+    gte(b: BN): boolean;
+    gten(b: number): boolean;
+    eq(b: BN): boolean;
+    eqn(b: number): boolean;
+    toTwos(width: number): BN;
+    fromTwos(width: number): BN;
+    toRed(red: Red): BN;
+    fromRed(): BN;
+  }
+
+  declare module.exports: typeof BN;
+}

--- a/definitions/npm/bn.js_v5.x.x/flow_v0.83.x-/test_bn.js_v5.x.x.js
+++ b/definitions/npm/bn.js_v5.x.x/flow_v0.83.x-/test_bn.js_v5.x.x.js
@@ -3,7 +3,7 @@ import { describe, it } from 'flow-typed-test';
 import BN from 'bn.js';
 
 describe('BN main usages', () => {
-  it('support different constructors', () => {
+  it('supports different constructors', () => {
     new BN(2);
     new BN('2');
     new BN('dead', 'hex');
@@ -14,6 +14,17 @@ describe('BN main usages', () => {
     new BN([1, 2, 3, 4], 'le');
     new BN(Buffer.from('dead', 'hex'));
     new BN(new BN('dead', 'hex'));
+  });
+
+  it('prevents invalid constructors', () => {
+    // $FlowExpectedError[incompatible-call]
+    new BN({});
+
+    // $FlowExpectedError[incompatible-call]
+    new BN('dead', 'dec', 'le');
+
+    // $FlowExpectedError[incompatible-call]
+    new BN('dead', 'hex', 'le', {});
   });
 
   it('handles arithmetics', () => {
@@ -77,6 +88,22 @@ describe('BN main usages', () => {
       .redNeg();
   });
 
+  it('prevents calling functions with wrong input types', () => {
+    const a = new BN(21);
+
+    // $FlowExpectedError[incompatible-call]
+    a.lt(2);
+
+    // $FlowExpectedError[incompatible-call]
+    a.ltn(new BN(2));
+
+    // $FlowExpectedError[incompatible-call]
+    a.mul(2);
+
+    // $FlowExpectedError[incompatible-call]
+    a.muln(new BN(2));
+  });
+
   it('handles utilities', () => {
     const a = new BN();
 
@@ -93,5 +120,21 @@ describe('BN main usages', () => {
     a.gte(new BN(2));
     a.toTwos(8);
     a.toRed(BN.red('p192')).fromRed();
+  });
+
+  it('prevents invalid utilities usage', () => {
+    const a = new BN();
+
+    // $FlowExpectedError[incompatible-call]
+    a.toString('dec');
+
+    // $FlowExpectedError[incompatible-call]
+    a.toArray('other');
+
+    // $FlowExpectedError[incompatible-call]
+    a.toArrayLike(Object, 'le', 8);
+
+    // $FlowExpectedError[incompatible-call]
+    a.cmp(0);
   });
 });

--- a/definitions/npm/bn.js_v5.x.x/flow_v0.83.x-/test_bn.js_v5.x.x.js
+++ b/definitions/npm/bn.js_v5.x.x/flow_v0.83.x-/test_bn.js_v5.x.x.js
@@ -1,0 +1,97 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import BN from 'bn.js';
+
+describe('BN main usages', () => {
+  it('support different constructors', () => {
+    new BN(2);
+    new BN('2');
+    new BN('dead', 'hex');
+    new BN('dead', 16);
+    new BN('dead', 'hex', 'le');
+
+    new BN([1, 2, 3, 4]);
+    new BN([1, 2, 3, 4], 'le');
+    new BN(Buffer.from('dead', 'hex'));
+    new BN(new BN('dead', 'hex'));
+  });
+
+  it('handles arithmetics', () => {
+    const a = new BN(21);
+    const b = new BN(42);
+
+    new BN(21)
+      .neg()
+      .abs()
+      .iadd(a)
+      .sub(b)
+      .mul(a)
+      .muln(20)
+      .sqr()
+      .pow(b)
+      .div(a)
+      .mod(b)
+      .addn(21);
+  });
+
+  it('handles bit operations', () => {
+    const a = new BN(21);
+    const b = new BN(42);
+
+    new BN(21)
+      .or(a)
+      .iand(b)
+      .xor(a)
+      .setn(2, true)
+      .shln(4)
+      .maskn(21)
+      .ishrn(4, 1, {
+        words: [],
+        length: 0,
+      })
+      .ushln(128);
+  });
+
+  it('handles reduction', () => {
+    const a = new BN(21);
+
+    new BN(21)
+      .gcd(a)
+      .egcd(a)
+      .invm(a);
+  });
+
+  it('handles fast reduction', () => {
+    BN.red(new BN(21));
+    BN.red('p224');
+    BN.mont(new BN(21));
+
+    const red = BN.red('p192');
+
+    const a = new BN(128).toRed(red);
+    const b = new BN(64).toRed(red);
+
+    a.redAdd(b)
+      .redSub(b)
+      .redInvm()
+      .redNeg();
+  });
+
+  it('handles utilities', () => {
+    const a = new BN();
+
+    a.clone().toString();
+    a.toString(16);
+    a.toNumber();
+    a.toArray('le', 8);
+    a.toBuffer('be', 8);
+    a.toArrayLike(Buffer, 'le', 8);
+    a.zeroBits();
+    a.byteLength();
+    a.cmp(new BN(2));
+    a.ltn(2);
+    a.gte(new BN(2));
+    a.toTwos(8);
+    a.toRed(BN.red('p192')).fromRed();
+  });
+});


### PR DESCRIPTION
- Links to documentation:
  - [v5](https://github.com/indutny/bn.js/blob/v5.2.0/README.md)
  - [v4](https://github.com/indutny/bn.js/blob/v4.12.0/README.md)
  - [v3](https://github.com/indutny/bn.js/blob/v3.3.0/README.md)
  - [v2](https://github.com/indutny/bn.js/blob/v2.2.0/README.md)
- Link to GitHub or NPM: [GitHub](https://github.com/indutny/bn.js)
- Type of contribution: new definition

Other notes:
- v5 and v4 are exactly the same
- v3 is missing some util functions compared to v4
- v2 is missing unsigned operations

