### PR TITLE
Relocate @@aria-query types into module

### DIFF
--- a/definitions/npm/@testing-library/react_v12.x.x/flow_v0.104.x-/react_v12.x.x.js
+++ b/definitions/npm/@testing-library/react_v12.x.x/flow_v0.104.x-/react_v12.x.x.js
@@ -1,168 +1,164 @@
-/**
- * A local copy from:
- * https://github.com/A11yance/aria-query/blob/2e6a3011a0d8987655f3a14853934fe3df38a8d8/flow/aria.js
- */
- declare module '@@aria-query' {
-  declare export type ARIAAbstractRole =
-    | 'command'
-    | 'composite'
-    | 'input'
-    | 'landmark'
-    | 'range'
-    | 'roletype'
-    | 'section'
-    | 'sectionhead'
-    | 'select'
-    | 'structure'
-    | 'widget'
-    | 'window';
-
-  declare export type ARIAWidgetRole =
-    | 'button'
-    | 'checkbox'
-    | 'gridcell'
-    | 'link'
-    | 'menuitem'
-    | 'menuitemcheckbox'
-    | 'menuitemradio'
-    | 'option'
-    | 'progressbar'
-    | 'radio'
-    | 'scrollbar'
-    | 'searchbox'
-    | 'slider'
-    | 'spinbutton'
-    | 'switch'
-    | 'tab'
-    | 'tabpanel'
-    | 'textbox'
-    | 'treeitem';
-
-  declare export type ARIACompositeWidgetRole =
-    | 'combobox'
-    | 'grid'
-    | 'listbox'
-    | 'menu'
-    | 'menubar'
-    | 'radiogroup'
-    | 'tablist'
-    | 'tree'
-    | 'treegrid';
-
-  declare export type ARIADocumentStructureRole =
-    | 'application'
-    | 'article'
-    | 'blockquote'
-    | 'caption'
-    | 'cell'
-    | 'columnheader'
-    | 'definition'
-    | 'deletion'
-    | 'directory'
-    | 'document'
-    | 'emphasis'
-    | 'feed'
-    | 'figure'
-    | 'generic'
-    | 'group'
-    | 'heading'
-    | 'img'
-    | 'insertion'
-    | 'list'
-    | 'listitem'
-    | 'math'
-    | 'meter'
-    | 'none'
-    | 'note'
-    | 'paragraph'
-    | 'presentation'
-    | 'row'
-    | 'rowgroup'
-    | 'rowheader'
-    | 'separator'
-    | 'strong'
-    | 'subscript'
-    | 'superscript'
-    | 'table'
-    | 'term'
-    | 'time'
-    | 'toolbar'
-    | 'tooltip';
-
-  declare export type ARIALandmarkRole =
-    | 'banner'
-    | 'complementary'
-    | 'contentinfo'
-    | 'form'
-    | 'main'
-    | 'navigation'
-    | 'region'
-    | 'search';
-
-  declare export type ARIALiveRegionRole =
-    | 'alert'
-    | 'log'
-    | 'marquee'
-    | 'status'
-    | 'timer';
-
-  declare export type ARIAWindowRole = 'alertdialog' | 'dialog';
-
-  declare export type ARIAUncategorizedRole = 'code';
-
-  declare export type ARIADPubRole =
-    | 'doc-abstract'
-    | 'doc-acknowledgments'
-    | 'doc-afterword'
-    | 'doc-appendix'
-    | 'doc-backlink'
-    | 'doc-biblioentry'
-    | 'doc-bibliography'
-    | 'doc-biblioref'
-    | 'doc-chapter'
-    | 'doc-colophon'
-    | 'doc-conclusion'
-    | 'doc-cover'
-    | 'doc-credit'
-    | 'doc-credits'
-    | 'doc-dedication'
-    | 'doc-endnote'
-    | 'doc-endnotes'
-    | 'doc-epigraph'
-    | 'doc-epilogue'
-    | 'doc-errata'
-    | 'doc-example'
-    | 'doc-footnote'
-    | 'doc-foreword'
-    | 'doc-glossary'
-    | 'doc-glossref'
-    | 'doc-index'
-    | 'doc-introduction'
-    | 'doc-noteref'
-    | 'doc-notice'
-    | 'doc-pagebreak'
-    | 'doc-pagelist'
-    | 'doc-part'
-    | 'doc-preface'
-    | 'doc-prologue'
-    | 'doc-pullquote'
-    | 'doc-qna'
-    | 'doc-subtitle'
-    | 'doc-tip'
-    | 'doc-toc';
-
-  declare export type ARIARole =
-    | ARIAWidgetRole
-    | ARIACompositeWidgetRole
-    | ARIADocumentStructureRole
-    | ARIALandmarkRole
-    | ARIALiveRegionRole
-    | ARIAWindowRole
-    | ARIAUncategorizedRole;
-}
-
 declare module '@testing-library/react' {
-  import type { ARIARole } from '@@aria-query';
+  /**
+   * A local copy from:
+   * https://github.com/A11yance/aria-query/blob/2e6a3011a0d8987655f3a14853934fe3df38a8d8/flow/aria.js
+   */
+  declare export type ARIAAbstractRole =
+      | 'command'
+      | 'composite'
+      | 'input'
+      | 'landmark'
+      | 'range'
+      | 'roletype'
+      | 'section'
+      | 'sectionhead'
+      | 'select'
+      | 'structure'
+      | 'widget'
+      | 'window';
+
+    declare export type ARIAWidgetRole =
+      | 'button'
+      | 'checkbox'
+      | 'gridcell'
+      | 'link'
+      | 'menuitem'
+      | 'menuitemcheckbox'
+      | 'menuitemradio'
+      | 'option'
+      | 'progressbar'
+      | 'radio'
+      | 'scrollbar'
+      | 'searchbox'
+      | 'slider'
+      | 'spinbutton'
+      | 'switch'
+      | 'tab'
+      | 'tabpanel'
+      | 'textbox'
+      | 'treeitem';
+
+    declare export type ARIACompositeWidgetRole =
+      | 'combobox'
+      | 'grid'
+      | 'listbox'
+      | 'menu'
+      | 'menubar'
+      | 'radiogroup'
+      | 'tablist'
+      | 'tree'
+      | 'treegrid';
+
+    declare export type ARIADocumentStructureRole =
+      | 'application'
+      | 'article'
+      | 'blockquote'
+      | 'caption'
+      | 'cell'
+      | 'columnheader'
+      | 'definition'
+      | 'deletion'
+      | 'directory'
+      | 'document'
+      | 'emphasis'
+      | 'feed'
+      | 'figure'
+      | 'generic'
+      | 'group'
+      | 'heading'
+      | 'img'
+      | 'insertion'
+      | 'list'
+      | 'listitem'
+      | 'math'
+      | 'meter'
+      | 'none'
+      | 'note'
+      | 'paragraph'
+      | 'presentation'
+      | 'row'
+      | 'rowgroup'
+      | 'rowheader'
+      | 'separator'
+      | 'strong'
+      | 'subscript'
+      | 'superscript'
+      | 'table'
+      | 'term'
+      | 'time'
+      | 'toolbar'
+      | 'tooltip';
+
+    declare export type ARIALandmarkRole =
+      | 'banner'
+      | 'complementary'
+      | 'contentinfo'
+      | 'form'
+      | 'main'
+      | 'navigation'
+      | 'region'
+      | 'search';
+
+    declare export type ARIALiveRegionRole =
+      | 'alert'
+      | 'log'
+      | 'marquee'
+      | 'status'
+      | 'timer';
+
+    declare export type ARIAWindowRole = 'alertdialog' | 'dialog';
+
+    declare export type ARIAUncategorizedRole = 'code';
+
+    declare export type ARIADPubRole =
+      | 'doc-abstract'
+      | 'doc-acknowledgments'
+      | 'doc-afterword'
+      | 'doc-appendix'
+      | 'doc-backlink'
+      | 'doc-biblioentry'
+      | 'doc-bibliography'
+      | 'doc-biblioref'
+      | 'doc-chapter'
+      | 'doc-colophon'
+      | 'doc-conclusion'
+      | 'doc-cover'
+      | 'doc-credit'
+      | 'doc-credits'
+      | 'doc-dedication'
+      | 'doc-endnote'
+      | 'doc-endnotes'
+      | 'doc-epigraph'
+      | 'doc-epilogue'
+      | 'doc-errata'
+      | 'doc-example'
+      | 'doc-footnote'
+      | 'doc-foreword'
+      | 'doc-glossary'
+      | 'doc-glossref'
+      | 'doc-index'
+      | 'doc-introduction'
+      | 'doc-noteref'
+      | 'doc-notice'
+      | 'doc-pagebreak'
+      | 'doc-pagelist'
+      | 'doc-part'
+      | 'doc-preface'
+      | 'doc-prologue'
+      | 'doc-pullquote'
+      | 'doc-qna'
+      | 'doc-subtitle'
+      | 'doc-tip'
+      | 'doc-toc';
+
+    declare export type ARIARole =
+      | ARIAWidgetRole
+      | ARIACompositeWidgetRole
+      | ARIADocumentStructureRole
+      | ARIALandmarkRole
+      | ARIALiveRegionRole
+      | ARIAWindowRole
+      | ARIAUncategorizedRole;
 
   // This type comes from react-dom_v17.x.x.js
   declare interface ReactDOMTestUtilsThenable {


### PR DESCRIPTION
Type of contribution: **fix**

Declaring types under `@@aria-query` is only valid if you depend on `@@aria-query`, since these are meant to be used locally within this type file we should relocate the types down into the `@testing-library/react` module instead.

If you try to use this file in a local `flow-typed` file without `@@aria-query` installed you will encounter `eslint` failures for an unresolved `@@aria-query` import (`import type { ARIARole } from '@@aria-query';`)