### PR TITLE
[redux] Add `legacy_createStore`

### DIFF
--- a/definitions/npm/redux_v4.x.x/flow_v0.134.x-/redux_v4.x.x.js
+++ b/definitions/npm/redux_v4.x.x/flow_v0.134.x-/redux_v4.x.x.js
@@ -63,6 +63,16 @@ declare module 'redux' {
     enhancer?: StoreEnhancer<S, A, D>
   ): Store<S, A, D>;
 
+  declare export function legacy_createStore<S, A, D>(
+    reducer: Reducer<S, A>,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>;
+  declare export function legacy_createStore<S, A, D>(
+    reducer: Reducer<S, A>,
+    preloadedState?: S,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>;
+
   declare export function applyMiddleware<S, A, D>(
     ...middlewares: Array<Middleware<S, A, D>>
   ): StoreEnhancer<S, A, D>;

--- a/definitions/npm/redux_v4.x.x/flow_v0.134.x-/test_createStore.js
+++ b/definitions/npm/redux_v4.x.x/flow_v0.134.x-/test_createStore.js
@@ -1,6 +1,6 @@
 // @flow
 import type { Store as ReduxStore, StoreEnhancer } from 'redux'
-import { createStore } from 'redux'
+import { createStore, legacy_createStore } from 'redux'
 
 type State = Array<number>;
 type Action = { type: 'A', ... };
@@ -27,6 +27,23 @@ const store7: Store = createStore(reducer, [1], 'wrong'); // wrong enhancer
 declare var myEnhancer: StoreEnhancer<State, Action>;
 const store8: Store = createStore(reducer, [1], myEnhancer);
 const store9: Store = createStore(reducer, undefined, myEnhancer);
+
+// $FlowExpectedError[incompatible-type-arg]
+// $FlowExpectedError[incompatible-call]
+const legacyStore1: Store = legacy_createStore(() => ({})); // wrong reducer
+const legacyStore2: Store = legacy_createStore(reducer);
+// $FlowExpectedError[incompatible-call]
+const legacyStore3: Store = legacy_createStore(reducer, {}); // wrong initialState shape
+const legacyStore4: Store = legacy_createStore(reducer, []);
+// $FlowExpectedError[incompatible-type]
+// $FlowExpectedError[incompatible-call]
+const legacyStore5: Store = legacy_createStore(reducer, ['wrong']); // wrong initialState content
+const legacyStore6: Store = legacy_createStore(reducer, [1]);
+// $FlowExpectedError[incompatible-call]
+const legacyStore7: Store = legacy_createStore(reducer, [1], 'wrong'); // wrong enhancer
+declare var legacyMyEnhancer: StoreEnhancer<State, Action>;
+const legacyStore8: Store = legacy_createStore(reducer, [1], myEnhancer);
+const legacyStore9: Store = legacy_createStore(reducer, undefined, myEnhancer);
 
 //
 // store members


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
As unfortunate as adding `legacy_createStore` is it's already been shipped so this adds the type definition for it for those that want to use it

- Links to documentation: https://github.com/reduxjs/redux/releases/tag/v4.2.0
- Link to GitHub or NPM: https://www.npmjs.com/package/redux
- Type of contribution: addition

Other notes: Open to feedback for whether I should add this as `4.2.x` instead of `4.x.x`

