### PR TITLE
[@faker-js/faker] Fix faker export

### DIFF
--- a/definitions/npm/@faker-js/faker_v6.x.x/flow_v0.104.x-/faker_v6.x.x.js
+++ b/definitions/npm/@faker-js/faker_v6.x.x/flow_v0.104.x-/faker_v6.x.x.js
@@ -1,7 +1,7 @@
 declare module "@faker-js/faker" {
   declare type SeedType = number | $ReadOnlyArray<number>;
 
-  declare module.exports: {
+  declare type Faker = {
     seedValue: ?SeedType,
     seed: (SeedType) => void,
     setLocale: (string) => void,
@@ -310,4 +310,8 @@ declare module "@faker-js/faker" {
     },
     ...
   };
+
+  declare module.exports: {|
+    faker: Faker,
+  |};
 }

--- a/definitions/npm/@faker-js/faker_v6.x.x/flow_v0.104.x-/test_faker_v6.x.x.js
+++ b/definitions/npm/@faker-js/faker_v6.x.x/flow_v0.104.x-/test_faker_v6.x.x.js
@@ -1,5 +1,5 @@
 import { describe, it } from "flow-typed-test";
-import faker from "@faker-js/faker";
+import { faker } from "@faker-js/faker";
 
 describe("prototype", () => {
   faker.seed(12);

--- a/definitions/npm/@faker-js/faker_v6.x.x/flow_v0.25.x-v0.103.x/faker_v6.x.x.js
+++ b/definitions/npm/@faker-js/faker_v6.x.x/flow_v0.25.x-v0.103.x/faker_v6.x.x.js
@@ -1,7 +1,7 @@
 declare module "@faker-js/faker" {
   declare type SeedType = number | $ReadOnlyArray<number>;
 
-  declare module.exports: {
+  declare type Faker = {
     seedValue: ?SeedType,
     seed: (SeedType) => void,
     setLocale: (string) => void,
@@ -267,4 +267,8 @@ declare module "@faker-js/faker" {
       semver: () => string
     }
   };
+
+  declare module.exports: {|
+    faker: Faker,
+  |};
 }

--- a/definitions/npm/@faker-js/faker_v6.x.x/flow_v0.25.x-v0.103.x/test_faker_v6.x.x.js
+++ b/definitions/npm/@faker-js/faker_v6.x.x/flow_v0.25.x-v0.103.x/test_faker_v6.x.x.js
@@ -1,5 +1,5 @@
 import { describe, it } from "flow-typed-test";
-import faker from "@faker-js/faker";
+import { faker } from "@faker-js/faker";
 
 describe("prototype", () => {
   faker.seed(12);


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Faker from v5 to v6 has been changed to instead now expose just a single named export which contains all categories

- Links to documentation: https://www.npmjs.com/package/@faker-js/faker/v/6.3.1
- Link to GitHub or NPM: https://www.npmjs.com/package/@faker-js/faker/v/6.3.1
- Type of contribution: fix

Other notes:

