### PR TITLE
[express] express request compat with https

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_v0.104.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.104.x-/express_v4.x.x.js
@@ -121,6 +121,7 @@ declare class express$Response extends http$ServerResponse mixins express$Reques
   redirect(url: string, ...args: Array<void>): this;
   redirect(status: number, url: string, ...args: Array<void>): this;
   render(view: string, locals?: { [name: string]: mixed, ... }, callback?: express$RenderCallback): this;
+  render(view: string, callback?: express$RenderCallback): this;
   send(body?: mixed): this;
   sendFile(path: string, options?: express$SendFileOptions, callback?: (err?: ?Error) => mixed): this;
   sendStatus(statusCode: number): this;
@@ -190,6 +191,8 @@ declare class express$Route<
   connect: express$RouteMethodType<this, Req, Res>;
 }
 
+declare type express$IncomingMessage = http$IncomingMessage<tls$TLSSocket> | http$IncomingMessage<>;
+
 declare class express$Router<
   Req: express$Request = express$Request,
   Res: express$Response = express$Response,
@@ -206,7 +209,7 @@ declare class express$Router<
     ...middleware: Array<express$Middleware<Req, Res>>
   ): this;
   use(path: string, router: express$Router<Req, Res>): this;
-  handle(req: http$IncomingMessage<>, res: http$ServerResponse, next: express$NextFunction): void;
+  handle(req: express$IncomingMessage, res: http$ServerResponse, next: express$NextFunction): void;
   param(
     param: string,
     callback: (
@@ -217,7 +220,7 @@ declare class express$Router<
       paramName: string,
     ) => mixed
   ): void;
-  (req: http$IncomingMessage<>, res: http$ServerResponse, next?: ?express$NextFunction): void;
+  (req: express$IncomingMessage, res: http$ServerResponse, next?: ?express$NextFunction): void;
 }
 
 declare class express$Application<
@@ -242,10 +245,11 @@ declare class express$Application<
    */
   //   get(name: string): mixed;
   set(name: string, value: mixed): mixed;
-  render(name: string, optionsOrFunction: { [name: string]: mixed, ... }, callback: express$RenderCallback): void;
-  handle(req: http$IncomingMessage<>, res: http$ServerResponse, next?: ?express$NextFunction): void;
+  render(name: string, options: { [name: string]: mixed, ... }, callback: express$RenderCallback): void;
+  render(name: string, callback: express$RenderCallback): void;
+  handle(req: express$IncomingMessage, res: http$ServerResponse, next?: ?express$NextFunction): void;
   // callable signature is not inherited
-  (req: http$IncomingMessage<>, res: http$ServerResponse, next?: ?express$NextFunction): void;
+  (req: express$IncomingMessage, res: http$ServerResponse, next?: ?express$NextFunction): void;
 }
 
 declare module 'express' {

--- a/definitions/npm/express_v4.x.x/flow_v0.104.x-/test_overrideUseMethodClassExtension.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.104.x-/test_overrideUseMethodClassExtension.js
@@ -20,7 +20,7 @@ declare class test_express$CustomApplication extends express$Application<
   constructor(expressConstructor: expressConstructor): this;
 }
 
-// Class Extensions: Test Functions
+// $FlowExpectedError[name-already-bound] Class Extensions: Test Functions
 function test_express$CustomApplication(
   expressConstructor: expressConstructor,
 ) {
@@ -41,15 +41,15 @@ function test_express$CustomApplication(
 // Class Extensions: Test
 const customApp = new test_express$CustomApplication(express);
 
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 const customApp_error = new test_express$CustomApplication();
 
 customApp.use(
   "/something",
   (req: express$Request, res: express$Response, next: express$NextFunction) => {
-    // $FlowExpectedError
+    // $FlowExpectedError[prop-missing]
     req.foo;
-    // $FlowExpectedError
+    // $FlowExpectedError[prop-missing]
     res.bar;
     next();
   }
@@ -63,14 +63,14 @@ customApp.use(
   ) => {
     req.foo;
     res.bar;
-    // $FlowExpectedError
+    // $FlowExpectedError[prop-missing]
     req.notHere;
-    // $FlowExpectedError
+    // $FlowExpectedError[prop-missing]
     res.notHere;
   }
 );
 
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 customApp.use("/something", (req: string, res: string, next: Function) => {
   next();
 });

--- a/definitions/npm/express_v4.x.x/flow_v0.104.x-/test_response.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.104.x-/test_response.js
@@ -44,7 +44,7 @@ const httpServer = http.createServer(app);
 httpServer.listen(9000);
 
 const badHttpServer = null;
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-use]
 badHttpServer.listen();
 
 // Can manually invoke app.handle() to handle a request

--- a/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
@@ -2,9 +2,9 @@
 import { describe, test } from 'flow-typed-test'
 import express, { Router } from 'express';
 
-const http = require('http')
-const https = require('https')
-const fs = require('fs')
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
 
 const app = express();
 

--- a/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
@@ -1,5 +1,10 @@
-/* @flow */
+// @flow
+import { describe, test } from 'flow-typed-test'
 import express, { Router } from 'express';
+
+const http = require('http')
+const https = require('https')
+const fs = require('fs')
 
 const app = express();
 
@@ -155,4 +160,22 @@ const validPaths = ['string', 'pattern?', /a[b-f]+g/];
 
 app.get(validPaths, (req: express$Request, res: express$Response) => {
   res.end();
+});
+
+describe('express', () => {
+  test('http vs https server usage', () => {
+    const app = express();
+
+    // start http server
+    const port = 15000;
+    let server = http.createServer(app).listen(port);
+
+    // start https server
+    const sslOptions = {
+      key: fs.readFileSync('key.pem'),
+      cert: fs.readFileSync('cert.pem')
+    };
+
+    let serverHttps = https.createServer(sslOptions, app).listen(443);
+  });
 });

--- a/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
@@ -3,15 +3,15 @@ import express, { Router } from 'express';
 
 const app = express();
 
-// $FlowExpectedError property `foo` Property not found in Application:
+// $FlowExpectedError[prop-missing] property `foo` Property not found in Application:
 app.foo();
 
 app.locals.title = 'My Express App';
 
-// $FlowExpectedError Symbol: This type is incompatible with string
+// $FlowExpectedError[incompatible-type] Symbol: This type is incompatible with string
 app.locals[Symbol('bad')] = 'Should not work';
 
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-type]
 const num: number = app.mountpath;
 
 const myRouter = new express.Router();
