### PR TITLE
[jwt-decode] Add definition

### DIFF
--- a/definitions/npm/jwt-decode_v3.x.x/flow_v0.83.x-/jwt-decode_v3.x.x.js
+++ b/definitions/npm/jwt-decode_v3.x.x/flow_v0.83.x-/jwt-decode_v3.x.x.js
@@ -1,0 +1,27 @@
+declare module 'jwt-decode' {
+  declare export class InvalidTokenError extends Error {}
+
+  declare type JwtDecodeOptions = {|
+    header?: boolean,
+  |};
+
+  declare type JwtHeader = {|
+    type?: string,
+    alg?: string,
+  |};
+
+  declare type JwtPayload = {|
+    iss?: string,
+    sub?: string,
+    aud?: Array<string> | string,
+    exp?: number,
+    nbf?: number,
+    iat?: number,
+    jti?: string,
+  |};
+
+  declare export default function jwtDecode<T>(
+    token: string,
+    options?: JwtDecodeOptions,
+  ): T;
+}

--- a/definitions/npm/jwt-decode_v3.x.x/flow_v0.83.x-/test_jwt-decode_v3.x.x.js
+++ b/definitions/npm/jwt-decode_v3.x.x/flow_v0.83.x-/test_jwt-decode_v3.x.x.js
@@ -1,0 +1,33 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import jwtDecode from 'jwt-decode';
+
+describe('jwt-decode', () => {
+  it('decodes', () => {
+    jwtDecode('test');
+    // It's any without generic passed in
+    jwtDecode('test').a.b.c;
+
+    jwtDecode<{ a: string, ... }>('test').a.toLowerCase();
+    // $FlowExpectedError[prop-missing] does not match generic structure
+    jwtDecode<{ a: string, ... }>('test').b;
+
+    jwtDecode('test', {
+      header: false,
+    });
+    jwtDecode('test', {
+      // $FlowExpectedError[incompatible-call]
+      header: '',
+    });
+    // $FlowExpectedError[prop-missing]
+    jwtDecode('test', {
+      aud: '',
+    });
+    jwtDecode('test', {});
+
+    // $FlowExpectedError[incompatible-call]
+    jwtDecode();
+    // $FlowExpectedError[incompatible-call]
+    jwtDecode('test', '');
+  });
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Adding jwt-decode using the `.d.ts` file in the package's node_modules

- Links to documentation: Referenced below
- Link to GitHub or NPM: https://www.npmjs.com/package/jwt-decode
- Type of contribution: new definition

Other notes: if you install `jwt-decode` you will `index.d.ts` that looks like this
```
export class InvalidTokenError extends Error {}

export interface JwtDecodeOptions {
  header?: boolean;
}

export interface JwtHeader {
  type?: string;
  alg?: string;
}

export interface JwtPayload {
  iss?: string;
  sub?: string;
  aud?: string[] | string;
  exp?: number;
  nbf?: number;
  iat?: number;
  jti?: string;
}

export default function jwtDecode<T = unknown>(
  token: string,
  options?: JwtDecodeOptions
): T;
```

