### PR TITLE
[react-twemoji] Add definition

### DIFF
--- a/definitions/__util__/tdd_framework.js
+++ b/definitions/__util__/tdd_framework.js
@@ -23,4 +23,5 @@
 declare module 'flow-typed-test' {
   declare export function describe(label: string, fn: (...any) => void): void;
   declare export function it(label: string, fn: (...any) => void | Promise<void>): void;
+  declare export function test(label: string, fn: (...any) => void | Promise<void>): void;
 }

--- a/definitions/npm/react-twemoji_v0.5.x/flow_v0.83.x-/react-twemoji_v0.5.x.js
+++ b/definitions/npm/react-twemoji_v0.5.x/flow_v0.83.x-/react-twemoji_v0.5.x.js
@@ -1,0 +1,77 @@
+declare module 'react-twemoji' {
+  /**
+   * If given to parse, this callback will be invoked per each found emoji.
+   *
+   * If this callback returns a falsy value instead of a valid `src` to use for the image, nothing will actually change for that specific emoji.
+   *
+   * @param icon the lower case HEX code point i.e. "1f4a9"
+   * @param options all info for this parsing operation
+   * @param variant the optional \uFE0F ("as image") variant, in case this info is anyhow meaningful. By default this is ignored.
+   */
+  declare type ParseCallback = (icon: string, options: TwemojiOptions, variant: string) => string | false;
+
+  declare type TwemojiOptions = {|
+    /**
+     * Default: MaxCDN
+     */
+    base?: string,
+    /**
+     * Default: .png
+     */
+    ext?: string,
+    /**
+     * Default: emoji
+     */
+    className?: string,
+    /**
+     * Default: 72x72
+     */
+    size?: string | number,
+    /**
+     * To render with SVG use `folder: svg, ext: .svg`
+     */
+    folder?: string,
+    /**
+     * The function to invoke in order to generate image src(s).
+     */
+    callback?: ParseCallback,
+    /**
+     * The function to invoke in order to generate additional, custom attributes for the image tag.
+     * Default () => ({})
+     * @param icon the lower case HEX code point i.e. "1f4a9"
+     * @param variant variant the optional \uFE0F ("as image") variant, in case this info is anyhow meaningful. By default this is ignored.
+     *
+     */
+    attributes?: (icon: string, variant: string) => { ... };
+  |};
+
+  declare type TwemojiProps = {|
+    children?: React$Node,
+
+    /**
+     * When it is true, Twemoji will not render a wrapping element (with tag)
+     * to contain its children. Note that since twemoji.parse needs a DOM element
+     * reference, any direct pure text child of Twemoji is not parsed when
+     * noWrapper is true. E.g. foo in
+     * <Twemoji noWrapper={true}>foo<p>bar</p></Twemoji> is not parsed.
+     */
+    noWrapper?: boolean,
+
+    /**
+     * twemoji.parse options.
+     */
+    options?: TwemojiOptions | ParseCallback,
+
+    /**
+     * The tag of the wrapping element. This option is ignored when noWrapper is
+     * true.
+     */
+    tag?: string,
+  |};
+
+  /**
+   * A simple React wrapper for Twemoji. It calls twemoji.parse() to convert emoji
+   * characters to Twemoji images.
+   */
+  declare module.exports: (props: TwemojiProps) => React$Node;
+}

--- a/definitions/npm/react-twemoji_v0.5.x/flow_v0.83.x-/test_react-twemoji_v0.5.x.js
+++ b/definitions/npm/react-twemoji_v0.5.x/flow_v0.83.x-/test_react-twemoji_v0.5.x.js
@@ -1,0 +1,117 @@
+// @flow
+import { describe, test } from 'flow-typed-test';
+import * as React from 'react';
+import Twemoji from 'react-twemoji';
+
+describe('react-twemoji', () => {
+  test('basic', () => {
+    (): React.Node => (
+      <Twemoji options={{ className: 'twemoji' }}>
+        <p>😂<span>😉</span></p>
+      </Twemoji>
+    );
+  });
+
+  test('all props are optional', () => {
+    (): React.Node => (
+      <Twemoji />
+    );
+  });
+
+  test('props take the right arg if passed', () => {
+    (): React.Node => (
+      <Twemoji
+        noWrapper={false}
+      />
+    );
+
+    (): React.Node => (
+      <Twemoji
+        // $FlowExpectedError[incompatible-type]
+        noWrapper="test"
+      />
+    );
+
+    (): React.Node => (
+      <Twemoji
+        tag="test"
+      />
+    );
+
+    (): React.Node => (
+      <Twemoji
+        // $FlowExpectedError[incompatible-type]
+        tag={true}
+      />
+    );
+
+    // Passing cb function into options
+    (): React.Node => (
+      <Twemoji
+        options={() => {
+          return '';
+        }}
+      />
+    );
+
+    (): React.Node => (
+      <Twemoji
+        options={() => {
+          return false;
+        }}
+      />
+    );
+
+    (): React.Node => (
+      <Twemoji
+        options={() => {
+          // $FlowExpectedError[incompatible-type]
+          return true;
+        }}
+      />
+    );
+    // ========================
+
+    // Passing object into options
+    (): React.Node => (
+      <Twemoji
+        options={{
+          base: 'test',
+          ext: 'test',
+          className: 'test',
+          size: 'test',
+          folder: 'test',
+          callback: () => 'test',
+          attributes: () => ({}),
+        }}
+      />
+    );
+
+    (): React.Node => (
+      <Twemoji
+        options={{
+          size: 123,
+        }}
+      />
+    );
+
+    (): React.Node => (
+      <Twemoji
+        // $FlowExpectedError[incompatible-type]
+        options={{
+          size: true,
+        }}
+      />
+    );
+
+    (): React.Node => (
+      <Twemoji
+        // $FlowExpectedError[incompatible-type]
+        options={{
+          foo: 'bar',
+        }}
+      />
+    );
+    // ========================
+  });
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-twemoji/index.d.ts
- Link to GitHub or NPM: https://www.npmjs.com/package/react-twemoji
- Type of contribution: new definition

Other notes: Additional props for typeof `options` are from https://github.com/twitter/twemoji/blob/master/index.d.ts#L87

- I've also added new `test` function to test utils so that test cases can read better depending on test. This exists in basic unit test frameworks too https://jestjs.io/docs/api#testname-fn-timeout