@@ -24,11 +24,11 @@ myRouter.use('/dang', (req, res: express$Response, next: express$NextFunction) =
     res.status(200);
     res.render('someTemplate', {}, (err, html: ?string) => null);
     res.render('someTemplate', (err, html: ?string) => null);
-    // $FlowExpectedError String: This type is incompatible with Function | {[name: string]: mixed}
+    // $FlowExpectedError[incompatible-call] String: This type is incompatible with Function | {[name: string]: mixed}
     res.render('someTemplate', 'Error');
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     res.sendFile('/myfile.txt', { dotfiles: 'none' })
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     next('Error');
 });
 
@@ -51,12 +51,12 @@ myRouter.use(handleRequest, (err: Error, req: express$Request, res: express$Resp
 
 app.on('mount', (parent: express$Application<>) => {
     console.log('Parent Loaded', parent);
-    // $FlowExpectedError
+    // $FlowExpectedError[prop-missing]
     parent.fail();
 })
 
 app.use('/foo', (req: express$Request, res: express$Response, next) => {
-    // $FlowExpectedError
+    // $FlowExpectedError[incompatible-call]
     res.status('400');
     res.send('should work')
         .status(300);
@@ -65,10 +65,10 @@ app.use('/foo', (req: express$Request, res: express$Response, next) => {
 const bar: express$Router<> = new Router();
 
 bar.get('/', (req: express$Request, res: express$Response): void => {
-  // $FlowExpectedError should be of type object
+  // $FlowExpectedError[incompatible-type] should be of type object
   const locals: Array<any> = res.locals;
   res.locals.title = 'Home Page';
-  // $FlowExpectedError should not allow to set keys to non string value.
+  // $FlowExpectedError[incompatible-type] should not allow to set keys to non string value.
   res.locals[0] = 'Fail';
   res.send('bar')
     .status(200);
@@ -90,7 +90,7 @@ app.listen(9004, () => {
   console.log('Example app listening on port 9004!');
 });
 
-// $FlowExpectedError backlog should be number
+// $FlowExpectedError[incompatible-call] backlog should be number
 app.listen(9005, '127.0.0.1', '256', () => {
   console.log('Example app listening on port 9005!');
 })
@@ -98,9 +98,9 @@ app.listen(9005, '127.0.0.1', '256', () => {
 app.set('foo');
 
 app.get('foo');
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-call]
 app.enable(100);
-// $FlowExpectedError
+// $FlowExpectedError[incompatible-type]
 const f: number = app.enabled('100');
 
 const g: express$Application<> = app.enable('foo');
@@ -119,7 +119,7 @@ app.use('/again', (req: express$Request, res: express$Response) => {
 });
 
 app.use('/something', (req: express$Request, res: express$Response) => {
-  // $FlowExpectedError
+  // $FlowExpectedError[incompatible-call]
   res.redirect('/different', 200);
 });
 
@@ -144,7 +144,7 @@ app.use((err: Error, req: express$Request, res: express$Response, next: express$
     next(err);
 });
 
-// $FlowExpectedError path could not be an Object
+// $FlowExpectedError[incompatible-type] path could not be an Object
 const invalidPath: express$Path = {};
 
 let validPath: express$Path = 'string_path';


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Closes #3879. Express flow types were basically only compatible with 'http' but not 'https' because they accepted different types.

- Links to documentation: 
  - Notice https://github.com/facebook/flow/blob/main/lib/node.js#L1638 takes `net$Socket`
  - While https://github.com/facebook/flow/blob/main/lib/node.js#L1684 takes `tls$TLSSocket`
- Link to GitHub or NPM: https://www.npmjs.com/package/express
- Type of contribution: fix

Other notes: Also fix existing flow test errors

cc: @drumbsd @AndrewSouthpaw 

