### PR TITLE
fix: HTMLElement for element passed to MatcherFunction

### DIFF
--- a/definitions/npm/@testing-library/react_v12.x.x/flow_v0.104.x-/react_v12.x.x.js
+++ b/definitions/npm/@testing-library/react_v12.x.x/flow_v0.104.x-/react_v12.x.x.js
@@ -184,7 +184,7 @@ declare module '@testing-library/react' {
 
   declare type MatcherFunction = (
     content: string,
-    element: ?Element
+    element: HTMLElement
   ) => boolean;
 
   declare type Matcher = MatcherFunction | RegExp | string | number;

--- a/definitions/npm/@testing-library/react_v12.x.x/flow_v0.104.x-/test_react_v12.x.x.js
+++ b/definitions/npm/@testing-library/react_v12.x.x/flow_v0.104.x-/test_react_v12.x.x.js
@@ -193,6 +193,12 @@ describe('render', () => {
     rerender(<Component />);
   });
 
+  it('matcher function should receive HTMLElement type elements', () => {
+    const a: IntersectionHTMLElement = getByText(
+      (_, node) => node.style.height === '100px'
+    );
+  });
+
   it('getByAltText should return HTML element', () => {
     const a: IntersectionHTMLElement = getByAltText('1');
   });


### PR DESCRIPTION
Type of contribution: **fix**

The change below changed the `Matcher` function type to what it is today from the following

```
export type MatcherFunction = (content: string, element: HTMLElement) => boolean
```
> https://github.com/testing-library/dom-testing-library/commit/accb6cc60628cb6b5bd4d9be2ead41724995e5ae

The previous type above seems more correct since the matcher function is not called with `null` elements as far as I can tell? The type being `HTMLElement` also allows the match function to correctly interact with the DOM properties of the element, whereas `Element` is too general and throws an error when you try to access fields such as `element.style`.

== Tests

Confirmed tests failed without my changes and now pass with my changes via `./quick_run_def_tests.sh`

> ![Screen Shot 2022-07-16 at 12 02 16 AM](https://user-images.githubusercontent.com/290084/179344736-b3e45ef6-ffb4-4b29-a476-bec9bc64c8ab.png)