### PR TITLE
[react-router-dom] Duplicate type on definition

### DIFF
--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
@@ -158,14 +158,6 @@ declare module "react-router-dom" {
     state?: any;
   |}) => null;
 
-  declare export var Route: React$ComponentType<{|
-    caseSensitive?: boolean,
-    children?: React$Node,
-    element?: React$Element<any> | null,
-    index?: boolean,
-    path?: string,
-  |}>
-
   declare export var Routes: React$ComponentType<{|
     children?: React$Node,
     location?: Location


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
New flow version highlights that there was a duplicate of a type that now throws errors

- Links to documentation: https://www.npmjs.com/package/react-router-dom
- Link to GitHub or NPM: https://www.npmjs.com/package/react-router-dom
- Type of contribution: fix

Other notes:

