### PR TITLE
[@redux/toolkit] Add configure store

### DIFF
--- a/definitions/npm/@reduxjs/toolkit_v1.x.x/flow_v0.104.x-/test_toolkit_v1.x.x.js
+++ b/definitions/npm/@reduxjs/toolkit_v1.x.x/flow_v0.104.x-/test_toolkit_v1.x.x.js
@@ -1,6 +1,11 @@
 // @flow
-import { describe, it } from 'flow-typed-test';
-import { createAction, createReducer } from '@reduxjs/toolkit';
+import { describe, it, test } from 'flow-typed-test';
+import {
+  createAction,
+  createReducer,
+  configureStore,
+  type Middleware,
+} from '@reduxjs/toolkit';
 
 describe('@redux/toolkit', () => {
   describe('createAction', () => {
@@ -45,5 +50,62 @@ describe('@redux/toolkit', () => {
         });
       });
     });
+  });
+
+  describe('createStore', () => {
+    const reducer = createReducer({}, {
+      'a': (state, action) => {
+        state.name = action.payload.name;
+      },
+    });
+
+    test('with basic reducer', () => {
+      configureStore({
+        reducer,
+      });
+    });
+
+    test('full example', () => {
+      const preloadedState = {
+        todos: [
+          {
+            text: 'Eat food',
+            completed: true,
+          },
+          {
+            text: 'Exercise',
+            completed: false,
+          },
+        ],
+        visibilityFilter: 'SHOW_COMPLETED',
+      };
+      const reduxBatch: any = {};
+
+      configureStore({
+        reducer,
+        devTools: process.env.NODE_ENV !== 'production',
+        preloadedState,
+        enhancers: [reduxBatch],
+      })
+    });
+
+    test('middleware', () => {
+      declare var logger: Middleware<any, any>;
+
+      configureStore({
+        reducer,
+        middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(logger),
+      })
+
+      configureStore({
+        reducer,
+        middleware: [logger],
+      })
+    });
+
+    test('errors', () => {
+      // $FlowExpectedError[incompatible-call]
+      configureStore();
+    })
   });
 });

