### PR TITLE
[dom-testing-library] MaybeIntersectionHTMLElement

### DIFF
--- a/definitions/npm/@testing-library/react_v12.x.x/flow_v0.104.x-/react_v12.x.x.js
+++ b/definitions/npm/@testing-library/react_v12.x.x/flow_v0.104.x-/react_v12.x.x.js
@@ -276,10 +276,12 @@ declare module '@testing-library/react' {
     & HTMLSelectElement;
   // End mixed html types
 
+  declare type MaybeIntersectionHTMLElement = null | IntersectionHTMLElement;
+
   declare type QueryByBoundAttribute = (
     text: Matcher,
     options?: MatcherOptions
-  ) => ?IntersectionHTMLElement;
+  ) => MaybeIntersectionHTMLElement;
 
   declare type AllByBoundAttribute = (
     text: Matcher,
@@ -306,7 +308,7 @@ declare module '@testing-library/react' {
   declare type QueryByText = (
     text: Matcher,
     options?: SelectorMatcherOptions
-  ) => ?IntersectionHTMLElement;
+  ) => MaybeIntersectionHTMLElement;
 
   declare type AllByText = (
     text: Matcher,
@@ -593,7 +595,7 @@ declare module '@testing-library/react' {
     container: UnionHTMLElement,
     id: Matcher,
     options?: MatcherOptions
-  ): ?IntersectionHTMLElement;
+  ): MaybeIntersectionHTMLElement;
   declare export function getByTestId(
     container: UnionHTMLElement,
     id: Matcher,
@@ -603,7 +605,7 @@ declare module '@testing-library/react' {
     container: UnionHTMLElement,
     text: Matcher,
     options?: MatcherOptions
-  ): ?IntersectionHTMLElement;
+  ): MaybeIntersectionHTMLElement;
   declare export function getByText(
     container: UnionHTMLElement,
     text: Matcher,
@@ -613,7 +615,7 @@ declare module '@testing-library/react' {
     container: UnionHTMLElement,
     text: Matcher,
     options?: MatcherOptions
-  ): ?IntersectionHTMLElement;
+  ): MaybeIntersectionHTMLElement;
   declare export function getByPlaceholderText(
     container: UnionHTMLElement,
     text: Matcher,
@@ -623,7 +625,7 @@ declare module '@testing-library/react' {
     container: UnionHTMLElement,
     text: Matcher,
     options?: MatcherOptions
-  ): ?IntersectionHTMLElement;
+  ): MaybeIntersectionHTMLElement;
   declare export function getByLabelText(
     container: UnionHTMLElement,
     text: Matcher,
@@ -633,7 +635,7 @@ declare module '@testing-library/react' {
     container: UnionHTMLElement,
     text: Matcher,
     options?: MatcherOptions
-  ): ?IntersectionHTMLElement;
+  ): MaybeIntersectionHTMLElement;
   declare export function getByAltText(
     container: UnionHTMLElement,
     text: Matcher,

--- a/definitions/npm/@testing-library/react_v12.x.x/flow_v0.104.x-/test_react_v12.x.x.js
+++ b/definitions/npm/@testing-library/react_v12.x.x/flow_v0.104.x-/test_react_v12.x.x.js
@@ -15,6 +15,8 @@ import {
 } from '@testing-library/react';
 import { describe, it } from 'flow-typed-test';
 
+declare type MaybeIntersectionHTMLElement = null | IntersectionHTMLElement;
+
 describe('act', () => {
   it('should fail on invalid inputs', () => {
     // $FlowExpectedError[incompatible-call]
@@ -212,7 +214,7 @@ describe('render', () => {
   it('queryByAltText should return maybe HTML element', () => {
     // $FlowExpectedError[incompatible-type]
     const a: IntersectionHTMLElement = queryByAltText('1');
-    const b: ?IntersectionHTMLElement = queryByAltText('2');
+    const b: MaybeIntersectionHTMLElement = queryByAltText('2');
   });
 
   it('queryAllByAltText should return array of HTML element', () => {
@@ -246,7 +248,7 @@ describe('render', () => {
   it('queryByDisplayValue should return maybe HTML element', () => {
     // $FlowExpectedError[incompatible-type]
     const a: IntersectionHTMLElement = queryByDisplayValue('1');
-    const b: ?IntersectionHTMLElement = queryByDisplayValue('2');
+    const b: MaybeIntersectionHTMLElement = queryByDisplayValue('2');
   });
 
   it('queryAllByDisplayValue should return array of HTML element', () => {
@@ -280,7 +282,7 @@ describe('render', () => {
   it('queryByLabelText should return maybe HTML element', () => {
     // $FlowExpectedError[incompatible-type]
     const a: IntersectionHTMLElement = queryByLabelText('1');
-    const b: ?IntersectionHTMLElement = queryByLabelText('2');
+    const b: MaybeIntersectionHTMLElement = queryByLabelText('2');
   });
 
   it('queryAllByLabelText should return array of HTML element', () => {
@@ -314,7 +316,7 @@ describe('render', () => {
   it('queryByPlaceholderText should return maybe HTML element', () => {
     // $FlowExpectedError[incompatible-type]
     const a: IntersectionHTMLElement = queryByPlaceholderText('1');
-    const b: ?IntersectionHTMLElement = queryByPlaceholderText('2');
+    const b: MaybeIntersectionHTMLElement = queryByPlaceholderText('2');
   });
 
   it('queryAllByPlaceholderText should return array of HTML element', () => {
@@ -350,7 +352,7 @@ describe('render', () => {
   it('queryByRole should return maybe HTML element', () => {
     // $FlowExpectedError[incompatible-type]
     const a: IntersectionHTMLElement = queryByRole('button');
-    const b: ?IntersectionHTMLElement = queryByRole('button');
+    const b: MaybeIntersectionHTMLElement = queryByRole('button');
   });
 
   it('queryAllByRole should return array of HTML element', () => {
@@ -391,7 +393,7 @@ describe('render', () => {
   it('queryByTestId should return maybe HTML element', () => {
     // $FlowExpectedError[incompatible-type]
     const a: IntersectionHTMLElement = queryByTestId('1');
-    const b: ?IntersectionHTMLElement = queryByTestId('2');
+    const b: MaybeIntersectionHTMLElement = queryByTestId('2');
   });
 
   it('queryAllByTestId should return array of HTML element', () => {
@@ -425,7 +427,7 @@ describe('render', () => {
   it('queryByText should return maybe HTML element', () => {
     // $FlowExpectedError[incompatible-type]
     const a: IntersectionHTMLElement = queryByText('1');
-    const b: ?IntersectionHTMLElement = queryByText('2');
+    const b: MaybeIntersectionHTMLElement = queryByText('2');
   });
 
   it('queryAllByText should return array of HTML element', () => {
@@ -459,7 +461,7 @@ describe('render', () => {
   it('queryByTitle should return maybe HTML element', () => {
     // $FlowExpectedError[incompatible-type]
     const a: IntersectionHTMLElement = queryByTitle('1');
-    const b: ?IntersectionHTMLElement = queryByTitle('2');
+    const b: MaybeIntersectionHTMLElement = queryByTitle('2');
   });
 
   it('queryAllByTitle should return array of HTML element', () => {


### PR DESCRIPTION
Type of contribution: **fix**

The type returned as a maybe `IntersectionHTMLElement` is `?IntersectionHTMLElement` however this is imprecise and includes `undefined` so the full type is `undefined | null | IntersectionHTMLElement`, this breaks when used with a very common scenario such as the type on the `JSDOM` `toContainElement` matcher which requires a `HTMLElement | SVGElement | null`. 

Something worth noting is #4135 introduced this union type (`IntersectionHTMLElement`) which is handling the fact that various HTML elements have different properties we may want to access during testing but we cannot use `HTMLElement` and refine into a more specific shape so we use a union to accomplish that.

We can confirm the type is `HTMLElement | null` here in `dom-testing-library`

> https://github.com/testing-library/dom-testing-library/blob/73a5694529dbfff289f3d7a01470c45ef5c77715/types/queries.d.ts#L5
> https://github.com/testing-library/dom-testing-library/blob/73a5694529dbfff289f3d7a01470c45ef5c77715/src/query-helpers.ts#L144

This work builds upon #4343 which is an ongoing effort at my company to get our `flow` types for this library correct

== Tests

Confirmed tests failed without my changes and now pass with my changes via `./quick_run_def_tests.sh`

> ![Screen Shot 2022-07-27 at 1 04 17 PM](https://user-images.githubusercontent.com/290084/181362111-ed7a8663-8ccd-4d26-bc99-f4c2a6b1fa81.png)

