### PR TITLE
[cli] Fix if dependency is resolved npm package

### DIFF
--- a/cli/src/lib/npm/__tests__/npmProjectUtils-test.js
+++ b/cli/src/lib/npm/__tests__/npmProjectUtils-test.js
@@ -1,0 +1,21 @@
+// @flow
+import {mergePackageJsonDependencies} from '../npmProjectUtils';
+
+describe('npmProjectUtils', () => {
+  describe('mergePackageJsonDependencies', () => {
+    it('does not break with deps that resolve with `npm:...', () => {
+      expect(
+        mergePackageJsonDependencies(
+          {
+            'react-intl-next': 'npm:react@16.8.0',
+          },
+          {
+            'react-intl-next': 'npm:react@16.8.0',
+          },
+        ),
+      ).toEqual({
+        'react-intl-next': 'npm:react@16.8.0',
+      });
+    });
+  });
+});

--- a/cli/src/lib/npm/npmProjectUtils.js
+++ b/cli/src/lib/npm/npmProjectUtils.js
@@ -186,7 +186,14 @@ export function mergePackageJsonDependencies(
   const result = {...a};
   for (const dep of Object.keys(b)) {
     const version = b[dep];
-    if (a[dep] != null && !intersects(result[dep], version)) {
+    let doesIntersect;
+    try {
+      doesIntersect = intersects(result[dep], version);
+    } catch (e) {
+      doesIntersect = false;
+    }
+
+    if (a[dep] != null && !doesIntersect) {
       console.log(
         colors.yellow(
           "\t  Conflicting versions for '%s' between '%s' and '%s'",

--- a/cli/src/lib/npm/npmProjectUtils.js
+++ b/cli/src/lib/npm/npmProjectUtils.js
@@ -190,7 +190,7 @@ export function mergePackageJsonDependencies(
     try {
       doesIntersect = intersects(result[dep], version);
     } catch (e) {
-      doesIntersect = false;
+      doesIntersect = result[dep] === version;
     }
 
     if (a[dep] != null && !doesIntersect) {


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
If an npm package has a value that resolves to a different dependency the value does not work with `semver` and crashes when using the CLI with monorepos.

Tests showcase what is being fixed

cc: @meandmax 