### PR TITLE
docs: `update` command doesn't take positional arguments

### DIFF
--- a/docs/update.md
+++ b/docs/update.md
@@ -6,7 +6,6 @@ Download updates for any installed libdefs. Note: This is just an alias of `flow
 
 ```
 flow-typed update
-flow-typed update underscore
 ```
 
 ### Flags


### PR DESCRIPTION
The docs are not correct, `flow-typed update package-name` will throw an error, only `flow-typed update` works.