### PR TITLE
Add new type for deep freeze

### DIFF
--- a/definitions/npm/deep-freeze_v0.0.1/flow_v0.104.x-/deep-freeze_v0.0.1.js
+++ b/definitions/npm/deep-freeze_v0.0.1/flow_v0.104.x-/deep-freeze_v0.0.1.js
@@ -12,4 +12,5 @@ declare module 'deep-freeze' {
   declare export type DeepReadOnly<T> = $Call<deepFreezeFnType, T>
 
   declare module.exports: deepFreezeFnType;
+
 }

--- a/definitions/npm/deep-freeze_v0.0.1/flow_v0.104.x-/deep-freeze_v0.0.1.js
+++ b/definitions/npm/deep-freeze_v0.0.1/flow_v0.104.x-/deep-freeze_v0.0.1.js
@@ -1,3 +1,14 @@
 declare module 'deep-freeze' {
-  declare module.exports: <T>(o: T) => T;
+  declare type deepFreezeFnType = {|
+    <T>(a: $ReadOnlyArray<T>): $ReadOnlyArray<DeepReadOnly<T>>,
+    <T>(a: T[]): $ReadOnlyArray<DeepReadOnly<T>>,
+    <T: boolean|string|number>(p: T): T,
+    <T>(o: T): $ReadOnly<
+      $ObjMapi<T, <P>(P) => DeepReadOnly<$ElementType<T, P>>>
+    >,
+  |};
+
+  declare export type DeepReadOnly<T> = $Call<deepFreezeFnType, T>
+
+  declare module.exports: deepFreezeFnType;
 }

--- a/definitions/npm/deep-freeze_v0.0.1/flow_v0.104.x-/deep-freeze_v0.0.1.js
+++ b/definitions/npm/deep-freeze_v0.0.1/flow_v0.104.x-/deep-freeze_v0.0.1.js
@@ -6,6 +6,7 @@ declare module 'deep-freeze' {
     <T>(o: T): $ReadOnly<
       $ObjMapi<T, <P>(P) => DeepReadOnly<$ElementType<T, P>>>
     >,
+    <T: Function>(f: T): T,
   |};
 
   declare export type DeepReadOnly<T> = $Call<deepFreezeFnType, T>

--- a/definitions/npm/deep-freeze_v0.0.1/flow_v0.104.x-/test_deep-freeze-v0.0.1.js
+++ b/definitions/npm/deep-freeze_v0.0.1/flow_v0.104.x-/test_deep-freeze-v0.0.1.js
@@ -1,13 +1,111 @@
 // @flow
 
-import deepFreeze from 'deep-freeze';
+import deepFreeze, { type DeepReadOnly } from 'deep-freeze';
+import { it, describe } from 'flow-typed-test';
 
-const obj: { foo: string, ... } = deepFreeze({foo: 'bar'});
-const arr: Array<string> = deepFreeze(['foo', 'bar']);
-const num: number = deepFreeze(42);
+describe('No properties', () => {
+  const test1 = deepFreeze(({}: { ... }));
 
-// $FlowExpectedError input type must match output type
-const notObj: { foo: string, ... } = deepFreeze(['foo', 'bar']);
+  it('throws error', () => {
+    // $FlowExpectedError[prop-missing]
+    test1.disabled = true;
+  });
+});
 
-// $FlowExpectedError input type must match output type
-const notArr: Array<string> = deepFreeze({foo: 'bar'});
+describe('Object', () => {
+  const test1 = deepFreeze(({ disabled: false }: {| disabled: boolean |}));
+
+  it('throws error', () => {
+    // $FlowExpectedError[cannot-write]
+    test1.disabled = true;
+
+    // $FlowExpectedError[prop-missing]
+    test1.newprop = true;
+  });
+});
+
+describe('$ReadOnly Object', () => {
+  const test1 = deepFreeze(
+    ({ disabled: false }: $ReadOnly<{| disabled: boolean |}>)
+  );
+
+  it('throws error', () => {
+    // $FlowExpectedError[cannot-write]
+    test1.disabled = true;
+
+    // $FlowExpectedError[prop-missing]
+    test1.newprop = true;
+  });
+});
+
+describe('Array', () => {
+  const test1: $ReadOnlyArray<DeepReadOnly<{| name: string |}>> = deepFreeze([
+    { name: 'foo' },
+  ]);
+
+  it('raises error', () => {
+    // $FlowExpectedError[cannot-write]
+    test1[0].name = true;
+  });
+});
+
+describe('$ReadOnlyArray', () => {
+  const test1: $ReadOnlyArray<DeepReadOnly<{| name: string |}>> = deepFreeze(
+    ([{ name: 'foo' }]: $ReadOnlyArray<{| name: string |}>)
+  );
+
+  it('raises error', () => {
+    // $FlowExpectedError[cannot-write]
+    test1[0].name = true;
+  });
+});
+
+describe('Nested object', () => {
+  const test1: $ReadOnlyArray<DeepReadOnly<{| name: string |}>> = deepFreeze(
+    ([{ name: 'foo' }]: $ReadOnlyArray<{| name: string |}>)
+  );
+
+  it('raises error', () => {
+    // $FlowExpectedError[cannot-write]
+    test1[0].name = true;
+  });
+});
+
+describe('Complex object', () => {
+  const test1: $ReadOnlyArray<DeepReadOnly<{foo: Array<{bar: Array<{foobar: boolean, ...}>, ...}>, ...}>> = deepFreeze([
+    {
+      foo: [
+        {
+          bar: [
+            {
+              foobar: false,
+            },
+          ],
+        },
+      ],
+    },
+  ]);
+
+  it('raises error', () => {
+    // $FlowExpectedError[prop-missing]
+    test1[0].push('foo');
+
+    // $FlowExpectedError[prop-missing]
+    test1[0].newprop = true;
+
+    // $FlowExpectedError[cannot-write]
+    test1[0].foo[0].bar[0].foobar = true;
+
+    // $FlowExpectedError[incompatible-type]
+    // $FlowExpectedError[cannot-write]
+    test1[1] = {foo: "value"}
+  });
+});
+
+describe('Number', () => {
+  const test1: number = deepFreeze(1);
+});
+
+describe('string', () => {
+  const test1: string = deepFreeze('3');
+});

