### PR TITLE
[react-redux] Add v8 definitions

### DIFF
--- a/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/test_useSelector.js
+++ b/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/test_useSelector.js
@@ -11,8 +11,11 @@ type State = {|
 describe('useSelector', () => {
   it('passes State as first parameter', () => {
     function Com() {
-      // $FlowExpectedError[prop-missing]: the state has no `b`
-      const count = useSelector<State, number>(state => state.b);
+      // $FlowExpectedError[incompatible-call]
+      const count = useSelector<State, number>(state => {
+        // $FlowExpectedError[prop-missing]: the state has no `b`
+        state.b
+      });
       return <div>{count}</div>;
     }
   });

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/react-redux_v8.x.x.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/react-redux_v8.x.x.js
@@ -26,7 +26,6 @@ Decrypting the abbreviations:
   Com = React Component
   SS = Selected state
   ST = Static properties of Com
-  EFO = Extra factory options (used only in connectAdvanced)
 */
 
 declare module "react-redux" {
@@ -224,63 +223,6 @@ declare module "react-redux" {
     subKey?: string,
   ): Class<Provider<*>>;
 
-  // ------------------------------------------------------------
-  // Typings for connectAdvanced()
-  // ------------------------------------------------------------
-
-  declare type ConnectAdvancedOptions = {
-    getDisplayName?: (name: string) => string,
-    methodName?: string,
-    renderCountProp?: string,
-    shouldHandleStateChanges?: boolean,
-    storeKey?: string,
-    forwardRef?: boolean,
-    ...
-  };
-
-  declare type SelectorFactoryOptions<Com> = {
-    getDisplayName: (name: string) => string,
-    methodName: string,
-    renderCountProp: ?string,
-    shouldHandleStateChanges: boolean,
-    storeKey: string,
-    forwardRef: boolean,
-    displayName: string,
-    wrappedComponentName: string,
-    WrappedComponent: Com,
-    ...
-  };
-
-  declare type MapStateToPropsEx<S: Object, SP: Object, RSP: Object> = (
-    state: S,
-    props: SP,
-  ) => RSP;
-
-  declare type SelectorFactory<
-    Com: React$ComponentType<*>,
-    Dispatch,
-    S: Object,
-    OP: Object,
-    EFO: Object,
-    CP: Object,
-  > = (
-    dispatch: Dispatch,
-    factoryOptions: SelectorFactoryOptions<Com> & EFO,
-  ) => MapStateToPropsEx<S, OP, CP>;
-
-  declare export function connectAdvanced<
-    Com: React$ComponentType<*>,
-    D,
-    S: Object,
-    OP: Object,
-    CP: Object,
-    EFO: Object,
-    ST: { [_: $Keys<Com>]: any, ... },
-  >(
-    selectorFactory: SelectorFactory<Com, D, S, OP, EFO, CP>,
-    connectAdvancedOptions: ?(ConnectAdvancedOptions & EFO),
-  ): (component: Com) => React$ComponentType<OP> & $Shape<ST>;
-
   declare export function batch(() => void): void
 
   declare export function shallowEqual<T>(left: T, right: any): boolean
@@ -289,7 +231,6 @@ declare module "react-redux" {
     Provider: typeof Provider,
     createProvider: typeof createProvider,
     connect: typeof connect,
-    connectAdvanced: typeof connectAdvanced,
     useDispatch: typeof useDispatch,
     useSelector: typeof useSelector,
     useStore: typeof useStore,

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/react-redux_v8.x.x.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/react-redux_v8.x.x.js
@@ -1,0 +1,299 @@
+/**
+The order of type arguments for connect() is as follows:
+
+connect<Props, OwnProps, StateProps, DispatchProps, State, Dispatch>(…)
+
+In Flow v0.89 only the first two are mandatory to specify. Other 4 can be repaced with the new awesome type placeholder:
+
+connect<Props, OwnProps, _, _, _, _>(…)
+
+But beware, in case of weird type errors somewhere in random places
+just type everything and get to a green field and only then try to
+remove the definitions you see bogus.
+
+Decrypting the abbreviations:
+  WC = Component being wrapped
+  S = State
+  D = Dispatch
+  OP = OwnProps
+  SP = StateProps
+  DP = DispatchProps
+  MP = Merge props
+  RSP = Returned state props
+  RDP = Returned dispatch props
+  RMP = Returned merge props
+  CP = Props for returned component
+  Com = React Component
+  SS = Selected state
+  ST = Static properties of Com
+  EFO = Extra factory options (used only in connectAdvanced)
+*/
+
+declare module "react-redux" {
+  // ------------------------------------------------------------
+  // Typings for connect()
+  // ------------------------------------------------------------
+
+  declare export type Options<S, OP, SP, MP> = {|
+    pure?: boolean,
+    forwardRef?: boolean,
+    areStatesEqual?: (next: S, prev: S) => boolean,
+    areOwnPropsEqual?: (next: OP, prev: OP) => boolean,
+    areStatePropsEqual?: (next: SP, prev: SP) => boolean,
+    areMergedPropsEqual?: (next: MP, prev: MP) => boolean,
+    storeKey?: string,
+  |};
+
+  declare type MapStateToProps<-S, -OP, +SP> =
+    | ((state: S, ownProps: OP) => SP)
+    // If you want to use the factory function but get a strange error
+    // like "function is not an object" then just type the factory function
+    // like this:
+    // const factory: (State, OwnProps) => (State, OwnProps) => StateProps
+    // and provide the StateProps type to the SP type parameter.
+    | ((state: S, ownProps: OP) => (state: S, ownProps: OP) => SP);
+
+  declare type Bind<D> = <A, R>((...A) => R) => (...A) => $Call<D, R>;
+
+  declare type MapDispatchToPropsFn<D, -OP, +DP> =
+    | ((dispatch: D, ownProps: OP) => DP)
+    // If you want to use the factory function but get a strange error
+    // like "function is not an object" then just type the factory function
+    // like this:
+    // const factory: (Dispatch, OwnProps) => (Dispatch, OwnProps) => DispatchProps
+    // and provide the DispatchProps type to the DP type parameter.
+    | ((dispatch: D, ownProps: OP) => (dispatch: D, ownProps: OP) => DP);
+
+  declare class ConnectedComponent<OP, +WC> extends React$Component<OP> {
+    static +WrappedComponent: WC;
+    getWrappedInstance(): React$ElementRef<WC>;
+  }
+  // The connection of the Wrapped Component and the Connected Component
+  // happens here in `MP: P`. It means that type wise MP belongs to P,
+  // so to say MP >= P.
+  declare type Connector<P, OP, MP: P> = <WC: React$ComponentType<P>>(
+    WC,
+  ) => Class<ConnectedComponent<OP, WC>> & WC;
+
+  // No `mergeProps` argument
+
+  // Got error like inexact OwnProps is incompatible with exact object type?
+  // Just make the OP parameter for `connect()` an exact object.
+  declare type MergeOP<OP, D> = {| ...$Exact<OP>, dispatch: D |};
+  declare type MergeOPSP<OP, SP, D> = {| ...$Exact<OP>, ...SP, dispatch: D |};
+  declare type MergeOPDP<OP, DP> = {| ...$Exact<OP>, ...DP |};
+  declare type MergeOPSPDP<OP, SP, DP> = {| ...$Exact<OP>, ...SP, ...DP |};
+
+  declare export function connect<-P, -OP, -SP, -DP, -S, -D>(
+    mapStateToProps?: null | void,
+    mapDispatchToProps?: null | void,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOP<OP, D>>,
+  ): Connector<P, OP, MergeOP<OP, D>>;
+
+  declare export function connect<-P, -OP, -SP, -DP, -S, -D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps?: null | void,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, MergeOPSP<OP, SP, D>>,
+  ): Connector<P, OP, MergeOPSP<OP, SP, D>>;
+
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOPDP<OP, DP>>,
+  ): Connector<P, OP, MergeOPDP<OP, DP>>;
+
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: DP,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOPDP<OP, DP>>,
+  ): Connector<P, OP, MergeOPDP<OP, $ObjMap<DP, Bind<D>>>>;
+
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, {| ...OP, ...SP, ...DP |}>,
+  ): Connector<P, OP, {| ...OP, ...SP, ...DP |}>;
+
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: DP,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, MergeOPSPDP<OP, SP, DP>>,
+  ): Connector<P, OP, MergeOPSPDP<OP, SP, $ObjMap<DP, Bind<D>>>>;
+
+  // With `mergeProps` argument
+
+  declare type MergeProps<+P, -OP, -SP, -DP> = (
+    stateProps: SP,
+    dispatchProps: DP,
+    ownProps: OP,
+  ) => P;
+
+  declare export function connect<-P, -OP, -SP: {||}, -DP: {||}, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: null | void,
+    // If you get error here try adding return type to you mapStateToProps function
+    mergeProps: MergeProps<P, OP, {||}, {| dispatch: D |}>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
+
+  declare export function connect<-P, -OP, -SP, -DP: {||}, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: null | void,
+    // If you get error here try adding return type to you mapStateToProps function
+    mergeProps: MergeProps<P, OP, SP, {| dispatch: D |}>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP: {||}, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps: MergeProps<P, OP, {||}, DP>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP: {||}, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: DP,
+    mergeProps: MergeProps<P, OP, {||}, $ObjMap<DP, Bind<D>>>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps: MergeProps<P, OP, SP, DP>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: DP,
+    mergeProps: MergeProps<P, OP, SP, $ObjMap<DP, Bind<D>>>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
+
+  // ------------------------------------------------------------
+  // Typings for Hooks
+  // ------------------------------------------------------------
+
+  declare export function useDispatch<D>(): D;
+
+  declare export function useSelector<S, SS>(
+    selector: (state: S) => SS,
+    equalityFn?: (a: SS, b: SS) => boolean,
+  ): SS;
+
+  declare export function useStore<Store>(): Store;
+
+  // ------------------------------------------------------------
+  // Typings for Provider
+  // ------------------------------------------------------------
+
+  declare export class Provider<Store> extends React$Component<{
+    store: Store,
+    children?: React$Node,
+    ...
+  }> {}
+
+  declare export function createProvider(
+    storeKey?: string,
+    subKey?: string,
+  ): Class<Provider<*>>;
+
+  // ------------------------------------------------------------
+  // Typings for connectAdvanced()
+  // ------------------------------------------------------------
+
+  declare type ConnectAdvancedOptions = {
+    getDisplayName?: (name: string) => string,
+    methodName?: string,
+    renderCountProp?: string,
+    shouldHandleStateChanges?: boolean,
+    storeKey?: string,
+    forwardRef?: boolean,
+    ...
+  };
+
+  declare type SelectorFactoryOptions<Com> = {
+    getDisplayName: (name: string) => string,
+    methodName: string,
+    renderCountProp: ?string,
+    shouldHandleStateChanges: boolean,
+    storeKey: string,
+    forwardRef: boolean,
+    displayName: string,
+    wrappedComponentName: string,
+    WrappedComponent: Com,
+    ...
+  };
+
+  declare type MapStateToPropsEx<S: Object, SP: Object, RSP: Object> = (
+    state: S,
+    props: SP,
+  ) => RSP;
+
+  declare type SelectorFactory<
+    Com: React$ComponentType<*>,
+    Dispatch,
+    S: Object,
+    OP: Object,
+    EFO: Object,
+    CP: Object,
+  > = (
+    dispatch: Dispatch,
+    factoryOptions: SelectorFactoryOptions<Com> & EFO,
+  ) => MapStateToPropsEx<S, OP, CP>;
+
+  declare export function connectAdvanced<
+    Com: React$ComponentType<*>,
+    D,
+    S: Object,
+    OP: Object,
+    CP: Object,
+    EFO: Object,
+    ST: { [_: $Keys<Com>]: any, ... },
+  >(
+    selectorFactory: SelectorFactory<Com, D, S, OP, EFO, CP>,
+    connectAdvancedOptions: ?(ConnectAdvancedOptions & EFO),
+  ): (component: Com) => React$ComponentType<OP> & $Shape<ST>;
+
+  declare export function batch(() => void): void
+
+  declare export function shallowEqual<T>(left: T, right: any): boolean
+
+  declare export default {
+    Provider: typeof Provider,
+    createProvider: typeof createProvider,
+    connect: typeof connect,
+    connectAdvanced: typeof connectAdvanced,
+    useDispatch: typeof useDispatch,
+    useSelector: typeof useSelector,
+    useStore: typeof useStore,
+    batch: typeof batch,
+    ...
+  };
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/react-redux_v8.x.x.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/react-redux_v8.x.x.js
@@ -34,7 +34,6 @@ declare module "react-redux" {
   // ------------------------------------------------------------
 
   declare export type Options<S, OP, SP, MP> = {|
-    pure?: boolean,
     forwardRef?: boolean,
     areStatesEqual?: (next: S, prev: S) => boolean,
     areOwnPropsEqual?: (next: OP, prev: OP) => boolean,

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_Provider.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_Provider.js
@@ -1,0 +1,55 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+
+import React from "react";
+import { Provider, createProvider } from "react-redux";
+
+describe('Provider', () => {
+  it('should give an error when the store is missing', () => {
+    // $FlowExpectedError[prop-missing]
+    <Provider />;
+
+    // Also for custom providers
+    const CustomProvider: Class<Provider<*>> = createProvider("ikea");
+
+    // $FlowExpectedError[prop-missing]
+    <CustomProvider />;
+  });
+});
+
+describe('Custom Store (eg for ThunkActions)', () => {
+
+  // This represents a common typing for Thunk Actions.
+
+  type Action = { type: 'SOME_ACTION', ... };
+  type State = { state: string, ... };
+
+  // ReduxStore should be imported from 'redux' but we can't do this with this
+  // test environment, so let's copy them once again...
+  declare type Redux$DispatchAPI<A> = (action: A) => A;
+  declare type Redux$Dispatch<A: { type: string, ... }> = Redux$DispatchAPI<A>;
+  declare type Redux$Reducer<S, A> = (state: S | void, action: A) => S;
+  declare type Redux$Store<S, A, D = Redux$Dispatch<A>> = {
+    dispatch: D,
+    getState(): S,
+    subscribe(listener: () => void): () => void,
+    replaceReducer(nextReducer: Redux$Reducer<S, A>): void,
+    ...
+  };
+
+  // R = Result of a thunk action
+  type ThunkDispatch = <R>(action: ThunkAction<R>) => R;
+  type PlainDispatch = (action: Action) => Action;
+  type GetState = () => State;
+  type ThunkAction<R> = (dispatch: Dispatch, GetState) => R;
+  // The `dispatch` function can accept either a plain action or a thunk action.
+  // This is similar to a type `(action: Action | ThunkAction) => any` except this
+  // allows to type the return value as well.
+  type Dispatch = PlainDispatch & ThunkDispatch;
+  type Store = Redux$Store<State, Action, Dispatch>;
+
+  it('accepts a custom store', () => {
+    declare var store: Store;
+    <Provider store={store} />;
+  });
+});

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_batch.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_batch.js
@@ -1,0 +1,27 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import { batch } from 'react-redux';
+
+describe('batch', () => {
+  it('should accept a function as an argument', () => {
+    batch(() => {
+      // ...
+    })
+  });
+
+  it('should not allow a values that is not a function as an argument', () => {
+    //$FlowExpectedError[incompatible-call] - only a function is allowed
+    batch(true)
+  });
+
+  it('returns void', () => {
+    (batch(() => {
+      // ...
+    }): void)
+
+    batch(() => {
+      //$FlowExpectedError[incompatible-call] - function must return void
+      return true;
+    })
+  });
+});

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connect.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connect.js
@@ -597,11 +597,11 @@ function testOptions() {
     }
   }
   // here in Props comes dispatch property
-  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {pure: true})(Com));
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {storeKey: 'test'})(Com));
   e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {forwardRef: true})(Com));
-  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {pure: false, forwardRef: false})(Com));
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {storeKey: 'test', forwardRef: false})(Com));
   // $FlowExpectedError[incompatible-call] wrong type
