### PR TITLE
[cli] Rename references to future main branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Make use of flow-typed.config.js for ignored (#4288)
 
 ### Changed
-- Consistent list logging (#4287) 
+- Consistent list logging (#4287)
 - Coerce cli version with semver to allow for prerelease tags (#4291)
 - Fix if dependency is resolved npm package (#4298)
 - Bump minimist from 1.2.0 to 1.2.6 in (#4293)
@@ -24,19 +24,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.7.0] 2022-02-21
 
 ### Added
-- New `outdated` command (#4171) 
+- New `outdated` command (#4171)
 
 ### Changed
-- CLI tool now ships with flowtypes (#4233) 
-- Install can match with alpha versions now (#4247) 
+- CLI tool now ships with flowtypes (#4233)
+- Install can match with alpha versions now (#4247)
 
 ### Fixed
 - Fix create def with scopes (#4234)
 - Fix buffer deprecation error (#4270)
-- Temporarily turn off validate-def checks against npm (#4249) 
-- Bump ajv from 6.11.0 to 6.12.6 in /cli (#4260) 
-- Bump node-fetch from 2.6.6 to 2.6.7 in /cli (#4254) 
-- Bump shelljs from 0.8.3 to 0.8.5 in /cli (#4237) 
+- Temporarily turn off validate-def checks against npm (#4249)
+- Bump ajv from 6.11.0 to 6.12.6 in /cli (#4260)
+- Bump node-fetch from 2.6.6 to 2.6.7 in /cli (#4254)
+- Bump shelljs from 0.8.3 to 0.8.5 in /cli (#4237)
 
 ## [3.6.1] 2022-01-09
 
@@ -249,7 +249,7 @@ A week after this release, all previous versions of `flow-typed` on npm will be 
 ### Added
 - Allow any file type (.md, .json) under `/definitions/npm/<library>_vx.x.x/` (#1962)
 - `describe` and `it` can now be importing from `'flow-typed-test'` in `_test` files (#1942)
-  - See [CONTRIBUTING.md](https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md)
+  - See [CONTRIBUTING.md](https://github.com/flow-typed/flow-typed/blob/main/CONTRIBUTING.md)
 - Root directory option (-rootDir) to install command (#1835)
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Contributing library definitions is as easy as sending a pull request!
 ## Understanding the definitions structure
 
 All definitions sit under the
-[/definitions](https://github.com/flowtype/flow-typed/tree/master/definitions)
+[/definitions](https://github.com/flowtype/flow-typed/tree/main/definitions)
 directory. They all must follow the following directory structure and naming
 format:
 
@@ -151,11 +151,11 @@ reasonable degree. At minimum your tests should:
 1. Use the library definition in a couple of ways that are *expected* to produce
    a type error. Though type errors should fail your tests, you can add [error suppressions](https://flow.org/en/docs/errors/) to the line above just like you would in your own codebase.
 
-[Here](https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/highlight.js_v8.x.x/test_highlight.js-v8.js)
+[Here](https://github.com/flow-typed/flow-typed/blob/main/definitions/npm/highlight.js_v8.x.x/test_highlight.js-v8.js)
 is an example of a nice and thorough test file. You don't necessarily have to be
 this thorough, but the more thorough you are the better!
 
-Sometimes you may want to break down your test suite instead of having one gigantic file. In that case you can actually write as many test files as you like as long as their names start with `test_`. [Redux](https://github.com/flow-typed/flow-typed/tree/master/definitions/npm/redux_v4.x.x/flow_v0.134.x-) followed this pattern.
+Sometimes you may want to break down your test suite instead of having one gigantic file. In that case you can actually write as many test files as you like as long as their names start with `test_`. [Redux](https://github.com/flow-typed/flow-typed/tree/main/definitions/npm/redux_v4.x.x/flow_v0.134.x-) followed this pattern.
 
 Alternatively you can add test files in the **package version directory** which will be run by
 the test-runner for *all* versions of flow the package version supports. Though general best practice as outlined above is using the **flow version directory**.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
-<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
+<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/main/CONTRIBUTING.md for details. --->
 
-- Links to documentation: 
-- Link to GitHub or NPM: 
+- Links to documentation:
+- Link to GitHub or NPM:
 - Type of contribution: new definition | addition | fix | refactor
 
 Other notes:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  A <a href="https://github.com/flow-typed/flow-typed/tree/master/definitions">repository</a> of
+  A <a href="https://github.com/flow-typed/flow-typed/tree/main/definitions">repository</a> of
   high-quality, third-party <a href="https://flow.org/en/docs/libdefs">library type definitions</a>
   for use with <a href="http://flow.org">Flow</a>.
 </p>
@@ -64,7 +64,7 @@ Chances are your question has already been answered! If not, don't hesitate to
 
 ## How Do I Contribute Library Definitions?
 
-Just send a pull request! The documentation highlighted in [CONTRIBUTING.md](https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md) should give a detailed overview of how to raise a pull request following our best practices.
+Just send a pull request! The documentation highlighted in [CONTRIBUTING.md](https://github.com/flow-typed/flow-typed/blob/main/CONTRIBUTING.md) should give a detailed overview of how to raise a pull request following our best practices.
 
 ### Contributing to the CLI
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-fb-flow": "^0.0.4",
     "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-prettier": "^4.0.0",
-    "flow-bin": "^0.165.1",
+    "flow-bin": "^0.183.0",
     "flow-copy-source": "^2.0.9",
     "jest": "^27.3.1"
   },

--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -1,6 +1,6 @@
 // @flow
 
-(require('../../lib/git'): any).rebaseRepoMaster = jest.fn();
+(require('../../lib/git'): any).rebaseRepoMainline = jest.fn();
 
 import {
   _clearCustomCacheDir as clearCustomCacheDir,

--- a/cli/src/commands/__tests__/outdated-test.js
+++ b/cli/src/commands/__tests__/outdated-test.js
@@ -1,5 +1,5 @@
 // @flow
-(require('../../lib/git'): any).rebaseRepoMaster = jest.fn();
+(require('../../lib/git'): any).rebaseRepoMainline = jest.fn();
 
 import {table} from 'table';
 import {

--- a/cli/src/commands/__tests__/runTests-test.js
+++ b/cli/src/commands/__tests__/runTests-test.js
@@ -1,5 +1,7 @@
 // @flow
-import {run} from '../runTests';
+import fs from 'fs';
+
+import {run, writeFlowConfig, TEST_DIR} from '../runTests';
 import {path} from '../../lib/node';
 
 describe('run-tests (command)', () => {
@@ -29,6 +31,169 @@ describe('run-tests (command)', () => {
       const calls = ((console.log: any): JestMockFn<*, *>).mock.calls;
       const lastErrorMsg = calls[calls.length - 1][1];
       expect(lastErrorMsg).toContain(expectedError);
+    });
+  });
+
+  describe('writeFlowConfig', () => {
+    const fixtureBasePath = path.join(
+      process.cwd(),
+      'src/commands/__tests__/__runTests-fixtures__',
+    );
+    const testDir = path.join(TEST_DIR, 'unit-test');
+    const flowConfigFile = path.join(testDir, '.flowconfig');
+
+    beforeAll(() => {
+      fs.mkdirSync(testDir, {recursive: true});
+    });
+
+    afterAll(() => {
+      fs.rmdirSync(testDir, {recursive: true});
+    });
+
+    it('writes the file correctly', async () => {
+      await writeFlowConfig(
+        fixtureBasePath,
+        testDir,
+        path.join(fixtureBasePath, 'definitions/npm/def/'),
+        '0.181.0',
+        [],
+      );
+
+      const flowConfigSplit = fs
+        .readFileSync(flowConfigFile, 'utf-8')
+        .split('\n');
+
+      const matches = [
+        '[libs]',
+        'def',
+        /.*cli\/src\/commands\/__tests__\/__util__\/tdd_framework\.js$/,
+        '',
+        '[options]',
+        'include_warnings=true',
+        'server.max_workers=0',
+        'sharedmemory.heap_size=3221225472',
+        '',
+        '',
+        '[ignore]',
+        /.*\/cli\/node_modules$/,
+        '',
+        '[lints]',
+        'implicit-inexact-object=error',
+      ];
+
+      matches.forEach((match, i) => {
+        expect(flowConfigSplit[i]).toMatch(match);
+      });
+    });
+
+    it('writes flow suppression if flow version is less than 0.125.0', async () => {
+      await writeFlowConfig(
+        fixtureBasePath,
+        testDir,
+        path.join(fixtureBasePath, 'definitions/npm/def/'),
+        '0.124.0',
+        [],
+      );
+
+      const flowConfigSplit = fs
+        .readFileSync(flowConfigFile, 'utf-8')
+        .split('\n');
+
+      const matches = [
+        '[libs]',
+        'def',
+        /.*cli\/src\/commands\/__tests__\/__util__\/tdd_framework\.js$/,
+        '',
+        '[options]',
+        'include_warnings=true',
+        'server.max_workers=0',
+        'sharedmemory.heap_size=3221225472',
+        'suppress_comment=\\\\(.\\\\|\\n\\\\)*\\\\$FlowExpectedError',
+        '',
+        '[ignore]',
+        /.*\/cli\/node_modules$/,
+        '',
+        '[lints]',
+        'implicit-inexact-object=error',
+      ];
+
+      matches.forEach((match, i) => {
+        expect(flowConfigSplit[i]).toMatch(match);
+      });
+    });
+
+    it('does not have inexplicit lint when less than flow version less than 0.104.0', async () => {
+      await writeFlowConfig(
+        fixtureBasePath,
+        testDir,
+        path.join(fixtureBasePath, 'definitions/npm/def/'),
+        '0.103.0',
+        [],
+      );
+
+      const flowConfigSplit = fs
+        .readFileSync(flowConfigFile, 'utf-8')
+        .split('\n');
+
+      const matches = [
+        '[libs]',
+        'def',
+        /.*cli\/src\/commands\/__tests__\/__util__\/tdd_framework\.js$/,
+        '',
+        '[options]',
+        'include_warnings=true',
+        'server.max_workers=0',
+        'sharedmemory.heap_size=3221225472',
+        'suppress_comment=\\\\(.\\\\|\\n\\\\)*\\\\$FlowExpectedError',
+        '',
+        '[ignore]',
+        /.*\/cli\/node_modules$/,
+        '',
+        '[lints]',
+        '',
+      ];
+
+      matches.forEach((match, i) => {
+        expect(flowConfigSplit[i]).toMatch(match);
+      });
+    });
+
+    it('writes the dependency definitions correctly', async () => {
+      await writeFlowConfig(
+        fixtureBasePath,
+        testDir,
+        path.join(fixtureBasePath, 'definitions/npm/def/'),
+        '0.183.0',
+        ['dep-1', 'dep-2'],
+      );
+
+      const flowConfigSplit = fs
+        .readFileSync(flowConfigFile, 'utf-8')
+        .split('\n');
+
+      const matches = [
+        '[libs]',
+        'dep-1',
+        'dep-2',
+        'def',
+        /.*cli\/src\/commands\/__tests__\/__util__\/tdd_framework\.js$/,
+        '',
+        '[options]',
+        'include_warnings=true',
+        'server.max_workers=0',
+        'sharedmemory.heap_size=3221225472',
+        '',
+        '',
+        '[ignore]',
+        /.*\/cli\/node_modules$/,
+        '',
+        '[lints]',
+        '',
+      ];
+
+      matches.forEach((match, i) => {
+        expect(flowConfigSplit[i]).toMatch(match);
+      });
     });
   });
 });

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -287,7 +287,7 @@ async function installEnvLibDefs(
                     `${en} already exists and appears to have been manually written or changed!`,
                   ),
                   colors.yellow(
-                    `Read more at https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md`,
+                    `Read more at https://github.com/flow-typed/flow-typed/blob/main/CONTRIBUTING.md`,
                   ),
                   colors.yellow(
                     `Use --overwrite to overwrite the existing env defs.`,
@@ -712,7 +712,7 @@ async function installNpmLibDef(
         colors.green(
           `Consider contributing your changes back to flow-typed repository :)`,
         ),
-        `Read more at https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md`,
+        `Read more at https://github.com/flow-typed/flow-typed/blob/main/CONTRIBUTING.md`,
         'Use --overwrite to overwrite the existing libdef.',
       );
       return true;

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -43,7 +43,7 @@ const BIN_PLATFORM = (_ => {
   }
 })();
 const PKG_ROOT_DIR = path.join(__dirname, '..', '..');
-const TEST_DIR = path.join(PKG_ROOT_DIR, '.test-dir');
+export const TEST_DIR: string = path.join(PKG_ROOT_DIR, '.test-dir');
 const BIN_DIR = path.join(PKG_ROOT_DIR, '.flow-bins-cache');
 const P = Promise;
 
@@ -331,11 +331,11 @@ async function getCachedFlowBinVersions(
   return versions.map(version => `v${version}`);
 }
 
-async function writeFlowConfig(
-  repoDirPath,
-  testDirPath,
-  libDefPath,
-  version,
+export async function writeFlowConfig(
+  repoDirPath: string,
+  testDirPath: string,
+  libDefPath: string,
+  version: string,
   depPaths: Array<string>,
 ) {
   // /!\---------------------------------------------------------------------/!\

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -346,7 +346,7 @@ async function writeFlowConfig(
 
   const flowConfigData = [
     '[libs]',
-    [...depPaths],
+    ...depPaths,
     path.basename(libDefPath),
     path.join(repoDirPath, '..', '__util__', 'tdd_framework.js'),
     '',

--- a/cli/src/lib/__tests__/cacheRepoUtils-test.js
+++ b/cli/src/lib/__tests__/cacheRepoUtils-test.js
@@ -14,7 +14,7 @@ import {
   verifyCLIVersion,
 } from '../cacheRepoUtils';
 
-import {cloneInto, rebaseRepoMaster} from '../git';
+import {cloneInto, rebaseRepoMainline} from '../git';
 
 import {fs} from '../node';
 
@@ -27,7 +27,7 @@ describe('cacheRepoUtils', () => {
     let origConsoleLog = console.log;
     beforeEach(() => {
       _mock(cloneInto).mockClear();
-      _mock(rebaseRepoMaster).mockClear();
+      _mock(rebaseRepoMainline).mockClear();
       (console: any).log = jest.fn();
       cacheRepoEnsureToken.lastEnsured = 0;
       cacheRepoEnsureToken.pendingEnsurance = Promise.resolve();
@@ -69,7 +69,7 @@ describe('cacheRepoUtils', () => {
       });
 
       await ensureCacheRepo();
-      expect(_mock(rebaseRepoMaster).mock.calls[0]).toEqual([
+      expect(_mock(rebaseRepoMainline).mock.calls[0]).toEqual([
         getCacheRepoDir(),
       ]);
     });
@@ -89,7 +89,7 @@ describe('cacheRepoUtils', () => {
       });
 
       await ensureCacheRepo();
-      expect(_mock(rebaseRepoMaster).mock.calls).toEqual([]);
+      expect(_mock(rebaseRepoMainline).mock.calls).toEqual([]);
     });
   });
 

--- a/cli/src/lib/__tests__/libDefs-test.js
+++ b/cli/src/lib/__tests__/libDefs-test.js
@@ -21,7 +21,7 @@ import {
   updateCacheRepo,
 } from '../libDefs.js';
 import {parseDirString as parseFlowDirString} from '../flowVersion';
-import {cloneInto, rebaseRepoMaster} from '../git.js';
+import {cloneInto, rebaseRepoMainline} from '../git.js';
 
 /**
  * Jest's process of mocking in place fools Flow, so we use this as an explicit
@@ -35,7 +35,7 @@ describe('libDefs', () => {
   describe('ensureCacheRepo', () => {
     beforeEach(() => {
       _mock(cloneInto).mockClear();
-      _mock(rebaseRepoMaster).mockClear();
+      _mock(rebaseRepoMainline).mockClear();
       cacheRepoAssure.lastAssured = 0;
       cacheRepoAssure.pendingAssure = Promise.resolve();
     });
@@ -69,7 +69,7 @@ describe('libDefs', () => {
       });
 
       await ensureCacheRepo();
-      expect(_mock(rebaseRepoMaster).mock.calls[0]).toEqual([CACHE_REPO_DIR]);
+      expect(_mock(rebaseRepoMainline).mock.calls[0]).toEqual([CACHE_REPO_DIR]);
     });
 
     it('does NOT rebase if on disk, but lastUpdated is recent', async () => {
@@ -87,13 +87,13 @@ describe('libDefs', () => {
       });
 
       await ensureCacheRepo();
-      expect(_mock(rebaseRepoMaster).mock.calls).toEqual([]);
+      expect(_mock(rebaseRepoMainline).mock.calls).toEqual([]);
     });
   });
 
   describe('updateCacheRepo', () => {
     beforeEach(() => {
-      _mock(rebaseRepoMaster).mockClear();
+      _mock(rebaseRepoMainline).mockClear();
       cacheRepoAssure.lastAssured = 0;
       cacheRepoAssure.pendingAssure = Promise.resolve();
     });
@@ -110,7 +110,7 @@ describe('libDefs', () => {
       });
 
       await updateCacheRepo();
-      expect(_mock(rebaseRepoMaster).mock.calls).toEqual([[CACHE_REPO_DIR]]);
+      expect(_mock(rebaseRepoMainline).mock.calls).toEqual([[CACHE_REPO_DIR]]);
     });
   });
 

--- a/cli/src/lib/cacheRepoUtils.js
+++ b/cli/src/lib/cacheRepoUtils.js
@@ -2,7 +2,7 @@
 
 import {mkdirp} from './fileUtils';
 
-import {cloneInto, rebaseRepoMaster} from './git';
+import {cloneInto, rebaseRepoMainline} from './git';
 
 import {fs, os, path} from './node';
 
@@ -49,7 +49,7 @@ async function rebaseCacheRepo() {
     (await fs.exists(getCacheRepoGitDir()))
   ) {
     try {
-      await rebaseRepoMaster(getCacheRepoDir());
+      await rebaseRepoMainline(getCacheRepoDir());
     } catch (e) {
       console.error(
         'ERROR: Unable to rebase the local cache repo. ' + e.message,

--- a/cli/src/lib/git.js
+++ b/cli/src/lib/git.js
@@ -76,7 +76,7 @@ export async function getDefinitionsDiff(): Promise<Array<string>> {
     // ]);
     let {stdout} = await child_process.spawnP(gitPath, [
       'diff',
-      'origin/master',
+      'origin/main',
       '--name-only',
     ]);
     console.log(stdout);
@@ -84,7 +84,7 @@ export async function getDefinitionsDiff(): Promise<Array<string>> {
     if (
       stdout.split('\n').filter(o => o.startsWith('definitions/')).length === 0
     ) {
-      // We are probably already on master, so compare to the last commit.
+      // We are probably already on main, so compare to the last commit.
       const {stdout: headDiff} = await child_process.spawnP(gitPath, [
         'diff',
         'HEAD~1',
@@ -137,13 +137,13 @@ export async function findLatestFileCommitHash(
   }
 }
 
-export async function rebaseRepoMaster(repoDirPath: string) {
+export async function rebaseRepoMainline(repoDirPath: string) {
   const gitPath = await getGitPath();
   await child_process
-    .spawnP(gitPath, ['checkout', 'master'], {cwd: repoDirPath})
+    .spawnP(gitPath, ['checkout', 'main'], {cwd: repoDirPath})
     .catch(({stderr}) => {
       throw new Error(
-        'Error checking out the `master` branch of the following repo:\n' +
+        'Error checking out the `main` branch of the following repo:\n' +
           `${repoDirPath}\n\n${stderr}`,
       );
     });
@@ -155,7 +155,7 @@ export async function rebaseRepoMaster(repoDirPath: string) {
   } catch (e) {
     const {stderr} = e;
     throw new Error(
-      'Error rebasing the `master` branch of the following repo:\n' +
+      'Error rebasing the `main` branch of the following repo:\n' +
         `${repoDirPath}\n\n${stderr}`,
     );
   }

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -2,7 +2,7 @@
 
 import semver from 'semver';
 
-import {cloneInto, rebaseRepoMaster} from './git.js';
+import {cloneInto, rebaseRepoMainline} from './git.js';
 import {mkdirp} from './fileUtils.js';
 import {fs, path, os} from './node.js';
 import {versionToString, type Version} from './semver.js';
@@ -55,7 +55,7 @@ async function rebaseCacheRepo(verbose?: VerboseOutput) {
     (await fs.exists(CACHE_REPO_GIT_DIR))
   ) {
     try {
-      await rebaseRepoMaster(CACHE_REPO_DIR);
+      await rebaseRepoMainline(CACHE_REPO_DIR);
     } catch (e) {
       writeVerbose(
         verbose,

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -2488,10 +2488,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.4.tgz#28d9969ea90661b5134259f312ab6aa7929ac5e2"
   integrity sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==
 
-flow-bin@^0.165.1:
-  version "0.165.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.165.1.tgz#55d584b10fe1ed8299fe12be968a9e58810303ee"
-  integrity sha512-AjmvNdY8oFsOb0ZQkYxFj3jnIzqrCIcMeuQCTYbTJuAJoCbz7GszOFzL0Sp2qcK2BcIYWnC4OJbLAQmnDjgI7A==
+flow-bin@^0.183.0:
+  version "0.183.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.183.0.tgz#17f37c94edd04b705a897b5890dd6cdc02e0c94e"
+  integrity sha512-7IJHUnMPYgNEZU8t9M4vJII/G+fJft9C/INm2+HRSXx5KDF2j+vD2iap6+Yg2FWgXTnNLUvk7kr1QdO5Fk/8/Q==
 
 flow-copy-source@^2.0.9:
   version "2.0.9"

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -75,7 +75,7 @@ This issue was first reported here:
 
 ### My flow-typed/npm dir is throwing lots of eslint errors after installing definitions
 
-When you install lib defs using `flow-typed install` the files are copied from the central [definition registry](https://github.com/flow-typed/flow-typed/tree/master/definitions/npm) which have their own code styles and standards which may (probably will) be vastly different to the ones in your project.
+When you install lib defs using `flow-typed install` the files are copied from the central [definition registry](https://github.com/flow-typed/flow-typed/tree/main/definitions/npm) which have their own code styles and standards which may (probably will) be vastly different to the ones in your project.
 
 You may first consider fixing the linting errors every time you install (eg: `yarn eslint ./flow-typed/npm --fix`) though you shouldn't, definitions may get updates which can install next time you run `flow-typed install` but the CLI will not update a definition if it sees a definition has been modified.
 

--- a/docs/flow-typed-config.md
+++ b/docs/flow-typed-config.md
@@ -6,7 +6,7 @@ Flow-typed supports a config file to help you set various project level settings
 
 ## env
 
-`env` accepts an array of strings that map to environment definitions that you can you can find [here](https://github.com/flow-typed/flow-typed/tree/master/definitions/environments).
+`env` accepts an array of strings that map to environment definitions that you can you can find [here](https://github.com/flow-typed/flow-typed/tree/main/definitions/environments).
 
 ```js
 {

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="icon" href="_media/favicon.ico" />
     <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
-    <link 
+    <link
       rel="stylesheet"
       href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
       title="docsify-darklight-theme"
@@ -34,8 +34,8 @@
     <script>
       window.$docsify = {
         alias: {
-          '.*?/changelog': 'https://raw.githubusercontent.com/flow-typed/flow-typed/master/CHANGELOG.md',
-          '.*?/contributing': 'https://raw.githubusercontent.com/flow-typed/flow-typed/master/CONTRIBUTING.md',
+          '.*?/changelog': 'https://raw.githubusercontent.com/flow-typed/flow-typed/main/CHANGELOG.md',
+          '.*?/contributing': 'https://raw.githubusercontent.com/flow-typed/flow-typed/main/CONTRIBUTING.md',
         },
         name: 'flow-typed',
         repo: 'flow-typed/flow-typed',
@@ -49,7 +49,7 @@
     <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
     <!-- Dark mode support -->
-    <script 
+    <script
         src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
         type="text/javascript">
     </script>

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 ## What is it?
 
-> flow-typed is a [repository](https://github.com/flow-typed/flow-typed/tree/master/definitions)
+> flow-typed is a [repository](https://github.com/flow-typed/flow-typed/tree/main/definitions)
 of third-party [library interface definitions](https://flow.org/en/docs/libdefs)
 for use with [Flow](http://flow.org).
 


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Targeting `main` update references to master

Also fixing an issue when there are more than one dep in config.json that caused running tests to not configure `.flowconfig` correctly in test runner.

- [x] Add tests to `writeFlowConfig`
