### PR TITLE
Removed dup typing. Modified the typing for the rest of multicast

### DIFF
--- a/definitions/npm/rxjs_v6.x.x/flow_v0.104.x-/rxjs_v6.x.x.js
+++ b/definitions/npm/rxjs_v6.x.x/flow_v0.104.x-/rxjs_v6.x.x.js
@@ -2527,20 +2527,16 @@ declare module "rxjs/operators" {
   ): rxjs$UnaryFunction<rxjs$Observable<T>, rxjs$ConnectableObservable<T>>;
 
   declare export function multicast<T>(
-    rxjs$SubjectFactory: () => rxjs$Subject<T>
-  ): rxjs$UnaryFunction<rxjs$Observable<T>, rxjs$ConnectableObservable<T>>;
-
-  declare export function multicast<T>(
-    rxjs$SubjectFactory: () => rxjs$Subject<T>,
+    subjectOrSubjectFactory: rxjs$FactoryOrValue<rxjs$Subject<T>>,
     selector?: rxjs$MonoTypeOperatorFunction<T>
   ): rxjs$MonoTypeOperatorFunction<T>;
 
   declare export function multicast<T, R>(
-    rxjs$SubjectFactory: () => rxjs$Subject<T>
+    subjectOrSubjectFactory: rxjs$FactoryOrValue<rxjs$Subject<T>>, 
   ): rxjs$UnaryFunction<rxjs$Observable<T>, rxjs$ConnectableObservable<R>>;
 
   declare export function multicast<T, R>(
-    rxjs$SubjectFactory: () => rxjs$Subject<T>,
+    subjectOrSubjectFactory: rxjs$FactoryOrValue<rxjs$Subject<T>>,
     selector?: rxjs$OperatorFunction<T, R>
   ): rxjs$OperatorFunction<T, R>;
 


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/ReactiveX/rxjs/blob/6.x/src/internal/operators/multicast.ts#L38
- Link to GitHub or NPM: 
- Type of contribution:  fix  | refactor

Other notes:
Modified the rest of the multicast typing to follow the official code. You are always allowed to pass in a function that returns a subject or just a subject. 