--- a/definitions/npm/@reduxjs/toolkit_v1.x.x/flow_v0.104.x-/toolkit_v1.x.x.js
+++ b/definitions/npm/@reduxjs/toolkit_v1.x.x/flow_v0.104.x-/toolkit_v1.x.x.js
@@ -10,6 +10,215 @@ declare module '@reduxjs/toolkit' {
 
   declare type Reducer<S, A> = (state: S | void, action: A) => S;
 
+  declare type DispatchAPI<A> = (action: A) => A;
+
+  declare type Dispatch<A: { type: any, ... }> = DispatchAPI<A>;
+
+  declare type MiddlewareAPI<S, A, D = Dispatch<A>> = {
+    dispatch: D,
+    getState(): S,
+    ...
+  };
+
+  declare type Middleware<S, A, D = Dispatch<A>> = (
+    api: MiddlewareAPI<S, A, D>
+  ) => (next: D) => D;
+
+  declare type StoreCreator<S, A, D = Dispatch<A>> = {
+    (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>,
+    (
+      reducer: Reducer<S, A>,
+      preloadedState: S,
+      enhancer?: StoreEnhancer<S, A, D>
+    ): Store<S, A, D>,
+    ...
+  };
+
+  declare type StoreEnhancer<S, A, D = Dispatch<A>> = (
+    next: StoreCreator<S, A, D>
+  ) => StoreCreator<S, A, D>;
+
+  declare type Store<S, A, D = Dispatch<A>> = {
+    // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
+    dispatch: D,
+    getState(): S,
+    subscribe(listener: () => void): () => void,
+    replaceReducer(nextReducer: Reducer<S, A>): void,
+    ...
+  };
+
+  // --------------------
+
+  declare type Middlewares<S> = $ReadOnlyArray<Middleware<{ ... }, S>>;
+
+  declare type DevToolsOptions = {|
+    /**
+     * the instance name to be showed on the monitor page. Default value is `document.title`.
+     * If not specified and there's no document title, it will consist of `tabId` and `instanceId`.
+     */
+    name?: string,
+    /**
+     * action creators functions to be available in the Dispatcher.
+     */
+    actionCreators?: BaseActionCreator<any>[] | {
+      [key: string]: BaseActionCreator<any>,
+      ...
+    },
+    /**
+     * if more than one action is dispatched in the indicated interval, all new actions will be collected and sent at once.
+     * It is the joint between performance and speed. When set to `0`, all actions will be sent instantly.
+     * Set it to a higher value when experiencing perf issues (also `maxAge` to a lower value).
+     *
+     * @default 500 ms.
+     */
+    latency?: number,
+    /**
+     * (> 1) - maximum allowed actions to be stored in the history tree. The oldest actions are removed once maxAge is reached. It's critical for performance.
+     *
+     * @default 50
+     */
+    maxAge?: number,
+    /**
+     * See detailed documentation at https://github.com/reduxjs/redux-devtools/blob/%40redux-devtools/extension%403.2.1/extension/docs/API/Arguments.md#serialize
+     */
+    serialize?: boolean | {|
+      options?: boolean | {|
+        date?: boolean,
+        regex?: boolean,
+        undefined?: boolean,
+        error?: boolean,
+        symbol?: boolean,
+        map?: boolean,
+        set?: boolean,
+        function?: boolean | (...args: Array<any>) => any,
+      |},
+      replacer?: (key: string, value: mixed) => mixed,
+      reviver?: (key: string, value: mixed) => mixed,
+      immutable?: mixed,
+      refs?: mixed[],
+    |},
+    /**
+     * function which takes `action` object and id number as arguments, and should return `action` object back.
+     */
+    actionSanitizer?: <A: Action<any>>(action: A, id: number) => A,
+    /**
+     * function which takes `state` object and index as arguments, and should return `state` object back.
+     */
+    stateSanitizer?: <S>(state: S, index: number) => S,
+    /**
+     * *string or array of strings as regex* - actions types to be hidden / shown in the monitors (while passed to the reducers).
+     * If `actionsWhitelist` specified, `actionsBlacklist` is ignored.
+     */
+    actionsBlacklist?: string | string[],
+    /**
+     * *string or array of strings as regex* - actions types to be hidden / shown in the monitors (while passed to the reducers).
+     * If `actionsWhitelist` specified, `actionsBlacklist` is ignored.
+     */
+    actionsWhitelist?: string | string[],
+    /**
+     * called for every action before sending, takes `state` and `action` object, and returns `true` in case it allows sending the current data to the monitor.
+     * Use it as a more advanced version of `actionsBlacklist`/`actionsWhitelist` parameters.
+     */
+    predicate?: <S, A: Action<any>>(state: S, action: A) => boolean,
+    /**
+     * if specified as `false`, it will not record the changes till clicking on `Start recording` button.
+     * Available only for Redux enhancer, for others use `autoPause`.
+     *
+     * @default true
+     */
+    shouldRecordChanges?: boolean,
+    /**
+     * if specified, whenever clicking on `Pause recording` button and there are actions in the history log, will add this action type.
+     * If not specified, will commit when paused. Available only for Redux enhancer.
+     *
+     * @default "@@PAUSED""
+     */
+    pauseActionType?: string,
+    /**
+     * auto pauses when the extension’s window is not opened, and so has zero impact on your app when not in use.
+     * Not available for Redux enhancer (as it already does it but storing the data to be sent).
+     *
+     * @default false
+     */
+    autoPause?: boolean,
+    /**
+     * if specified as `true`, it will not allow any non-monitor actions to be dispatched till clicking on `Unlock changes` button.
+     * Available only for Redux enhancer.
+     *
+     * @default false
+     */
+    shouldStartLocked?: boolean,
+    /**
+     * if set to `false`, will not recompute the states on hot reloading (or on replacing the reducers). Available only for Redux enhancer.
+     *
+     * @default true
+     */
+    shouldHotReload?: boolean,
+    /**
+     * if specified as `true`, whenever there's an exception in reducers, the monitors will show the error message, and next actions will not be dispatched.
+     *
+     * @default false
+     */
+    shouldCatchErrors?: boolean,
+    /**
+     * If you want to restrict the extension, specify the features you allow.
+     * If not specified, all of the features are enabled. When set as an object, only those included as `true` will be allowed.
+     * Note that except `true`/`false`, `import` and `export` can be set as `custom` (which is by default for Redux enhancer), meaning that the importing/exporting occurs on the client side.
+     * Otherwise, you'll get/set the data right from the monitor part.
+     */
+    features?: {|
+      /**
+       * start/pause recording of dispatched actions
+       */
+      pause?: boolean,
+      /**
+       * lock/unlock dispatching actions and side effects
+       */
+      lock?: boolean,
+      /**
+       * persist states on page reloading
+       */
+      persist?: boolean,
+      /**
+       * export history of actions in a file
+       */
+      export?: boolean | 'custom',
+      /**
+       * import history of actions from a file
+       */
+      import?: boolean | 'custom',
+      /**
+       * jump back and forth (time travelling)
+       */
+      jump?: boolean,
+      /**
+       * skip (cancel) actions
+       */
+      skip?: boolean,
+      /**
+       * drag and drop actions in the history list
+       */
+      reorder?: boolean,
+      /**
+       * dispatch custom actions or action creators
+       */
+      dispatch?: boolean,
+      /**
+       * generate tests for the selected actions
+       */
+      test?: boolean,
+    |},
+    /**
+     * Set to true or a stacktrace-returning function to record call stack traces for dispatched actions.
+     * Defaults to false.
+     */
+    trace?: boolean | (<A: Action<any>>(action: A) => string),
+    /**
+     * The maximum number of stack trace entries to record per action. Defaults to 10.
+     */
+    traceLimit?: number,
+  |};
+
   declare interface TypedActionCreator<Type = string> {
     (...args: any[]): Action<Type>;
     type: Type;
@@ -94,7 +303,7 @@ declare module '@reduxjs/toolkit' {
    *             It might be removed in the future.
    * @public
    */
-  declare type CaseReducers<S, AS = Actions<string>> = $ObjMapi<AS, (K, V) => {| [K]: CaseReducer<S, V> |}>;
+  declare type CaseReducers<S, AS = Actions<string>, K = any, V = any> = $ObjMapi<AS, (K, V) => {| [key: K]: CaseReducer<S, V> |}>;
 
   /**
    * Defines a mapping from action types to corresponding action object shapes.
@@ -104,7 +313,9 @@ declare module '@reduxjs/toolkit' {
    *             It might be removed in the future.
    * @public
    */
-  declare type Actions<T = string> = Record<T, Action<T>>;
+  declare type Actions<T = string> = {|
+    [key: T]: Action<T>,
+  |};
 
 
   /**
@@ -158,8 +369,8 @@ declare module '@reduxjs/toolkit' {
    *
    * @public
    */
-  declare function createAction(type: T): ActionCreatorWithoutPayload<typeof T>;
-  declare function createAction<P = void>(type: T): ActionCreatorWithPayload<P, typeof T>;
+  declare function createAction<T>(type: T): ActionCreatorWithoutPayload<T>;
+  declare function createAction<P = void, T = any>(type: T): ActionCreatorWithPayload<P, T>;
 
   /**
    * A utility function that allows defining a reducer as a mapping from action
@@ -179,7 +390,10 @@ declare module '@reduxjs/toolkit' {
    *
    * @public
    */
-  declare function createReducer<S, CR = {| [string]: (S, Action<string>) => S |}>(initialState: S, actionsMap: CR): (state: S | void, action: A) => S;
+  declare function createReducer<S, CR = {| [string]: (S, Action<string>) => S |}, A = any>(
+    initialState: S,
+    actionsMap: CR
+  ): (state: S | void, action: A) => S;
 
 
   /**
@@ -199,5 +413,69 @@ declare module '@reduxjs/toolkit' {
    *
    * @public
    */
-  declare function createReducer<S>(initialState: S, builderCallback: (builder: ActionReducerMapBuilder<S>) => void): (state: S | void, action: A) => S;
+  declare function createReducer<S, A>(
+    initialState: S,
+    builderCallback: (builder: ActionReducerMapBuilder<S>) => void,
+  ): (state: S | void, action: A) => S;
+
+  /**
+   * Callback function type, to be used in `ConfigureStoreOptions.enhancers`
+   */
+  declare type ConfigureEnhancersCallback = <S, A>(defaultEnhancers: $ReadOnlyArray<StoreEnhancer<S, A>>) => Array<StoreEnhancer<S, A>>;
+
+  /**
+   * Options for `configureStore()`.
+   */
+  declare type ConfigureStoreOptions<S, A, M> = {|
+    /**
+     * A single reducer function that will be used as the root reducer, or an
+     * object of slice reducers that will be passed to `combineReducers()`.
+     */
+    reducer: Reducer<S, A> | {
+      [key: string]: Reducer<S, A>,
+      ...
+    },
+    /**
+     * An array of Redux middleware to install. If not supplied, defaults to
+     * the set of middleware returned by `getDefaultMiddleware()`.
+     *
+     * @example `middleware: (gDM) => gDM().concat(logger, apiMiddleware, yourCustomMiddleware)`
+     * @see https://redux-toolkit.js.org/api/getDefaultMiddleware#intended-usage
+     */
+    middleware?: M,
+    /**
+     * Whether to enable Redux DevTools integration. Defaults to `true`.
+     *
+     * Additional configuration can be done by passing Redux DevTools options
+     */
+    devTools?: boolean | DevToolsOptions,
+    /**
+     * The initial state, same as Redux's createStore.
+     * You may optionally specify it to hydrate the state
+     * from the server in universal apps, or to restore a previously serialized
+     * user session. If you use `combineReducers()` to produce the root reducer
+     * function (either directly or indirectly by passing an object as `reducer`),
+     * this must be an object with the same shape as the reducer map keys.
+     */
+    preloadedState?: { [key: string]: any },
+    /**
+     * The store enhancers to apply. See Redux's `createStore()`.
+     * All enhancers will be included before the DevTools Extension enhancer.
+     * If you need to customize the order of enhancers, supply a callback
+     * function that will receive the original array (ie, `[applyMiddleware]`),
+     * and should return a new array (such as `[applyMiddleware, offline]`).
+     * If you only need to add middleware, you can use the `middleware` parameter instead.
+     */
+    enhancers?: StoreEnhancer<S, A>[] | ConfigureEnhancersCallback,
+  |};
+
+  /**
+   * A friendly abstraction over the standard Redux `createStore()` function.
+   *
+   * @param config The store configuration.
+   * @returns A configured Redux store.
+   *
+   * @public
+   */
+  declare function configureStore<S = any, A: Action<any> = Action<any>, M: Middlewares<S> = []>(options: ConfigureStoreOptions<S, A, M>): Store<S, A>;
 }

--- a/definitions/npm/@reduxjs/toolkit_v1.x.x/flow_v0.104.x-/toolkit_v1.x.x.js
+++ b/definitions/npm/@reduxjs/toolkit_v1.x.x/flow_v0.104.x-/toolkit_v1.x.x.js
@@ -442,7 +442,7 @@ declare module '@reduxjs/toolkit' {
      * @example `middleware: (gDM) => gDM().concat(logger, apiMiddleware, yourCustomMiddleware)`
      * @see https://redux-toolkit.js.org/api/getDefaultMiddleware#intended-usage
      */
-    middleware?: M,
+    middleware?: M | ((gDM: () => M) => M),
     /**
      * Whether to enable Redux DevTools integration. Defaults to `true`.
      *


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Closes #4326. Add `configureStore` types

- Links to documentation: https://redux-toolkit.js.org/api/configureStore
- Link to GitHub or NPM: https://www.npmjs.com/package/@reduxjs/toolkit
- Type of contribution: addition

Other notes: I don't personally use this package so if things don't work as expected, I can improve it. More concerned about adding some types as opposed to making it exactly correct as keeping redux types and these types in sync are a pain 🥲 [Shameless plug](https://github.com/flow-typed/flow-typed/discussions/4242#discussioncomment-2838850)

cc: @michaelmior