--- a/definitions/npm/deep-freeze_v0.0.1/flow_v0.104.x-/test_deep-freeze-v0.0.1.js
+++ b/definitions/npm/deep-freeze_v0.0.1/flow_v0.104.x-/test_deep-freeze-v0.0.1.js
@@ -60,16 +60,6 @@ describe('$ReadOnlyArray', () => {
   });
 });
 
-describe('Nested object', () => {
-  const test1: $ReadOnlyArray<DeepReadOnly<{| name: string |}>> = deepFreeze(
-    ([{ name: 'foo' }]: $ReadOnlyArray<{| name: string |}>)
-  );
-
-  it('raises error', () => {
-    // $FlowExpectedError[cannot-write]
-    test1[0].name = true;
-  });
-});
 
 describe('Complex object', () => {
   const test1: $ReadOnlyArray<DeepReadOnly<{foo: Array<{bar: Array<{foobar: boolean, ...}>, ...}>, ...}>> = deepFreeze([

--- a/definitions/npm/deep-freeze_v0.0.1/flow_v0.104.x-/test_deep-freeze-v0.0.1.js
+++ b/definitions/npm/deep-freeze_v0.0.1/flow_v0.104.x-/test_deep-freeze-v0.0.1.js
@@ -99,3 +99,22 @@ describe('Number', () => {
 describe('string', () => {
   const test1: string = deepFreeze('3');
 });
+
+
+describe('Function', () => {
+    const example = (foo: number) => 'bar';
+    const frozenExample = deepFreeze(example);
+
+    it('works', () => {
+        example(3);
+        frozenExample(3);
+    });
+
+    it('raises error', () => {
+        // $FlowExpectedError[incompatible-call]
+        example('foo');
+
+        // $FlowExpectedError[incompatible-call]
+        frozenExample('foo');
+    });
+  });


### PR DESCRIPTION

- Links to documentation:
  - Github repo: https://github.com/substack/deep-freeze
  - Example of it on flow playground: https://flow.org/try/#0CYUwxgNghgTiAEBbA9sArhEA6EAPADsjAC4DOAXPKCPgGJwgBeItAdgCoCe+IA3AFD9QkWAmLcE1Og2ZsuPeAF54AbwA+-ePAA87AHwAKKJQAkAJRBRgAeVYROAQRgwonXXoCUpi1dv2nLm4AIiA0PjZ2bvp6ADSaOvpGlOwA2gC6XvDmlhH+zq7aIWE5flF6sfG6lABGyMiYUKxqpMQwAJasAOZqrGiI1SAwhvjJmexxWu4GyKPeJZHa8VoA9MtZ1tUAVgCyUPi6MVSh0qGyHBJ6S+tbu-htBzoACoaPHkp68EX44aXaJgCimEQIFYxHkIAez3K8QqagAvgJ+OIFF8fgt9EosgBhKAQCDaKT0U4sc48Q76QRCcDQODwABusCONCJTBAlEJMhJ4MRHOJBhSKgARMA2qQoNVMMBBZRWmgQHCMikAAxpLAisUSkDATEAM1xpD4-CAA

- Type of contribution: fix

Other notes:

This is a new type definition for the deep freeze library. It acts pretty much the same as https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/deep-freeze/index.d.ts. 

It wraps any objects and arrays with ReadOnly / ReadOnlyArray then returns. That means any modifications are not possible.

