### PR TITLE
[has-ansi] Add v4/5 

### DIFF
--- a/definitions/npm/has-ansi_v4.x.x/flow_v0.83.x-/has-ansi_v4.x.x.js
+++ b/definitions/npm/has-ansi_v4.x.x/flow_v0.83.x-/has-ansi_v4.x.x.js
@@ -1,0 +1,3 @@
+declare module 'has-ansi' {
+  declare module.exports: (input: string) => boolean;
+}

--- a/definitions/npm/has-ansi_v4.x.x/flow_v0.83.x-/test_has-ansi_v4.x.x.js
+++ b/definitions/npm/has-ansi_v4.x.x/flow_v0.83.x-/test_has-ansi_v4.x.x.js
@@ -1,0 +1,15 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+
+const hasAnsi = require('has-ansi');
+
+describe('has-ansi', () => {
+  it('works', () => {
+    hasAnsi('test');
+
+    // $FlowExpectedError[incompatible-call]
+    hasAnsi();
+    // $FlowExpectedError[incompatible-call]
+    hasAnsi(123);
+  });
+});

--- a/definitions/npm/has-ansi_v5.x.x/flow_v0.83.x-/has-ansi_v5.x.x.js
+++ b/definitions/npm/has-ansi_v5.x.x/flow_v0.83.x-/has-ansi_v5.x.x.js
@@ -1,0 +1,3 @@
+declare module 'has-ansi' {
+  declare export default (input: string) => boolean;
+}

--- a/definitions/npm/has-ansi_v5.x.x/flow_v0.83.x-/test_has-ansi_v5.x.x.js
+++ b/definitions/npm/has-ansi_v5.x.x/flow_v0.83.x-/test_has-ansi_v5.x.x.js
@@ -1,0 +1,15 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+
+import hasAnsi from 'has-ansi';
+
+describe('has-ansi', () => {
+  it('works', () => {
+    hasAnsi('test');
+
+    // $FlowExpectedError[incompatible-call]
+    hasAnsi();
+    // $FlowExpectedError[incompatible-call]
+    hasAnsi(123);
+  });
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Add `has-ansi` v5 which is latest and v4 that will still be commonly used because it accepts native node require syntax

- Links to documentation: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/has-ansi/index.d.ts
- Link to GitHub or NPM: https://www.npmjs.com/package/has-ansi
- Type of contribution: new definition

Other notes:

