### PR TITLE
[react-helmet] remove var re-declaration of Helmet

### DIFF
--- a/definitions/npm/react-helmet_v6.x.x/flow_v0.134.x-/react-helmet_v6.x.x.js
+++ b/definitions/npm/react-helmet_v6.x.x/flow_v0.134.x-/react-helmet_v6.x.x.js
@@ -30,13 +30,12 @@ declare module 'react-helmet' {
     titleAttributes?: { [key: string]: any } | void;
     titleTemplate?: string | void;
   }
-  declare class Helmet mixins React$Component<HelmetProps> {
+  declare export class Helmet mixins React$Component<HelmetProps> {
     static rewind(): HelmetData;
     static renderStatic(): HelmetData;
     static canUseDOM: boolean;
   }
   declare var HelmetExport: typeof Helmet;
-  declare export var Helmet: typeof HelmetExport;
   declare export var canUseDOM: boolean;
   declare export default typeof HelmetExport;
   declare interface HelmetData {


### PR DESCRIPTION
- Links to documentation: https://github.com/facebook/flow/blob/main/Changelog.md#01820
- Link to GitHub or NPM: https://github.com/nfl/react-helmet
- Type of contribution: fix

Other notes:

The re-declaration of var Helmet causes the following error in flow 0.182.0:
```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ flow-typed/npm/react-helmet_v6.x.x.js:42:22

Cannot declare Helmet [1] because var redeclaration is not supported. [name-already-bound]

 [1] 36│   declare class Helmet mixins React$Component<HelmetProps> {
     37│     static rewind(): HelmetData;
     38│     static renderStatic(): HelmetData;
     39│     static canUseDOM: boolean;
     40│   }
     41│   declare var HelmetExport: typeof Helmet;
     42│   declare export var Helmet: typeof HelmetExport;
     43│   declare export var canUseDOM: boolean;
     44│   declare export default typeof HelmetExport;
     45│   declare interface HelmetData {
```