### PR TITLE
[react-dom] Export createRoot, hydrateRoot from main index

### DIFF
--- a/definitions/npm/react-dom_v18.x.x/flow_v0.127.x-/react-dom_v18.x.x.js
+++ b/definitions/npm/react-dom_v18.x.x/flow_v0.127.x-/react-dom_v18.x.x.js
@@ -99,9 +99,19 @@ declare module 'react-dom_shared-types' {
     _currentlyRenderingFiber?: any,
     _initialVersionAsOfFirstRender?: MutableSourceVersion | null,
   |};
+
+  declare opaque type FiberRoot;
 }
 
 declare module 'react-dom' {
+  import typeof {
+    createRoot as client_createRoot,
+    hydrateRoot as client_hydrateRoot,
+  } from 'react-dom/client';
+
+  declare var createRoot: client_createRoot;
+  declare var hydrateRoot: client_hydrateRoot;
+
   declare var version: string;
 
   declare function findDOMNode(
@@ -151,9 +161,8 @@ declare module 'react-dom/client' {
     TransitionTracingCallbacks,
     ReactNodeList,
     MutableSource,
+    FiberRoot,
   } from 'react-dom_shared-types';
-
-  declare opaque type FiberRoot;
 
   declare type RootType = {
     render(children: ReactNodeList): void,

--- a/definitions/npm/react-dom_v18.x.x/flow_v0.127.x-/react-dom_v18.x.x.js
+++ b/definitions/npm/react-dom_v18.x.x/flow_v0.127.x-/react-dom_v18.x.x.js
@@ -109,7 +109,15 @@ declare module 'react-dom' {
     hydrateRoot as client_hydrateRoot,
   } from 'react-dom/client';
 
+  /**
+   * @deprecated
+   * You are importing createRoot from "react-dom" which is not supported. You should instead import it from "react-dom/client".
+   */
   declare var createRoot: client_createRoot;
+  /**
+   * @deprecated
+   * You are importing hydrateRoot from "react-dom" which is not supported. You should instead import it from "react-dom/client".
+   */
   declare var hydrateRoot: client_hydrateRoot;
 
   declare var version: string;

--- a/definitions/npm/react-dom_v18.x.x/flow_v0.127.x-/test_react-dom_v18.x.x.js
+++ b/definitions/npm/react-dom_v18.x.x/flow_v0.127.x-/test_react-dom_v18.x.x.js
@@ -2,152 +2,205 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { createRoot, hydrateRoot } from 'react-dom/client';
+import TestUtils from 'react-dom/test-utils';
 import { describe, it } from 'flow-typed-test';
-
-// All of these tests were originally in the flow repository.
 
 declare function test$getElementById(string): HTMLElement | null;
 
-declare class MyPortalComponent extends React.Component<{ ... }> {}
+describe('react-dom', () => {
+  describe('render', () => {
+    it('basic usage', () => {
+      class JDiv extends React.Component<{ id: string, ... }> {}
 
-class MyComponent extends React.Component<{ ... }> {
-  render() {
-    return ReactDOM.createPortal(
-      <MyPortalComponent />,
+      // $FlowExpectedError[incompatible-type]
+      <JDiv id={42} />;
+
+      class Example extends React.Component<{ bar: string, ... }> {
+        render() {
+          return <div>{this.props.bar}</div>;
+        }
+      }
+
+      ReactDOM.render(
+        // $FlowExpectedError[prop-missing]
+        <Example foo="foo" />,
+        // $FlowExpectedError[incompatible-call]
+        document.body
+      );
+
+      function Clock(props) {
+        return (
+          <div>
+            <h1>Hello, world!</h1>
+            <h2>It is {props.date.toLocaleTimeString()}.</h2>
+          </div>
+        );
+      }
+
+      function tick() {
+        const element = document.getElementById('root');
+        if (element) {
+          ReactDOM.render(<Clock date={new Date()} />, element);
+        }
+      }
+    });
+
+    it('callback tests', () => {
+      declare function test$querySelector(selector: string): HTMLElement | null;
+
+      const Example2 = React.createClass({
+        propTypes: {},
+        render() {
+          return <div>Hello</div>;
+        },
+      });
+
       // $FlowExpectedError[incompatible-call]
-      test$getElementById('portal')
-    );
-  }
-}
+      ReactDOM.render(<Example2 />, test$querySelector('#site'), () => {
+        console.log('Rendered - arrow callback');
+      });
 
-class JDiv extends React.Component<{ id: string, ... }> {}
+      // $FlowExpectedError[incompatible-call]
+      ReactDOM.render(<Example2 />, test$querySelector('#site'), function () {
+        console.log('Rendered - function callback');
+      });
 
-// $FlowExpectedError[incompatible-type]
-<JDiv id={42} />;
-
-class Example extends React.Component<{ bar: string, ... }> {
-  render() {
-    return <div>{this.props.bar}</div>;
-  }
-}
-
-ReactDOM.render(
-  // $FlowExpectedError[prop-missing]
-  <Example foo="foo" />,
-  // $FlowExpectedError[incompatible-call]
-  document.body
-);
-
-function Clock(props) {
-  return (
-    <div>
-      <h1>Hello, world!</h1>
-      <h2>It is {props.date.toLocaleTimeString()}.</h2>
-    </div>
-  );
-}
-
-function tick() {
-  const element = document.getElementById('root');
-  if (element) {
-    ReactDOM.render(<Clock date={new Date()} />, element);
-  }
-}
-
-// test-utils tests
-import TestUtils from 'react-dom/test-utils';
-
-class MyTestingComponent extends React.Component<{ ... }> {
-  render() {
-    return <button className="my-button" />;
-  }
-}
-
-const tree = TestUtils.renderIntoDocument(<MyTestingComponent />);
-TestUtils.mockComponent(MyTestingComponent);
-TestUtils.mockComponent(MyTestingComponent, 'span');
-(TestUtils.isElement(<MyTestingComponent />): boolean);
-(TestUtils.isElementOfType(
-  <MyTestingComponent />,
-  MyTestingComponent
-): boolean);
-(TestUtils.findRenderedDOMComponentWithClass(tree, 'my-button'): ?Element);
-(TestUtils.isDOMComponent(MyTestingComponent): boolean);
-(TestUtils.isCompositeComponent(tree): boolean);
-(TestUtils.isCompositeComponentWithType(tree, MyTestingComponent): boolean);
-(TestUtils.findAllInRenderedTree(
-  tree,
-  // $FlowExpectedError[prop-missing]
-  (child) => child.tagName === 'BUTTON'
-): Array<React.Component<any, any>>);
-(TestUtils.scryRenderedDOMComponentsWithClass(
-  tree,
-  'my-button'
-): Array<Element>);
-
-const buttonEl = TestUtils.findRenderedDOMComponentWithClass(tree, 'my-button');
-if (buttonEl != null) {
-  TestUtils.Simulate.click(buttonEl);
-}
-
-(TestUtils.scryRenderedDOMComponentsWithTag(tree, 'button'): Array<Element>);
-(TestUtils.findRenderedDOMComponentWithTag(tree, 'button'): ?Element);
-(TestUtils.scryRenderedComponentsWithType(tree, MyTestingComponent): Array<
-  React.Component<any, any>
->);
-(TestUtils.findRenderedComponentWithType(
-  tree,
-  MyTestingComponent
-): ?React.Component<any, any>);
-TestUtils.act(() => {
-  Math.random();
-});
-// $FlowExpectedError[incompatible-call]
-TestUtils.act(() => ({ count: 123 }));
-async function runTest() {
-  await TestUtils.act(async () => {
-    // .. some test code
-    await Promise.resolve();
+      // $FlowExpectedError[incompatible-call]
+      ReactDOM.render(<Example2 />, test$querySelector('#site'), 1);
+      // $FlowExpectedError[prop-missing]
+      // $FlowExpectedError[incompatible-call]
+      ReactDOM.render(<Example2 />, test$querySelector('#site'), {});
+      // $FlowExpectedError[incompatible-call]
+      ReactDOM.render(<Example2 />, test$querySelector('#site'), '');
+      // $FlowExpectedError[incompatible-call]
+      ReactDOM.render(<Example2 />, test$querySelector('#site'), null);
+    });
   });
-  /* // wishlist -
-  act(async () => {
-    // some test code
-  }); // ideally this should error
-  await act(() => {
-    // ...
-  }); // ideally this should error
-  */
-}
 
-// render callback tests
-declare function test$querySelector(selector: string): HTMLElement | null;
+  describe('TestUtils', () => {
+    it('works', () => {
+      class MyTestingComponent extends React.Component<{ ... }> {
+        render() {
+          return <button className="my-button" />;
+        }
+      }
 
-const Example2 = React.createClass({
-  propTypes: {},
-  render() {
-    return <div>Hello</div>;
-  },
+      const tree = TestUtils.renderIntoDocument(<MyTestingComponent />);
+      TestUtils.mockComponent(MyTestingComponent);
+      TestUtils.mockComponent(MyTestingComponent, 'span');
+      (TestUtils.isElement(<MyTestingComponent />): boolean);
+      (TestUtils.isElementOfType(
+        <MyTestingComponent />,
+        MyTestingComponent
+      ): boolean);
+      (TestUtils.findRenderedDOMComponentWithClass(tree, 'my-button'): ?Element);
+      (TestUtils.isDOMComponent(MyTestingComponent): boolean);
+      (TestUtils.isCompositeComponent(tree): boolean);
+      (TestUtils.isCompositeComponentWithType(tree, MyTestingComponent): boolean);
+      (TestUtils.findAllInRenderedTree(
+        tree,
+        // $FlowExpectedError[prop-missing]
+        (child) => child.tagName === 'BUTTON'
+      ): Array<React.Component<any, any>>);
+      (TestUtils.scryRenderedDOMComponentsWithClass(
+        tree,
+        'my-button'
+      ): Array<Element>);
+
+      const buttonEl = TestUtils.findRenderedDOMComponentWithClass(tree, 'my-button');
+      if (buttonEl != null) {
+        TestUtils.Simulate.click(buttonEl);
+      }
+
+      (TestUtils.scryRenderedDOMComponentsWithTag(tree, 'button'): Array<Element>);
+      (TestUtils.findRenderedDOMComponentWithTag(tree, 'button'): ?Element);
+      (TestUtils.scryRenderedComponentsWithType(tree, MyTestingComponent): Array<
+        React.Component<any, any>
+      >);
+      (TestUtils.findRenderedComponentWithType(
+        tree,
+        MyTestingComponent
+      ): ?React.Component<any, any>);
+      TestUtils.act(() => {
+        Math.random();
+      });
+      // $FlowExpectedError[incompatible-call]
+      TestUtils.act(() => ({ count: 123 }));
+      async function runTest() {
+        await TestUtils.act(async () => {
+          // .. some test code
+          await Promise.resolve();
+        });
+        /* // wishlist -
+        act(async () => {
+          // some test code
+        }); // ideally this should error
+        await act(() => {
+          // ...
+        }); // ideally this should error
+        */
+      }
+    });
+  });
+
+  describe('createPortal', () => {
+    it('works', () => {
+      declare class MyPortalComponent extends React.Component<{ ... }> {}
+
+      class MyComponent extends React.Component<{ ... }> {
+        render() {
+          return ReactDOM.createPortal(
+            <MyPortalComponent />,
+            // $FlowExpectedError[incompatible-call]
+            test$getElementById('portal')
+          );
+        }
+      }
+    });
+  });
+
+  describe('createRoot', () => {
+    it('works', () => {
+      declare var container: HTMLElement;
+
+      const root = ReactDOM.createRoot(container);
+      (root.render(<div />): void);
+      (root.unmount(): void);
+    });
+
+    it('needs createRoot to have valid param', () => {
+      // $FlowExpectedError[incompatible-call] needs to be non-null container
+      createRoot(document.getElementById('root'));
+      // $FlowExpectedError[incompatible-call] takes container only
+      ReactDOM.createRoot('test');
+    });
+
+    it('unmount takes no params and returns nothing', () => {
+      declare var container: HTMLElement;
+
+      const root = ReactDOM.createRoot(container);
+      // $FlowExpectedError[extra-arg]
+      root.unmount('test');
+      // $FlowExpectedError[incompatible-cast]
+      (root.unmount(): string);
+    });
+  });
+
+  describe('hydrateRoot', () => {
+    it('works', () => {
+      declare var container: HTMLElement;
+      ReactDOM.hydrateRoot(container, <div />);
+      ReactDOM.hydrateRoot(container);
+    });
+
+    it('errors', () => {
+      declare var container: HTMLElement;
+
+      // $FlowExpectedError[incompatible-call] can't be empty
+      ReactDOM.hydrateRoot();
+    });
+  });
 });
-
-// $FlowExpectedError[incompatible-call]
-ReactDOM.render(<Example2 />, test$querySelector('#site'), () => {
-  console.log('Rendered - arrow callback');
-});
-
-// $FlowExpectedError[incompatible-call]
-ReactDOM.render(<Example2 />, test$querySelector('#site'), function () {
-  console.log('Rendered - function callback');
-});
-
-// $FlowExpectedError[incompatible-call]
-ReactDOM.render(<Example2 />, test$querySelector('#site'), 1);
-// $FlowExpectedError[prop-missing]
-// $FlowExpectedError[incompatible-call]
-ReactDOM.render(<Example2 />, test$querySelector('#site'), {});
-// $FlowExpectedError[incompatible-call]
-ReactDOM.render(<Example2 />, test$querySelector('#site'), '');
-// $FlowExpectedError[incompatible-call]
-ReactDOM.render(<Example2 />, test$querySelector('#site'), null);
 
 describe('react-dom/client', () => {
   describe('createRoot', () => {


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
The new functions `createRoot` and `hydrateRoot` are actually available in `react-dom` but throw errors when called from `react-dom` instead of `react-dom/client`. Deprecation JS docs have been added suggest against usage though usage is completely valid from a soundness perspective.

This change was originally proposed by @noahehall in #4301 and I'm simply completing it with proper test verification.

- Links to documentation: https://github.com/facebook/react/blob/main/packages/react-dom/index.js#L15
- Link to GitHub or NPM: https://www.npmjs.com/package/react-dom
- Type of contribution: fix

Other notes: Refactor react-dom tests to match describe/it format

