### PR TITLE
[docs] Add v4 announcement to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@
   </a>
 </p>
 
+---
+
+## We're migrating our mainline from `master` to `main`
+
+And with that comes new features, most notably the support for **definition dependencies**.
+
+Learn how to add dependencies to a definition from the `main` branch [docs](https://github.com/flow-typed/flow-typed/blob/main/CONTRIBUTING.md#importing-types-from-other-libdefs) which can be consumed with the `v4` CLI.
+
+```bash
+$ yarn global add flow-typed@next
+# or
+$ npm install -g flow-typed@next
+```
+
+---
+
 Check out the [quick start](https://flow-typed.github.io/flow-typed/#/quickstart) page
 in the docs to get started. It will walk you through installing typedefs, using them,
 as well as writing and including your own.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ $ yarn global add flow-typed@next
 $ npm install -g flow-typed@next
 ```
 
+### What's happening to `master`?
+
+Nothing for the most part! CLI versions < `v4` will still pull definitions from `master` so if you have library definitions that don't require dependencies we still recommend you contribute to `master` and it'll get periodically synced back to `main` for users >= `v4`.
+
+Eventually we will deprecate `master` in favour of `main`.
+
 ---
 
 Check out the [quick start](https://flow-typed.github.io/flow-typed/#/quickstart) page

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,6 +4,8 @@ We recommend installing the CLI globally.
 
 ```bash
 $ yarn global add flow-typed
+# or
+$ npm install -g flow-typed
 ```
 
 ## Initialize


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Add docs to encourage users to try out v4 and `main` branch.

@GAntoine when you publish can you tag the alpha with `next` in npm?