-  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {pure: 123})(Com));
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {storeKey: 123})(Com));
   // $FlowExpectedError[incompatible-call] wrong type
   e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {ref: 123})(Com));
   // $FlowExpectedError[incompatible-call] wrong key

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connect.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connect.js
@@ -1,0 +1,779 @@
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+export let e: Array<any> = []
+
+function testPassingPropsToConnectedComponent() {
+  type OwnProps = {|
+    passthrough: number,
+    passthroughWithDefaultProp?: number,
+    forMapStateToProps: string
+  |}
+  type Props = {
+    ...OwnProps,
+    fromStateToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    static defaultProps = { passthroughWithDefaultProp: 123 };
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = { a: number, ... };
+  type InputProps = { forMapStateToProps: string, ... };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  Connected.WrappedComponent;
+  <Connected passthrough={123} forMapStateToProps={'data'} passthroughWithDefaultProp={123}/>;
+  // OK without passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for passthrough
+  <Connected passthrough={''} forMapStateToProps={'data'} passthroughWithDefaultProp={123}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321} passthroughWithDefaultProp={123}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for  passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'} passthroughWithDefaultProp={''}/>;
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError[incompatible-call] takes in only React components
+  const Connected2 = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)('');
+  e.push(Connected2);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck1case() {
+  type Props = { stringProp: string, ... };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = (state: {...}) => ({
+    stringProp: false,
+  });
+
+  //$FlowExpectedError[incompatible-type-arg] wrong type for stringProp
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps)(Component);
+  <Connected />;
+  e.push(Connected);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck2case() {
+  type Props = { numProp: string, ... };
+
+  const Component = ({ numProp }: Props) => {
+    return <span>{numProp}</span>;
+  };
+
+  const mapDispatchToProps = () => ({
+    numProp: false,
+  });
+
+  //$FlowExpectedError[incompatible-type-arg] wrong type for numProp
+  const Connected = connect<Props, {||}, _,_,_,_>(null, mapDispatchToProps)(Component);
+  <Connected />;
+  e.push(Connected);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck3case() {
+  type Props = {
+    stringProp: string,
+    numProp: number,
+    ...
+  };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = (state: {...}) => ({
+    stringProp: false,
+  });
+
+  const mapDispatchToProps = () => ({
+    numProp: false,
+  });
+
+  //$FlowExpectedError[incompatible-call] wrong type for stringProp
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps, mapDispatchToProps)(Component);
+  <Connected />;
+  e.push(Connected);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck4case() {
+  type Props = { stringProp: string, ... };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = (state: {...}) => ({
+    stringProp: false,
+  });
+
+  //$FlowExpectedError[incompatible-call] wrong type for stringProp
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps, {})(Component);
+  <Connected />;
+  e.push(Connected);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck5case() {
+  type Props = { stringProp: string, ... };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = () => ({});
+  const mapDispatchToProps = () => ({});
+
+  const mergeProps = () => ({
+    stringProp: true
+  });
+
+  //$FlowExpectedError[incompatible-call] wrong type for stringProp
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps, mapDispatchToProps, mergeProps)(Component);
+  <Connected />;
+  e.push(Connected);
+}
+
+function testExactProps() {
+  type Dispatch = () => void;
+  type OwnProps = {|
+    passthrough: number,
+    forMapStateToProps: string,
+  |};
+  type Props = {|
+    ...OwnProps,
+    fromStateToProps: string,
+    dispatch: Dispatch,
+  |};
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = { a: number, ... };
+  type InputProps = {|
+    forMapStateToProps: string,
+    passthrough: number,
+  |};
+
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect<Props, OwnProps,_,_,_,Dispatch>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] extraProp what exact props does not allow
+  <Connected passthrough={123} forMapStateToProps={321} extraProp={123}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321}/>;
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError[incompatible-call] takes in only React components
+  const Connected2 = connect<Props, OwnProps,_,_,_,Dispatch>(mapStateToProps)('');
+  e.push(Connected2);
+}
+
+function testInexactOwnProps() {
+  type OwnProps = {
+    passthrough: number,
+    forMapStateToProps: string,
+    ...
+  };
+  type Props = {
+    // to eliminate the cripy `undefined`
+    ...$Exact<OwnProps>,
+    fromStateToProps: string,
+    ...
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = { a: number, ... };
+  type InputProps = {
+    forMapStateToProps: string,
+    passthrough: number,
+    ...
+  };
+
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] extraProp what exact props does not allow
+  <Connected passthrough={123} forMapStateToProps={321} extraProp={123}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321}/>;
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError[incompatible-call] takes in only React components
+  const Connected2 = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)('');
+  e.push(Connected2);
+}
+
+function testWithStatelessFunctionalComponent() {
+  type OwnProps = {|
+    passthrough: number,
+    forMapStateToProps: string,
+  |};
+  type Props = {
+    ...OwnProps,
+    fromStateToProps: string,
+    ...
+  };
+  const Com = (props: Props) => <div>{props.passthrough} {props.fromStateToProps}</div>
+
+  type State = { a: number, ... };
+  type InputProps = { forMapStateToProps: string, ... };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for passthrough
+  <Connected passthrough={''} forMapStateToProps={'data'}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321} />;
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError[incompatible-call] takes in only React components
+  const Connected2 = connect(mapStateToProps)('');
+  e.push(Connected2);
+}
+
+function testMapStateToPropsDoesNotNeedProps() {
+  type OwnProps = {|
+    passthrough: number
+  |};
+  type Props = {
+    ...OwnProps,
+    fromStateToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+
+  type State = { a: string, ... }
+  const mapStateToProps = (state: State) => {
+    return {
+      fromStateToProps: state.a
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError[incompatible-use] component property passthrough not found
+  <Connected />;
+}
+
+function testMapDispatchToProps() {
+  type OwnProps = {|
+    passthrough: number,
+    forMapStateToProps: string,
+    forMapDispatchToProps: string
+  |};
+  type Props = {
+    ...OwnProps,
+    fromMapDispatchToProps: string,
+    fromMapStateToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.passthrough}
+        {this.props.fromMapDispatchToProps}
+        {this.props.fromMapStateToProps}
+        </div>;
+    }
+  }
+
+  type State = { a: number, ... }
+  type MapStateToPropsProps = { forMapStateToProps: string, ... }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: 'str' + state.a
+    }
+  }
+  type MapDispatchToPropsProps = { forMapDispatchToProps: string, ... }
+  const mapDispatchToProps = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected passthrough={123} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] forMapDispatchToProps missing
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+}
+
+function testMapDispatchToPropsDoesNotPassDispatch() {
+  type Dispatch = () => void;
+  type OwnProps = {||};
+  type Props = {| ...OwnProps, fromMapDispatchToProps: string, dispatch: Dispatch |};
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.fromMapDispatchToProps}</div>;
+    }
+  }
+
+  const mapStateToProps = (state: *, props: *) => ({})
+  const mapDispatchToProps = (dispatch: *, ownProps: *) => {
+    return {fromMapDispatchToProps: 'yo'}
+  }
+  // $FlowExpectedError[prop-missing] dispatch should not be provided in Props when mapDispatchToProps is present
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(mapStateToProps, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function testMapDispatchToPropsWithoutMapStateToProps() {
+  type OwnProps = {|
+    passthrough: number,
+    forMapStateToProps: string,
+    forMapDispatchToProps: string,
+  |};
+  type Props = {
+    ...OwnProps,
+    fromMapDispatchToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.passthrough}
+        {this.props.fromMapDispatchToProps}
+      </div>;
+    }
+  }
+
+  type MapDispatchToPropsProps = { forMapDispatchToProps: string, ... };
+  const mapDispatchToProps = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const Connected = connect<Props, OwnProps, _,_,_,_>(null, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] forMapDispatchToProps missing
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+}
+
+function testMapDispatchToPropsPassesActionCreators() {
+  type OwnProps = {|
+    passthrough: number,
+  |};
+  type Props = {
+    ...OwnProps,
+    dispatch1: (num: number) => void,
+    dispatch2: () => void,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+
+  const mapDispatchToProps = {
+    dispatch1: (num: number) => {},
+    dispatch2: () => {}
+  };
+  const Connected = connect<Props, OwnProps, _,_,_,_>(null, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError[incompatible-use] no passthrough
+  <Connected/>;
+
+  const mapDispatchToPropsWithoutDispatch2 = {
+    dispatch1: (num: number) => {}
+  };
+  //$FlowExpectedError[prop-missing] no dispatch2
+  const Connected2 = connect<Props, OwnProps, _,_,_,_>(null, mapDispatchToPropsWithoutDispatch2)(Com);
+  e.push(Connected2);
+  <Connected2 passthrough={123}/>;
+
+  const mapDispatchToPropsWithWrongDispatch1 = {
+    dispatch1: (num: string) => {},
+    dispatch2: () => {}
+  };
+  //$FlowExpectedError[invalid-obj-map] dispatch1 should be number
+  const Connected3 = connect<Props, OwnProps, _,_,_,_>(null, mapDispatchToPropsWithWrongDispatch1)(Com);
+  e.push(Connected3);
+  <Connected3 passthrough={123}/>;
+}
+
+function testMapDispatchToPropsPassesActionCreatorsWithMapStateToProps() {
+  type OwnProps = {|
+    passthrough: number,
+    forMapStateToProps: string
+  |};
+  type Props = {
+    ...OwnProps,
+    dispatch1: () => void,
+    dispatch2: () => void,
+    fromMapStateToProps: number,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+  type State = { a: number, ... }
+  type MapStateToPropsProps = { forMapStateToProps: string, ... }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  const mapDispatchToProps = {
+    dispatch1: () => {},
+    dispatch2: () => {}
+  };
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps="str"/>;
+  //$FlowExpectedError[incompatible-use] no passthrough
+  <Connected forMapStateToProps="str" />;
+
+  const mapDispatchToProps2 = {
+    dispatch1: () => {}
+  };
+  //$FlowExpectedError[prop-missing] no dispatch2
+  const Connected2 = connect<Props, OwnProps, _,_,_,_>(mapStateToProps, mapDispatchToProps2)(Com);
+  e.push(Connected2);
+  <Connected2 passthrough={123} forMapStateToProps="str"/>;
+}
+
+function testMapDispatchToPropsPassesActionCreatorsWithMapStateToPropsAndMergeProps() {
+  type OwnProps1 = {|
+    passthrough: number,
+    forMapStateToProps: string,
+    forMergeProps: number
+  |};
+  type OwnProps2 = {|
+    passthrough: number,
+    forMapStateToProps: string,
+  |};
+  type Props = {
+    passthrough: number,
+    dispatch1: () => void,
+    dispatch2: () => void,
+    fromMapStateToProps: number,
+    fromMergeProps: number,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+  type State = { a: number, ... }
+  type MapStateToPropsProps = { forMapStateToProps: string, ... }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  const mapDispatchToProps = {
+    dispatch1: () => {},
+    dispatch2: () => {}
+  };
+  const mergeProps = (stateProps, dispatchProps, ownProps: { forMergeProps: number, ... }) => {
+    return Object.assign({}, stateProps, dispatchProps, { fromMergeProps: 123 });
+  }
+  const Connected = connect<Props, OwnProps1, _,_,_,_>(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps="str" forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] no passthrough
+  <Connected forMapStateToProps="str" forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMergeProps is missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] forMergeProps is wrong type
+  <Connected forMapStateToProps={'data'} forMergeProps={'not number'} />;
+
+  const mapDispatchToProps2 = {
+    dispatch1: () => {}
+  };
+  //$FlowExpectedError[prop-missing] no dispatch2
+  const Connected2 = connect<Props, OwnProps2, _,_,_,_>(mapStateToProps, mapDispatchToProps2)(Com);
+  e.push(Connected2);
+  <Connected2 passthrough={123} forMapStateToProps="str"/>;
+}
+
+function testMergeProps() {
+  type OwnProps = {|
+    forMapStateToProps: string,
+    forMapDispatchToProps: string,
+    forMergeProps: number
+  |};
+  type Props = { fromMergeProps: number, ... };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.fromMergeProps}
+      </div>;
+    }
+  }
+
+  type State = { a: number, ... }
+  type MapStateToPropsProps = { forMapStateToProps: string, ... }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  type MapDispatchToPropsProps = { forMapDispatchToProps: string, ... }
+  const mapDispatchToProps = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const mergeProps = (stateProps, dispatchProps, ownProps: { forMergeProps: number, ... }) => {
+    return {fromMergeProps: 123};
+  }
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
+  e.push(Connected);
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected forMapDispatchToProps={'more data'} forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMergeProps is missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] forMapDispatchToProps is missing
+  <Connected forMapStateToProps={'data'} forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMapDispatchToProps is wrong type
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} forMergeProps={'not number'} />;
+}
+
+function testOptions() {
+  class Com extends React.Component<{...}> {
+    render() {
+      return <div></div>;
+    }
+  }
+  // here in Props comes dispatch property
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {pure: true})(Com));
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {forwardRef: true})(Com));
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {pure: false, forwardRef: false})(Com));
+  // $FlowExpectedError[incompatible-call] wrong type
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {pure: 123})(Com));
+  // $FlowExpectedError[incompatible-call] wrong type
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {ref: 123})(Com));
+  // $FlowExpectedError[incompatible-call] wrong key
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {wrongKey: true})(Com));
+}
+
+function testDispatch() {
+  type Props = { dispatch: empty => empty, ... }
+  class Com extends React.Component<Props> {
+    render() {
+      return <div></div>;
+    }
+  }
+  e.push(connect<Props, {||}, _,_,_,_>()(Com));
+}
+function testNoDispatch() {
+  type Props = {||}
+  class Com extends React.Component<Props> {
+    render() {
+      return <div></div>;
+    }
+  }
+  // $FlowExpectedError[prop-missing] property `dispatch` is missing in `Props`
+  e.push(connect<Props, {||}, _,_,_,_>()(Com));
+}
+
+function testHoistConnectedComponent() {
+  type OwnProps = {|
+    passthrough: number,
+    passthroughWithDefaultProp?: number,
+    forMapStateToProps: string
+  |};
+  type Props = {
+    ...OwnProps,
+    fromStateToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    static defaultProps = { passthroughWithDefaultProp: 123 };
+    static myStatic = 1;
+
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = { a: number, ... };
+  type InputProps = { forMapStateToProps: string, ... };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  // OK without passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  // OK with passthroughWithDefaultProp
+  <Connected passthrough={123} passthroughWithDefaultProp={456} forMapStateToProps={'data'}/>;
+  // OK with declared static property
+  Connected.myStatic;
+}
+
+function itsOkToReturnMoreThanNeededPropsFromMapStateToProps() {
+  type Props = { stringProp: string, ... };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  // This is actually required to reproduce an issue with Flow and the `*` type.
+  function getBoolean() {
+    return false;
+  }
+
+  const mapStateToProps = () => ({
+    stringProp: 'foo',
+    numProp: getBoolean()
+  });
+
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps)(Component);
+  <Connected />;
+  e.push(Connected)
+}
+
+function doesNotRequireDefinedComponentToTypeCheck2case() {
+  type Props = {
+    stringProp: string,
+    numProp: number,
+    ...
+  };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  // This is actually required to reproduce an issue with Flow and the `*` type.
+  function getBoolean() {
+    //$FlowExpectedError[incompatible-return] boolean [1] is incompatible with number [2]
+    return false;
+  }
+
+  const mapStateToProps = () => ({
+    stringProp: 'foo',
+    numProp: getBoolean()
+  });
+
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps)(Component);
+  <Connected />;
+  e.push(Connected)
+}
+
+function checkIfStateTypeIsRespectedAgain() {
+  type State = {
+  num: number, ... };
+
+  const mapStateToProps = (state: State) => {
+    return {
+      str: state.num
+    }
+  };
+
+  type Props = { str: string, ... };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  //$FlowExpectedError[incompatible-type-arg] number [1] is incompatible with string [2] in property `str`
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps)(Com);
+  <Connected />;
+  e.push(Connected);
+}
+
+function testPassingDispatchPropWithoutDispatchFunction() {
+  type Dispatch = () => void;
+  type OwnProps = {||}
+  type Props = {| ...OwnProps, dispatch: Dispatch |};
+  class Com extends React.Component<Props> {
+    render() {
+      return <div />;
+    }
+  }
+
+  type State = { a: number, ... };
+  type InputProps = {...};
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {}
+  };
+
+  const Connected = connect<Props, OwnProps,_,_,_,Dispatch>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function testPassingDispatchTypeIsPassedThrough() {
+  type Dispatch = () => void;
+  type OwnProps = {||}
+  type Props = {| ...OwnProps, dispatch: string |};
+  class Com extends React.Component<Props> {
+    render() {
+      return <div />;
+    }
+  }
+
+  const mapStateToProps = (state: *, props: *) => ({});
+
+  // $FlowExpectedError[incompatible-type-arg] dispatch mismatched from type Dispatch
+  const Connected = connect<Props, OwnProps,_,_,_,Dispatch>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connectDispatch.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connectDispatch.js
@@ -1,0 +1,105 @@
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+export let e: Array<any> = []
+
+function object_sameDispatchIsOK() {
+  type Action1 = {|
+    type: string
+  |};
+  type Dispatch1 = Action1 => Action1;
+  const action1 = (): Action1 => ({ type: 'str' })
+  const mapDispatchToProps = {
+    action1
+  };
+
+  type Props = { action1: typeof action1, ... };
+  class Com extends React.Component<Props> {}
+
+  const Connected1 = connect<Props, {||}, _,_,_,Dispatch1>(null, mapDispatchToProps)(Com);
+  e.push(Connected1);
+  <Connected1 />;
+}
+
+function object_differentDispatchesAreNotOK() {
+  type Action1 = {|
+    type: string
+  |};
+  type Dispatch1 = Action1 => Action1;
+  const action1 = (): Action1 => ({ type: 'str' })
+  const mapDispatchToProps = {
+    action1
+  };
+
+  type Action2 = {|
+    type: number
+  |};
+  type Dispatch2 = Action2 => Action2;
+
+  type Props = { action1: typeof action1, ... };
+  class Com extends React.Component<Props> {}
+
+  const Connected1 = connect<Props, {||}, _,_,_,Dispatch1>(null, mapDispatchToProps)(Com);
+  e.push(Connected1);
+  <Connected1 />;
+
+  //$FlowExpectedError[invalid-obj-map] `string` is incompatible with `number` in property `type`
+  const Connected2 = connect<Props, {||}, _,_,_,Dispatch2>(null, mapDispatchToProps)(Com);
+  e.push(Connected2);
+  <Connected2 />;
+}
+
+function function_sameDispatchIsOK() {
+  type Action1 = {|
+    type: string
+  |};
+  type Dispatch1 = Action1 => Action1;
+  const action1 = (): Action1 => ({ type: 'str' });
+  type DispatchProps = {|
+    action1: () => Action1
+  |};
+  type MapDispatchToPropsFn = Dispatch1 => DispatchProps;
+  const mapDispatchToProps: MapDispatchToPropsFn = (dispatch: Dispatch1) => ({
+    action1: (...args) => dispatch(action1(...args))
+  });
+
+  type Props = { action1: typeof action1, ... };
+  class Com extends React.Component<Props> {}
+
+  const Connected1 = connect<Props, {||}, _,DispatchProps,_,Dispatch1>(null, mapDispatchToProps)(Com);
+  e.push(Connected1);
+  <Connected1 />;
+}
+
+function function_differentDispatchesAreNotOK() {
+  type Action1 = {|
+    type: string
+  |};
+  type Dispatch1 = Action1 => Action1;
+  const action1 = (): Action1 => ({ type: 'str' });
+  type DispatchProps = {|
+    action1: () => Action1
+  |};
+  type MapDispatchToPropsFn = Dispatch1 => DispatchProps;
+  const mapDispatchToProps: MapDispatchToPropsFn = (dispatch: Dispatch1) => ({
+    action1: (...args) => dispatch(action1(...args))
+  });
+
+  type Action2 = {|
+    type: number
+  |};
+  type Dispatch2 = Action2 => Action2;
+
+  type Props = { action1: typeof action1, ... };
+  class Com extends React.Component<Props> {}
+
+  const Connected1 = connect<Props, {||}, _,DispatchProps,_,Dispatch1>(null, mapDispatchToProps)(Com);
+  e.push(Connected1);
+  <Connected1 />;
+
+  //$FlowExpectedError[incompatible-call] `string` is incompatible with `number` in property `type`
+  const Connected2 = connect<Props, {||}, _,DispatchProps,_,Dispatch2>(null, mapDispatchToProps)(Com);
+  e.push(Connected2);
+  <Connected2 />;
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connectHOC.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connectHOC.js
@@ -1,0 +1,172 @@
+// @flow
+import * as React from "react";
+import { connect } from "react-redux";
+
+export let e: Array<any> = [];
+
+function checkSimplePropertyInjection() {
+  type OwnProps = {
+    foo: number,
+    bar: string,
+    ...
+  };
+  type Props = {
+    ...OwnProps,
+    foo: number,
+    ...
+  };
+  const mapStateToProps = () => ({ foo: 5 });
+
+  class Com extends React.Component<Props> {}
+
+  const Connected = connect<Props, OwnProps, _, _, _, _>(mapStateToProps)(Com);
+
+  <Connected foo={42} bar="str" />;
+  //$FlowExpectedError[incompatible-use] property `foo` is missing in props [1] but exists in `OwnProps`
+  <Connected bar="str" />;
+  e.push(Connected);
+
+  function injectProp<Config: {...}>(
+    Component: React.AbstractComponent<Config>,
+  ): React.AbstractComponent<$Diff<Config, { foo: number | void, ... }>> {
+    return function WrapperComponent(
+      props: $Diff<Config, { foo?: number, ... }>,
+    ) {
+      return <Component {...props} foo={42} />;
+    };
+  }
+
+  const Decorated = injectProp(Connected);
+  // OK without `foo`
+  <Decorated bar="str" />;
+  // OK with a not needed `foo`
+  <Decorated foo={42} bar="str" />;
+  //$FlowExpectedError[prop-missing] property `bar` is missing in props [3] but exists in `Props` [4]
+  <Decorated />;
+  e.push(Decorated);
+}
+
+function composeWithOtherHOC_OK() {
+  type OwnProps = {
+    own1: number,
+    injected1: string,
+    ...
+  };
+  type Props = {
+    ...$Exact<OwnProps>,
+    state1: number,
+    ...
+  };
+  const mapStateToProps = () => ({ state1: 5 });
+
+  class Com extends React.Component<Props> {}
+
+  function injectProp<Config: {...}>(
+    Component: React.AbstractComponent<Config>,
+  ): React.AbstractComponent<$Diff<Config, { injected1: string | void, ... }>> {
+    return function WrapperComponent(
+      props: $Diff<Config, { injected1: string | void, ... }>,
+    ) {
+      return <Component {...props} injected1="str" />;
+    };
+  }
+
+  declare var compose: $Compose;
+
+  const composedDecorators = compose(
+    injectProp,
+    connect<Props, OwnProps, _, _, _, _>(mapStateToProps),
+  );
+
+  const Decorated = composedDecorators(Com);
+  // OK without `injected1`
+  <Decorated own1={1} />;
+  // OK with a not needed `injected1`
+  <Decorated own1={1} injected1="str" />;
+  //$FlowExpectedError[prop-missing] property `own1` is missing in props [3] but exists in `Props` [4]
+  <Decorated />;
+  e.push(Decorated);
+}
+
+function composeWithOtherHOC_exactOK() {
+  type OwnProps = {
+    own1: number,
+    injected1: string,
+    ...
+  };
+  type Props = {
+    ...$Exact<OwnProps>,
+    state1: number,
+    ...
+  };
+  const mapStateToProps = () => ({ state1: 5 });
+
+  class Com extends React.Component<Props> {}
+
+  function injectProp<Config: {...}>(
+    Component: React.AbstractComponent<Config>,
+  ): React.AbstractComponent<$Diff<Config, { injected1: string | void, ... }>> {
+    return function WrapperComponent(
+      props: $Diff<Config, { injected1: string | void, ... }>,
+    ) {
+      return <Component {...props} injected1="str" />;
+    };
+  }
+
+  declare var compose: $Compose;
+
+  const composedDecorators = compose(
+    injectProp,
+    connect<Props, OwnProps, _, _, _, _>(mapStateToProps),
+  );
+
+  const Decorated = composedDecorators(Com);
+  // OK without `injected1`
+  <Decorated own1={1} />;
+  //$FlowExpectedError[prop-missing] property `injected1` is missing in `OwnProps` [1] but exists in props
+  <Decorated own1={1} injected1="str" />;
+  //$FlowExpectedError[prop-missing] property `own1` is missing in props [1] but exists in `OwnProps` [2]
+  <Decorated />;
+  e.push(Decorated);
+}
+
+function composeWithOtherHOC_wrongOrder() {
+  type OwnProps = {
+    own1: number,
+    injected1: string,
+    ...
+  };
+  type Props = {
+    ...$Exact<OwnProps>,
+    state1: number,
+    ...
+  };
+  const mapStateToProps = () => ({ state1: 5 });
+
+  class Com extends React.Component<Props> {}
+
+  function injectProp<Config: {...}>(
+    Component: React.AbstractComponent<Config>,
+  ): React.AbstractComponent<$Diff<Config, { injected1: string | void, ... }>> {
+    return function WrapperComponent(
+      props: $Diff<Config, { injected1: string | void, ... }>,
+    ) {
+      return <Component {...props} injected1="str" />;
+    };
+  }
+
+  declare var compose: $Compose;
+
+  // injectProp must go before connect()
+  const composedDecorators = compose(
+    connect<Props, OwnProps, _, _, _, _>(mapStateToProps),
+    injectProp,
+  );
+
+  const Decorated = composedDecorators(Com);
+  //$FlowExpectedError[incompatible-use] property `injected1` is missing in props
+  <Decorated own1={1} />;
+  // OK with an explicitly provided `injected1`
+  <Decorated own1={1} injected1="str" />;
+  e.push(Decorated);
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connectInfer.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connectInfer.js
@@ -396,11 +396,11 @@ function testOptions() {
       return <div></div>;
     }
   }
-  connect(null, null, null, {pure: true})(Com);
+  connect(null, null, null, {storeKey: 'test'})(Com);
   connect(null, null, null, {forwardRef: true})(Com);
-  connect(null, null, null, {pure: false, forwardRef: false})(Com);
+  connect(null, null, null, {storeKey: 'test', forwardRef: false})(Com);
   // $FlowExpectedError[incompatible-call] wrong type
-  connect(null, null, null, {pure: 123})(Com);
+  connect(null, null, null, {storeKey: 123})(Com);
   // $FlowExpectedError[incompatible-call] wrong type
   connect(null, null, null, {ref: 123})(Com);
   // $FlowExpectedError[incompatible-call] wrong key

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connectInfer.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connectInfer.js
@@ -1,0 +1,588 @@
+/*
+  Keep here examples which still work without type parameters specified,
+  even if the current Flow verion still reports misleading errors.
+  This helps keep the usage of Flow amazing type inferent on the good level.
+*/
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+function testPassingPropsToConnectedComponent() {
+  type OwnProps = {|
+    passthrough: number,
+    passthroughWithDefaultProp?: number,
+    forMapStateToProps: string
+  |}
+  type Props = {
+    ...OwnProps,
+    fromStateToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    static defaultProps = { passthroughWithDefaultProp: 123 };
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = { a: number, ... };
+  type InputProps = { forMapStateToProps: string, ... };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect(mapStateToProps)(Com);
+  Connected.WrappedComponent;
+  <Connected passthrough={123} forMapStateToProps={'data'} passthroughWithDefaultProp={123}/>;
+  // OK without passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  // Flow erroneously complains about `fromStateToProps`
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] wrong type for passthrough
+  <Connected passthrough={''} forMapStateToProps={'data'} passthroughWithDefaultProp={123}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321} passthroughWithDefaultProp={123}/>;
+  // Flow erroneously complains about `fromStateToProps`
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] wrong type for  passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'} passthroughWithDefaultProp={''}/>;
+  // Flow also erroneously complains about fromStateToProps
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError[incompatible-call] takes in only React components
+  connect(mapStateToProps)('');
+}
+
+function doesNotRequireDefinedComponentToTypeCheck5case() {
+  type Props = { stringProp: string, ... };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = () => ({});
+  const mapDispatchToProps = () => ({});
+
+  const mergeProps = () => ({
+    stringProp: true
+  });
+
+  //$FlowExpectedError[incompatible-call] wrong type for stringProp
+  connect(mapStateToProps, mapDispatchToProps, mergeProps)(Component);
+}
+
+function testWithStatelessFunctionalComponent() {
+  type Props = {
+    passthrough: number,
+    fromStateToProps: string,
+    ...
+  };
+  const Com = (props: Props) => <div>{props.passthrough} {props.fromStateToProps}</div>
+
+  type State = { a: number, ... };
+  type InputProps = { forMapStateToProps: string, ... };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect(mapStateToProps)(Com);
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the wrong type for passthroug,
+  // giving passthrough a number fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] wrong type for passthrough
+  <Connected passthrough={''} forMapStateToProps={'data'}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321} />;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError[incompatible-call] takes in only React components
+  connect(mapStateToProps)('');
+}
+
+function testMapStateToPropsDoesNotNeedProps() {
+  type Props = {
+    passthrough: number,
+    fromStateToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+
+  type State = { a: string, ... }
+  const mapStateToProps = (state: State) => {
+    return {
+      fromStateToProps: state.a
+    }
+  }
+
+  const Connected = connect(mapStateToProps)(Com);
+  <Connected passthrough={123}/>;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] component property passthrough not found
+  <Connected />;
+}
+
+function testMapDispatchToProps() {
+  type Props = {
+    passthrough: number,
+    fromMapDispatchToProps: string,
+    fromMapStateToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.passthrough}
+        {this.props.fromMapDispatchToProps}
+        {this.props.fromMapStateToProps}
+        </div>;
+    }
+  }
+
+  type State = { a: number, ... }
+  type MapStateToPropsProps = { forMapStateToProps: string, ... }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: 'str' + state.a
+    }
+  }
+  type MapDispatchToPropsProps = { forMapDispatchToProps: string, ... }
+  const mapDispatchToProps = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const Connected = connect(mapStateToProps, mapDispatchToProps)(Com);
+  <Connected passthrough={123} forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected passthrough={123} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] forMapDispatchToProps missing
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+}
+
+function testMapDispatchToPropsWithoutMapStateToProps() {
+  type Props = {
+    passthrough: number,
+    fromMapDispatchToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.passthrough}
+        {this.props.fromMapDispatchToProps}
+      </div>;
+    }
+  }
+
+  type MapDispatchToPropsProps = { forMapDispatchToProps: string, ... };
+  const mapDispatchToProps = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const Connected = connect(null, mapDispatchToProps)(Com);
+  <Connected passthrough={123} forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] forMapDispatchToProps missing
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+}
+
+function testMapDispatchToPropsPassesActionCreators() {
+  type Props = {
+    passthrough: number,
+    dispatch1: (num: number) => void,
+    dispatch2: () => void,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+
+  const mapDispatchToProps = {
+    dispatch1: (num: number) => {},
+    dispatch2: () => {}
+  };
+  const Connected = connect(null, mapDispatchToProps)(Com);
+  <Connected passthrough={123}/>;
+  // Here Flow reports that `dispatch1` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] no passthrough
+  <Connected />;
+
+  const mapDispatchToPropsWithoutDispatch2 = {
+    dispatch1: (num: number) => {}
+  };
+  const Connected2 = connect(null, mapDispatchToPropsWithoutDispatch2)(Com);
+  // Here Flow reports that `dispatch1` is missing from props,
+  // while the real error is still the missing `dispatch2`,
+  // giving the `mapDispatchToProps` to connect above
+  // fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] no dispatch2
+  <Connected2 passthrough={123}/>;
+
+  const mapDispatchToPropsWithWrongDispatch1 = {
+    dispatch1: (num: string) => {},
+    dispatch2: () => {}
+  };
+  const Connected3 = connect(null, mapDispatchToPropsWithWrongDispatch1)(Com);
+  // Here Flow reports that `dispatch1` is missing from props,
+  // while the real error is still the wrong type of `dispatch1`,
+  // giving `num` the correct type fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] dispatch1 should be number
+  <Connected3 passthrough={123}/>;
+}
+
+function testMapDispatchToPropsPassesActionCreatorsWithMapStateToProps() {
+  type Props = {
+    passthrough: number,
+    dispatch1: () => void,
+    dispatch2: () => void,
+    fromMapStateToProps: number,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+  type State = { a: number, ... }
+  type MapStateToPropsProps = { forMapStateToProps: string, ... }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  const mapDispatchToProps = {
+    dispatch1: () => {},
+    dispatch2: () => {}
+  };
+  const Connected = connect(mapStateToProps, mapDispatchToProps)(Com);
+  <Connected passthrough={123} forMapStateToProps="str"/>;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] no passthrough
+  <Connected/>;
+
+  const mapDispatchToProps2 = {
+    dispatch1: () => {}
+  };
+  const Connected2 = connect(mapStateToProps, mapDispatchToProps2)(Com);
+  // Here Flow reports that `dispatch1` is missing from props,
+  // while the real error is still the missing `dispatch2`,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] no dispatch2
+  <Connected2 passthrough={123} forMapStateToProps="str"/>;
+}
+
+function testMapDispatchToPropsPassesActionCreatorsWithMapStateToPropsAndMergeProps() {
+  type Props = {
+    passthrough: number,
+    dispatch1: () => void,
+    dispatch2: () => void,
+    fromMapStateToProps: number,
+    fromMergeProps: number,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+  type State = { a: number, ... }
+  type MapStateToPropsProps = { forMapStateToProps: string, ... }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  const mapDispatchToProps = {
+    dispatch1: () => {},
+    dispatch2: () => {}
+  };
+  const mergeProps = (stateProps, dispatchProps, ownProps: { forMergeProps: number, ... }) => {
+    return Object.assign({}, stateProps, dispatchProps, { fromMergeProps: 123 });
+  }
+  const Connected = connect(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
+  <Connected passthrough={123} forMapStateToProps="str" forMergeProps={1234}/>;
+  // Here Flow reports that `forMapStateToProps` is missing from props,
+  // while the real error is still the missing `passthrough`,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] no passthrough
+  <Connected/>;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected forMapDispatchToProps={'more data'} forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMergeProps is missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] forMergeProps is wrong type
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} forMergeProps={'not number'} />;
+
+  const mapDispatchToProps2 = {
+    dispatch1: () => {}
+  };
+  const Connected2 = connect(mapStateToProps, mapDispatchToProps2)(Com);
+  // Here Flow reports that `dispatch1` is missing from props,
+  // while the real error is still the missing `dispatch2`,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] no dispatch2
+  <Connected2 passthrough={123} forMapStateToProps="str"/>;
+}
+
+function testMergeProps() {
+  type Props = { fromMergeProps: number, ... };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.fromMergeProps}
+      </div>;
+    }
+  }
+
+  type State = { a: number, ... }
+  type MapStateToPropsProps = { forMapStateToProps: string, ... }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  type MapDispatchToPropsProps = { forMapDispatchToProps: string, ... }
+  const mapDispatchToProps = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const mergeProps = (stateProps, dispatchProps, ownProps: { forMergeProps: number, ... }) => {
+    return {fromMergeProps: 123};
+  }
+  const Connected = connect(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected forMapDispatchToProps={'more data'} forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMergeProps is missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] forMapDispatchToProps is missing
+  <Connected forMapStateToProps={'data'} forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMapDispatchToProps is wrong type
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} forMergeProps={'not number'} />;
+}
+
+function testOptions() {
+  class Com extends React.Component<{...}> {
+    render() {
+      return <div></div>;
+    }
+  }
+  connect(null, null, null, {pure: true})(Com);
+  connect(null, null, null, {forwardRef: true})(Com);
+  connect(null, null, null, {pure: false, forwardRef: false})(Com);
+  // $FlowExpectedError[incompatible-call] wrong type
+  connect(null, null, null, {pure: 123})(Com);
+  // $FlowExpectedError[incompatible-call] wrong type
+  connect(null, null, null, {ref: 123})(Com);
+  // $FlowExpectedError[incompatible-call] wrong key
+  connect(null, null, null, {wrongKey: true})(Com);
+}
+
+function testHoistConnectedComponent() {
+  type Props = {
+    passthrough: number,
+    passthroughWithDefaultProp: number,
+    fromStateToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    static defaultProps = { passthroughWithDefaultProp: 123 };
+    static myStatic = 1;
+
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = { a: number, ... };
+  type InputProps = { forMapStateToProps: string, ... };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect(mapStateToProps)(Com);
+  // OK without passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  // OK with passthroughWithDefaultProp
+  <Connected passthrough={123} passthroughWithDefaultProp={456} forMapStateToProps={'data'}/>;
+  // OK with declared static property
+  Connected.myStatic;
+  //$FlowExpectedError[incompatible-use] property `notStatic` is missing in statics
+  Connected.notStatic;
+}
+
+function checkIfStateTypeIsRespectedAgain() {
+  type State = {
+    num: number,
+    str: string,
+    ...
+  };
+
+  const mapStateToProps = (state: State) => {
+    return { // no error
+      str: state.num
+    }
+  };
+
+  type Props = { str: string, ... };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  const Connected = connect(mapStateToProps)(Com);
+  // Here Flow reports that `str` is missing from props,
+  // while the real error is still the type mismatch,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use]
+  <Connected />;
+}
+
+
+
+function testAllowsKnownPropInMapStateToProps() {
+  type Props = { str: string, ... };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {
+    num: number,
+    str: string,
+    ...
+  };
+
+  const mapStateToProps = (state: State) => {
+    return {
+      str: state.str
+    }
+  };
+
+  const Connected = connect(mapStateToProps)(Com);
+  <Connected />;
+}
+
+function testForbidsLiteralOfInvalidTypeInMapStateToProps() {
+  type Props = {
+  str: string, ... };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {
+    num: number,
+    str: string,
+    ...
+  };
+
+  const mapStateToPropsWithLiteralOfInvalidType = (state: State) => {
+    return {
+      str: 123
+    }
+  };
+
+  const Connected = connect(mapStateToPropsWithLiteralOfInvalidType)(Com);
+  //$FlowExpectedError[incompatible-use] string is incompatible with number
+  <Connected />
+}
+
+function testForbidsStateProperyOfInvalidTypeInMapStateToProps() {
+  type Props = { str: string, ... };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {
+    num: number,
+    str: string,
+    ...
+  };
+
+  const mapStateToPropsWithStatePropertyOfInvalidType = (state: State) => {
+    return {
+      str: state.num
+    }
+  };
+
+  const Connected = connect(mapStateToPropsWithStatePropertyOfInvalidType)(Com);
+  // Here Flow reports that `str` is missing from props,
+  // while the real error is still the type mismatch,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use]
+  <Connected />;
+}
+
+function testForbidsSelectorWithInvalidReturnTypeInMapStateToProps() {
+  type Props = { str: string, ... };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {
+    num: number,
+    str: string,
+    ...
+  };
+
+  function selectorReturningNumber(state: State) {
+    return state.num
+  }
+
+  const mapStateToPropsWithSelectorWithInvalidTypeReturnValue = (state: State) => {
+    return {
+      str: selectorReturningNumber(state)
+    }
+  };
+
+  const Connected = connect(mapStateToPropsWithSelectorWithInvalidTypeReturnValue)(Com);
+  // Here Flow reports that `str` is missing from props,
+  // while the real error is still the type mismatch,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use]
+  <Connected />
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connectMergeProps.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connectMergeProps.js
@@ -1,0 +1,608 @@
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+export let e: Array<any> = []
+
+function onlyOwnProps_ok() {
+  opaque type Action = 'action';
+  type Dispatch = Action => Action;
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type Props = { ...OwnProps, ... };
+  class Com extends React.Component<Props> {}
+
+  const mergeProps = (stateProps: {||}, dispatchProps: {|dispatch: Dispatch|}, ownProps: OwnProps) => {
+    return {
+      ...ownProps
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(null, null, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyOwnProps_wrongDispatch() {
+  opaque type Action = 'action';
+  type Dispatch = Action => Action;
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type Props = { ...OwnProps, ... };
+  class Com extends React.Component<Props> {}
+
+  const mergeProps = (stateProps: {||}, dispatchProps: {|dispatch: string|}, ownProps: OwnProps) => {
+    return {
+      ...ownProps
+    }
+  }
+
+  //$FlowExpectedError[incompatible-call] string [1] is incompatible with  `Dispatch` [2] in property `dispatch`
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    null,
+    null,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyOwnProps_noPassthrough() {
+  opaque type Action = 'action';
+  type Dispatch = Action => Action;
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type Props = { ...OwnProps, ... };
+  class Com extends React.Component<Props> {}
+
+  const mergeProps = (stateProps: {||}, dispatchProps: {|dispatch: Dispatch|}, ownProps: OwnProps) => {
+    return {
+      a: 1
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    null,
+    null,
+    //$FlowExpectedError[prop-missing] property `passthrough` is missing in object literal [1] but exists in `OwnProps` [2]
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyStateProps_ok() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action';
+  type Dispatch = Action => Action;
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type Props = {
+    ...OwnProps,
+    ...StateProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({state1: state.state1})
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: {|dispatch: Dispatch|}, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...stateProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(mapStateToProps, null, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyStateProps_wrongDispatch() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action';
+  type Dispatch = Action => Action;
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type Props = {
+    ...OwnProps,
+    ...StateProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: {|dispatch: string|}, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...stateProps
+    }
+  }
+
+  //$FlowExpectedError[incompatible-call] string [1] is incompatible with  `Dispatch` [2] in property `dispatch`
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    mapStateToProps,
+    null,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyDispatchPropsObject_ok() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapDispatchToProps = {
+    action1
+  }
+
+  const mergeProps = (stateProps: {||}, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(undefined, mapDispatchToProps, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyDispatchPropsObject_wrongExpectedState() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapDispatchToProps = {
+    action1
+  }
+
+  const mergeProps = (stateProps: { wrong: boolean, ... }, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...dispatchProps,
+    }
+  }
+
+  //$FlowExpectedError[incompatible-call] property `wrong` is missing in object type [1] but exists in object type [2]
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    undefined,
+    mapDispatchToProps,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyDispatchPropsFunction_ok() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (stateProps: {||}, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(null, mapDispatchToPropsFn, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyDispatchPropsFunction_WrongExpectedState() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  type MapDispatchToPropsFn = Dispatch => DispatchProps
+  const mapDispatchToPropsFn: MapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (stateProps: {|wrong:boolean|}, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...dispatchProps,
+    }
+  }
+
+  //$FlowExpectedError[incompatible-call] property `wrong` is missing in  object type [1] but exists in  object type [2]
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(null, mapDispatchToPropsFn, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyDispatchPropsFunction_wrongDispatchProp() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => 123
+  })
+
+  const mergeProps = (stateProps: {||}, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    null,
+    //$FlowExpectedError[incompatible-call] number [1] is incompatible with  string literal `action1` [2]
+    mapDispatchToPropsFn,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function stateAndDispatchPropsFunction_ok() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...StateProps,
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...stateProps,
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    mapStateToProps,
+    mapDispatchToPropsFn,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function stateAndDispatchPropsFunction_wrongState() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...StateProps,
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (
+    stateProps: {|wrong:boolean|},
+    dispatchProps: DispatchProps,
+    ownProps: OwnProps
+  ) => {
+    return {
+      ...ownProps,
+      state1: 'state1',
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    // yes, a bit cryptic
+    //$FlowExpectedError[prop-missing] property `state1` is missing in  object type [1] but exists in  object literal [2]
+    mapStateToProps,
+    mapDispatchToPropsFn,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function stateAndDispatchPropsFunction_wrongDispatch() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...StateProps,
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => 123
+  })
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...stateProps,
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    mapStateToProps,
+    //$FlowExpectedError[incompatible-call] number [1] is incompatible with string literal `action1` [2]
+    mapDispatchToPropsFn,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function returnsTotallyDifferentProps() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    a: 1,
+    b: 2,
+    c: 3,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    mapStateToProps,
+    mapDispatchToPropsFn,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function returnsTotallyDifferentPropsWithError() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    a: 1,
+    b: 2,
+    c: 3,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      a: 1,
+      b: 2,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    mapStateToProps,
+    mapDispatchToPropsFn,
+    //$FlowExpectedError[prop-missing] property `c` is missing in object literal [1] but exists in  `Props` [2]
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connectState.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connectState.js
@@ -1,0 +1,41 @@
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+export let e: Array<any> = []
+
+function sameStateIsOK() {
+  type Props = {...};
+  class Com extends React.Component<Props> {}
+
+  type State = {|
+    a: number
+  |};
+  const mapStateToProps = (state: State) => {
+    return {}
+  };
+
+  const Connected = connect<Props, {||}, _,_,State,empty>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function differentStatesAreNotOK() {
+  type Props = {...};
+  class Com extends React.Component<Props> {}
+
+  type State = {|
+    a: number
+  |};
+  const mapStateToProps = (state: State) => {
+    return {}
+  };
+  type OtherState = {|
+    b: number
+  |};
+
+  //$FlowExpectedError[incompatible-call] property `b` is missing in `State` but exists in `OtherState`
+  const Connected = connect<Props, {||}, _,_,OtherState,empty>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connectThunk.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_connectThunk.js
@@ -1,0 +1,199 @@
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+export let e: Array<any> = []
+
+function onlyDispatchFunction_samePropsAreOK() {
+  type State = {||}
+  type Action = {|
+    type: 'action'
+  |};
+  type DispatchAction = Action => Action;
+  type Thunk = (Dispatch, State) => Promise<number>
+  type DispatchThunk = Thunk => Promise<number>
+  type Dispatch = DispatchAction & DispatchThunk
+
+  const action = (): Action => ({ type: 'action' });
+  const thunk = (): Thunk => (d: Dispatch) => Promise.resolve(1);
+  type DispatchProps = {|
+    action: typeof action,
+    thunk: () => Promise<number>,
+  |};
+  type MapDispatchToPropsFn = Dispatch => DispatchProps;
+  const mapDispatchToProps: MapDispatchToPropsFn = (dispatch) => ({
+    action: () => dispatch(action()),
+    thunk: () => dispatch(thunk())
+  });
+
+  type Props = { // in the case of a function passed to `connect()` Flow infers
+  // the same type of function is both the Props and DispatchProps objects
+  // (see the testDispatchThunk() to get the difference)
+  ...DispatchProps, ... };
+  class Com extends React.Component<Props> {}
+
+  const Connected = connect<Props, {||}, _,DispatchProps,_,Dispatch>(null, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function onlyDispatchObject_differentDispatchPropsAreOK() {
+  type State = {||}
+  type Action = {|
+    type: 'action'
+  |};
+  type DispatchAction = Action => Action;
+  type Thunk = (Dispatch, State) => Promise<number>
+  type DispatchThunk = Thunk => Promise<number>
+  type Dispatch = DispatchAction & DispatchThunk
+
+  const action = (): Action => ({ type: 'action' });
+  const thunk = (): Thunk => (d: Dispatch) => Promise.resolve(1);
+
+  type DispatchProps = {|
+    action: typeof action,
+    // here the property returns a thunk...
+    thunk: () => Thunk,
+  |};
+  const mapDispatchToProps = {
+    action,
+    thunk
+  };
+
+  type Props = {
+    action: typeof action,
+    // ... and here the property returns a return value of thunk
+    // as dispatch calls it for us with `dispatch` and `getState`
+    thunk: () => Promise<number>,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const Connected = connect<Props, {||}, _,DispatchProps,_,Dispatch>(null, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function onlyDispatchObject_sameDispatchPropsAreErroneous() {
+  type State = {||}
+  type Action = {|
+    type: 'action'
+  |};
+  type DispatchAction = Action => Action;
+  type Thunk = (Dispatch, State) => Promise<number>
+  type DispatchThunk = Thunk => Promise<number>
+  type Dispatch = DispatchAction & DispatchThunk
+
+  const action = (): Action => ({ type: 'action' });
+  const thunk = (): Thunk => (d: Dispatch) => Promise.resolve(1);
+
+  type DispatchProps = {|
+    action: typeof action,
+    thunk: () => Thunk,
+  |};
+  const mapDispatchToProps = {
+    action,
+    thunk
+  };
+
+  type Props = { // trying to pass the not passed to dispatch types (against the redux dispatch monad)
+  ...DispatchProps, ... };
+  class Com extends React.Component<Props> {}
+
+  //$FlowExpectedError[prop-missing] here the property returns a thunk...
+  //$FlowExpectedError[incompatible-type-arg]
+  const Connected = connect<Props, {||}, _,DispatchProps,_,Dispatch>(null, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function stateAndDispatchObject_differentDispatchPropsAreOK() {
+  type State = {|
+    state1: 'state1'
+  |}
+  type Action = {|
+    type: 'action'
+  |};
+  type DispatchAction = Action => Action;
+  type Thunk = (Dispatch, State) => Promise<number>
+  type DispatchThunk = Thunk => Promise<number>
+  type Dispatch = DispatchAction & DispatchThunk
+
+  const action = (): Action => ({ type: 'action' });
+  const thunk = (): Thunk => (d: Dispatch) => Promise.resolve(1);
+
+  type StateProps = {|
+    state1: 'state1',
+  |};
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  type DispatchProps = {|
+    action: typeof action,
+    // here the property returns a thunk...
+    thunk: () => Thunk,
+  |};
+  const mapDispatchToProps = {
+    action,
+    thunk
+  };
+
+  type Props = {
+    ...StateProps,
+    action: typeof action,
+    // ... and here the property returns a return value of thunk
+    // as dispatch calls it for us with `dispatch` and `getState`
+    thunk: () => Promise<number>,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const Connected = connect<Props, {||}, _,DispatchProps,_,Dispatch>(mapStateToProps, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function stateAndDispatchObject_sameDispatchPropsAreErroneous() {
+  type State = {||}
+  type Action = {|
+    type: 'action'
+  |};
+  type DispatchAction = Action => Action;
+  type Thunk = (Dispatch, State) => Promise<number>
+  type DispatchThunk = Thunk => Promise<number>
+  type Dispatch = DispatchAction & DispatchThunk
+
+  const action = (): Action => ({ type: 'action' });
+  const thunk = (): Thunk => (d: Dispatch) => Promise.resolve(1);
+
+  type StateProps = {|
+    state1: 'state1',
+  |};
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  type DispatchProps = {|
+    action: typeof action,
+    thunk: () => Thunk,
+  |};
+  const mapDispatchToProps = {
+    action,
+    thunk
+  };
+
+  type Props = {
+    ...StateProps,
+    // trying to pass the not passed to dispatch types (against the redux dispatch monad)
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  //$FlowExpectedError[prop-missing] here the property returns a thunk...
+  //$FlowExpectedError[incompatible-call]
+  const Connected = connect<Props, {||}, _,DispatchProps,_,Dispatch>(mapStateToProps, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_shallowEqual.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_shallowEqual.js
@@ -1,0 +1,29 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import { shallowEqual } from 'react-redux';
+
+describe('shallowEqual', () => {
+  it('returns a boolean', () => {
+    const x: boolean = shallowEqual('a', 'a');
+
+    //$FlowExpectedError[incompatible-type]
+    const y: number = shallowEqual('a', 'a');
+  });
+
+  it('can be called with any argument types', () => {
+    shallowEqual('a', 'a');
+    shallowEqual({ test: 'test' }, { test: 'test' });
+    shallowEqual({ test: 'test' }, 'a');
+  });
+
+  it('should be called with two arguments', () => {
+    // Flow considers these compatible with shallowEqual<T>(a: T, b: any).
+
+    // The same is seen in tests for _.isEqual and the comment below is copied from those tests
+    // Reasonable people disagree about whether these should be considered legal calls.
+    // See https://github.com/splodingsocks/FlowTyped/pull/1#issuecomment-149345275
+    // and https://github.com/facebook/flow/issues/956
+    shallowEqual();
+    shallowEqual('a');
+  });
+});

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_useDispatch.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_useDispatch.js
@@ -1,0 +1,43 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import React from 'react';
+import { useDispatch } from 'react-redux';
+
+type Action = {|
+  type: 'action',
+|};
+type Dispatch = Action => Action;
+
+describe('useDispatch', () => {
+  it('returns type `Dispatch` which accepts only type `Action` as param', () => {
+    function Com() {
+      const dispatch = useDispatch<Dispatch>();
+      return (
+        <button
+          onClick={function() {
+            dispatch({ type: 'action' });
+          }}
+        >
+          Dispatch time
+        </button>
+      );
+    }
+  });
+
+  it('errors if returned type is passed invalid Action', () => {
+    function Com() {
+      const dispatch = useDispatch<Dispatch>();
+      return (
+        <div
+          onClick={() => {
+            // $FlowExpectedError[incompatible-call]: return value of `useDispatch` should make `Dispatch` and expect an `Action`.
+            dispatch();
+          }}
+        >
+          Dispatch time
+        </div>
+      );
+    }
+  });
+});

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_useSelector.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_useSelector.js
@@ -1,0 +1,48 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import React from 'react';
+import { useSelector, shallowEqual } from 'react-redux';
+
+type State = {|
+  a: number,
+|};
+
+describe('useSelector', () => {
+  it('passes State as first parameter', () => {
+    function Com() {
+      // $FlowExpectedError[prop-missing]: the state has no `b`
+      const count = useSelector<State, number>(state => state.b);
+      return <div>{count}</div>;
+    }
+  });
+
+  it('passes type of second parameter as params to `equalityFn`', () => {
+    function Com2() {
+      const count = useSelector<State, number>(
+        state => state.a,
+        // $FlowExpectedError[prop-missing]: `equalityFn` is passed params of the second type, do not have `.size`
+        (a, b) => a.size === b.size
+      );
+      return <div>{count}</div>;
+    }
+  });
+
+  it('returns type of second parameter', () => {
+    function Com3() {
+      const count = useSelector<State, number>(
+        state => state.a,
+        (a, b) => a === b
+      );
+      // `count` is type `number` and allows addition
+      return <div>{count + 5}</div>;
+    }
+  });
+
+  it('can use shallowEqual as the `equalityFn`', () => {
+    function Com4() {
+      const count = useSelector<State, number>(state => state.a, shallowEqual);
+      return <div>{count}</div>;
+    }
+  });
+});

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_useStore.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.104.x-v0.141.x/test_useStore.js
@@ -1,0 +1,42 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import React from 'react';
+import { useStore } from 'react-redux';
+
+describe('useStore', () => {
+  type Action = { type: 'SOME_ACTION', ... };
+  type State = { state: string, ... };
+
+  // ReduxStore should be imported from 'redux' but we can't do this with this
+  // test environment, so let's copy them once again...
+  declare type Redux$DispatchAPI<A> = (action: A) => A;
+  declare type Redux$Dispatch<A: { type: string, ... }> = Redux$DispatchAPI<A>;
+  declare type Redux$Reducer<S, A> = (state: S | void, action: A) => S;
+  declare type Redux$Store<S, A, D = Redux$Dispatch<A>> = {
+    dispatch: D,
+    getState(): S,
+    subscribe(listener: () => void): () => void,
+    replaceReducer(nextReducer: Redux$Reducer<S, A>): void,
+    ...
+  };
+
+  type Dispatch = (action: Action) => Action;
+  type GetState = () => State;
+  type Store = Redux$Store<State, Action, Dispatch>;
+
+  it('returns instance of Store', () => {
+    function Com() {
+      const store = useStore<Store>();
+      return <div>{store.getState().state}</div>;
+    }
+  });
+
+  it('returns instance of Store, no extra keys', () => {
+    function Com() {
+      const store = useStore<Store>();
+      // $FlowExpectedError[prop-missing]: `foobar` is not a member of the Store instance
+      return <div>{store.getState().foobar}</div>;
+    }
+  });
+});

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/react-redux_v8.x.x.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/react-redux_v8.x.x.js
@@ -1,0 +1,310 @@
+/**
+The order of type arguments for connect() is as follows:
+
+connect<Props, OwnProps, StateProps, DispatchProps, State, Dispatch>(…)
+
+In Flow v0.89 only the first two are mandatory to specify. Other 4 can be repaced with the new awesome type placeholder:
+
+connect<Props, OwnProps, _, _, _, _>(…)
+
+But beware, in case of weird type errors somewhere in random places
+just type everything and get to a green field and only then try to
+remove the definitions you see bogus.
+
+Decrypting the abbreviations:
+  WC = Component being wrapped
+  S = State
+  D = Dispatch
+  OP = OwnProps
+  SP = StateProps
+  DP = DispatchProps
+  MP = Merge props
+  RSP = Returned state props
+  RDP = Returned dispatch props
+  RMP = Returned merge props
+  CP = Props for returned component
+  Com = React Component
+  SS = Selected state
+  ST = Static properties of Com
+  EFO = Extra factory options (used only in connectAdvanced)
+*/
+
+declare module "react-redux" {
+  // ------------------------------------------------------------
+  // Typings for connect()
+  // ------------------------------------------------------------
+
+  declare export type Options<S, OP, SP, MP> = {|
+    pure?: boolean,
+    forwardRef?: boolean,
+    areStatesEqual?: (next: S, prev: S) => boolean,
+    areOwnPropsEqual?: (next: OP, prev: OP) => boolean,
+    areStatePropsEqual?: (next: SP, prev: SP) => boolean,
+    areMergedPropsEqual?: (next: MP, prev: MP) => boolean,
+    storeKey?: string,
+  |};
+
+  declare type MapStateToProps<-S, -OP, +SP> =
+    | ((state: S, ownProps: OP) => SP)
+    // If you want to use the factory function but get a strange error
+    // like "function is not an object" then just type the factory function
+    // like this:
+    // const factory: (State, OwnProps) => (State, OwnProps) => StateProps
+    // and provide the StateProps type to the SP type parameter.
+    | ((state: S, ownProps: OP) => (state: S, ownProps: OP) => SP);
+
+  declare type Bind<D> = <A, R>((...A) => R) => (...A) => $Call<D, R>;
+
+  declare type MapDispatchToPropsFn<D, -OP, +DP> =
+    | ((dispatch: D, ownProps: OP) => DP)
+    // If you want to use the factory function but get a strange error
+    // like "function is not an object" then just type the factory function
+    // like this:
+    // const factory: (Dispatch, OwnProps) => (Dispatch, OwnProps) => DispatchProps
+    // and provide the DispatchProps type to the DP type parameter.
+    | ((dispatch: D, ownProps: OP) => (dispatch: D, ownProps: OP) => DP);
+
+  declare class ConnectedComponentClass<OP, +WC> extends React$Component<OP> {
+    static +WrappedComponent: WC;
+    getWrappedInstance(): React$ElementRef<WC>;
+  }
+
+  declare export type ConnectedComponent<OP, +WC> = ConnectedComponentClass<OP, WC>;
+
+  // The connection of the Wrapped Component and the Connected Component
+  // happens here in `MP: P`. It means that type wise MP belongs to P,
+  // so to say MP >= P.
+  declare type Connector<P, OP, MP: P> = <WC: React$ComponentType<P>>(
+    WC,
+  ) => Class<ConnectedComponentClass<OP, WC>> & WC;
+
+  // No `mergeProps` argument
+
+  // Got error like inexact OwnProps is incompatible with exact object type?
+  // Just make the OP parameter for `connect()` an exact object.
+  declare type MergeOP<OP, D> = {| ...$Exact<OP>, dispatch: D |};
+  declare type MergeOPSP<OP, SP, D> = {| ...$Exact<OP>, ...SP, dispatch: D |};
+  declare type MergeOPDP<OP, DP> = {| ...$Exact<OP>, ...DP |};
+  declare type MergeOPSPDP<OP, SP, DP> = {| ...$Exact<OP>, ...SP, ...DP |};
+
+  declare export function connect<-P, -OP, -SP, -DP, -S, -D>(
+    mapStateToProps?: null | void,
+    mapDispatchToProps?: null | void,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOP<OP, D>>,
+  ): Connector<P, OP, MergeOP<OP, D>>;
+
+  declare export function connect<-P, -OP, -SP, -DP, -S, -D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps?: null | void,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, MergeOPSP<OP, SP, D>>,
+  ): Connector<P, OP, MergeOPSP<OP, SP, D>>;
+
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOPDP<OP, DP>>,
+  ): Connector<P, OP, MergeOPDP<OP, DP>>;
+
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: DP,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOPDP<OP, DP>>,
+  ): Connector<P, OP, MergeOPDP<OP, $ObjMap<DP, Bind<D>>>>;
+
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, {| ...OP, ...SP, ...DP |}>,
+  ): Connector<P, OP, {| ...OP, ...SP, ...DP |}>;
+
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: DP,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, MergeOPSPDP<OP, SP, DP>>,
+  ): Connector<P, OP, MergeOPSPDP<OP, SP, $ObjMap<DP, Bind<D>>>>;
+
+  // With `mergeProps` argument
+
+  declare type MergeProps<+P, -OP, -SP, -DP> = (
+    stateProps: SP,
+    dispatchProps: DP,
+    ownProps: OP,
+  ) => P;
+
+  declare export function connect<-P, -OP, -SP: {||}, -DP: {||}, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: null | void,
+    // If you get error here try adding return type to you mapStateToProps function
+    mergeProps: MergeProps<P, OP, {||}, {| dispatch: D |}>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
+
+  declare export function connect<-P, -OP, -SP, -DP: {||}, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: null | void,
+    // If you get error here try adding return type to you mapStateToProps function
+    mergeProps: MergeProps<P, OP, SP, {| dispatch: D |}>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP: {||}, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps: MergeProps<P, OP, {||}, DP>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP: {||}, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: DP,
+    mergeProps: MergeProps<P, OP, {||}, $ObjMap<DP, Bind<D>>>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps: MergeProps<P, OP, SP, DP>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: DP,
+    mergeProps: MergeProps<P, OP, SP, $ObjMap<DP, Bind<D>>>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
+
+  // ------------------------------------------------------------
+  // Typings for Hooks
+  // ------------------------------------------------------------
+
+  declare export function useDispatch<D>(): (
+    & (<T: { [key: string]: any }>(T) => T)
+    // Supports thunks at their various lengths and use cases depending if user has typed them as tuple vs array
+    & (<T>((...args: [any]) => T) => T)
+    & (<T>((...args: [any, any]) => T) => T)
+    & (<T>((...args: [any, any, any]) => T) => T)
+    & (<T>((...args: Array<any>) => T) => T)
+    & D
+  );
+
+  declare export function useSelector<S, SS>(
+    selector: (state: S) => SS,
+    equalityFn?: (a: SS, b: SS) => boolean,
+  ): SS;
+
+  declare export function useStore<Store>(): Store;
+
+  // ------------------------------------------------------------
+  // Typings for Provider
+  // ------------------------------------------------------------
+
+  declare export class Provider<Store> extends React$Component<{
+    store: Store,
+    children?: React$Node,
+    ...
+  }> {}
+
+  declare export function createProvider(
+    storeKey?: string,
+    subKey?: string,
+  ): Class<Provider<*>>;
+
+  // ------------------------------------------------------------
+  // Typings for connectAdvanced()
+  // ------------------------------------------------------------
+
+  declare type ConnectAdvancedOptions = {
+    getDisplayName?: (name: string) => string,
+    methodName?: string,
+    renderCountProp?: string,
+    shouldHandleStateChanges?: boolean,
+    storeKey?: string,
+    forwardRef?: boolean,
+    ...
+  };
+
+  declare type SelectorFactoryOptions<Com> = {
+    getDisplayName: (name: string) => string,
+    methodName: string,
+    renderCountProp: ?string,
+    shouldHandleStateChanges: boolean,
+    storeKey: string,
+    forwardRef: boolean,
+    displayName: string,
+    wrappedComponentName: string,
+    WrappedComponent: Com,
+    ...
+  };
+
+  declare type MapStateToPropsEx<S: Object, SP: Object, RSP: Object> = (
+    state: S,
+    props: SP,
+  ) => RSP;
+
+  declare type SelectorFactory<
+    Com: React$ComponentType<*>,
+    Dispatch,
+    S: Object,
+    OP: Object,
+    EFO: Object,
+    CP: Object,
+  > = (
+    dispatch: Dispatch,
+    factoryOptions: SelectorFactoryOptions<Com> & EFO,
+  ) => MapStateToPropsEx<S, OP, CP>;
+
+  declare export function connectAdvanced<
+    Com: React$ComponentType<*>,
+    D,
+    S: Object,
+    OP: Object,
+    CP: Object,
+    EFO: Object,
+    ST: { [_: $Keys<Com>]: any, ... },
+  >(
+    selectorFactory: SelectorFactory<Com, D, S, OP, EFO, CP>,
+    connectAdvancedOptions: ?(ConnectAdvancedOptions & EFO),
+  ): (component: Com) => React$ComponentType<OP> & $Shape<ST>;
+
+  declare export function batch(() => void): void
+
+  declare export function shallowEqual<T>(left: T, right: any): boolean
+
+  declare export default {
+    Provider: typeof Provider,
+    createProvider: typeof createProvider,
+    connect: typeof connect,
+    connectAdvanced: typeof connectAdvanced,
+    useDispatch: typeof useDispatch,
+    useSelector: typeof useSelector,
+    useStore: typeof useStore,
+    batch: typeof batch,
+    ...
+  };
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/react-redux_v8.x.x.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/react-redux_v8.x.x.js
@@ -34,7 +34,6 @@ declare module "react-redux" {
   // ------------------------------------------------------------
 
   declare export type Options<S, OP, SP, MP> = {|
-    pure?: boolean,
     forwardRef?: boolean,
     areStatesEqual?: (next: S, prev: S) => boolean,
     areOwnPropsEqual?: (next: OP, prev: OP) => boolean,

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/react-redux_v8.x.x.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/react-redux_v8.x.x.js
@@ -26,7 +26,6 @@ Decrypting the abbreviations:
   Com = React Component
   SS = Selected state
   ST = Static properties of Com
-  EFO = Extra factory options (used only in connectAdvanced)
 */
 
 declare module "react-redux" {
@@ -235,63 +234,6 @@ declare module "react-redux" {
     subKey?: string,
   ): Class<Provider<*>>;
 
-  // ------------------------------------------------------------
-  // Typings for connectAdvanced()
-  // ------------------------------------------------------------
-
-  declare type ConnectAdvancedOptions = {
-    getDisplayName?: (name: string) => string,
-    methodName?: string,
-    renderCountProp?: string,
-    shouldHandleStateChanges?: boolean,
-    storeKey?: string,
-    forwardRef?: boolean,
-    ...
-  };
-
-  declare type SelectorFactoryOptions<Com> = {
-    getDisplayName: (name: string) => string,
-    methodName: string,
-    renderCountProp: ?string,
-    shouldHandleStateChanges: boolean,
-    storeKey: string,
-    forwardRef: boolean,
-    displayName: string,
-    wrappedComponentName: string,
-    WrappedComponent: Com,
-    ...
-  };
-
-  declare type MapStateToPropsEx<S: Object, SP: Object, RSP: Object> = (
-    state: S,
-    props: SP,
-  ) => RSP;
-
-  declare type SelectorFactory<
-    Com: React$ComponentType<*>,
-    Dispatch,
-    S: Object,
-    OP: Object,
-    EFO: Object,
-    CP: Object,
-  > = (
-    dispatch: Dispatch,
-    factoryOptions: SelectorFactoryOptions<Com> & EFO,
-  ) => MapStateToPropsEx<S, OP, CP>;
-
-  declare export function connectAdvanced<
-    Com: React$ComponentType<*>,
-    D,
-    S: Object,
-    OP: Object,
-    CP: Object,
-    EFO: Object,
-    ST: { [_: $Keys<Com>]: any, ... },
-  >(
-    selectorFactory: SelectorFactory<Com, D, S, OP, EFO, CP>,
-    connectAdvancedOptions: ?(ConnectAdvancedOptions & EFO),
-  ): (component: Com) => React$ComponentType<OP> & $Shape<ST>;
-
   declare export function batch(() => void): void
 
   declare export function shallowEqual<T>(left: T, right: any): boolean
@@ -300,7 +242,6 @@ declare module "react-redux" {
     Provider: typeof Provider,
     createProvider: typeof createProvider,
     connect: typeof connect,
-    connectAdvanced: typeof connectAdvanced,
     useDispatch: typeof useDispatch,
     useSelector: typeof useSelector,
     useStore: typeof useStore,

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_Provider.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_Provider.js
@@ -1,0 +1,55 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+
+import React from "react";
+import { Provider, createProvider } from "react-redux";
+
+describe('Provider', () => {
+  it('should give an error when the store is missing', () => {
+    // $FlowExpectedError[prop-missing]
+    <Provider />;
+
+    // Also for custom providers
+    const CustomProvider: Class<Provider<any>> = createProvider("ikea");
+
+    // $FlowExpectedError[prop-missing]
+    <CustomProvider />;
+  });
+});
+
+describe('Custom Store (eg for ThunkActions)', () => {
+
+  // This represents a common typing for Thunk Actions.
+
+  type Action = { type: 'SOME_ACTION', ... };
+  type State = { state: string, ... };
+
+  // ReduxStore should be imported from 'redux' but we can't do this with this
+  // test environment, so let's copy them once again...
+  declare type Redux$DispatchAPI<A> = (action: A) => A;
+  declare type Redux$Dispatch<A: { type: string, ... }> = Redux$DispatchAPI<A>;
+  declare type Redux$Reducer<S, A> = (state: S | void, action: A) => S;
+  declare type Redux$Store<S, A, D = Redux$Dispatch<A>> = {
+    dispatch: D,
+    getState(): S,
+    subscribe(listener: () => void): () => void,
+    replaceReducer(nextReducer: Redux$Reducer<S, A>): void,
+    ...
+  };
+
+  // R = Result of a thunk action
+  type ThunkDispatch = <R>(action: ThunkAction<R>) => R;
+  type PlainDispatch = (action: Action) => Action;
+  type GetState = () => State;
+  type ThunkAction<R> = (dispatch: Dispatch, GetState) => R;
+  // The `dispatch` function can accept either a plain action or a thunk action.
+  // This is similar to a type `(action: Action | ThunkAction) => any` except this
+  // allows to type the return value as well.
+  type Dispatch = PlainDispatch & ThunkDispatch;
+  type Store = Redux$Store<State, Action, Dispatch>;
+
+  it('accepts a custom store', () => {
+    declare var store: Store;
+    <Provider store={store} />;
+  });
+});

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_batch.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_batch.js
@@ -1,0 +1,27 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import { batch } from 'react-redux';
+
+describe('batch', () => {
+  it('should accept a function as an argument', () => {
+    batch(() => {
+      // ...
+    })
+  });
+
+  it('should not allow a values that is not a function as an argument', () => {
+    //$FlowExpectedError[incompatible-call] - only a function is allowed
+    batch(true)
+  });
+
+  it('returns void', () => {
+    (batch(() => {
+      // ...
+    }): void)
+
+    batch(() => {
+      //$FlowExpectedError[incompatible-call] - function must return void
+      return true;
+    })
+  });
+});

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connect.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connect.js
@@ -598,11 +598,11 @@ function testOptions() {
     }
   }
   // here in Props comes dispatch property
-  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {pure: true})(Com));
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {storeKey: 'test'})(Com));
   e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {forwardRef: true})(Com));
-  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {pure: false, forwardRef: false})(Com));
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {storeKey: 'test', forwardRef: false})(Com));
   // $FlowExpectedError[incompatible-call] wrong type
-  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {pure: 123})(Com));
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {storeKey: 123})(Com));
   // $FlowExpectedError[incompatible-call] wrong type
   e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {ref: 123})(Com));
   // $FlowExpectedError[incompatible-call] wrong key

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connect.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connect.js
@@ -1,0 +1,819 @@
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+import type { ConnectedComponent } from "react-redux";
+
+export let e: Array<any> = []
+
+function testPassingPropsToConnectedComponent() {
+  type OwnProps = {|
+    passthrough: number,
+    passthroughWithDefaultProp?: number,
+    forMapStateToProps: string
+  |}
+  type Props = {
+    ...OwnProps,
+    fromStateToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    static defaultProps = { passthroughWithDefaultProp: 123 };
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = { a: number, ... };
+  type InputProps = { forMapStateToProps: string, ... };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  Connected.WrappedComponent;
+  <Connected passthrough={123} forMapStateToProps={'data'} passthroughWithDefaultProp={123}/>;
+  // OK without passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for passthrough
+  <Connected passthrough={''} forMapStateToProps={'data'} passthroughWithDefaultProp={123}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321} passthroughWithDefaultProp={123}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for  passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'} passthroughWithDefaultProp={''}/>;
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError[incompatible-call] takes in only React components
+  const Connected2 = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)('');
+  e.push(Connected2);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck1case() {
+  type Props = { stringProp: string, ... };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = (state: {...}) => ({
+    stringProp: false,
+  });
+
+  //$FlowExpectedError[incompatible-type-arg] wrong type for stringProp
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps)(Component);
+  <Connected />;
+  e.push(Connected);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck2case() {
+  type Props = { numProp: string, ... };
+
+  const Component = ({ numProp }: Props) => {
+    return <span>{numProp}</span>;
+  };
+
+  const mapDispatchToProps = () => ({
+    numProp: false,
+  });
+
+  //$FlowExpectedError[incompatible-type-arg] wrong type for numProp
+  const Connected = connect<Props, {||}, _,_,_,_>(null, mapDispatchToProps)(Component);
+  <Connected />;
+  e.push(Connected);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck3case() {
+  type Props = {
+    stringProp: string,
+    numProp: number,
+    ...
+  };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = (state: {...}) => ({
+    stringProp: false,
+  });
+
+  const mapDispatchToProps = () => ({
+    numProp: false,
+  });
+
+  //$FlowExpectedError[incompatible-call] wrong type for stringProp
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps, mapDispatchToProps)(Component);
+  <Connected />;
+  e.push(Connected);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck4case() {
+  type Props = { stringProp: string, ... };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = (state: {...}) => ({
+    stringProp: false,
+  });
+
+  //$FlowExpectedError[incompatible-call] wrong type for stringProp
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps, {})(Component);
+  <Connected />;
+  e.push(Connected);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck5case() {
+  type Props = { stringProp: string, ... };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = () => ({});
+  const mapDispatchToProps = () => ({});
+
+  const mergeProps = () => ({
+    stringProp: true
+  });
+
+  //$FlowExpectedError[incompatible-call] wrong type for stringProp
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps, mapDispatchToProps, mergeProps)(Component);
+  <Connected />;
+  e.push(Connected);
+}
+
+function testExactProps() {
+  type Dispatch = () => void;
+  type OwnProps = {|
+    passthrough: number,
+    forMapStateToProps: string,
+  |};
+  type Props = {|
+    ...OwnProps,
+    fromStateToProps: string,
+    dispatch: Dispatch,
+  |};
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = { a: number, ... };
+  type InputProps = {|
+    forMapStateToProps: string,
+    passthrough: number,
+  |};
+
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect<Props, OwnProps,_,_,_,Dispatch>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] extraProp what exact props does not allow
+  <Connected passthrough={123} forMapStateToProps={321} extraProp={123}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321}/>;
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError[incompatible-call] takes in only React components
+  const Connected2 = connect<Props, OwnProps,_,_,_,Dispatch>(mapStateToProps)('');
+  e.push(Connected2);
+}
+
+function testInexactOwnProps() {
+  type OwnProps = {
+    passthrough: number,
+    forMapStateToProps: string,
+    ...
+  };
+  type Props = {
+    // to eliminate the cripy `undefined`
+    ...$Exact<OwnProps>,
+    fromStateToProps: string,
+    ...
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = { a: number, ... };
+  type InputProps = {
+    forMapStateToProps: string,
+    passthrough: number,
+    ...
+  };
+
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] extraProp what exact props does not allow
+  <Connected passthrough={123} forMapStateToProps={321} extraProp={123}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321}/>;
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError[incompatible-call] takes in only React components
+  const Connected2 = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)('');
+  e.push(Connected2);
+}
+
+function testWithStatelessFunctionalComponent() {
+  type OwnProps = {|
+    passthrough: number,
+    forMapStateToProps: string,
+  |};
+  type Props = {
+    ...OwnProps,
+    fromStateToProps: string,
+    ...
+  };
+  const Com = (props: Props) => <div>{props.passthrough} {props.fromStateToProps}</div>
+
+  type State = { a: number, ... };
+  type InputProps = { forMapStateToProps: string, ... };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for passthrough
+  <Connected passthrough={''} forMapStateToProps={'data'}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321} />;
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError[incompatible-call] takes in only React components
+  const Connected2 = connect(mapStateToProps)('');
+  e.push(Connected2);
+}
+
+function testMapStateToPropsDoesNotNeedProps() {
+  type OwnProps = {|
+    passthrough: number
+  |};
+  type Props = {
+    ...OwnProps,
+    fromStateToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+
+  type State = { a: string, ... }
+  const mapStateToProps = (state: State) => {
+    return {
+      fromStateToProps: state.a
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError[incompatible-use] component property passthrough not found
+  <Connected />;
+}
+
+function testMapDispatchToProps() {
+  type OwnProps = {|
+    passthrough: number,
+    forMapStateToProps: string,
+    forMapDispatchToProps: string
+  |};
+  type Props = {
+    ...OwnProps,
+    fromMapDispatchToProps: string,
+    fromMapStateToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.passthrough}
+        {this.props.fromMapDispatchToProps}
+        {this.props.fromMapStateToProps}
+        </div>;
+    }
+  }
+
+  type State = { a: number, ... }
+  type MapStateToPropsProps = { forMapStateToProps: string, ... }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: 'str' + state.a
+    }
+  }
+  type MapDispatchToPropsProps = { forMapDispatchToProps: string, ... }
+  const mapDispatchToProps = (dispatch: any, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected passthrough={123} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] forMapDispatchToProps missing
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+}
+
+function testMapDispatchToPropsDoesNotPassDispatch() {
+  type Dispatch = () => void;
+  type OwnProps = {||};
+  type Props = {| ...OwnProps, fromMapDispatchToProps: string, dispatch: Dispatch |};
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.fromMapDispatchToProps}</div>;
+    }
+  }
+
+  const mapStateToProps = (state: any, props: any) => ({})
+  const mapDispatchToProps = (dispatch: any, ownProps: any) => {
+    return {fromMapDispatchToProps: 'yo'}
+  }
+  // $FlowExpectedError[prop-missing] dispatch should not be provided in Props when mapDispatchToProps is present
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(mapStateToProps, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function testMapDispatchToPropsWithoutMapStateToProps() {
+  type OwnProps = {|
+    passthrough: number,
+    forMapStateToProps: string,
+    forMapDispatchToProps: string,
+  |};
+  type Props = {
+    ...OwnProps,
+    fromMapDispatchToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.passthrough}
+        {this.props.fromMapDispatchToProps}
+      </div>;
+    }
+  }
+
+  type MapDispatchToPropsProps = { forMapDispatchToProps: string, ... };
+  const mapDispatchToProps = (dispatch: any, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const Connected = connect<Props, OwnProps, _,_,_,_>(null, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] forMapDispatchToProps missing
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+}
+
+function testMapDispatchToPropsPassesActionCreators() {
+  type OwnProps = {|
+    passthrough: number,
+  |};
+  type Props = {
+    ...OwnProps,
+    dispatch1: (num: number) => void,
+    dispatch2: () => void,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+
+  const mapDispatchToProps = {
+    dispatch1: (num: number) => {},
+    dispatch2: () => {}
+  };
+  const Connected = connect<Props, OwnProps, _,_,_,_>(null, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError[incompatible-use] no passthrough
+  <Connected/>;
+
+  const mapDispatchToPropsWithoutDispatch2 = {
+    dispatch1: (num: number) => {}
+  };
+  //$FlowExpectedError[prop-missing] no dispatch2
+  const Connected2 = connect<Props, OwnProps, _,_,_,_>(null, mapDispatchToPropsWithoutDispatch2)(Com);
+  e.push(Connected2);
+  <Connected2 passthrough={123}/>;
+
+  const mapDispatchToPropsWithWrongDispatch1 = {
+    dispatch1: (num: string) => {},
+    dispatch2: () => {}
+  };
+  //$FlowExpectedError[invalid-obj-map] dispatch1 should be number
+  const Connected3 = connect<Props, OwnProps, _,_,_,_>(null, mapDispatchToPropsWithWrongDispatch1)(Com);
+  e.push(Connected3);
+  <Connected3 passthrough={123}/>;
+}
+
+function testMapDispatchToPropsPassesActionCreatorsWithMapStateToProps() {
+  type OwnProps = {|
+    passthrough: number,
+    forMapStateToProps: string
+  |};
+  type Props = {
+    ...OwnProps,
+    dispatch1: () => void,
+    dispatch2: () => void,
+    fromMapStateToProps: number,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+  type State = { a: number, ... }
+  type MapStateToPropsProps = { forMapStateToProps: string, ... }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  const mapDispatchToProps = {
+    dispatch1: () => {},
+    dispatch2: () => {}
+  };
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps="str"/>;
+  //$FlowExpectedError[incompatible-use] no passthrough
+  <Connected forMapStateToProps="str" />;
+
+  const mapDispatchToProps2 = {
+    dispatch1: () => {}
+  };
+  //$FlowExpectedError[prop-missing] no dispatch2
+  const Connected2 = connect<Props, OwnProps, _,_,_,_>(mapStateToProps, mapDispatchToProps2)(Com);
+  e.push(Connected2);
+  <Connected2 passthrough={123} forMapStateToProps="str"/>;
+}
+
+function testMapDispatchToPropsPassesActionCreatorsWithMapStateToPropsAndMergeProps() {
+  type OwnProps1 = {|
+    passthrough: number,
+    forMapStateToProps: string,
+    forMergeProps: number
+  |};
+  type OwnProps2 = {|
+    passthrough: number,
+    forMapStateToProps: string,
+  |};
+  type Props = {
+    passthrough: number,
+    dispatch1: () => void,
+    dispatch2: () => void,
+    fromMapStateToProps: number,
+    fromMergeProps: number,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+  type State = { a: number, ... }
+  type MapStateToPropsProps = { forMapStateToProps: string, ... }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  const mapDispatchToProps = {
+    dispatch1: () => {},
+    dispatch2: () => {}
+  };
+  const mergeProps = (stateProps, dispatchProps, ownProps: { forMergeProps: number, ... }) => {
+    return Object.assign({}, stateProps, dispatchProps, { fromMergeProps: 123 });
+  }
+  const Connected = connect<Props, OwnProps1, _,_,_,_>(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps="str" forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] no passthrough
+  <Connected forMapStateToProps="str" forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMergeProps is missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] forMergeProps is wrong type
+  <Connected forMapStateToProps={'data'} forMergeProps={'not number'} />;
+
+  const mapDispatchToProps2 = {
+    dispatch1: () => {}
+  };
+  //$FlowExpectedError[prop-missing] no dispatch2
+  const Connected2 = connect<Props, OwnProps2, _,_,_,_>(mapStateToProps, mapDispatchToProps2)(Com);
+  e.push(Connected2);
+  <Connected2 passthrough={123} forMapStateToProps="str"/>;
+}
+
+function testMergeProps() {
+  type OwnProps = {|
+    forMapStateToProps: string,
+    forMapDispatchToProps: string,
+    forMergeProps: number
+  |};
+  type Props = { fromMergeProps: number, ... };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.fromMergeProps}
+      </div>;
+    }
+  }
+
+  type State = { a: number, ... }
+  type MapStateToPropsProps = { forMapStateToProps: string, ... }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  type MapDispatchToPropsProps = { forMapDispatchToProps: string, ... }
+  const mapDispatchToProps = (dispatch: any, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const mergeProps = (stateProps, dispatchProps, ownProps: { forMergeProps: number, ... }) => {
+    return {fromMergeProps: 123};
+  }
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
+  e.push(Connected);
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected forMapDispatchToProps={'more data'} forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMergeProps is missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] forMapDispatchToProps is missing
+  <Connected forMapStateToProps={'data'} forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMapDispatchToProps is wrong type
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} forMergeProps={'not number'} />;
+}
+
+function testOptions() {
+  class Com extends React.Component<{...}> {
+    render() {
+      return <div></div>;
+    }
+  }
+  // here in Props comes dispatch property
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {pure: true})(Com));
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {forwardRef: true})(Com));
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {pure: false, forwardRef: false})(Com));
+  // $FlowExpectedError[incompatible-call] wrong type
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {pure: 123})(Com));
+  // $FlowExpectedError[incompatible-call] wrong type
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {ref: 123})(Com));
+  // $FlowExpectedError[incompatible-call] wrong key
+  e.push(connect<{...}, {||}, _,_,_,_>(null, null, null, {wrongKey: true})(Com));
+}
+
+function testDispatch() {
+  type Props = { dispatch: empty => empty, ... }
+  class Com extends React.Component<Props> {
+    render() {
+      return <div></div>;
+    }
+  }
+  e.push(connect<Props, {||}, _,_,_,_>()(Com));
+}
+function testNoDispatch() {
+  type Props = {||}
+  class Com extends React.Component<Props> {
+    render() {
+      return <div></div>;
+    }
+  }
+  // $FlowExpectedError[prop-missing] property `dispatch` is missing in `Props`
+  e.push(connect<Props, {||}, _,_,_,_>()(Com));
+}
+
+function testHoistConnectedComponent() {
+  type OwnProps = {|
+    passthrough: number,
+    passthroughWithDefaultProp?: number,
+    forMapStateToProps: string
+  |};
+  type Props = {
+    ...OwnProps,
+    fromStateToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    static defaultProps = { passthroughWithDefaultProp: 123 };
+    static myStatic = 1;
+
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = { a: number, ... };
+  type InputProps = { forMapStateToProps: string, ... };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  // OK without passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  // OK with passthroughWithDefaultProp
+  <Connected passthrough={123} passthroughWithDefaultProp={456} forMapStateToProps={'data'}/>;
+  // OK with declared static property
+  Connected.myStatic;
+}
+
+function itsOkToReturnMoreThanNeededPropsFromMapStateToProps() {
+  type Props = { stringProp: string, ... };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  // This is actually required to reproduce an issue with Flow and the `*` type.
+  function getBoolean() {
+    return false;
+  }
+
+  const mapStateToProps = () => ({
+    stringProp: 'foo',
+    numProp: getBoolean()
+  });
+
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps)(Component);
+  <Connected />;
+  e.push(Connected)
+}
+
+function doesNotRequireDefinedComponentToTypeCheck2caseAgain() {
+  type Props = {
+    stringProp: string,
+    numProp: number,
+    ...
+  };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  // This is actually required to reproduce an issue with Flow and the `*` type.
+  function getBoolean() {
+    //$FlowExpectedError[incompatible-return] boolean [1] is incompatible with number [2]
+    return false;
+  }
+
+  const mapStateToProps = () => ({
+    stringProp: 'foo',
+    numProp: getBoolean()
+  });
+
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps)(Component);
+  <Connected />;
+  e.push(Connected)
+}
+
+function checkIfStateTypeIsRespectedAgain() {
+  type State = {
+  num: number, ... };
+
+  const mapStateToProps = (state: State) => {
+    return {
+      str: state.num
+    }
+  };
+
+  type Props = { str: string, ... };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  //$FlowExpectedError[incompatible-type-arg] number [1] is incompatible with string [2] in property `str`
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps)(Com);
+  <Connected />;
+  e.push(Connected);
+}
+
+function testPassingDispatchPropWithoutDispatchFunction() {
+  type Dispatch = () => void;
+  type OwnProps = {||}
+  type Props = {| ...OwnProps, dispatch: Dispatch |};
+  class Com extends React.Component<Props> {
+    render() {
+      return <div />;
+    }
+  }
+
+  type State = { a: number, ... };
+  type InputProps = {...};
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {}
+  };
+
+  const Connected = connect<Props, OwnProps,_,_,_,Dispatch>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function testPassingDispatchTypeIsPassedThrough() {
+  type Dispatch = () => void;
+  type OwnProps = {||}
+  type Props = {| ...OwnProps, dispatch: string |};
+  class Com extends React.Component<Props> {
+    render() {
+      return <div />;
+    }
+  }
+
+  const mapStateToProps = (state: any, props: any) => ({});
+
+  // $FlowExpectedError[incompatible-type-arg] dispatch mismatched from type Dispatch
+  const Connected = connect<Props, OwnProps,_,_,_,Dispatch>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function testNestedComponent() {
+  type OwnProps = {|
+    passthrough: number
+  |};
+  type Props = {
+    ...OwnProps,
+    fromStateToProps: string,
+    fromDispatchToProps: string,
+    ...
+  };
+
+  const Component = ({ passthrough, fromStateToProps, fromDispatchToProps }: Props) => {
+    return <span>{`${passthrough}: ${fromStateToProps}, ${fromDispatchToProps}`}</span>;
+  };
+
+  const Wrapper = ({ children }: { children: React$Element<any>, ... }) => {
+    return <span>{children}</span>;
+  };
+
+  const mapStateToProps = (state: {...}) => ({
+    fromStateToProps: '',
+  });
+
+  const mapDispatchToProps = () => ({
+    fromDispatchToProps: '',
+  });
+
+  const Connected = (connect<Props, OwnProps, _, _, _, _>(
+    mapStateToProps,
+    mapDispatchToProps
+  )(Component): Class<ConnectedComponent<OwnProps, typeof Component>>);
+
+  return (
+    <Wrapper>
+      <Connected passthrough={2} />
+    </Wrapper>
+  );
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectDispatch.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectDispatch.js
@@ -1,0 +1,105 @@
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+export let e: Array<any> = []
+
+function object_sameDispatchIsOK() {
+  type Action1 = {|
+    type: string
+  |};
+  type Dispatch1 = Action1 => Action1;
+  const action1 = (): Action1 => ({ type: 'str' })
+  const mapDispatchToProps = {
+    action1
+  };
+
+  type Props = { action1: typeof action1, ... };
+  class Com extends React.Component<Props> {}
+
+  const Connected1 = connect<Props, {||}, _,_,_,Dispatch1>(null, mapDispatchToProps)(Com);
+  e.push(Connected1);
+  <Connected1 />;
+}
+
+function object_differentDispatchesAreNotOK() {
+  type Action1 = {|
+    type: string
+  |};
+  type Dispatch1 = Action1 => Action1;
+  const action1 = (): Action1 => ({ type: 'str' })
+  const mapDispatchToProps = {
+    action1
+  };
+
+  type Action2 = {|
+    type: number
+  |};
+  type Dispatch2 = Action2 => Action2;
+
+  type Props = { action1: typeof action1, ... };
+  class Com extends React.Component<Props> {}
+
+  const Connected1 = connect<Props, {||}, _,_,_,Dispatch1>(null, mapDispatchToProps)(Com);
+  e.push(Connected1);
+  <Connected1 />;
+
+  //$FlowExpectedError[invalid-obj-map] `string` is incompatible with `number` in property `type`
+  const Connected2 = connect<Props, {||}, _,_,_,Dispatch2>(null, mapDispatchToProps)(Com);
+  e.push(Connected2);
+  <Connected2 />;
+}
+
+function function_sameDispatchIsOK() {
+  type Action1 = {|
+    type: string
+  |};
+  type Dispatch1 = Action1 => Action1;
+  const action1 = (): Action1 => ({ type: 'str' });
+  type DispatchProps = {|
+    action1: () => Action1
+  |};
+  type MapDispatchToPropsFn = Dispatch1 => DispatchProps;
+  const mapDispatchToProps: MapDispatchToPropsFn = (dispatch: Dispatch1) => ({
+    action1: (...args) => dispatch(action1(...args))
+  });
+
+  type Props = { action1: typeof action1, ... };
+  class Com extends React.Component<Props> {}
+
+  const Connected1 = connect<Props, {||}, _,DispatchProps,_,Dispatch1>(null, mapDispatchToProps)(Com);
+  e.push(Connected1);
+  <Connected1 />;
+}
+
+function function_differentDispatchesAreNotOK() {
+  type Action1 = {|
+    type: string
+  |};
+  type Dispatch1 = Action1 => Action1;
+  const action1 = (): Action1 => ({ type: 'str' });
+  type DispatchProps = {|
+    action1: () => Action1
+  |};
+  type MapDispatchToPropsFn = Dispatch1 => DispatchProps;
+  const mapDispatchToProps: MapDispatchToPropsFn = (dispatch: Dispatch1) => ({
+    action1: (...args) => dispatch(action1(...args))
+  });
+
+  type Action2 = {|
+    type: number
+  |};
+  type Dispatch2 = Action2 => Action2;
+
+  type Props = { action1: typeof action1, ... };
+  class Com extends React.Component<Props> {}
+
+  const Connected1 = connect<Props, {||}, _,DispatchProps,_,Dispatch1>(null, mapDispatchToProps)(Com);
+  e.push(Connected1);
+  <Connected1 />;
+
+  //$FlowExpectedError[incompatible-call] `string` is incompatible with `number` in property `type`
+  const Connected2 = connect<Props, {||}, _,DispatchProps,_,Dispatch2>(null, mapDispatchToProps)(Com);
+  e.push(Connected2);
+  <Connected2 />;
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectHOC.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectHOC.js
@@ -1,0 +1,171 @@
+// @flow
+import * as React from "react";
+import { connect } from "react-redux";
+
+export let e: Array<any> = [];
+
+function checkSimplePropertyInjection() {
+  type OwnProps = {
+    foo: number,
+    bar: string,
+    ...
+  };
+  type Props = {
+    ...OwnProps,
+    foo: number,
+    ...
+  };
+  const mapStateToProps = () => ({ foo: 5 });
+
+  class Com extends React.Component<Props> {}
+
+  const Connected = connect<Props, OwnProps, _, _, _, _>(mapStateToProps)(Com);
+
+  <Connected foo={42} bar="str" />;
+  //$FlowExpectedError[incompatible-use] property `foo` is missing in props [1] but exists in `OwnProps`
+  <Connected bar="str" />;
+  e.push(Connected);
+
+  function injectProp<Config: {...}>(
+    Component: React.AbstractComponent<Config>,
+  ): React.AbstractComponent<$Diff<Config, { foo: number | void, ... }>> {
+    return function WrapperComponent(
+      props: $Diff<Config, { foo?: number, ... }>,
+    ) {
+      return <Component {...props} foo={42} />;
+    };
+  }
+
+  const Decorated = injectProp(Connected);
+  // OK without `foo`
+  <Decorated bar="str" />;
+  // OK with a not needed `foo`
+  <Decorated foo={42} bar="str" />;
+  //$FlowExpectedError[prop-missing] property `bar` is missing in props [3] but exists in `Props` [4]
+  <Decorated />;
+  e.push(Decorated);
+}
+
+function composeWithOtherHOC_OK() {
+  type OwnProps = {
+    own1: number,
+    injected1: string,
+    ...
+  };
+  type Props = {
+    ...$Exact<OwnProps>,
+    state1: number,
+    ...
+  };
+  const mapStateToProps = () => ({ state1: 5 });
+
+  class Com extends React.Component<Props> {}
+
+  function injectProp<Config: {...}>(
+    Component: React.AbstractComponent<Config>,
+  ): React.AbstractComponent<$Diff<Config, { injected1: string | void, ... }>> {
+    return function WrapperComponent(
+      props: $Diff<Config, { injected1: string | void, ... }>,
+    ) {
+      return <Component {...props} injected1="str" />;
+    };
+  }
+
+  declare var compose: $Compose;
+
+  const composedDecorators = compose(
+    injectProp,
+    connect<Props, OwnProps, _, _, _, _>(mapStateToProps),
+  );
+
+  const Decorated = composedDecorators(Com);
+  // OK without `injected1`
+  <Decorated own1={1} />;
+  // OK with a not needed `injected1`
+  <Decorated own1={1} injected1="str" />;
+  //$FlowExpectedError[prop-missing] property `own1` is missing in props [3] but exists in `Props` [4]
+  <Decorated />;
+  e.push(Decorated);
+}
+
+function composeWithOtherHOC_exactOK() {
+  type OwnProps = {|
+    own1: number,
+    injected1: string,
+  |};
+  type Props = {
+    ...$Exact<OwnProps>,
+    state1: number,
+    ...
+  };
+  const mapStateToProps = () => ({ state1: 5 });
+
+  class Com extends React.Component<Props> {}
+
+  function injectProp<Config: {...}>(
+    Component: React.AbstractComponent<Config>,
+  ): React.AbstractComponent<$Diff<Config, { injected1: string | void, ... }>> {
+    return function WrapperComponent(
+      props: $Diff<Config, { injected1: string | void, ... }>,
+    ) {
+      return <Component {...props} injected1="str" />;
+    };
+  }
+
+  declare var compose: $Compose;
+
+  const composedDecorators = compose(
+    injectProp,
+    connect<Props, OwnProps, _, _, _, _>(mapStateToProps),
+  );
+
+  const Decorated = composedDecorators(Com);
+  // OK without `injected1`
+  <Decorated own1={1} />;
+  //$FlowExpectedError[prop-missing] property `injected1` is missing in `OwnProps` [1] but exists in props
+  <Decorated own1={1} injected1="str" />;
+  //$FlowExpectedError[prop-missing] property `own1` is missing in props [1] but exists in `OwnProps` [2]
+  <Decorated />;
+  e.push(Decorated);
+}
+
+function composeWithOtherHOC_wrongOrder() {
+  type OwnProps = {
+    own1: number,
+    injected1: string,
+    ...
+  };
+  type Props = {
+    ...$Exact<OwnProps>,
+    state1: number,
+    ...
+  };
+  const mapStateToProps = () => ({ state1: 5 });
+
+  class Com extends React.Component<Props> {}
+
+  function injectProp<Config: {...}>(
+    Component: React.AbstractComponent<Config>,
+  ): React.AbstractComponent<$Diff<Config, { injected1: string | void, ... }>> {
+    return function WrapperComponent(
+      props: $Diff<Config, { injected1: string | void, ... }>,
+    ) {
+      return <Component {...props} injected1="str" />;
+    };
+  }
+
+  declare var compose: $Compose;
+
+  // injectProp must go before connect()
+  const composedDecorators = compose(
+    connect<Props, OwnProps, _, _, _, _>(mapStateToProps),
+    injectProp,
+  );
+
+  const Decorated = composedDecorators(Com);
+  //$FlowExpectedError[incompatible-use] property `injected1` is missing in props
+  <Decorated own1={1} />;
+  // OK with an explicitly provided `injected1`
+  <Decorated own1={1} injected1="str" />;
+  e.push(Decorated);
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectInfer.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectInfer.js
@@ -396,11 +396,11 @@ function testOptions() {
       return <div></div>;
     }
   }
-  connect(null, null, null, {pure: true})(Com);
+  connect(null, null, null, {storeKey: 'test'})(Com);
   connect(null, null, null, {forwardRef: true})(Com);
-  connect(null, null, null, {pure: false, forwardRef: false})(Com);
+  connect(null, null, null, {storeKey: 'test', forwardRef: false})(Com);
   // $FlowExpectedError[incompatible-call] wrong type
-  connect(null, null, null, {pure: 123})(Com);
+  connect(null, null, null, {storeKey: 123})(Com);
   // $FlowExpectedError[incompatible-call] wrong type
   connect(null, null, null, {ref: 123})(Com);
   // $FlowExpectedError[incompatible-call] wrong key

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectInfer.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectInfer.js
@@ -1,0 +1,588 @@
+/*
+  Keep here examples which still work without type parameters specified,
+  even if the current Flow verion still reports misleading errors.
+  This helps keep the usage of Flow amazing type inferent on the good level.
+*/
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+function testPassingPropsToConnectedComponent() {
+  type OwnProps = {|
+    passthrough: number,
+    passthroughWithDefaultProp?: number,
+    forMapStateToProps: string
+  |}
+  type Props = {
+    ...OwnProps,
+    fromStateToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    static defaultProps = { passthroughWithDefaultProp: 123 };
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = { a: number, ... };
+  type InputProps = { forMapStateToProps: string, ... };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect(mapStateToProps)(Com);
+  Connected.WrappedComponent;
+  <Connected passthrough={123} forMapStateToProps={'data'} passthroughWithDefaultProp={123}/>;
+  // OK without passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  // Flow erroneously complains about `fromStateToProps`
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] wrong type for passthrough
+  <Connected passthrough={''} forMapStateToProps={'data'} passthroughWithDefaultProp={123}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321} passthroughWithDefaultProp={123}/>;
+  // Flow erroneously complains about `fromStateToProps`
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] wrong type for  passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'} passthroughWithDefaultProp={''}/>;
+  // Flow also erroneously complains about fromStateToProps
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError[incompatible-call] takes in only React components
+  connect(mapStateToProps)('');
+}
+
+function doesNotRequireDefinedComponentToTypeCheck5case() {
+  type Props = { stringProp: string, ... };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = () => ({});
+  const mapDispatchToProps = () => ({});
+
+  const mergeProps = () => ({
+    stringProp: true
+  });
+
+  //$FlowExpectedError[incompatible-call] wrong type for stringProp
+  connect(mapStateToProps, mapDispatchToProps, mergeProps)(Component);
+}
+
+function testWithStatelessFunctionalComponent() {
+  type Props = {
+    passthrough: number,
+    fromStateToProps: string,
+    ...
+  };
+  const Com = (props: Props) => <div>{props.passthrough} {props.fromStateToProps}</div>
+
+  type State = { a: number, ... };
+  type InputProps = { forMapStateToProps: string, ... };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect(mapStateToProps)(Com);
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the wrong type for passthroug,
+  // giving passthrough a number fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] wrong type for passthrough
+  <Connected passthrough={''} forMapStateToProps={'data'}/>;
+  //$FlowExpectedError[incompatible-use] wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321} />;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError[incompatible-call] takes in only React components
+  connect(mapStateToProps)('');
+}
+
+function testMapStateToPropsDoesNotNeedProps() {
+  type Props = {
+    passthrough: number,
+    fromStateToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+
+  type State = { a: string, ... }
+  const mapStateToProps = (state: State) => {
+    return {
+      fromStateToProps: state.a
+    }
+  }
+
+  const Connected = connect(mapStateToProps)(Com);
+  <Connected passthrough={123}/>;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] component property passthrough not found
+  <Connected />;
+}
+
+function testMapDispatchToProps() {
+  type Props = {
+    passthrough: number,
+    fromMapDispatchToProps: string,
+    fromMapStateToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.passthrough}
+        {this.props.fromMapDispatchToProps}
+        {this.props.fromMapStateToProps}
+        </div>;
+    }
+  }
+
+  type State = { a: number, ... }
+  type MapStateToPropsProps = { forMapStateToProps: string, ... }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: 'str' + state.a
+    }
+  }
+  type MapDispatchToPropsProps = { forMapDispatchToProps: string, ... }
+  const mapDispatchToProps = (dispatch: any, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const Connected = connect(mapStateToProps, mapDispatchToProps)(Com);
+  <Connected passthrough={123} forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected passthrough={123} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] forMapDispatchToProps missing
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+}
+
+function testMapDispatchToPropsWithoutMapStateToProps() {
+  type Props = {
+    passthrough: number,
+    fromMapDispatchToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.passthrough}
+        {this.props.fromMapDispatchToProps}
+      </div>;
+    }
+  }
+
+  type MapDispatchToPropsProps = { forMapDispatchToProps: string, ... };
+  const mapDispatchToProps = (dispatch: any, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const Connected = connect(null, mapDispatchToProps)(Com);
+  <Connected passthrough={123} forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] passthrough missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] forMapDispatchToProps missing
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+}
+
+function testMapDispatchToPropsPassesActionCreators() {
+  type Props = {
+    passthrough: number,
+    dispatch1: (num: number) => void,
+    dispatch2: () => void,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+
+  const mapDispatchToProps = {
+    dispatch1: (num: number) => {},
+    dispatch2: () => {}
+  };
+  const Connected = connect(null, mapDispatchToProps)(Com);
+  <Connected passthrough={123}/>;
+  // Here Flow reports that `dispatch1` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] no passthrough
+  <Connected />;
+
+  const mapDispatchToPropsWithoutDispatch2 = {
+    dispatch1: (num: number) => {}
+  };
+  const Connected2 = connect(null, mapDispatchToPropsWithoutDispatch2)(Com);
+  // Here Flow reports that `dispatch1` is missing from props,
+  // while the real error is still the missing `dispatch2`,
+  // giving the `mapDispatchToProps` to connect above
+  // fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] no dispatch2
+  <Connected2 passthrough={123}/>;
+
+  const mapDispatchToPropsWithWrongDispatch1 = {
+    dispatch1: (num: string) => {},
+    dispatch2: () => {}
+  };
+  const Connected3 = connect(null, mapDispatchToPropsWithWrongDispatch1)(Com);
+  // Here Flow reports that `dispatch1` is missing from props,
+  // while the real error is still the wrong type of `dispatch1`,
+  // giving `num` the correct type fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] dispatch1 should be number
+  <Connected3 passthrough={123}/>;
+}
+
+function testMapDispatchToPropsPassesActionCreatorsWithMapStateToProps() {
+  type Props = {
+    passthrough: number,
+    dispatch1: () => void,
+    dispatch2: () => void,
+    fromMapStateToProps: number,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+  type State = { a: number, ... }
+  type MapStateToPropsProps = { forMapStateToProps: string, ... }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  const mapDispatchToProps = {
+    dispatch1: () => {},
+    dispatch2: () => {}
+  };
+  const Connected = connect(mapStateToProps, mapDispatchToProps)(Com);
+  <Connected passthrough={123} forMapStateToProps="str"/>;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] no passthrough
+  <Connected/>;
+
+  const mapDispatchToProps2 = {
+    dispatch1: () => {}
+  };
+  const Connected2 = connect(mapStateToProps, mapDispatchToProps2)(Com);
+  // Here Flow reports that `dispatch1` is missing from props,
+  // while the real error is still the missing `dispatch2`,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] no dispatch2
+  <Connected2 passthrough={123} forMapStateToProps="str"/>;
+}
+
+function testMapDispatchToPropsPassesActionCreatorsWithMapStateToPropsAndMergeProps() {
+  type Props = {
+    passthrough: number,
+    dispatch1: () => void,
+    dispatch2: () => void,
+    fromMapStateToProps: number,
+    fromMergeProps: number,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+  type State = { a: number, ... }
+  type MapStateToPropsProps = { forMapStateToProps: string, ... }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  const mapDispatchToProps = {
+    dispatch1: () => {},
+    dispatch2: () => {}
+  };
+  const mergeProps = (stateProps, dispatchProps, ownProps: { forMergeProps: number, ... }) => {
+    return Object.assign({}, stateProps, dispatchProps, { fromMergeProps: 123 });
+  }
+  const Connected = connect(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
+  <Connected passthrough={123} forMapStateToProps="str" forMergeProps={1234}/>;
+  // Here Flow reports that `forMapStateToProps` is missing from props,
+  // while the real error is still the missing `passthrough`,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] no passthrough
+  <Connected/>;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected forMapDispatchToProps={'more data'} forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMergeProps is missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError[incompatible-use] forMergeProps is wrong type
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} forMergeProps={'not number'} />;
+
+  const mapDispatchToProps2 = {
+    dispatch1: () => {}
+  };
+  const Connected2 = connect(mapStateToProps, mapDispatchToProps2)(Com);
+  // Here Flow reports that `dispatch1` is missing from props,
+  // while the real error is still the missing `dispatch2`,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use] no dispatch2
+  <Connected2 passthrough={123} forMapStateToProps="str"/>;
+}
+
+function testMergeProps() {
+  type Props = { fromMergeProps: number, ... };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.fromMergeProps}
+      </div>;
+    }
+  }
+
+  type State = { a: number, ... }
+  type MapStateToPropsProps = { forMapStateToProps: string, ... }
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  type MapDispatchToPropsProps = { forMapDispatchToProps: string, ... }
+  const mapDispatchToProps = (dispatch: any, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const mergeProps = (stateProps, dispatchProps, ownProps: { forMergeProps: number, ... }) => {
+    return {fromMergeProps: 123};
+  }
+  const Connected = connect(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMapStateToProps missing
+  <Connected forMapDispatchToProps={'more data'} forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMergeProps is missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError[incompatible-use] forMapDispatchToProps is missing
+  <Connected forMapStateToProps={'data'} forMergeProps={1234} />;
+  //$FlowExpectedError[incompatible-use] forMapDispatchToProps is wrong type
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} forMergeProps={'not number'} />;
+}
+
+function testOptions() {
+  class Com extends React.Component<{...}> {
+    render() {
+      return <div></div>;
+    }
+  }
+  connect(null, null, null, {pure: true})(Com);
+  connect(null, null, null, {forwardRef: true})(Com);
+  connect(null, null, null, {pure: false, forwardRef: false})(Com);
+  // $FlowExpectedError[incompatible-call] wrong type
+  connect(null, null, null, {pure: 123})(Com);
+  // $FlowExpectedError[incompatible-call] wrong type
+  connect(null, null, null, {ref: 123})(Com);
+  // $FlowExpectedError[incompatible-call] wrong key
+  connect(null, null, null, {wrongKey: true})(Com);
+}
+
+function testHoistConnectedComponent() {
+  type Props = {
+    passthrough: number,
+    passthroughWithDefaultProp: number,
+    fromStateToProps: string,
+    ...
+  };
+  class Com extends React.Component<Props> {
+    static defaultProps = { passthroughWithDefaultProp: 123 };
+    static myStatic = 1;
+
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = { a: number, ... };
+  type InputProps = { forMapStateToProps: string, ... };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect(mapStateToProps)(Com);
+  // OK without passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  // OK with passthroughWithDefaultProp
+  <Connected passthrough={123} passthroughWithDefaultProp={456} forMapStateToProps={'data'}/>;
+  // OK with declared static property
+  Connected.myStatic;
+  //$FlowExpectedError[incompatible-use] property `notStatic` is missing in statics
+  Connected.notStatic;
+}
+
+function checkIfStateTypeIsRespectedAgain() {
+  type State = {
+    num: number,
+    str: string,
+    ...
+  };
+
+  const mapStateToProps = (state: State) => {
+    return { // no error
+      str: state.num
+    }
+  };
+
+  type Props = { str: string, ... };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  const Connected = connect(mapStateToProps)(Com);
+  // Here Flow reports that `str` is missing from props,
+  // while the real error is still the type mismatch,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use]
+  <Connected />;
+}
+
+
+
+function testAllowsKnownPropInMapStateToProps() {
+  type Props = { str: string, ... };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {
+    num: number,
+    str: string,
+    ...
+  };
+
+  const mapStateToProps = (state: State) => {
+    return {
+      str: state.str
+    }
+  };
+
+  const Connected = connect(mapStateToProps)(Com);
+  <Connected />;
+}
+
+function testForbidsLiteralOfInvalidTypeInMapStateToProps() {
+  type Props = {
+  str: string, ... };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {
+    num: number,
+    str: string,
+    ...
+  };
+
+  const mapStateToPropsWithLiteralOfInvalidType = (state: State) => {
+    return {
+      str: 123
+    }
+  };
+
+  const Connected = connect(mapStateToPropsWithLiteralOfInvalidType)(Com);
+  //$FlowExpectedError[incompatible-use] string is incompatible with number
+  <Connected />
+}
+
+function testForbidsStateProperyOfInvalidTypeInMapStateToProps() {
+  type Props = { str: string, ... };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {
+    num: number,
+    str: string,
+    ...
+  };
+
+  const mapStateToPropsWithStatePropertyOfInvalidType = (state: State) => {
+    return {
+      str: state.num
+    }
+  };
+
+  const Connected = connect(mapStateToPropsWithStatePropertyOfInvalidType)(Com);
+  // Here Flow reports that `str` is missing from props,
+  // while the real error is still the type mismatch,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use]
+  <Connected />;
+}
+
+function testForbidsSelectorWithInvalidReturnTypeInMapStateToProps() {
+  type Props = { str: string, ... };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {
+    num: number,
+    str: string,
+    ...
+  };
+
+  function selectorReturningNumber(state: State) {
+    return state.num
+  }
+
+  const mapStateToPropsWithSelectorWithInvalidTypeReturnValue = (state: State) => {
+    return {
+      str: selectorReturningNumber(state)
+    }
+  };
+
+  const Connected = connect(mapStateToPropsWithSelectorWithInvalidTypeReturnValue)(Com);
+  // Here Flow reports that `str` is missing from props,
+  // while the real error is still the type mismatch,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError[incompatible-use]
+  <Connected />
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectMergeProps.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectMergeProps.js
@@ -1,0 +1,608 @@
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+export let e: Array<any> = []
+
+function onlyOwnProps_ok() {
+  opaque type Action = 'action';
+  type Dispatch = Action => Action;
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type Props = { ...OwnProps, ... };
+  class Com extends React.Component<Props> {}
+
+  const mergeProps = (stateProps: {||}, dispatchProps: {|dispatch: Dispatch|}, ownProps: OwnProps) => {
+    return {
+      ...ownProps
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(null, null, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyOwnProps_wrongDispatch() {
+  opaque type Action = 'action';
+  type Dispatch = Action => Action;
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type Props = { ...OwnProps, ... };
+  class Com extends React.Component<Props> {}
+
+  const mergeProps = (stateProps: {||}, dispatchProps: {|dispatch: string|}, ownProps: OwnProps) => {
+    return {
+      ...ownProps
+    }
+  }
+
+  //$FlowExpectedError[incompatible-call] string [1] is incompatible with  `Dispatch` [2] in property `dispatch`
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    null,
+    null,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyOwnProps_noPassthrough() {
+  opaque type Action = 'action';
+  type Dispatch = Action => Action;
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type Props = { ...OwnProps, ... };
+  class Com extends React.Component<Props> {}
+
+  const mergeProps = (stateProps: {||}, dispatchProps: {|dispatch: Dispatch|}, ownProps: OwnProps) => {
+    return {
+      a: 1
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    null,
+    null,
+    //$FlowExpectedError[prop-missing] property `passthrough` is missing in object literal [1] but exists in `OwnProps` [2]
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyStateProps_ok() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action';
+  type Dispatch = Action => Action;
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type Props = {
+    ...OwnProps,
+    ...StateProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({state1: state.state1})
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: {|dispatch: Dispatch|}, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...stateProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(mapStateToProps, null, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyStateProps_wrongDispatch() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action';
+  type Dispatch = Action => Action;
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type Props = {
+    ...OwnProps,
+    ...StateProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: {|dispatch: string|}, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...stateProps
+    }
+  }
+
+  //$FlowExpectedError[incompatible-call] string [1] is incompatible with  `Dispatch` [2] in property `dispatch`
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    mapStateToProps,
+    null,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyDispatchPropsObject_ok() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapDispatchToProps = {
+    action1
+  }
+
+  const mergeProps = (stateProps: {||}, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(undefined, mapDispatchToProps, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyDispatchPropsObject_wrongExpectedState() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapDispatchToProps = {
+    action1
+  }
+
+  const mergeProps = (stateProps: { wrong: boolean, ... }, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...dispatchProps,
+    }
+  }
+
+  //$FlowExpectedError[incompatible-call] property `wrong` is missing in object type [1] but exists in object type [2]
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    undefined,
+    mapDispatchToProps,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyDispatchPropsFunction_ok() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (stateProps: {||}, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(null, mapDispatchToPropsFn, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyDispatchPropsFunction_WrongExpectedState() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  type MapDispatchToPropsFn = Dispatch => DispatchProps
+  const mapDispatchToPropsFn: MapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (stateProps: {|wrong:boolean|}, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...dispatchProps,
+    }
+  }
+
+  //$FlowExpectedError[incompatible-call] property `wrong` is missing in  object type [1] but exists in  object type [2]
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(null, mapDispatchToPropsFn, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyDispatchPropsFunction_wrongDispatchProp() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => 123
+  })
+
+  const mergeProps = (stateProps: {||}, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    null,
+    //$FlowExpectedError[incompatible-call] number [1] is incompatible with  string literal `action1` [2]
+    mapDispatchToPropsFn,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function stateAndDispatchPropsFunction_ok() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...StateProps,
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...stateProps,
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    mapStateToProps,
+    mapDispatchToPropsFn,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function stateAndDispatchPropsFunction_wrongState() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...StateProps,
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (
+    stateProps: {|wrong:boolean|},
+    dispatchProps: DispatchProps,
+    ownProps: OwnProps
+  ) => {
+    return {
+      ...ownProps,
+      state1: 'state1',
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    // yes, a bit cryptic
+    //$FlowExpectedError[prop-missing] property `state1` is missing in  object type [1] but exists in  object literal [2]
+    mapStateToProps,
+    mapDispatchToPropsFn,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function stateAndDispatchPropsFunction_wrongDispatch() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...StateProps,
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => 123
+  })
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...stateProps,
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    mapStateToProps,
+    //$FlowExpectedError[incompatible-call] number [1] is incompatible with string literal `action1` [2]
+    mapDispatchToPropsFn,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function returnsTotallyDifferentProps() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    a: 1,
+    b: 2,
+    c: 3,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    mapStateToProps,
+    mapDispatchToPropsFn,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function returnsTotallyDifferentPropsWithError() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    a: 1,
+    b: 2,
+    c: 3,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      a: 1,
+      b: 2,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    mapStateToProps,
+    mapDispatchToPropsFn,
+    //$FlowExpectedError[prop-missing] property `c` is missing in object literal [1] but exists in  `Props` [2]
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectState.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectState.js
@@ -1,0 +1,41 @@
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+export let e: Array<any> = []
+
+function sameStateIsOK() {
+  type Props = {...};
+  class Com extends React.Component<Props> {}
+
+  type State = {|
+    a: number
+  |};
+  const mapStateToProps = (state: State) => {
+    return {}
+  };
+
+  const Connected = connect<Props, {||}, _,_,State,empty>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function differentStatesAreNotOK() {
+  type Props = {...};
+  class Com extends React.Component<Props> {}
+
+  type State = {|
+    a: number
+  |};
+  const mapStateToProps = (state: State) => {
+    return {}
+  };
+  type OtherState = {|
+    b: number
+  |};
+
+  //$FlowExpectedError[incompatible-call] property `b` is missing in `State` but exists in `OtherState`
+  const Connected = connect<Props, {||}, _,_,OtherState,empty>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectThunk.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectThunk.js
@@ -1,0 +1,199 @@
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+export let e: Array<any> = []
+
+function onlyDispatchFunction_samePropsAreOK() {
+  type State = {||}
+  type Action = {|
+    type: 'action'
+  |};
+  type DispatchAction = Action => Action;
+  type Thunk = (Dispatch, State) => Promise<number>
+  type DispatchThunk = Thunk => Promise<number>
+  type Dispatch = DispatchAction & DispatchThunk
+
+  const action = (): Action => ({ type: 'action' });
+  const thunk = (): Thunk => (d: Dispatch) => Promise.resolve(1);
+  type DispatchProps = {|
+    action: typeof action,
+    thunk: () => Promise<number>,
+  |};
+  type MapDispatchToPropsFn = Dispatch => DispatchProps;
+  const mapDispatchToProps: MapDispatchToPropsFn = (dispatch) => ({
+    action: () => dispatch(action()),
+    thunk: () => dispatch(thunk())
+  });
+
+  type Props = { // in the case of a function passed to `connect()` Flow infers
+  // the same type of function is both the Props and DispatchProps objects
+  // (see the testDispatchThunk() to get the difference)
+  ...DispatchProps, ... };
+  class Com extends React.Component<Props> {}
+
+  const Connected = connect<Props, {||}, _,DispatchProps,_,Dispatch>(null, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function onlyDispatchObject_differentDispatchPropsAreOK() {
+  type State = {||}
+  type Action = {|
+    type: 'action'
+  |};
+  type DispatchAction = Action => Action;
+  type Thunk = (Dispatch, State) => Promise<number>
+  type DispatchThunk = Thunk => Promise<number>
+  type Dispatch = DispatchAction & DispatchThunk
+
+  const action = (): Action => ({ type: 'action' });
+  const thunk = (): Thunk => (d: Dispatch) => Promise.resolve(1);
+
+  type DispatchProps = {|
+    action: typeof action,
+    // here the property returns a thunk...
+    thunk: () => Thunk,
+  |};
+  const mapDispatchToProps = {
+    action,
+    thunk
+  };
+
+  type Props = {
+    action: typeof action,
+    // ... and here the property returns a return value of thunk
+    // as dispatch calls it for us with `dispatch` and `getState`
+    thunk: () => Promise<number>,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const Connected = connect<Props, {||}, _,DispatchProps,_,Dispatch>(null, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function onlyDispatchObject_sameDispatchPropsAreErroneous() {
+  type State = {||}
+  type Action = {|
+    type: 'action'
+  |};
+  type DispatchAction = Action => Action;
+  type Thunk = (Dispatch, State) => Promise<number>
+  type DispatchThunk = Thunk => Promise<number>
+  type Dispatch = DispatchAction & DispatchThunk
+
+  const action = (): Action => ({ type: 'action' });
+  const thunk = (): Thunk => (d: Dispatch) => Promise.resolve(1);
+
+  type DispatchProps = {|
+    action: typeof action,
+    thunk: () => Thunk,
+  |};
+  const mapDispatchToProps = {
+    action,
+    thunk
+  };
+
+  type Props = { // trying to pass the not passed to dispatch types (against the redux dispatch monad)
+  ...DispatchProps, ... };
+  class Com extends React.Component<Props> {}
+
+  //$FlowExpectedError[prop-missing] here the property returns a thunk...
+  //$FlowExpectedError[incompatible-type-arg]
+  const Connected = connect<Props, {||}, _,DispatchProps,_,Dispatch>(null, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function stateAndDispatchObject_differentDispatchPropsAreOK() {
+  type State = {|
+    state1: 'state1'
+  |}
+  type Action = {|
+    type: 'action'
+  |};
+  type DispatchAction = Action => Action;
+  type Thunk = (Dispatch, State) => Promise<number>
+  type DispatchThunk = Thunk => Promise<number>
+  type Dispatch = DispatchAction & DispatchThunk
+
+  const action = (): Action => ({ type: 'action' });
+  const thunk = (): Thunk => (d: Dispatch) => Promise.resolve(1);
+
+  type StateProps = {|
+    state1: 'state1',
+  |};
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  type DispatchProps = {|
+    action: typeof action,
+    // here the property returns a thunk...
+    thunk: () => Thunk,
+  |};
+  const mapDispatchToProps = {
+    action,
+    thunk
+  };
+
+  type Props = {
+    ...StateProps,
+    action: typeof action,
+    // ... and here the property returns a return value of thunk
+    // as dispatch calls it for us with `dispatch` and `getState`
+    thunk: () => Promise<number>,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  const Connected = connect<Props, {||}, _,DispatchProps,_,Dispatch>(mapStateToProps, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function stateAndDispatchObject_sameDispatchPropsAreErroneous() {
+  type State = {||}
+  type Action = {|
+    type: 'action'
+  |};
+  type DispatchAction = Action => Action;
+  type Thunk = (Dispatch, State) => Promise<number>
+  type DispatchThunk = Thunk => Promise<number>
+  type Dispatch = DispatchAction & DispatchThunk
+
+  const action = (): Action => ({ type: 'action' });
+  const thunk = (): Thunk => (d: Dispatch) => Promise.resolve(1);
+
+  type StateProps = {|
+    state1: 'state1',
+  |};
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  type DispatchProps = {|
+    action: typeof action,
+    thunk: () => Thunk,
+  |};
+  const mapDispatchToProps = {
+    action,
+    thunk
+  };
+
+  type Props = {
+    ...StateProps,
+    // trying to pass the not passed to dispatch types (against the redux dispatch monad)
+    ...DispatchProps,
+    ...
+  };
+  class Com extends React.Component<Props> {}
+
+  //$FlowExpectedError[prop-missing] here the property returns a thunk...
+  //$FlowExpectedError[incompatible-call]
+  const Connected = connect<Props, {||}, _,DispatchProps,_,Dispatch>(mapStateToProps, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_shallowEqual.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_shallowEqual.js
@@ -1,0 +1,29 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import { shallowEqual } from 'react-redux';
+
+describe('shallowEqual', () => {
+  it('returns a boolean', () => {
+    const x: boolean = shallowEqual('a', 'a');
+
+    //$FlowExpectedError[incompatible-type]
+    const y: number = shallowEqual('a', 'a');
+  });
+
+  it('can be called with any argument types', () => {
+    shallowEqual('a', 'a');
+    shallowEqual({ test: 'test' }, { test: 'test' });
+    shallowEqual({ test: 'test' }, 'a');
+  });
+
+  it('should be called with two arguments', () => {
+    // Flow considers these compatible with shallowEqual<T>(a: T, b: any).
+
+    // The same is seen in tests for _.isEqual and the comment below is copied from those tests
+    // Reasonable people disagree about whether these should be considered legal calls.
+    // See https://github.com/splodingsocks/FlowTyped/pull/1#issuecomment-149345275
+    // and https://github.com/facebook/flow/issues/956
+    shallowEqual();
+    shallowEqual('a');
+  });
+});

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_useDispatch.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_useDispatch.js
@@ -1,0 +1,150 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import React from 'react';
+import { useDispatch } from 'react-redux';
+
+type Action = {|
+  type: 'action',
+|};
+type Dispatch = Action => Action;
+
+describe('useDispatch', () => {
+  it('returns type `Dispatch` which accepts only type `Action` as param', () => {
+    const dispatch = useDispatch<Dispatch>();
+
+    const action = dispatch({ type: 'action' });
+    (action.type: string);
+    // $FlowExpectedError[incompatible-cast] will be string because of passed generic
+    (action.type: number);
+  });
+
+  it('errors if returned type is passed invalid Action', () => {
+    const dispatch = useDispatch<Dispatch>();
+
+    // $FlowExpectedError[incompatible-call]: return value of `useDispatch` should make `Dispatch` and expect an `Action`.
+    dispatch();
+  });
+
+  it('handles action creator passed in and is typed', () => {
+    const dispatch = useDispatch();
+
+    const action = dispatch({ anything: 'string' });
+    (action.anything: string);
+    // $FlowExpectedError[incompatible-cast] will be string because of passed action
+    (action.anything: number);
+  });
+
+  it('handles thunks being passed to return the right value', () => {
+    const thunkAction = () => (dispatch) => {
+      return '';
+    }
+    const dispatch = useDispatch();
+
+    const a = dispatch(thunkAction());
+    a.toString();
+    // $FlowExpectedError[incompatible-cast] it will return a string, not any which could be cast to number
+    (a: number)
+  });
+
+  it('handles thunks defined as a promise to keep their type', () => {
+    const thunkPromiseAction = () => (dispatch) => new Promise((resolve) => {
+      resolve('');
+    });
+    const dispatch = useDispatch();
+
+    const dispatched = dispatch(thunkPromiseAction());
+    (dispatched: Promise<string>);
+    // $FlowExpectedError[incompatible-cast] it will return a string, not any which could be cast to number
+    (dispatched: Promise<number>);
+  });
+
+  it('handles thunks defined as a 1 arg tuple', () => {
+    type ThunkAction = () => ((...args: [
+      () => void,
+    ]) => string);
+    const thunkAction: ThunkAction = () => (dispatch) => {
+      dispatch();
+      return '';
+    }
+    const dispatch = useDispatch();
+
+    const a = dispatch(thunkAction());
+    a.toString();
+    // $FlowExpectedError[incompatible-cast] it will return a string, not any which could be cast to number
+    (a: number)
+  });
+
+  it('handles thunks defined as a 2 arg tuple', () => {
+    type ThunkAction = () => ((...args: [
+      () => void,
+      () => { [key: string]: any },
+    ]) => string);
+    const thunkAction: ThunkAction = () => (dispatch, getState) => {
+      dispatch();
+      getState().property1.property2;
+      return '';
+    }
+    const dispatch = useDispatch();
+
+    const a = dispatch(thunkAction());
+    a.toString();
+    // $FlowExpectedError[incompatible-cast] it will return a string, not any which could be cast to number
+    (a: number)
+  });
+
+  it('handles thunks defined as a 3 arg tuple', () => {
+    type ThunkAction = () => ((...args: [
+      () => void,
+      () => { [key: string]: any },
+      {| test: number |},
+    ]) => string);
+    const thunkAction: ThunkAction = () => (dispatch, getState, extraArg) => {
+      dispatch();
+      getState().property1.property2;
+      extraArg.test.toFixed(2);
+      return '';
+    }
+    const dispatch = useDispatch();
+
+    const a = dispatch(thunkAction());
+    a.toString();
+    // $FlowExpectedError[incompatible-cast] it will return a string, not any which could be cast to number
+    (a: number)
+  });
+
+  it('handles thunks defined as each arg', () => {
+    type ThunkAction = () => ((
+      dispatch: () => void,
+      getState: () => { [key: string]: any },
+      extraArg: {| test: number |},
+    ) => string);
+    const thunkAction: ThunkAction = () => (dispatch, getState, extraArg) => {
+      dispatch();
+      getState().property1.property2;
+      extraArg.test.toFixed(2);
+      return '';
+    }
+    const dispatch = useDispatch();
+
+    const a = dispatch(thunkAction());
+    a.toString();
+    // $FlowExpectedError[incompatible-cast] it will return a string, not any which could be cast to number
+    (a: number)
+  });
+
+  it('handles thunks without a clear args', () => {
+    type ThunkAction = () => ((...args: Array<any>) => string);
+    const thunkAction: ThunkAction = () => (dispatch, getState, extraArg) => {
+      dispatch.test.a();
+      getState.test.a();
+      extraArg.test.a();
+      return '';
+    }
+    const dispatch = useDispatch();
+
+    const a = dispatch(thunkAction());
+    a.toString();
+    // $FlowExpectedError[incompatible-cast] it will return a string, not any which could be cast to number
+    (a: number)
+  });
+});

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_useSelector.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_useSelector.js
@@ -11,8 +11,11 @@ type State = {|
 describe('useSelector', () => {
   it('passes State as first parameter', () => {
     function Com() {
-      // $FlowExpectedError[prop-missing]: the state has no `b`
-      const count = useSelector<State, number>(state => state.b);
+      // $FlowExpectedError[incompatible-call]
+      const count = useSelector<State, number>(state => {
+        // $FlowExpectedError[prop-missing]: the state has no `b`
+        state.b
+      });
       return <div>{count}</div>;
     }
   });

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_useSelector.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_useSelector.js
@@ -1,0 +1,48 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import React from 'react';
+import { useSelector, shallowEqual } from 'react-redux';
+
+type State = {|
+  a: number,
+|};
+
+describe('useSelector', () => {
+  it('passes State as first parameter', () => {
+    function Com() {
+      // $FlowExpectedError[prop-missing]: the state has no `b`
+      const count = useSelector<State, number>(state => state.b);
+      return <div>{count}</div>;
+    }
+  });
+
+  it('passes type of second parameter as params to `equalityFn`', () => {
+    function Com2() {
+      const count = useSelector<State, number>(
+        state => state.a,
+        // $FlowExpectedError[prop-missing]: `equalityFn` is passed params of the second type, do not have `.size`
+        (a, b) => a.size === b.size
+      );
+      return <div>{count}</div>;
+    }
+  });
+
+  it('returns type of second parameter', () => {
+    function Com3() {
+      const count = useSelector<State, number>(
+        state => state.a,
+        (a, b) => a === b
+      );
+      // `count` is type `number` and allows addition
+      return <div>{count + 5}</div>;
+    }
+  });
+
+  it('can use shallowEqual as the `equalityFn`', () => {
+    function Com4() {
+      const count = useSelector<State, number>(state => state.a, shallowEqual);
+      return <div>{count}</div>;
+    }
+  });
+});

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_useStore.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_useStore.js
@@ -1,0 +1,42 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import React from 'react';
+import { useStore } from 'react-redux';
+
+describe('useStore', () => {
+  type Action = { type: 'SOME_ACTION', ... };
+  type State = { state: string, ... };
+
+  // ReduxStore should be imported from 'redux' but we can't do this with this
+  // test environment, so let's copy them once again...
+  declare type Redux$DispatchAPI<A> = (action: A) => A;
+  declare type Redux$Dispatch<A: { type: string, ... }> = Redux$DispatchAPI<A>;
+  declare type Redux$Reducer<S, A> = (state: S | void, action: A) => S;
+  declare type Redux$Store<S, A, D = Redux$Dispatch<A>> = {
+    dispatch: D,
+    getState(): S,
+    subscribe(listener: () => void): () => void,
+    replaceReducer(nextReducer: Redux$Reducer<S, A>): void,
+    ...
+  };
+
+  type Dispatch = (action: Action) => Action;
+  type GetState = () => State;
+  type Store = Redux$Store<State, Action, Dispatch>;
+
+  it('returns instance of Store', () => {
+    function Com() {
+      const store = useStore<Store>();
+      return <div>{store.getState().state}</div>;
+    }
+  });
+
+  it('returns instance of Store, no extra keys', () => {
+    function Com() {
+      const store = useStore<Store>();
+      // $FlowExpectedError[prop-missing]: `foobar` is not a member of the Store instance
+      return <div>{store.getState().foobar}</div>;
+    }
+  });
+});

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/react-redux_v8.x.x.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/react-redux_v8.x.x.js
@@ -26,7 +26,6 @@ Decrypting the abbreviations:
   Com = React Component
   SS = Selected state
   ST = Static properties of Com
-  EFO = Extra factory options (used only in connectAdvanced)
 */
 
 declare module "react-redux" {
@@ -223,61 +222,6 @@ declare module "react-redux" {
     subKey?: string,
   ): Class<Provider<*>>;
 
-  // ------------------------------------------------------------
-  // Typings for connectAdvanced()
-  // ------------------------------------------------------------
-
-  declare type ConnectAdvancedOptions = {
-    getDisplayName?: (name: string) => string,
-    methodName?: string,
-    renderCountProp?: string,
-    shouldHandleStateChanges?: boolean,
-    storeKey?: string,
-    forwardRef?: boolean,
-  };
-
-  declare type SelectorFactoryOptions<Com> = {
-    getDisplayName: (name: string) => string,
-    methodName: string,
-    renderCountProp: ?string,
-    shouldHandleStateChanges: boolean,
-    storeKey: string,
-    forwardRef: boolean,
-    displayName: string,
-    wrappedComponentName: string,
-    WrappedComponent: Com,
-  };
-
-  declare type MapStateToPropsEx<S: Object, SP: Object, RSP: Object> = (
-    state: S,
-    props: SP,
-  ) => RSP;
-
-  declare type SelectorFactory<
-    Com: React$ComponentType<*>,
-    Dispatch,
-    S: Object,
-    OP: Object,
-    EFO: Object,
-    CP: Object,
-  > = (
-    dispatch: Dispatch,
-    factoryOptions: SelectorFactoryOptions<Com> & EFO,
-  ) => MapStateToPropsEx<S, OP, CP>;
-
-  declare export function connectAdvanced<
-    Com: React$ComponentType<*>,
-    D,
-    S: Object,
-    OP: Object,
-    CP: Object,
-    EFO: Object,
-    ST: { [_: $Keys<Com>]: any },
-  >(
-    selectorFactory: SelectorFactory<Com, D, S, OP, EFO, CP>,
-    connectAdvancedOptions: ?(ConnectAdvancedOptions & EFO),
-  ): (component: Com) => React$ComponentType<OP> & $Shape<ST>;
-
   declare export function batch(() => void): void
 
   declare export function shallowEqual<T>(left: T, right: any): boolean
@@ -286,7 +230,6 @@ declare module "react-redux" {
     Provider: typeof Provider,
     createProvider: typeof createProvider,
     connect: typeof connect,
-    connectAdvanced: typeof connectAdvanced,
     useDispatch: typeof useDispatch,
     useSelector: typeof useSelector,
     useStore: typeof useStore,

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/react-redux_v8.x.x.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/react-redux_v8.x.x.js
@@ -34,7 +34,6 @@ declare module "react-redux" {
   // ------------------------------------------------------------
 
   declare export type Options<S, OP, SP, MP> = {|
-    pure?: boolean,
     forwardRef?: boolean,
     areStatesEqual?: (next: S, prev: S) => boolean,
     areOwnPropsEqual?: (next: OP, prev: OP) => boolean,

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/react-redux_v8.x.x.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/react-redux_v8.x.x.js
@@ -1,0 +1,295 @@
+/**
+The order of type arguments for connect() is as follows:
+
+connect<Props, OwnProps, StateProps, DispatchProps, State, Dispatch>(…)
+
+In Flow v0.89 only the first two are mandatory to specify. Other 4 can be repaced with the new awesome type placeholder:
+
+connect<Props, OwnProps, _, _, _, _>(…)
+
+But beware, in case of weird type errors somewhere in random places
+just type everything and get to a green field and only then try to
+remove the definitions you see bogus.
+
+Decrypting the abbreviations:
+  WC = Component being wrapped
+  S = State
+  D = Dispatch
+  OP = OwnProps
+  SP = StateProps
+  DP = DispatchProps
+  MP = Merge props
+  RSP = Returned state props
+  RDP = Returned dispatch props
+  RMP = Returned merge props
+  CP = Props for returned component
+  Com = React Component
+  SS = Selected state
+  ST = Static properties of Com
+  EFO = Extra factory options (used only in connectAdvanced)
+*/
+
+declare module "react-redux" {
+  // ------------------------------------------------------------
+  // Typings for connect()
+  // ------------------------------------------------------------
+
+  declare export type Options<S, OP, SP, MP> = {|
+    pure?: boolean,
+    forwardRef?: boolean,
+    areStatesEqual?: (next: S, prev: S) => boolean,
+    areOwnPropsEqual?: (next: OP, prev: OP) => boolean,
+    areStatePropsEqual?: (next: SP, prev: SP) => boolean,
+    areMergedPropsEqual?: (next: MP, prev: MP) => boolean,
+    storeKey?: string,
+  |};
+
+  declare type MapStateToProps<-S, -OP, +SP> =
+    | ((state: S, ownProps: OP) => SP)
+    // If you want to use the factory function but get a strange error
+    // like "function is not an object" then just type the factory function
+    // like this:
+    // const factory: (State, OwnProps) => (State, OwnProps) => StateProps
+    // and provide the StateProps type to the SP type parameter.
+    | ((state: S, ownProps: OP) => (state: S, ownProps: OP) => SP);
+
+  declare type Bind<D> = <A, R>((...A) => R) => (...A) => $Call<D, R>;
+
+  declare type MapDispatchToPropsFn<D, -OP, +DP> =
+    | ((dispatch: D, ownProps: OP) => DP)
+    // If you want to use the factory function but get a strange error
+    // like "function is not an object" then just type the factory function
+    // like this:
+    // const factory: (Dispatch, OwnProps) => (Dispatch, OwnProps) => DispatchProps
+    // and provide the DispatchProps type to the DP type parameter.
+    | ((dispatch: D, ownProps: OP) => (dispatch: D, ownProps: OP) => DP);
+
+  declare class ConnectedComponent<OP, +WC> extends React$Component<OP> {
+    static +WrappedComponent: WC;
+    getWrappedInstance(): React$ElementRef<WC>;
+  }
+  // The connection of the Wrapped Component and the Connected Component
+  // happens here in `MP: P`. It means that type wise MP belongs to P,
+  // so to say MP >= P.
+  declare type Connector<P, OP, MP: P> = <WC: React$ComponentType<P>>(
+    WC,
+  ) => Class<ConnectedComponent<OP, WC>> & WC;
+
+  // No `mergeProps` argument
+
+  // Got error like inexact OwnProps is incompatible with exact object type?
+  // Just make the OP parameter for `connect()` an exact object.
+  declare type MergeOP<OP, D> = {| ...$Exact<OP>, dispatch: D |};
+  declare type MergeOPSP<OP, SP, D> = {| ...$Exact<OP>, ...SP, dispatch: D |};
+  declare type MergeOPDP<OP, DP> = {| ...$Exact<OP>, ...DP |};
+  declare type MergeOPSPDP<OP, SP, DP> = {| ...$Exact<OP>, ...SP, ...DP |};
+
+  declare export function connect<-P, -OP, -SP, -DP, -S, -D>(
+    mapStateToProps?: null | void,
+    mapDispatchToProps?: null | void,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOP<OP, D>>,
+  ): Connector<P, OP, MergeOP<OP, D>>;
+
+  declare export function connect<-P, -OP, -SP, -DP, -S, -D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps?: null | void,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, MergeOPSP<OP, SP, D>>,
+  ): Connector<P, OP, MergeOPSP<OP, SP, D>>;
+
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOPDP<OP, DP>>,
+  ): Connector<P, OP, MergeOPDP<OP, DP>>;
+
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: DP,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, {||}, MergeOPDP<OP, DP>>,
+  ): Connector<P, OP, MergeOPDP<OP, $ObjMap<DP, Bind<D>>>>;
+
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, {| ...OP, ...SP, ...DP |}>,
+  ): Connector<P, OP, {| ...OP, ...SP, ...DP |}>;
+
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    // If you get error here try adding return type to your mapStateToProps function
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: DP,
+    mergeProps?: null | void,
+    options?: ?Options<S, OP, SP, MergeOPSPDP<OP, SP, DP>>,
+  ): Connector<P, OP, MergeOPSPDP<OP, SP, $ObjMap<DP, Bind<D>>>>;
+
+  // With `mergeProps` argument
+
+  declare type MergeProps<+P, -OP, -SP, -DP> = (
+    stateProps: SP,
+    dispatchProps: DP,
+    ownProps: OP,
+  ) => P;
+
+  declare export function connect<-P, -OP, -SP: {||}, -DP: {||}, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: null | void,
+    // If you get error here try adding return type to you mapStateToProps function
+    mergeProps: MergeProps<P, OP, {||}, {| dispatch: D |}>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
+
+  declare export function connect<-P, -OP, -SP, -DP: {||}, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: null | void,
+    // If you get error here try adding return type to you mapStateToProps function
+    mergeProps: MergeProps<P, OP, SP, {| dispatch: D |}>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP: {||}, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps: MergeProps<P, OP, {||}, DP>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP: {||}, -DP, S, D>(
+    mapStateToProps: null | void,
+    mapDispatchToProps: DP,
+    mergeProps: MergeProps<P, OP, {||}, $ObjMap<DP, Bind<D>>>,
+    options?: ?Options<S, OP, {||}, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of functions which has been bound to dispatch
+  // by the given mapDispatchToProps function.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: MapDispatchToPropsFn<D, OP, DP>,
+    mergeProps: MergeProps<P, OP, SP, DP>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
+
+  // In this case DP is an object of action creators not yet bound to dispatch,
+  // this difference is not important in the vanila redux,
+  // but in case of usage with redux-thunk, the return type may differ.
+  declare export function connect<-P, -OP, -SP, -DP, S, D>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: DP,
+    mergeProps: MergeProps<P, OP, SP, $ObjMap<DP, Bind<D>>>,
+    options?: ?Options<S, OP, SP, P>,
+  ): Connector<P, OP, P>;
+
+  // ------------------------------------------------------------
+  // Typings for Hooks
+  // ------------------------------------------------------------
+
+  declare export function useDispatch<D>(): D;
+
+  declare export function useSelector<S, SS>(
+    selector: (state: S) => SS,
+    equalityFn?: (a: SS, b: SS) => boolean,
+  ): SS;
+
+  declare export function useStore<Store>(): Store;
+
+  // ------------------------------------------------------------
+  // Typings for Provider
+  // ------------------------------------------------------------
+
+  declare export class Provider<Store> extends React$Component<{
+    store: Store,
+    children?: React$Node,
+  }> {}
+
+  declare export function createProvider(
+    storeKey?: string,
+    subKey?: string,
+  ): Class<Provider<*>>;
+
+  // ------------------------------------------------------------
+  // Typings for connectAdvanced()
+  // ------------------------------------------------------------
+
+  declare type ConnectAdvancedOptions = {
+    getDisplayName?: (name: string) => string,
+    methodName?: string,
+    renderCountProp?: string,
+    shouldHandleStateChanges?: boolean,
+    storeKey?: string,
+    forwardRef?: boolean,
+  };
+
+  declare type SelectorFactoryOptions<Com> = {
+    getDisplayName: (name: string) => string,
+    methodName: string,
+    renderCountProp: ?string,
+    shouldHandleStateChanges: boolean,
+    storeKey: string,
+    forwardRef: boolean,
+    displayName: string,
+    wrappedComponentName: string,
+    WrappedComponent: Com,
+  };
+
+  declare type MapStateToPropsEx<S: Object, SP: Object, RSP: Object> = (
+    state: S,
+    props: SP,
+  ) => RSP;
+
+  declare type SelectorFactory<
+    Com: React$ComponentType<*>,
+    Dispatch,
+    S: Object,
+    OP: Object,
+    EFO: Object,
+    CP: Object,
+  > = (
+    dispatch: Dispatch,
+    factoryOptions: SelectorFactoryOptions<Com> & EFO,
+  ) => MapStateToPropsEx<S, OP, CP>;
+
+  declare export function connectAdvanced<
+    Com: React$ComponentType<*>,
+    D,
+    S: Object,
+    OP: Object,
+    CP: Object,
+    EFO: Object,
+    ST: { [_: $Keys<Com>]: any },
+  >(
+    selectorFactory: SelectorFactory<Com, D, S, OP, EFO, CP>,
+    connectAdvancedOptions: ?(ConnectAdvancedOptions & EFO),
+  ): (component: Com) => React$ComponentType<OP> & $Shape<ST>;
+
+  declare export function batch(() => void): void
+
+  declare export function shallowEqual<T>(left: T, right: any): boolean
+
+  declare export default {
+    Provider: typeof Provider,
+    createProvider: typeof createProvider,
+    connect: typeof connect,
+    connectAdvanced: typeof connectAdvanced,
+    useDispatch: typeof useDispatch,
+    useSelector: typeof useSelector,
+    useStore: typeof useStore,
+    batch: typeof batch,
+  };
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_Provider.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_Provider.js
@@ -1,0 +1,54 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+
+import React from "react";
+import { Provider, createProvider } from "react-redux";
+
+describe('Provider', () => {
+  it('should give an error when the store is missing', () => {
+    // $FlowExpectedError
+    <Provider />;
+
+    // Also for custom providers
+    const CustomProvider: Class<Provider<*>> = createProvider("ikea");
+
+    // $FlowExpectedError
+    <CustomProvider />;
+  });
+});
+
+describe('Custom Store (eg for ThunkActions)', () => {
+
+  // This represents a common typing for Thunk Actions.
+
+  type Action = { type: 'SOME_ACTION' };
+  type State = { state: string };
+
+  // ReduxStore should be imported from 'redux' but we can't do this with this
+  // test environment, so let's copy them once again...
+  declare type Redux$DispatchAPI<A> = (action: A) => A;
+  declare type Redux$Dispatch<A: { type: string }> = Redux$DispatchAPI<A>;
+  declare type Redux$Reducer<S, A> = (state: S | void, action: A) => S;
+  declare type Redux$Store<S, A, D = Redux$Dispatch<A>> = {
+    dispatch: D;
+    getState(): S;
+    subscribe(listener: () => void): () => void;
+    replaceReducer(nextReducer: Redux$Reducer<S, A>): void
+  };
+
+  // R = Result of a thunk action
+  type ThunkDispatch = <R>(action: ThunkAction<R>) => R;
+  type PlainDispatch = (action: Action) => Action;
+  type GetState = () => State;
+  type ThunkAction<R> = (dispatch: Dispatch, GetState) => R;
+  // The `dispatch` function can accept either a plain action or a thunk action.
+  // This is similar to a type `(action: Action | ThunkAction) => any` except this
+  // allows to type the return value as well.
+  type Dispatch = PlainDispatch & ThunkDispatch;
+  type Store = Redux$Store<State, Action, Dispatch>;
+
+  it('accepts a custom store', () => {
+    declare var store: Store;
+    <Provider store={store} />;
+  });
+});

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_batch.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_batch.js
@@ -1,0 +1,28 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import { batch } from 'react-redux';
+
+describe('batch', () => {
+  it('should accept a function as an argument', () => {
+    batch(() => {
+      // ...
+    })
+  });
+
+  it('should not allow a values that is not a function as an argument', () => {
+    // $ExpectError - only a function is allowed
+    batch(true)
+  });
+
+  it('returns void', () => {
+    (batch(() => {
+      // ...
+    }): void)
+    
+    batch(() => {
+      // $ExpectError - function must return void
+      return true; 
+    })
+  })
+
+})

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connect.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connect.js
@@ -1,0 +1,785 @@
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+export let e = []
+
+function testPassingPropsToConnectedComponent() {
+  type OwnProps = {|
+    passthrough: number,
+    passthroughWithDefaultProp?: number,
+    forMapStateToProps: string
+  |}
+  type Props = { ...OwnProps, fromStateToProps: string};
+  class Com extends React.Component<Props> {
+    static defaultProps = { passthroughWithDefaultProp: 123 };
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = {a: number};
+  type InputProps = {
+    forMapStateToProps: string
+  };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  Connected.WrappedComponent;
+  <Connected passthrough={123} forMapStateToProps={'data'} passthroughWithDefaultProp={123}/>;
+  // OK without passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  //$FlowExpectedError wrong type for passthrough
+  <Connected passthrough={''} forMapStateToProps={'data'} passthroughWithDefaultProp={123}/>;
+  //$FlowExpectedError wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321} passthroughWithDefaultProp={123}/>;
+  //$FlowExpectedError wrong type for  passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'} passthroughWithDefaultProp={''}/>;
+  //$FlowExpectedError passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError takes in only React components
+  const Connected2 = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)('');
+  e.push(Connected2);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck1case() {
+  type Props = {
+    stringProp: string,
+  };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = (state: {}) => ({
+    // $FlowExpectedError wrong type for stringProp
+    stringProp: false,
+  });
+
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps)(Component);
+  <Connected />;
+  e.push(Connected);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck2case() {
+  type Props = {
+    numProp: string,
+  };
+
+  const Component = ({ numProp }: Props) => {
+    return <span>{numProp}</span>;
+  };
+
+  const mapDispatchToProps = () => ({
+    // $FlowExpectedError wrong type for numProp
+    numProp: false,
+  });
+
+  const Connected = connect<Props, {||}, _,_,_,_>(null, mapDispatchToProps)(Component);
+  <Connected />;
+  e.push(Connected);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck3case() {
+  type Props = {
+    stringProp: string,
+    numProp: number
+  };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = (state: {}) => ({
+    // $FlowExpectedError wrong type for stringProp
+    stringProp: false,
+  });
+
+  const mapDispatchToProps = () => ({
+    // $FlowExpectedError wrong type for numProp
+    numProp: false,
+  });
+
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps, mapDispatchToProps)(Component);
+  <Connected />;
+  e.push(Connected);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck4case() {
+  type Props = {
+    stringProp: string,
+  };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = (state: {}) => ({
+    // $FlowExpectedError wrong type for stringProp
+    stringProp: false,
+  });
+
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps, {})(Component);
+  <Connected />;
+  e.push(Connected);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck5case() {
+  type Props = {
+    stringProp: string
+  };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = () => ({});
+  const mapDispatchToProps = () => ({});
+
+  const mergeProps = () => ({
+    // $FlowExpectedError wrong type for stringProp
+    stringProp: true
+  });
+
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps, mapDispatchToProps, mergeProps)(Component);
+  <Connected />;
+  e.push(Connected);
+}
+
+function testExactProps() {
+  type Dispatch = () => void;
+  type OwnProps = {|
+    passthrough: number,
+    forMapStateToProps: string,
+  |};
+  type Props = {|
+    ...OwnProps,
+    fromStateToProps: string,
+    dispatch: Dispatch,
+  |};
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = {a: number};
+  type InputProps = {|
+    forMapStateToProps: string,
+    passthrough: number,
+  |};
+
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect<Props, OwnProps,_,_,_,Dispatch>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+  //$FlowExpectedError extraProp what exact props does not allow
+  <Connected passthrough={123} forMapStateToProps={321} extraProp={123}/>;
+  //$FlowExpectedError wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321}/>;
+  //$FlowExpectedError passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError takes in only React components
+  const Connected2 = connect<Props, OwnProps,_,_,_,Dispatch>(mapStateToProps)('');
+  e.push(Connected2);
+}
+
+function testInexactOwnProps() {
+  type OwnProps = {
+    passthrough: number,
+    forMapStateToProps: string,
+  };
+  type Props = {
+    ...$Exact<OwnProps>, // to eliminate the cripy `undefined`
+    fromStateToProps: string
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = {a: number};
+  type InputProps = {
+    forMapStateToProps: string,
+    passthrough: number,
+  };
+
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+  //$FlowExpectedError extraProp what exact props does not allow
+  <Connected passthrough={123} forMapStateToProps={321} extraProp={123}/>;
+  //$FlowExpectedError wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321}/>;
+  //$FlowExpectedError passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError takes in only React components
+  const Connected2 = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)('');
+  e.push(Connected2);
+}
+
+function testWithStatelessFunctionalComponent() {
+  type OwnProps = {|
+    passthrough: number,
+    forMapStateToProps: string,
+  |};
+  type Props = {
+    ...OwnProps,
+    fromStateToProps: string
+  };
+  const Com = (props: Props) => <div>{props.passthrough} {props.fromStateToProps}</div>
+
+  type State = {a: number};
+  type InputProps = {
+    forMapStateToProps: string
+  };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  //$FlowExpectedError wrong type for passthrough
+  <Connected passthrough={''} forMapStateToProps={'data'}/>;
+  //$FlowExpectedError wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321} />;
+  //$FlowExpectedError passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError takes in only React components
+  const Connected2 = connect(mapStateToProps)('');
+  e.push(Connected2);
+}
+
+function testMapStateToPropsDoesNotNeedProps() {
+  type OwnProps = {|
+    passthrough: number
+  |};
+  type Props = {
+    ...OwnProps,
+    fromStateToProps: string
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+
+  type State = {a: string}
+  const mapStateToProps = (state: State) => {
+    return {
+      fromStateToProps: state.a
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError component property passthrough not found
+  <Connected />;
+}
+
+function testMapDispatchToProps() {
+  type OwnProps = {|
+    passthrough: number,
+    forMapStateToProps: string,
+    forMapDispatchToProps: string
+  |};
+  type Props = {
+    ...OwnProps,
+    fromMapDispatchToProps: string,
+    fromMapStateToProps: string
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.passthrough}
+        {this.props.fromMapDispatchToProps}
+        {this.props.fromMapStateToProps}
+        </div>;
+    }
+  }
+
+  type State = {a: number}
+  type MapStateToPropsProps = {forMapStateToProps: string}
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: 'str' + state.a
+    }
+  }
+  type MapDispatchToPropsProps = {forMapDispatchToProps: string}
+  const mapDispatchToProps = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError passthrough missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError forMapStateToProps missing
+  <Connected passthrough={123} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError forMapDispatchToProps missing
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+}
+
+function testMapDispatchToPropsDoesNotPassDispatch() {
+  type Dispatch = () => void;
+  type OwnProps = {||};
+  type Props = {| ...OwnProps, fromMapDispatchToProps: string, dispatch: Dispatch |};
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.fromMapDispatchToProps}</div>;
+    }
+  }
+
+  const mapStateToProps = (state: *, props: *) => ({})
+  const mapDispatchToProps = (dispatch: *, ownProps: *) => {
+    return {fromMapDispatchToProps: 'yo'}
+  }
+  // $FlowExpectedError dispatch should not be provided in Props when mapDispatchToProps is present
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(mapStateToProps, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function testMapDispatchToPropsWithoutMapStateToProps() {
+  type OwnProps = {|
+    passthrough: number,
+    forMapStateToProps: string,
+    forMapDispatchToProps: string,
+  |};
+  type Props = {
+    ...OwnProps,
+    fromMapDispatchToProps: string
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.passthrough}
+        {this.props.fromMapDispatchToProps}
+      </div>;
+    }
+  }
+
+  type MapDispatchToPropsProps = {forMapDispatchToProps: string};
+  const mapDispatchToProps = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const Connected = connect<Props, OwnProps, _,_,_,_>(null, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError passthrough missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError forMapDispatchToProps missing
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+}
+
+function testMapDispatchToPropsPassesActionCreators() {
+  type OwnProps = {|
+    passthrough: number,
+  |};
+  type Props = {
+    ...OwnProps,
+    dispatch1: (num: number) => void,
+    dispatch2: () => void
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+
+  const mapDispatchToProps = {
+    dispatch1: (num: number) => {},
+    dispatch2: () => {}
+  };
+  const Connected = connect<Props, OwnProps, _,_,_,_>(null, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError no passthrough
+  <Connected/>;
+
+  const mapDispatchToPropsWithoutDispatch2 = {
+    dispatch1: (num: number) => {}
+  };
+  //$FlowExpectedError no dispatch2
+  const Connected2 = connect<Props, OwnProps, _,_,_,_>(null, mapDispatchToPropsWithoutDispatch2)(Com);
+  e.push(Connected2);
+  <Connected2 passthrough={123}/>;
+
+  const mapDispatchToPropsWithWrongDispatch1 = {
+    //$FlowExpectedError dispatch1 should be number
+    dispatch1: (num: string) => {},
+    dispatch2: () => {}
+  };
+  const Connected3 = connect<Props, OwnProps, _,_,_,_>(null, mapDispatchToPropsWithWrongDispatch1)(Com);
+  e.push(Connected3);
+  <Connected3 passthrough={123}/>;
+}
+
+function testMapDispatchToPropsPassesActionCreatorsWithMapStateToProps() {
+  type OwnProps = {|
+    passthrough: number,
+    forMapStateToProps: string
+  |};
+  type Props = {
+    ...OwnProps,
+    dispatch1: () => void,
+    dispatch2: () => void,
+    fromMapStateToProps: number
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+  type State = {a: number}
+  type MapStateToPropsProps = {forMapStateToProps: string}
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  const mapDispatchToProps = {
+    dispatch1: () => {},
+    dispatch2: () => {}
+  };
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps="str"/>;
+  //$FlowExpectedError no passthrough
+  <Connected forMapStateToProps="str" />;
+
+  const mapDispatchToProps2 = {
+    dispatch1: () => {}
+  };
+  //$FlowExpectedError no dispatch2
+  const Connected2 = connect<Props, OwnProps, _,_,_,_>(mapStateToProps, mapDispatchToProps2)(Com);
+  e.push(Connected2);
+  <Connected2 passthrough={123} forMapStateToProps="str"/>;
+}
+
+function testMapDispatchToPropsPassesActionCreatorsWithMapStateToPropsAndMergeProps() {
+  type OwnProps1 = {|
+    passthrough: number,
+    forMapStateToProps: string,
+    forMergeProps: number
+  |};
+  type OwnProps2 = {|
+    passthrough: number,
+    forMapStateToProps: string,
+  |};
+  type Props = {
+    passthrough: number,
+    dispatch1: () => void,
+    dispatch2: () => void,
+    fromMapStateToProps: number,
+    fromMergeProps: number
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+  type State = {a: number}
+  type MapStateToPropsProps = {forMapStateToProps: string}
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  const mapDispatchToProps = {
+    dispatch1: () => {},
+    dispatch2: () => {}
+  };
+  const mergeProps = (stateProps, dispatchProps, ownProps: {forMergeProps: number}) => {
+    return Object.assign({}, stateProps, dispatchProps, { fromMergeProps: 123 });
+  }
+  const Connected = connect<Props, OwnProps1, _,_,_,_>(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough={123} forMapStateToProps="str" forMergeProps={1234} />;
+  //$FlowExpectedError no passthrough
+  <Connected forMapStateToProps="str" forMergeProps={1234} />;
+  //$FlowExpectedError forMapStateToProps missing
+  <Connected forMergeProps={1234} />;
+  //$FlowExpectedError forMergeProps is missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError forMergeProps is wrong type
+  <Connected forMapStateToProps={'data'} forMergeProps={'not number'} />;
+
+  const mapDispatchToProps2 = {
+    dispatch1: () => {}
+  };
+  //$FlowExpectedError no dispatch2
+  const Connected2 = connect<Props, OwnProps2, _,_,_,_>(mapStateToProps, mapDispatchToProps2)(Com);
+  e.push(Connected2);
+  <Connected2 passthrough={123} forMapStateToProps="str"/>;
+}
+
+function testMergeProps() {
+  type OwnProps = {|
+    forMapStateToProps: string,
+    forMapDispatchToProps: string,
+    forMergeProps: number
+  |};
+  type Props = {
+    fromMergeProps: number,
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.fromMergeProps}
+      </div>;
+    }
+  }
+
+  type State = {a: number}
+  type MapStateToPropsProps = {forMapStateToProps: string}
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  type MapDispatchToPropsProps = {forMapDispatchToProps: string}
+  const mapDispatchToProps = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const mergeProps = (stateProps, dispatchProps, ownProps: {forMergeProps: number}) => {
+    return {fromMergeProps: 123};
+  }
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
+  e.push(Connected);
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} forMergeProps={1234} />;
+  //$FlowExpectedError forMapStateToProps missing
+  <Connected forMapDispatchToProps={'more data'} forMergeProps={1234} />;
+  //$FlowExpectedError forMergeProps is missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError forMapDispatchToProps is missing
+  <Connected forMapStateToProps={'data'} forMergeProps={1234} />;
+  //$FlowExpectedError forMapDispatchToProps is wrong type
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} forMergeProps={'not number'} />;
+}
+
+function testOptions() {
+  class Com extends React.Component<{}> {
+    render() {
+      return <div></div>;
+    }
+  }
+  // here in Props comes dispatch property
+  e.push(connect<{}, {||}, _,_,_,_>(null, null, null, {pure: true})(Com));
+  e.push(connect<{}, {||}, _,_,_,_>(null, null, null, {forwardRef: true})(Com));
+  e.push(connect<{}, {||}, _,_,_,_>(null, null, null, {pure: false, forwardRef: false})(Com));
+  // $FlowExpectedError wrong type
+  e.push(connect<{}, {||}, _,_,_,_>(null, null, null, {pure: 123})(Com));
+  // $FlowExpectedError wrong type
+  e.push(connect<{}, {||}, _,_,_,_>(null, null, null, {ref: 123})(Com));
+  // $FlowExpectedError wrong key
+  e.push(connect<{}, {||}, _,_,_,_>(null, null, null, {wrongKey: true})(Com));
+}
+
+function testDispatch() {
+  type Props = {
+    dispatch: empty => empty
+  }
+  class Com extends React.Component<Props> {
+    render() {
+      return <div></div>;
+    }
+  }
+  e.push(connect<Props, {||}, _,_,_,_>()(Com));
+}
+function testNoDispatch() {
+  type Props = {||}
+  class Com extends React.Component<Props> {
+    render() {
+      return <div></div>;
+    }
+  }
+  // $FlowExpectedError property `dispatch` is missing in `Props`
+  e.push(connect<Props, {||}, _,_,_,_>()(Com));
+}
+
+function testHoistConnectedComponent() {
+  type OwnProps = {|
+    passthrough: number,
+    passthroughWithDefaultProp?: number,
+    forMapStateToProps: string
+  |};
+  type Props = {
+    ...OwnProps,
+    fromStateToProps: string
+  };
+  class Com extends React.Component<Props> {
+    static defaultProps = { passthroughWithDefaultProp: 123 };
+    static myStatic = 1;
+
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = {a: number};
+  type InputProps = {
+    forMapStateToProps: string
+  };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps)(Com);
+  e.push(Connected);
+  // OK without passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  // OK with passthroughWithDefaultProp
+  <Connected passthrough={123} passthroughWithDefaultProp={456} forMapStateToProps={'data'}/>;
+  // OK with declared static property
+  Connected.myStatic;
+}
+
+function itsOkToReturnMoreThanNeededPropsFromMapStateToProps() {
+  type Props = {
+    stringProp: string,
+  };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  // This is actually required to reproduce an issue with Flow and the `*` type.
+  function getBoolean() {
+    return false;
+  }
+
+  const mapStateToProps = () => ({
+    stringProp: 'foo',
+    numProp: getBoolean()
+  });
+
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps)(Component);
+  <Connected />;
+  e.push(Connected)
+}
+
+function doesNotRequireDefinedComponentToTypeCheck2case() {
+  type Props = {
+    stringProp: string,
+    numProp: number
+  };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  // This is actually required to reproduce an issue with Flow and the `*` type.
+  function getBoolean() {
+    //$FlowExpectedError boolean [1] is incompatible with number [2]
+    return false;
+  }
+
+  const mapStateToProps = () => ({
+    stringProp: 'foo',
+    numProp: getBoolean()
+  });
+
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps)(Component);
+  <Connected />;
+  e.push(Connected)
+}
+
+function checkIfStateTypeIsRespectedAgain() {
+  type State = {
+    //$FlowExpectedError number [1] is incompatible with string [2] in property `str`
+    num: number
+  };
+
+  const mapStateToProps = (state: State) => {
+    return {
+      str: state.num
+    }
+  };
+
+  type Props = {
+    str: string
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  const Connected = connect<Props, {||}, _,_,_,_>(mapStateToProps)(Com);
+  <Connected />;
+  e.push(Connected);
+}
+
+function testPassingDispatchPropWithoutDispatchFunction() {
+  type Dispatch = () => void;
+  type OwnProps = {||}
+  type Props = {| ...OwnProps, dispatch: Dispatch |};
+  class Com extends React.Component<Props> {
+    render() {
+      return <div />;
+    }
+  }
+
+  type State = {a: number};
+  type InputProps = {};
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {}
+  };
+
+  const Connected = connect<Props, OwnProps,_,_,_,Dispatch>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function testPassingDispatchTypeIsPassedThrough() {
+  type Dispatch = () => void;
+  type OwnProps = {||}
+  type Props = {| ...OwnProps, dispatch: string |};
+  class Com extends React.Component<Props> {
+    render() {
+      return <div />;
+    }
+  }
+
+  const mapStateToProps = (state: *, props: *) => ({});
+
+  // $FlowExpectedError dispatch mismatched from type Dispatch
+  const Connected = connect<Props, OwnProps,_,_,_,Dispatch>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connect.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connect.js
@@ -596,11 +596,11 @@ function testOptions() {
     }
   }
   // here in Props comes dispatch property
-  e.push(connect<{}, {||}, _,_,_,_>(null, null, null, {pure: true})(Com));
+  e.push(connect<{}, {||}, _,_,_,_>(null, null, null, {storeKey: 'test'})(Com));
   e.push(connect<{}, {||}, _,_,_,_>(null, null, null, {forwardRef: true})(Com));
-  e.push(connect<{}, {||}, _,_,_,_>(null, null, null, {pure: false, forwardRef: false})(Com));
+  e.push(connect<{}, {||}, _,_,_,_>(null, null, null, {storeKey: 'test', forwardRef: false})(Com));
   // $FlowExpectedError wrong type
-  e.push(connect<{}, {||}, _,_,_,_>(null, null, null, {pure: 123})(Com));
+  e.push(connect<{}, {||}, _,_,_,_>(null, null, null, {storeKey: 123})(Com));
   // $FlowExpectedError wrong type
   e.push(connect<{}, {||}, _,_,_,_>(null, null, null, {ref: 123})(Com));
   // $FlowExpectedError wrong key

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connectDispatch.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connectDispatch.js
@@ -1,0 +1,113 @@
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+export let e = []
+
+function object_sameDispatchIsOK() {
+  type Action1 = {|
+    type: string
+  |};
+  type Dispatch1 = Action1 => Action1;
+  const action1 = (): Action1 => ({ type: 'str' })
+  const mapDispatchToProps = {
+    action1
+  };
+
+  type Props = {
+    action1: typeof action1,
+  };
+  class Com extends React.Component<Props> {}
+
+  const Connected1 = connect<Props, {||}, _,_,_,Dispatch1>(null, mapDispatchToProps)(Com);
+  e.push(Connected1);
+  <Connected1 />;
+}
+
+function object_differentDispatchesAreNotOK() {
+  type Action1 = {|
+    type: string
+  |};
+  type Dispatch1 = Action1 => Action1;
+  const action1 = (): Action1 => ({ type: 'str' })
+  const mapDispatchToProps = {
+    action1
+  };
+
+  type Action2 = {|
+  //$FlowExpectedError `string` is incompatible with `number` in property `type`
+    type: number
+  |};
+  type Dispatch2 = Action2 => Action2;
+
+  type Props = {
+    action1: typeof action1,
+  };
+  class Com extends React.Component<Props> {}
+
+  const Connected1 = connect<Props, {||}, _,_,_,Dispatch1>(null, mapDispatchToProps)(Com);
+  e.push(Connected1);
+  <Connected1 />;
+
+  const Connected2 = connect<Props, {||}, _,_,_,Dispatch2>(null, mapDispatchToProps)(Com);
+  e.push(Connected2);
+  <Connected2 />;
+}
+
+function function_sameDispatchIsOK() {
+  type Action1 = {|
+    type: string
+  |};
+  type Dispatch1 = Action1 => Action1;
+  const action1 = (): Action1 => ({ type: 'str' });
+  type DispatchProps = {|
+    action1: () => Action1
+  |};
+  type MapDispatchToPropsFn = Dispatch1 => DispatchProps;
+  const mapDispatchToProps: MapDispatchToPropsFn = (dispatch: Dispatch1) => ({
+    action1: (...args) => dispatch(action1(...args))
+  });
+
+  type Props = {
+    action1: typeof action1,
+  };
+  class Com extends React.Component<Props> {}
+
+  const Connected1 = connect<Props, {||}, _,DispatchProps,_,Dispatch1>(null, mapDispatchToProps)(Com);
+  e.push(Connected1);
+  <Connected1 />;
+}
+
+function function_differentDispatchesAreNotOK() {
+  type Action1 = {|
+    type: string
+  |};
+  type Dispatch1 = Action1 => Action1;
+  const action1 = (): Action1 => ({ type: 'str' });
+  type DispatchProps = {|
+    action1: () => Action1
+  |};
+  type MapDispatchToPropsFn = Dispatch1 => DispatchProps;
+  const mapDispatchToProps: MapDispatchToPropsFn = (dispatch: Dispatch1) => ({
+    action1: (...args) => dispatch(action1(...args))
+  });
+
+  type Action2 = {|
+  //$FlowExpectedError `string` is incompatible with `number` in property `type`
+    type: number
+  |};
+  type Dispatch2 = Action2 => Action2;
+
+  type Props = {
+    action1: typeof action1,
+  };
+  class Com extends React.Component<Props> {}
+
+  const Connected1 = connect<Props, {||}, _,DispatchProps,_,Dispatch1>(null, mapDispatchToProps)(Com);
+  e.push(Connected1);
+  <Connected1 />;
+
+  const Connected2 = connect<Props, {||}, _,DispatchProps,_,Dispatch2>(null, mapDispatchToProps)(Com);
+  e.push(Connected2);
+  <Connected2 />;
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connectHOC.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connectHOC.js
@@ -1,0 +1,161 @@
+// @flow
+import * as React from "react";
+import { connect } from "react-redux";
+
+export let e = [];
+
+function checkSimplePropertyInjection() {
+  type OwnProps = {|
+    foo: number,
+    bar: string,
+  |};
+  type Props = { ...OwnProps, foo: number };
+  const mapStateToProps = () => ({ foo: 5 });
+
+  class Com extends React.Component<Props> {}
+
+  const Connected = connect<Props, OwnProps, _, _, _, _>(mapStateToProps)(Com);
+
+  <Connected foo={42} bar="str" />;
+  //$FlowExpectedError property `foo` is missing in props [1] but exists in `OwnProps`
+  <Connected bar="str" />;
+  e.push(Connected);
+
+  function injectProp<Config: {}>(
+    Component: React.AbstractComponent<Config>,
+  ): React.AbstractComponent<$Diff<Config, { foo: number | void }>> {
+    return function WrapperComponent(
+      props: $Diff<Config, { foo: number | void }>,
+    ) {
+      return <Component {...props} foo={42} />;
+    };
+  }
+
+  const Decorated = injectProp(Connected);
+  // OK without `foo`
+  <Decorated bar="str" />;
+  // OK with a not needed `foo`
+  <Decorated foo={42} bar="str" />;
+  //$FlowExpectedError property `bar` is missing in props [3] but exists in `Props` [4]
+  <Decorated />;
+  e.push(Decorated);
+}
+
+function composeWithOtherHOC_OK() {
+  type OwnProps = {
+    own1: number,
+    injected1: string,
+  };
+  type Props = {
+    ...$Exact<OwnProps>,
+    state1: number,
+  };
+  const mapStateToProps = () => ({ state1: 5 });
+
+  class Com extends React.Component<Props> {}
+
+  function injectProp<Config: {}>(
+    Component: React.AbstractComponent<Config>,
+  ): React.AbstractComponent<$Diff<Config, { injected1: string | void }>> {
+    return function WrapperComponent(
+      props: $Diff<Config, { injected1: string | void }>,
+    ) {
+      return <Component {...props} injected1="str" />;
+    };
+  }
+
+  declare var compose: $Compose;
+
+  const composedDecorators = compose(
+    injectProp,
+    connect<Props, OwnProps, _, _, _, _>(mapStateToProps),
+  );
+
+  const Decorated = composedDecorators(Com);
+  // OK without `injected1`
+  <Decorated own1={1} />;
+  // OK with a not needed `injected1`
+  <Decorated own1={1} injected1="str" />;
+  //$FlowExpectedError property `own1` is missing in props [3] but exists in `Props` [4]
+  <Decorated />;
+  e.push(Decorated);
+}
+
+function composeWithOtherHOC_exactOK() {
+  type OwnProps = {|
+    own1: number,
+    injected1: string,
+  |};
+  type Props = {
+    ...$Exact<OwnProps>,
+    state1: number,
+  };
+  const mapStateToProps = () => ({ state1: 5 });
+
+  class Com extends React.Component<Props> {}
+
+  function injectProp<Config: {}>(
+    Component: React.AbstractComponent<Config>,
+  ): React.AbstractComponent<$Diff<Config, { injected1: string | void }>> {
+    return function WrapperComponent(
+      props: $Diff<Config, { injected1: string | void }>,
+    ) {
+      return <Component {...props} injected1="str" />;
+    };
+  }
+
+  declare var compose: $Compose;
+
+  const composedDecorators = compose(
+    injectProp,
+    connect<Props, OwnProps, _, _, _, _>(mapStateToProps),
+  );
+
+  const Decorated = composedDecorators(Com);
+  // OK without `injected1`
+  <Decorated own1={1} />;
+  //$FlowExpectedError property `injected1` is missing in `OwnProps` [1] but exists in props
+  <Decorated own1={1} injected1="str" />;
+  // the ExpectError above masks the misssing `own1` error below :(
+  <Decorated />;
+  e.push(Decorated);
+}
+
+function composeWithOtherHOC_wrongOrder() {
+  type OwnProps = {
+    own1: number,
+    injected1: string,
+  };
+  type Props = {
+    ...$Exact<OwnProps>,
+    state1: number,
+  };
+  const mapStateToProps = () => ({ state1: 5 });
+
+  class Com extends React.Component<Props> {}
+
+  function injectProp<Config: {}>(
+    Component: React.AbstractComponent<Config>,
+  ): React.AbstractComponent<$Diff<Config, { injected1: string | void }>> {
+    return function WrapperComponent(
+      props: $Diff<Config, { injected1: string | void }>,
+    ) {
+      return <Component {...props} injected1="str" />;
+    };
+  }
+
+  declare var compose: $Compose;
+
+  // injectProp must go before connect()
+  const composedDecorators = compose(
+    connect<Props, OwnProps, _, _, _, _>(mapStateToProps),
+    injectProp,
+  );
+
+  const Decorated = composedDecorators(Com);
+  //$FlowExpectedError property `injected1` is missing in props
+  <Decorated own1={1} />;
+  // OK with an explicitly provided `injected1`
+  <Decorated own1={1} injected1="str" />;
+  e.push(Decorated);
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connectInfer.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connectInfer.js
@@ -387,11 +387,11 @@ function testOptions() {
       return <div></div>;
     }
   }
-  connect(null, null, null, {pure: true})(Com);
+  connect(null, null, null, {storeKey: 'test'})(Com);
   connect(null, null, null, {forwardRef: true})(Com);
-  connect(null, null, null, {pure: false, forwardRef: false})(Com);
+  connect(null, null, null, {storeKey: 'test', forwardRef: false})(Com);
   // $FlowExpectedError wrong type
-  connect(null, null, null, {pure: 123})(Com);
+  connect(null, null, null, {storeKey: 123})(Com);
   // $FlowExpectedError wrong type
   connect(null, null, null, {ref: 123})(Com);
   // $FlowExpectedError wrong key

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connectInfer.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connectInfer.js
@@ -1,0 +1,565 @@
+/*
+  Keep here examples which still work without type parameters specified,
+  even if the current Flow verion still reports misleading errors.
+  This helps keep the usage of Flow amazing type inferent on the good level.
+*/
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+function testPassingPropsToConnectedComponent() {
+  type OwnProps = {|
+    passthrough: number,
+    passthroughWithDefaultProp?: number,
+    forMapStateToProps: string
+  |}
+  type Props = { ...OwnProps, fromStateToProps: string};
+  class Com extends React.Component<Props> {
+    static defaultProps = { passthroughWithDefaultProp: 123 };
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = {a: number};
+  type InputProps = {
+    forMapStateToProps: string
+  };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect(mapStateToProps)(Com);
+  Connected.WrappedComponent;
+  <Connected passthrough={123} forMapStateToProps={'data'} passthroughWithDefaultProp={123}/>;
+  // OK without passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  // Flow erroneously complains about `fromStateToProps`
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError wrong type for passthrough
+  <Connected passthrough={''} forMapStateToProps={'data'} passthroughWithDefaultProp={123}/>;
+  //$FlowExpectedError wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321} passthroughWithDefaultProp={123}/>;
+  // Flow erroneously complains about `fromStateToProps`
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError wrong type for  passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'} passthroughWithDefaultProp={''}/>;
+  // Flow also erroneously complains about fromStateToProps
+  //$FlowExpectedError passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError takes in only React components
+  connect(mapStateToProps)('');
+}
+
+function doesNotRequireDefinedComponentToTypeCheck5case() {
+  type Props = {
+    stringProp: string
+  };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = () => ({});
+  const mapDispatchToProps = () => ({});
+
+  const mergeProps = () => ({
+    // $FlowExpectedError wrong type for stringProp
+    stringProp: true
+  });
+
+  connect(mapStateToProps, mapDispatchToProps, mergeProps)(Component);
+}
+
+function testWithStatelessFunctionalComponent() {
+  type Props = {passthrough: number, fromStateToProps: string};
+  const Com = (props: Props) => <div>{props.passthrough} {props.fromStateToProps}</div>
+
+  type State = {a: number};
+  type InputProps = {
+    forMapStateToProps: string
+  };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect(mapStateToProps)(Com);
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the wrong type for passthroug,
+  // giving passthrough a number fixes the wrongly titled error.
+  //$FlowExpectedError wrong type for passthrough
+  <Connected passthrough={''} forMapStateToProps={'data'}/>;
+  //$FlowExpectedError wrong type for forMapStateToProps
+  <Connected passthrough={123} forMapStateToProps={321} />;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError passthrough missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError forMapStateToProps missing
+  <Connected passthrough={123}/>;
+  //$FlowExpectedError takes in only React components
+  connect(mapStateToProps)('');
+}
+
+function testMapStateToPropsDoesNotNeedProps() {
+  type Props = {passthrough: number, fromStateToProps: string};
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+
+  type State = {a: string}
+  const mapStateToProps = (state: State) => {
+    return {
+      fromStateToProps: state.a
+    }
+  }
+
+  const Connected = connect(mapStateToProps)(Com);
+  <Connected passthrough={123}/>;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError component property passthrough not found
+  <Connected />;
+}
+
+function testMapDispatchToProps() {
+  type Props = {
+    passthrough: number,
+    fromMapDispatchToProps: string,
+    fromMapStateToProps: string
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.passthrough}
+        {this.props.fromMapDispatchToProps}
+        {this.props.fromMapStateToProps}
+        </div>;
+    }
+  }
+
+  type State = {a: number}
+  type MapStateToPropsProps = {forMapStateToProps: string}
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: 'str' + state.a
+    }
+  }
+  type MapDispatchToPropsProps = {forMapDispatchToProps: string}
+  const mapDispatchToProps = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const Connected = connect(mapStateToProps, mapDispatchToProps)(Com);
+  <Connected passthrough={123} forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError passthrough missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError forMapStateToProps missing
+  <Connected passthrough={123} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError forMapDispatchToProps missing
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+}
+
+function testMapDispatchToPropsWithoutMapStateToProps() {
+  type Props = {
+    passthrough: number,
+    fromMapDispatchToProps: string
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.passthrough}
+        {this.props.fromMapDispatchToProps}
+      </div>;
+    }
+  }
+
+  type MapDispatchToPropsProps = {forMapDispatchToProps: string};
+  const mapDispatchToProps = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const Connected = connect(null, mapDispatchToProps)(Com);
+  <Connected passthrough={123} forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError passthrough missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError forMapDispatchToProps missing
+  <Connected passthrough={123} forMapStateToProps={'data'} />;
+}
+
+function testMapDispatchToPropsPassesActionCreators() {
+  type Props = {
+    passthrough: number,
+    dispatch1: (num: number) => void,
+    dispatch2: () => void
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+
+  const mapDispatchToProps = {
+    dispatch1: (num: number) => {},
+    dispatch2: () => {}
+  };
+  const Connected = connect(null, mapDispatchToProps)(Com);
+  <Connected passthrough={123}/>;
+  // Here Flow reports that `dispatch1` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError no passthrough
+  <Connected />;
+
+  const mapDispatchToPropsWithoutDispatch2 = {
+    dispatch1: (num: number) => {}
+  };
+  const Connected2 = connect(null, mapDispatchToPropsWithoutDispatch2)(Com);
+  // Here Flow reports that `dispatch1` is missing from props,
+  // while the real error is still the missing `dispatch2`,
+  // giving the `mapDispatchToProps` to connect above
+  // fixes the wrongly titled error.
+  //$FlowExpectedError no dispatch2
+  <Connected2 passthrough={123}/>;
+
+  const mapDispatchToPropsWithWrongDispatch1 = {
+    dispatch1: (num: string) => {},
+    dispatch2: () => {}
+  };
+  const Connected3 = connect(null, mapDispatchToPropsWithWrongDispatch1)(Com);
+  // Here Flow reports that `dispatch1` is missing from props,
+  // while the real error is still the wrong type of `dispatch1`,
+  // giving `num` the correct type fixes the wrongly titled error.
+  //$FlowExpectedError dispatch1 should be number
+  <Connected3 passthrough={123}/>;
+}
+
+function testMapDispatchToPropsPassesActionCreatorsWithMapStateToProps() {
+  type Props = {
+    passthrough: number,
+    dispatch1: () => void,
+    dispatch2: () => void,
+    fromMapStateToProps: number
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+  type State = {a: number}
+  type MapStateToPropsProps = {forMapStateToProps: string}
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  const mapDispatchToProps = {
+    dispatch1: () => {},
+    dispatch2: () => {}
+  };
+  const Connected = connect(mapStateToProps, mapDispatchToProps)(Com);
+  <Connected passthrough={123} forMapStateToProps="str"/>;
+  // Here Flow reports that `fromStateToProps` is missing from props,
+  // while the real error is still the missing passthroug property,
+  // giving the passthrough property fixes the wrongly titled error.
+  //$FlowExpectedError no passthrough
+  <Connected/>;
+
+  const mapDispatchToProps2 = {
+    dispatch1: () => {}
+  };
+  const Connected2 = connect(mapStateToProps, mapDispatchToProps2)(Com);
+  // Here Flow reports that `dispatch1` is missing from props,
+  // while the real error is still the missing `dispatch2`,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError no dispatch2
+  <Connected2 passthrough={123} forMapStateToProps="str"/>;
+}
+
+function testMapDispatchToPropsPassesActionCreatorsWithMapStateToPropsAndMergeProps() {
+  type Props = {
+    passthrough: number,
+    dispatch1: () => void,
+    dispatch2: () => void,
+    fromMapStateToProps: number,
+    fromMergeProps: number
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.passthrough}</div>;
+    }
+  }
+  type State = {a: number}
+  type MapStateToPropsProps = {forMapStateToProps: string}
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  const mapDispatchToProps = {
+    dispatch1: () => {},
+    dispatch2: () => {}
+  };
+  const mergeProps = (stateProps, dispatchProps, ownProps: {forMergeProps: number}) => {
+    return Object.assign({}, stateProps, dispatchProps, { fromMergeProps: 123 });
+  }
+  const Connected = connect(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
+  <Connected passthrough={123} forMapStateToProps="str" forMergeProps={1234}/>;
+  // Here Flow reports that `forMapStateToProps` is missing from props,
+  // while the real error is still the missing `passthrough`,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError no passthrough
+  <Connected/>;
+  //$FlowExpectedError forMapStateToProps missing
+  <Connected forMapDispatchToProps={'more data'} forMergeProps={1234} />;
+  //$FlowExpectedError forMergeProps is missing
+  <Connected forMapStateToProps={'data'} />;
+  //$FlowExpectedError forMergeProps is wrong type
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} forMergeProps={'not number'} />;
+
+  const mapDispatchToProps2 = {
+    dispatch1: () => {}
+  };
+  const Connected2 = connect(mapStateToProps, mapDispatchToProps2)(Com);
+  // Here Flow reports that `dispatch1` is missing from props,
+  // while the real error is still the missing `dispatch2`,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError no dispatch2
+  <Connected2 passthrough={123} forMapStateToProps="str"/>;
+}
+
+function testMergeProps() {
+  type Props = {
+    fromMergeProps: number,
+  };
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>
+        {this.props.fromMergeProps}
+      </div>;
+    }
+  }
+
+  type State = {a: number}
+  type MapStateToPropsProps = {forMapStateToProps: string}
+  const mapStateToProps = (state: State, props: MapStateToPropsProps) => {
+    return {
+      fromMapStateToProps: state.a
+    }
+  }
+  type MapDispatchToPropsProps = {forMapDispatchToProps: string}
+  const mapDispatchToProps = (dispatch: *, ownProps: MapDispatchToPropsProps) => {
+    return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
+  }
+  const mergeProps = (stateProps, dispatchProps, ownProps: {forMergeProps: number}) => {
+    return {fromMergeProps: 123};
+  }
+  const Connected = connect(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} forMergeProps={1234} />;
+  //$FlowExpectedError forMapStateToProps missing
+  <Connected forMapDispatchToProps={'more data'} forMergeProps={1234} />;
+  //$FlowExpectedError forMergeProps is missing
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} />;
+  //$FlowExpectedError forMapDispatchToProps is missing
+  <Connected forMapStateToProps={'data'} forMergeProps={1234} />;
+  //$FlowExpectedError forMapDispatchToProps is wrong type
+  <Connected forMapStateToProps={'data'} forMapDispatchToProps={'more data'} forMergeProps={'not number'} />;
+}
+
+function testOptions() {
+  class Com extends React.Component<{}> {
+    render() {
+      return <div></div>;
+    }
+  }
+  connect(null, null, null, {pure: true})(Com);
+  connect(null, null, null, {forwardRef: true})(Com);
+  connect(null, null, null, {pure: false, forwardRef: false})(Com);
+  // $FlowExpectedError wrong type
+  connect(null, null, null, {pure: 123})(Com);
+  // $FlowExpectedError wrong type
+  connect(null, null, null, {ref: 123})(Com);
+  // $FlowExpectedError wrong key
+  connect(null, null, null, {wrongKey: true})(Com);
+}
+
+function testHoistConnectedComponent() {
+  type Props = {passthrough: number, passthroughWithDefaultProp: number, fromStateToProps: string};
+  class Com extends React.Component<Props> {
+    static defaultProps = { passthroughWithDefaultProp: 123 };
+    static myStatic = 1;
+
+    render() {
+      return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
+    }
+  }
+
+  type State = {a: number};
+  type InputProps = {
+    forMapStateToProps: string
+  };
+  const mapStateToProps = (state: State, props: InputProps) => {
+    return {
+      fromStateToProps: 'str' + state.a
+    }
+  };
+
+  const Connected = connect(mapStateToProps)(Com);
+  // OK without passthroughWithDefaultProp
+  <Connected passthrough={123} forMapStateToProps={'data'}/>;
+  // OK with passthroughWithDefaultProp
+  <Connected passthrough={123} passthroughWithDefaultProp={456} forMapStateToProps={'data'}/>;
+  // OK with declared static property
+  Connected.myStatic;
+  //$FlowExpectedError property `notStatic` is missing in statics
+  Connected.notStatic;
+}
+
+function checkIfStateTypeIsRespectedAgain() {
+  type State = {num: number, str: string};
+
+  const mapStateToProps = (state: State) => {
+    return { // no error
+      str: state.num
+    }
+  };
+
+  type Props = {
+    str: string
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  const Connected = connect(mapStateToProps)(Com);
+  // Here Flow reports that `str` is missing from props,
+  // while the real error is still the type mismatch,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError
+  <Connected />;
+}
+
+
+
+function testAllowsKnownPropInMapStateToProps() {
+  type Props = {
+    str: string
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {num: number, str: string};
+
+  const mapStateToProps = (state: State) => {
+    return {
+      str: state.str
+    }
+  };
+
+  const Connected = connect(mapStateToProps)(Com);
+  <Connected />;
+}
+
+function testForbidsLiteralOfInvalidTypeInMapStateToProps() {
+  type Props = {
+    //$FlowExpectedError string is incompatible with number
+    str: string
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {num: number, str: string};
+
+  const mapStateToPropsWithLiteralOfInvalidType = (state: State) => {
+    return {
+      str: 123
+    }
+  };
+
+  const Connected = connect(mapStateToPropsWithLiteralOfInvalidType)(Com);
+  <Connected />
+}
+
+function testForbidsStateProperyOfInvalidTypeInMapStateToProps() {
+  type Props = {
+    str: string
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {num: number, str: string};
+
+  const mapStateToPropsWithStatePropertyOfInvalidType = (state: State) => {
+    return {
+      str: state.num
+    }
+  };
+
+  const Connected = connect(mapStateToPropsWithStatePropertyOfInvalidType)(Com);
+  // Here Flow reports that `str` is missing from props,
+  // while the real error is still the type mismatch,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError
+  <Connected />;
+}
+
+function testForbidsSelectorWithInvalidReturnTypeInMapStateToProps() {
+  type Props = {
+    str: string
+  };
+
+  class Com extends React.Component<Props> {
+    render() {
+      return <div>{this.props.str}</div>;
+    }
+  }
+
+  type State = {num: number, str: string};
+
+  function selectorReturningNumber(state: State) {
+    return state.num
+  }
+
+  const mapStateToPropsWithSelectorWithInvalidTypeReturnValue = (state: State) => {
+    return {
+      str: selectorReturningNumber(state)
+    }
+  };
+
+  const Connected = connect(mapStateToPropsWithSelectorWithInvalidTypeReturnValue)(Com);
+  // Here Flow reports that `str` is missing from props,
+  // while the real error is still the type mismatch,
+  // fixing the original issue fixes the wrongly titled error.
+  //$FlowExpectedError
+  <Connected />
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connectMergeProps.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connectMergeProps.js
@@ -1,0 +1,602 @@
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+export let e = []
+
+function onlyOwnProps_ok() {
+  opaque type Action = 'action';
+  type Dispatch = Action => Action;
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type Props = {
+    ...OwnProps
+  };
+  class Com extends React.Component<Props> {}
+
+  const mergeProps = (stateProps: {||}, dispatchProps: {|dispatch: Dispatch|}, ownProps: OwnProps) => {
+    return {
+      ...ownProps
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(null, null, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyOwnProps_wrongDispatch() {
+  opaque type Action = 'action';
+  type Dispatch = Action => Action;
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type Props = {
+    ...OwnProps
+  };
+  class Com extends React.Component<Props> {}
+
+  const mergeProps = (stateProps: {||}, dispatchProps: {|dispatch: string|}, ownProps: OwnProps) => {
+    return {
+      ...ownProps
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    null,
+    null,
+    //$FlowExpectedError string [1] is incompatible with  `Dispatch` [2] in property `dispatch`
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyOwnProps_noPassthrough() {
+  opaque type Action = 'action';
+  type Dispatch = Action => Action;
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type Props = {
+    ...OwnProps
+  };
+  class Com extends React.Component<Props> {}
+
+  const mergeProps = (stateProps: {||}, dispatchProps: {|dispatch: Dispatch|}, ownProps: OwnProps) => {
+    return {
+      a: 1
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    null,
+    null,
+    //$FlowExpectedError property `passthrough` is missing in object literal [1] but exists in `OwnProps` [2]
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyStateProps_ok() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action';
+  type Dispatch = Action => Action;
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type Props = {
+    ...OwnProps,
+    ...StateProps,
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({state1: state.state1})
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: {|dispatch: Dispatch|}, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...stateProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(mapStateToProps, null, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyStateProps_wrongDispatch() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action';
+  type Dispatch = Action => Action;
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type Props = {
+    ...OwnProps,
+    ...StateProps
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: {|dispatch: string|}, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...stateProps
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    mapStateToProps,
+    null,
+    //$FlowExpectedError string [1] is incompatible with  `Dispatch` [2] in property `dispatch`
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyDispatchPropsObject_ok() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...DispatchProps,
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapDispatchToProps = {
+    action1
+  }
+
+  const mergeProps = (stateProps: {||}, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(undefined, mapDispatchToProps, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyDispatchPropsObject_wrongExpectedState() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...DispatchProps,
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapDispatchToProps = {
+    action1
+  }
+
+  const mergeProps = (stateProps: {wrong: boolean}, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    undefined,
+    mapDispatchToProps,
+    //$FlowExpectedError property `wrong` is missing in object type [1] but exists in object type [2]
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyDispatchPropsFunction_ok() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...DispatchProps,
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (stateProps: {||}, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(null, mapDispatchToPropsFn, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyDispatchPropsFunction_WrongExpectedState() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...DispatchProps,
+  };
+  class Com extends React.Component<Props> {}
+
+  type MapDispatchToPropsFn = Dispatch => DispatchProps
+  const mapDispatchToPropsFn: MapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (stateProps: {|wrong:boolean|}, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...dispatchProps,
+    }
+  }
+
+  //$FlowExpectedError property `wrong` is missing in  object type [1] but exists in  object type [2]
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(null, mapDispatchToPropsFn, mergeProps)(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function onlyDispatchPropsFunction_wrongDispatchProp() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...DispatchProps,
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => 123
+  })
+
+  const mergeProps = (stateProps: {||}, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    null,
+    //$FlowExpectedError number [1] is incompatible with  string literal `action1` [2]
+    mapDispatchToPropsFn,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function stateAndDispatchPropsFunction_ok() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...StateProps,
+    ...DispatchProps,
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...stateProps,
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    mapStateToProps,
+    mapDispatchToPropsFn,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function stateAndDispatchPropsFunction_wrongState() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...StateProps,
+    ...DispatchProps,
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (
+    // yes, a bit cryptic
+    //$FlowExpectedError property `state1` is missing in  object type [1] but exists in  object literal [2]
+    stateProps: {|wrong:boolean|},
+    dispatchProps: DispatchProps,
+    ownProps: OwnProps
+  ) => {
+    return {
+      ...ownProps,
+      state1: 'state1',
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    mapStateToProps,
+    mapDispatchToPropsFn,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function stateAndDispatchPropsFunction_wrongDispatch() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    ...OwnProps,
+    ...StateProps,
+    ...DispatchProps,
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mapDispatchToPropsFn = dispatch => ({
+    //$FlowExpectedError number [1] is incompatible with string literal `action1` [2]
+    action1: () => 123
+  })
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      ...ownProps,
+      ...stateProps,
+      ...dispatchProps,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    mapStateToProps,
+    mapDispatchToPropsFn,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function returnsTotallyDifferentProps() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    a: 1,
+    b: 2,
+    c: 3
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    return {
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    mapStateToProps,
+    mapDispatchToPropsFn,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}
+
+function returnsTotallyDifferentPropsWithError() {
+  type State = {|
+    +state1: 'state1'
+  |}
+  opaque type Action = 'action1';
+  type Dispatch = Action => Action;
+  const action1 = (): Action => 'action1'
+
+  type OwnProps = {|
+    passthrough: string
+  |}
+  type StateProps = {|
+    state1: 'state1'
+  |}
+  type DispatchProps = {|
+    action1: typeof action1
+  |}
+  type Props = {
+    a: 1,
+    b: 2,
+    c: 3
+  };
+  class Com extends React.Component<Props> {}
+
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  const mapDispatchToPropsFn = dispatch => ({
+    action1: () => dispatch(action1())
+  })
+
+  const mergeProps = (stateProps: StateProps, dispatchProps: DispatchProps, ownProps: OwnProps) => {
+    //$FlowExpectedError property `c` is missing in object literal [1] but exists in  `Props` [2]
+    return {
+      a: 1,
+      b: 2,
+    }
+  }
+
+  const Connected = connect<Props, OwnProps, _,_,_,Dispatch>(
+    mapStateToProps,
+    mapDispatchToPropsFn,
+    mergeProps
+  )(Com);
+  e.push(Connected);
+  <Connected passthrough="foo" />;
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connectState.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connectState.js
@@ -1,0 +1,41 @@
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+export let e = []
+
+function sameStateIsOK() {
+  type Props = {};
+  class Com extends React.Component<Props> {}
+
+  type State = {|
+    a: number
+  |};
+  const mapStateToProps = (state: State) => {
+    return {}
+  };
+
+  const Connected = connect<Props, {||}, _,_,State,empty>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function differentStatesAreNotOK() {
+  type Props = {};
+  class Com extends React.Component<Props> {}
+
+  type State = {|
+    a: number
+  |};
+  const mapStateToProps = (state: State) => {
+    return {}
+  };
+  type OtherState = {|
+    b: number
+  |};
+
+  //$FlowExpectedError property `b` is missing in `State` but exists in `OtherState`
+  const Connected = connect<Props, {||}, _,_,OtherState,empty>(mapStateToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connectThunk.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_connectThunk.js
@@ -1,0 +1,198 @@
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+
+export let e = []
+
+function onlyDispatchFunction_samePropsAreOK() {
+  type State = {||}
+  type Action = {|
+    type: 'action'
+  |};
+  type DispatchAction = Action => Action;
+  type Thunk = (Dispatch, State) => Promise<number>
+  type DispatchThunk = Thunk => Promise<number>
+  type Dispatch = DispatchAction & DispatchThunk
+
+  const action = (): Action => ({ type: 'action' });
+  const thunk = (): Thunk => (d: Dispatch) => Promise.resolve(1);
+  type DispatchProps = {|
+    action: typeof action,
+    thunk: () => Promise<number>,
+  |};
+  type MapDispatchToPropsFn = Dispatch => DispatchProps;
+  const mapDispatchToProps: MapDispatchToPropsFn = (dispatch) => ({
+    action: () => dispatch(action()),
+    thunk: () => dispatch(thunk())
+  });
+
+  type Props = {
+    // in the case of a function passed to `connect()` Flow infers
+    // the same type of function is both the Props and DispatchProps objects
+    // (see the testDispatchThunk() to get the difference)
+    ...DispatchProps
+  };
+  class Com extends React.Component<Props> {}
+
+  const Connected = connect<Props, {||}, _,DispatchProps,_,Dispatch>(null, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function onlyDispatchObject_differentDispatchPropsAreOK() {
+  type State = {||}
+  type Action = {|
+    type: 'action'
+  |};
+  type DispatchAction = Action => Action;
+  type Thunk = (Dispatch, State) => Promise<number>
+  type DispatchThunk = Thunk => Promise<number>
+  type Dispatch = DispatchAction & DispatchThunk
+
+  const action = (): Action => ({ type: 'action' });
+  const thunk = (): Thunk => (d: Dispatch) => Promise.resolve(1);
+
+  type DispatchProps = {|
+    action: typeof action,
+    // here the property returns a thunk...
+    thunk: () => Thunk,
+  |};
+  const mapDispatchToProps = {
+    action,
+    thunk
+  };
+
+  type Props = {
+    action: typeof action,
+    // ... and here the property returns a return value of thunk
+    // as dispatch calls it for us with `dispatch` and `getState`
+    thunk: () => Promise<number>,
+  };
+  class Com extends React.Component<Props> {}
+
+  const Connected = connect<Props, {||}, _,DispatchProps,_,Dispatch>(null, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function onlyDispatchObject_sameDispatchPropsAreErroneous() {
+  type State = {||}
+  type Action = {|
+    type: 'action'
+  |};
+  type DispatchAction = Action => Action;
+  type Thunk = (Dispatch, State) => Promise<number>
+  type DispatchThunk = Thunk => Promise<number>
+  type Dispatch = DispatchAction & DispatchThunk
+
+  const action = (): Action => ({ type: 'action' });
+  const thunk = (): Thunk => (d: Dispatch) => Promise.resolve(1);
+
+  type DispatchProps = {|
+    action: typeof action,
+    //$FlowExpectedError here the property returns a thunk...
+    thunk: () => Thunk,
+  |};
+  const mapDispatchToProps = {
+    action,
+    thunk
+  };
+
+  type Props = {
+    // trying to pass the not passed to dispatch types (against the redux dispatch monad)
+    ...DispatchProps,
+  };
+  class Com extends React.Component<Props> {}
+
+  const Connected = connect<Props, {||}, _,DispatchProps,_,Dispatch>(null, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function stateAndDispatchObject_differentDispatchPropsAreOK() {
+  type State = {|
+    state1: 'state1'
+  |}
+  type Action = {|
+    type: 'action'
+  |};
+  type DispatchAction = Action => Action;
+  type Thunk = (Dispatch, State) => Promise<number>
+  type DispatchThunk = Thunk => Promise<number>
+  type Dispatch = DispatchAction & DispatchThunk
+
+  const action = (): Action => ({ type: 'action' });
+  const thunk = (): Thunk => (d: Dispatch) => Promise.resolve(1);
+
+  type StateProps = {|
+    state1: 'state1',
+  |};
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  type DispatchProps = {|
+    action: typeof action,
+    // here the property returns a thunk...
+    thunk: () => Thunk,
+  |};
+  const mapDispatchToProps = {
+    action,
+    thunk
+  };
+
+  type Props = {
+    ...StateProps,
+    action: typeof action,
+    // ... and here the property returns a return value of thunk
+    // as dispatch calls it for us with `dispatch` and `getState`
+    thunk: () => Promise<number>,
+  };
+  class Com extends React.Component<Props> {}
+
+  const Connected = connect<Props, {||}, _,DispatchProps,_,Dispatch>(mapStateToProps, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}
+
+function stateAndDispatchObject_sameDispatchPropsAreErroneous() {
+  type State = {||}
+  type Action = {|
+    type: 'action'
+  |};
+  type DispatchAction = Action => Action;
+  type Thunk = (Dispatch, State) => Promise<number>
+  type DispatchThunk = Thunk => Promise<number>
+  type Dispatch = DispatchAction & DispatchThunk
+
+  const action = (): Action => ({ type: 'action' });
+  const thunk = (): Thunk => (d: Dispatch) => Promise.resolve(1);
+
+  type StateProps = {|
+    state1: 'state1',
+  |};
+  const mapStateToProps = state => ({
+    state1: state.state1
+  })
+
+  type DispatchProps = {|
+    action: typeof action,
+    //$FlowExpectedError here the property returns a thunk...
+    thunk: () => Thunk,
+  |};
+  const mapDispatchToProps = {
+    action,
+    thunk
+  };
+
+  type Props = {
+    ...StateProps,
+    // trying to pass the not passed to dispatch types (against the redux dispatch monad)
+    ...DispatchProps,
+  };
+  class Com extends React.Component<Props> {}
+
+  const Connected = connect<Props, {||}, _,DispatchProps,_,Dispatch>(mapStateToProps, mapDispatchToProps)(Com);
+  e.push(Connected);
+  <Connected />;
+}

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_shallowEqual.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_shallowEqual.js
@@ -1,0 +1,29 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+import { shallowEqual } from 'react-redux';
+
+describe('shallowEqual', () => {
+  it('returns a boolean', () => {
+    const x: boolean = shallowEqual('a', 'a');
+
+    //$FlowExpectedError[incompatible-type]
+    const y: number = shallowEqual('a', 'a');
+  });
+
+  it('can be called with any argument types', () => {
+    shallowEqual('a', 'a');
+    shallowEqual({ test: 'test' }, { test: 'test' });
+    shallowEqual({ test: 'test' }, 'a');
+  });
+
+  it('should be called with two arguments', () => {
+    // Flow considers these compatible with shallowEqual<T>(a: T, b: any).
+
+    // The same is seen in tests for _.isEqual and the comment below is copied from those tests
+    // Reasonable people disagree about whether these should be considered legal calls.
+    // See https://github.com/splodingsocks/FlowTyped/pull/1#issuecomment-149345275
+    // and https://github.com/facebook/flow/issues/956
+    shallowEqual();
+    shallowEqual('a');
+  });
+});

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_useDispatch.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_useDispatch.js
@@ -1,0 +1,43 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import React from 'react';
+import { useDispatch } from 'react-redux';
+
+type Action = {|
+  type: 'action',
+|};
+type Dispatch = Action => Action;
+
+describe('useDispatch', () => {
+  it('returns type `Dispatch` which accepts only type `Action` as param', () => {
+    function Com() {
+      const dispatch = useDispatch<Dispatch>();
+      return (
+        <button
+          onClick={function() {
+            dispatch({ type: 'action' });
+          }}
+        >
+          Dispatch time
+        </button>
+      );
+    }
+  });
+
+  it('errors if returned type is passed invalid Action', () => {
+    function Com() {
+      const dispatch = useDispatch<Dispatch>();
+      return (
+        <div
+          onClick={() => {
+            // $FlowExpectedError: return value of `useDispatch` should make `Dispatch` and expect an `Action`.
+            dispatch();
+          }}
+        >
+          Dispatch time
+        </div>
+      );
+    }
+  });
+});

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_useSelector.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_useSelector.js
@@ -1,0 +1,48 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import React from 'react';
+import { useSelector, shallowEqual } from 'react-redux';
+
+type State = {|
+  a: number,
+|};
+
+describe('useSelector', () => {
+  it('passes State as first parameter', () => {
+    function Com() {
+      // $FlowExpectedError: the state has no `b`
+      const count = useSelector<State, number>(state => state.b);
+      return <div>{count}</div>;
+    }
+  });
+
+  it('passes type of second parameter as params to `equalityFn`', () => {
+    function Com2() {
+      // $FlowExpectedError: `equalityFn` is passed params of the second type, do not have `.size`
+      const count = useSelector<State, number>(
+        state => state.a,
+        (a, b) => a.size === b.size
+      );
+      return <div>{count}</div>;
+    }
+  });
+
+  it('returns type of second parameter', () => {
+    function Com3() {
+      const count = useSelector<State, number>(
+        state => state.a,
+        (a, b) => a === b
+      );
+      // `count` is type `number` and allows addition
+      return <div>{count + 5}</div>;
+    }
+  });
+
+  it('can use shallowEqual as the `equalityFn`', () => {
+    function Com4() {
+      const count = useSelector<State, number>(state => state.a, shallowEqual);
+      return <div>{count}</div>;
+    }
+  });
+});

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_useStore.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.89.x-v0.103.x/test_useStore.js
@@ -1,0 +1,41 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import React from 'react';
+import { useStore } from 'react-redux';
+
+describe('useStore', () => {
+  type Action = { type: 'SOME_ACTION' };
+  type State = { state: string };
+
+  // ReduxStore should be imported from 'redux' but we can't do this with this
+  // test environment, so let's copy them once again...
+  declare type Redux$DispatchAPI<A> = (action: A) => A;
+  declare type Redux$Dispatch<A: { type: string }> = Redux$DispatchAPI<A>;
+  declare type Redux$Reducer<S, A> = (state: S | void, action: A) => S;
+  declare type Redux$Store<S, A, D = Redux$Dispatch<A>> = {
+    dispatch: D,
+    getState(): S,
+    subscribe(listener: () => void): () => void,
+    replaceReducer(nextReducer: Redux$Reducer<S, A>): void,
+  };
+
+  type Dispatch = (action: Action) => Action;
+  type GetState = () => State;
+  type Store = Redux$Store<State, Action, Dispatch>;
+
+  it('returns instance of Store', () => {
+    function Com() {
+      const store = useStore<Store>();
+      return <div>{store.getState().state}</div>;
+    }
+  });
+
+  it('returns instance of Store, no extra keys', () => {
+    function Com() {
+      const store = useStore<Store>();
+      // $FlowExpectedError: `foobar` is not a member of the Store instance
+      return <div>{store.getState().foobar}</div>;
+    }
+  });
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Add v8 defs copied from v7. The major change for the lib was a rewrite to TS but also they removed `connectAdvanced` and `pure` option from `connect`

- Links to documentation: https://github.com/reduxjs/react-redux/releases/tag/v8.0.0
- Link to GitHub or NPM: https://www.npmjs.com/package/react-redux
- Type of contribution: new definition

Other notes:
commits broken down from initial copy to updates of each change
