### PR TITLE
[is-dark-color] New definition 

### DIFF
--- a/definitions/npm/is-dark-color_v1.x.x/flow_v0.83.x-/is-dark-color_v1.x.x.js
+++ b/definitions/npm/is-dark-color_v1.x.x/flow_v0.83.x-/is-dark-color_v1.x.x.js
@@ -1,0 +1,12 @@
+declare module 'is-dark-color' {
+  declare type isDarkColorOptions = {|
+    override: { [hex: string]: boolean, ... },
+  |};
+
+  declare var isDarkColor: (
+    hexColor: string,
+    options?: isDarkColorOptions
+  ) => boolean;
+
+  declare module.exports: typeof isDarkColor;
+}

--- a/definitions/npm/is-dark-color_v1.x.x/flow_v0.83.x-/test_is-dark-color_v1.x.x.js
+++ b/definitions/npm/is-dark-color_v1.x.x/flow_v0.83.x-/test_is-dark-color_v1.x.x.js
@@ -1,0 +1,31 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import isDarkColor from 'is-dark-color';
+
+describe('is-dark-color', () => {
+  it('works', () => {
+    (isDarkColor('#ffffff'): boolean);
+    isDarkColor('#ffffff', {
+      override: {
+        '#000000': true,
+      },
+    });
+  });
+
+  it('errors', () => {
+    // $FlowExpectedError[incompatible-call]
+    isDarkColor();
+    // $FlowExpectedError[incompatible-call]
+    isDarkColor(123);
+    // $FlowExpectedError[incompatible-cast]
+    (isDarkColor('#ffffff'): string);
+    // $FlowExpectedError[prop-missing]
+    isDarkColor('#ffffff', {
+      random: 'string',
+    });
+    // $FlowExpectedError[prop-missing]
+    isDarkColor('#ffffff', {
+      '#123': 'fail',
+    });
+  });
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/gion/is-dark-color/blob/master/index.d.ts
- Link to GitHub or NPM: https://www.npmjs.com/package/is-dark-color
- Type of contribution: new definition

Other notes:

