### PR TITLE
docs: document `create-stub --typescript` flag

### DIFF
--- a/docs/stub.md
+++ b/docs/stub.md
@@ -11,8 +11,9 @@ flow-typed create-stub foo bar baz
 
 ### Flags
 
-|Shorthand|Longhand|Description|Type|
+|Shorthand|Longhand&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Description|Type|
 |---------|--------|-----------|----|
 |-o|--overwrite|Overwrite an existing stub if it is already present in the`flow-typed` directory and has been modified|boolean|
 |-l|--libdefDir|Use a custom directory to install libdefs (instead of the default, `./flow-typed`)|string|
 |-r|--rootDir|Directory of .flowconfig relative to node_modules|string|
+|  |--typescript|Generates the types starting from its TypeScript definitions|boolean|


### PR DESCRIPTION
Added docs for the `--typescript` flag, I had to add some non-breaking-spaces because otherwise the table column would be too narrow and would have wrapped `--typescript` on two lines.