### PR TITLE
[json-api] New env definition

### DIFF
--- a/definitions/environments/json-api/flow_v0.83.x-/json-api.js
+++ b/definitions/environments/json-api/flow_v0.83.x-/json-api.js
@@ -1,0 +1,120 @@
+declare type JsonApi$Json =
+	| null
+	| void
+	| string
+	| number
+	| boolean
+	| { [key: string]: JsonApi$Json }
+	| Array<JsonApi$Json>;
+
+declare type JsonApi$Meta = { [key: string]: Json };
+
+declare type JsonApi$Link =
+	| string
+	| {|
+			href: string,
+			meta?: JsonApi$Meta,
+	  |};
+
+declare type JsonApi$Links = {
+	self?: JsonApi$Link,
+	related?: JsonApi$Link,
+	[key: string]: JsonApi$Link,
+  ...
+};
+
+declare type JsonApi$PaginationLinks = {|
+	first?: ?JsonApi$Link,
+	last?: ?JsonApi$Link,
+	prev?: ?JsonApi$Link,
+	next?: ?JsonApi$Link,
+|};
+
+declare type JsonApi$Error = {|
+	id?: string,
+	links?: {|
+		about: JsonApi$Link,
+	|},
+	status?: string,
+	code?: string,
+	title?: string,
+	detail?: string,
+	source?: {|
+		pointer?: string,
+		parameter?: string,
+	|},
+	meta?: JsonApi$Meta,
+|};
+
+declare type JsonApi$Object = {|
+	version?: string,
+	meta?: JsonApi$ApiMeta,
+|};
+
+declare type JsonApi$Attributes = {
+	[key: string]: JSON,
+  ...
+};
+
+declare type JsonApi$ResourceIdentifier = {|
+	id: string,
+	type: string,
+	meta?: JsonApi$ApiMeta,
+|};
+
+declare type JsonApi$ResourceLinkage =
+	| Array<JsonApi$ResourceIdentifier>
+	| JsonApi$ResourceIdentifier
+	| null;
+
+declare type JsonApi$Relationship = {|
+	links?: {|
+		self?: JsonApi$Link,
+		related?: JsonApi$Link,
+	|} & JsonApi$Links,
+	data?: JsonApi$ResourceLinkage,
+	meta?: JsonApi$Meta,
+|};
+
+declare type JsonApi$Relationships = {
+	[string]: JsonApi$Relationship,
+};
+
+declare type JsonApi$Resource = {|
+	id?: string,
+	type: string,
+	attributes?: JsonApi$Attributes,
+	relationships?: JsonApi$Relationships,
+	links?: JsonApi$Links,
+	meta?: JsonApi$Meta,
+|};
+
+declare type JsonApi$DataDocument = {|
+	data:
+		| Array<JsonApi$Resource | JsonApi$ResourceIdentifier>
+		| JsonApi$Resource
+		| JsonApi$ResourceIdentifier
+		| null,
+	meta?: JsonApi$Meta,
+	jsonapi?: JsonApi$Object,
+	links?: JsonApi$PaginationLinks & JsonApi$Links,
+	included?: Array<JsonApi$Resource>,
+|};
+
+declare type JsonApi$MetaDocument = {|
+	meta: JsonApi$Meta,
+	jsonapi?: JsonApi$Object,
+	links?: JsonApi$Links,
+|};
+
+declare type JsonApi$ErrorDocument = {|
+	errors: Array<JsonApi$Error>,
+	meta?: JsonApi$Meta,
+	jsonapi?: JsonApi$Object,
+	links?: JsonApi$Links,
+|};
+
+declare type JsonApi$Document =
+	| JsonApi$DataDocument
+	| JsonApi$MetaDocument
+	| JsonApi$ErrorDocument;

--- a/definitions/environments/json-api/flow_v0.83.x-/json-api.js
+++ b/definitions/environments/json-api/flow_v0.83.x-/json-api.js
@@ -101,7 +101,7 @@ declare type JsonApi$DataDocument = {|
 		| null,
 	meta?: JsonApi$Meta,
 	jsonapi?: JsonApi$Object,
-	links?: JsonApi$PaginationLinks & JsonApi$Links,
+	links?: JsonApi$PaginationLinks | JsonApi$Links,
 	included?: Array<JsonApi$Resource>,
 |};
 

--- a/definitions/environments/json-api/flow_v0.83.x-/json-api.js
+++ b/definitions/environments/json-api/flow_v0.83.x-/json-api.js
@@ -74,16 +74,14 @@ declare type JsonApi$ResourceLinkage =
 	| null;
 
 declare type JsonApi$Relationship = {|
-	links?: {|
-		self?: JsonApi$Link,
-		related?: JsonApi$Link,
-	|} & JsonApi$Links,
+	links?: JsonApi$Links,
 	data?: JsonApi$ResourceLinkage,
 	meta?: JsonApi$Meta,
 |};
 
 declare type JsonApi$Relationships = {
 	[string]: JsonApi$Relationship,
+	...
 };
 
 declare type JsonApi$Resource = {|

--- a/definitions/environments/json-api/flow_v0.83.x-/json-api.js
+++ b/definitions/environments/json-api/flow_v0.83.x-/json-api.js
@@ -1,3 +1,9 @@
+/**
+ * A collection of flow types representing json:api
+ *
+ * Visit https://jsonapi.org/ to learn more about the specification
+ */
+
 declare type JsonApi$Json =
 	| null
 	| void
@@ -7,7 +13,7 @@ declare type JsonApi$Json =
 	| { [key: string]: JsonApi$Json }
 	| Array<JsonApi$Json>;
 
-declare type JsonApi$Meta = { [key: string]: Json };
+declare type JsonApi$Meta = { [key: string]: JsonApi$Json };
 
 declare type JsonApi$Link =
 	| string
@@ -48,18 +54,18 @@ declare type JsonApi$Error = {|
 
 declare type JsonApi$Object = {|
 	version?: string,
-	meta?: JsonApi$ApiMeta,
+	meta?: JsonApi$Meta,
 |};
 
 declare type JsonApi$Attributes = {
-	[key: string]: JSON,
+	[key: string]: JsonApi$Json,
   ...
 };
 
 declare type JsonApi$ResourceIdentifier = {|
 	id: string,
 	type: string,
-	meta?: JsonApi$ApiMeta,
+	meta?: JsonApi$Meta,
 |};
 
 declare type JsonApi$ResourceLinkage =

--- a/definitions/environments/json-api/flow_v0.83.x-/test_json-api.js
+++ b/definitions/environments/json-api/flow_v0.83.x-/test_json-api.js
@@ -1,0 +1,17 @@
+// @flow
+import { describe, test } from 'flow-typed-test';
+
+describe('json-api', () => {
+  test('JsonApi$Json', () => {
+    const json1 : JsonApi$Json = { foo: 123 };
+
+    const json2: JsonApi$Json = { $call: 123 };
+
+    // $FlowExpectedError[incompatible-type]
+    const json3: JsonApi$Json = () => {};
+
+    const json4: JsonApi$Json = {
+      strings: ['asdf', 'qwer'],
+    };
+  });
+});

--- a/definitions/environments/json-api/flow_v0.83.x-/test_json-api.js
+++ b/definitions/environments/json-api/flow_v0.83.x-/test_json-api.js
@@ -286,22 +286,189 @@ describe('json-api', () => {
   });
 
   test('JsonApi$Resource', () => {
+    declare var attributes: JsonApi$Attributes;
+    declare var relationships: JsonApi$Relationships;
+    declare var links: JsonApi$Links;
+    declare var meta: JsonApi$Meta;
 
+    ({ type: 'test' }: JsonApi$Resource);
+    ({
+      type: 'test',
+      id: 'test',
+      attributes,
+      relationships,
+      links,
+      meta,
+    }: JsonApi$Resource);
+
+    // $FlowExpectedError[prop-missing]
+    ({ ...null }: JsonApi$Resource);
+    ({
+      type: 'test',
+      // $FlowExpectedError[incompatible-cast]
+      id: 1,
+     }: JsonApi$Resource);
+     ({
+      type: 'test',
+      // $FlowExpectedError[incompatible-cast]
+      attributes: 1,
+     }: JsonApi$Resource);
+     ({
+      type: 'test',
+      // $FlowExpectedError[incompatible-cast]
+      relationships: 1,
+     }: JsonApi$Resource);
+     ({
+      type: 'test',
+      // $FlowExpectedError[incompatible-cast]
+      links: 1,
+     }: JsonApi$Resource);
+     ({
+      type: 'test',
+      // $FlowExpectedError[incompatible-cast]
+      meta: 1,
+     }: JsonApi$Resource);
   });
 
   test('JsonApi$DataDocument', () => {
+    declare var resource: JsonApi$Resource;
+    declare var resourceIdentifier: JsonApi$ResourceIdentifier;
+    declare var meta: JsonApi$Meta;
+    declare var object: JsonApi$Object;
+    declare var links: JsonApi$Links;
+    declare var paginationLinks: JsonApi$PaginationLinks;
 
+    ({
+      data: [resource, resourceIdentifier],
+    }: JsonApi$DataDocument);
+    ({
+    data: resource,
+    }: JsonApi$DataDocument);
+    ({
+    data: resourceIdentifier,
+    }: JsonApi$DataDocument);
+    ({
+    data: null,
+    meta,
+    jsonapi: object,
+    links,
+    included: [resource],
+    }: JsonApi$DataDocument);
+    ({
+    data: null,
+    links: paginationLinks,
+    }: JsonApi$DataDocument);
+
+    // $FlowExpectedError[prop-missing]
+    ({ ...null }: JsonApi$DataDocument);
+    ({
+      data: null,
+      // $FlowExpectedError[incompatible-cast]
+      meta: 1,
+    }: JsonApi$DataDocument);
+    ({
+      data: null,
+      // $FlowExpectedError[incompatible-cast]
+      jsonapi: 1,
+    }: JsonApi$DataDocument);
+    ({
+      data: null,
+      // $FlowExpectedError[incompatible-cast]
+      links: 1,
+    }: JsonApi$DataDocument);
+    ({
+      data: null,
+      // $FlowExpectedError[incompatible-cast]
+      included: 1,
+    }: JsonApi$DataDocument);
+    ({
+      data: null,
+      // $FlowExpectedError[incompatible-cast]
+      included: resource,
+    }: JsonApi$DataDocument);
   });
 
   test('JsonApi$MetaDocument', () => {
+    declare var meta: JsonApi$Meta;
+    declare var object: JsonApi$Object;
+    declare var links: JsonApi$Links;
 
+    ({
+      meta,
+    }: JsonApi$MetaDocument);
+    ({
+      meta,
+      jsonapi: object,
+      links,
+    }: JsonApi$MetaDocument);
+
+    // $FlowExpectedError[prop-missing]
+    ({ ...null }: JsonApi$MetaDocument);
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      meta: 1,
+    }: JsonApi$MetaDocument);
+    ({
+      meta,
+      // $FlowExpectedError[incompatible-cast]
+      jsonapi: 1,
+    }: JsonApi$MetaDocument);
+    ({
+      meta,
+      // $FlowExpectedError[incompatible-cast]
+      links: 1,
+    }: JsonApi$MetaDocument);
   });
 
   test('JsonApi$ErrorDocument', () => {
+    declare var error: JsonApi$Error;
+    declare var meta: JsonApi$Meta;
+    declare var object: JsonApi$Object;
+    declare var links: JsonApi$Links;
 
+    ({
+      errors: [error],
+    }: JsonApi$ErrorDocument);
+    ({
+      errors: [error],
+      meta,
+      jsonapi: object,
+      links,
+    }: JsonApi$ErrorDocument);
+
+    // $FlowExpectedError[prop-missing]
+    ({ ...null }: JsonApi$ErrorDocument);
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      errors: error,
+    }: JsonApi$ErrorDocument);
+    ({
+      errors: [error],
+      // $FlowExpectedError[incompatible-cast]
+      meta: 1,
+    }: JsonApi$ErrorDocument);
+    ({
+      errors: [error],
+      // $FlowExpectedError[incompatible-cast]
+      jsonapi: 1,
+    }: JsonApi$ErrorDocument);
+    ({
+      errors: [error],
+      // $FlowExpectedError[incompatible-cast]
+      links: 1,
+    }: JsonApi$ErrorDocument);
   });
 
   test('JsonApi$Document', () => {
+    declare var dataDocument: JsonApi$DataDocument;
+    declare var metaDocument: JsonApi$MetaDocument;
+    declare var errorDocument: JsonApi$ErrorDocument;
 
+    (dataDocument: JsonApi$Document);
+    (metaDocument: JsonApi$Document);
+    (errorDocument: JsonApi$Document);
+
+    // $FlowExpectedError[incompatible-cast]
+    ('': JsonApi$Document);
   });
 });

--- a/definitions/environments/json-api/flow_v0.83.x-/test_json-api.js
+++ b/definitions/environments/json-api/flow_v0.83.x-/test_json-api.js
@@ -98,4 +98,168 @@ describe('json-api', () => {
       first: 1,
     }: JsonApi$PaginationLinks);
   });
+
+  test('JsonApi$Error', () => {
+    ({ ...null }: JsonApi$Error);
+    ({
+      id: 'test',
+      links: {
+        about: {
+          href: 'test',
+        },
+      },
+      status: 'test',
+      code: 'test',
+      title: 'test',
+      detail: 'test',
+      source: {
+        pointer: 'test',
+        parameter: 'test',
+      },
+      meta: {
+        foo: null,
+      },
+    }: JsonApi$Error);
+
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      id: 1,
+    }: JsonApi$Error);
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      links: 'test',
+    }: JsonApi$Error);
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      status: 1,
+    }: JsonApi$Error);
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      code: 1,
+    }: JsonApi$Error);
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      title: 1,
+    }: JsonApi$Error);
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      detail: 1,
+    }: JsonApi$Error);
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      source: 1,
+    }: JsonApi$Error);
+    // $FlowExpectedError[prop-missing]
+    ({
+      source: {
+        foo: 'test',
+      },
+    }: JsonApi$Error);
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      meta: 'test',
+    }: JsonApi$Error);
+  });
+
+  test('JsonApi$Object', () => {
+    ({ ...null }: JsonApi$Object);
+    ({
+      version: 'test',
+      meta: {
+        foo: 'test',
+      }
+    }: JsonApi$Object);
+
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      version: 1,
+    }: JsonApi$Object);
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      meta: 1,
+    }: JsonApi$Object);
+    // $FlowExpectedError[prop-missing]
+    ({
+      foo: 'test',
+    }: JsonApi$Object);
+  });
+
+  test('JsonApi$Attributes', () => {
+    ({}: JsonApi$Attributes);
+    ({
+      foo: '',
+      bar: {},
+      baz: null,
+    }: JsonApi$Attributes);
+
+    // $FlowExpectedError[incompatible-function-indexer]
+    (() => {}: JsonApi$Attributes);
+  });
+
+  test('JsonApi$ResourceIdentifier', () => {
+    ({
+      id: 'test',
+      type: 'test',
+    }: JsonApi$ResourceIdentifier);
+    ({
+      id: 'test',
+      type: 'test',
+      meta: {
+        foo: 'a',
+      }
+    }: JsonApi$ResourceIdentifier);
+
+    // $FlowExpectedError[prop-missing]
+    ({ ...null }: JsonApi$ResourceIdentifier);
+    // $FlowExpectedError[prop-missing]
+    ({
+      id: 'test',
+      type: 'test',
+      foo: 'test',
+    }: JsonApi$ResourceIdentifier);
+  });
+
+  test('JsonApi$ResourceLinkage', () => {
+    const resourceIdentifier: JsonApi$ResourceIdentifier = {
+      id: 'test',
+      type: 'test',
+    };
+
+    (resourceIdentifier: JsonApi$ResourceLinkage);
+    ([resourceIdentifier]: JsonApi$ResourceLinkage);
+    (null: JsonApi$ResourceLinkage);
+
+    // $FlowExpectedError[incompatible-cast]
+    ({ foo: 'a' }: JsonApi$ResourceLinkage);
+    // $FlowExpectedError[incompatible-cast]
+    (['', resourceIdentifier]: JsonApi$ResourceLinkage);
+  });
+
+  test('JsonApi$Relationship', () => {
+
+  });
+
+  test('JsonApi$Relationships', () => {
+
+  });
+
+  test('JsonApi$Resource', () => {
+
+  });
+
+  test('JsonApi$DataDocument', () => {
+
+  });
+
+  test('JsonApi$MetaDocument', () => {
+
+  });
+
+  test('JsonApi$ErrorDocument', () => {
+
+  });
+
+  test('JsonApi$Document', () => {
+
+  });
 });

--- a/definitions/environments/json-api/flow_v0.83.x-/test_json-api.js
+++ b/definitions/environments/json-api/flow_v0.83.x-/test_json-api.js
@@ -3,15 +3,99 @@ import { describe, test } from 'flow-typed-test';
 
 describe('json-api', () => {
   test('JsonApi$Json', () => {
-    const json1 : JsonApi$Json = { foo: 123 };
-
-    const json2: JsonApi$Json = { $call: 123 };
-
-    // $FlowExpectedError[incompatible-type]
-    const json3: JsonApi$Json = () => {};
-
-    const json4: JsonApi$Json = {
+    ({ foo: 123 }: JsonApi$Json);
+    ({ $call: 123 }: JsonApi$Json);
+    ({
       strings: ['asdf', 'qwer'],
-    };
+    }: JsonApi$Json);
+    (null: JsonApi$Json);
+
+    (JSON.parse(''): JsonApi$Json);
+
+    // $FlowExpectedError[incompatible-cast]
+    (() => {}: JsonApi$Json);
+  });
+
+  test('JsonApi$Meta', () => {
+    ({ a: null }: JsonApi$Meta);
+    ({ a: '' }: JsonApi$Meta);
+    ({ a: { a: { a: '' } } }: JsonApi$Meta);
+
+    // $FlowExpectedError[incompatible-cast]
+    ('test': JsonApi$Meta);
+  });
+
+  test('JsonApi$Link', () => {
+    ('test': JsonApi$Link);
+    ({
+      href: 'test',
+    }: JsonApi$Link);
+    ({
+      href: 'test',
+      meta: {
+        href: 'test',
+      },
+    }: JsonApi$Link);
+
+    // $FlowExpectedError[incompatible-cast]
+    ({}: JsonApi$Link);
+    // $FlowExpectedError[incompatible-cast]
+    ({
+      href: 1,
+    }: JsonApi$Link);
+    // $FlowExpectedError[incompatible-cast]
+    ({
+      href: 'test',
+      meta: 1,
+    }: JsonApi$Link);
+    // $FlowExpectedError[incompatible-cast]
+    ({
+      href: 'test',
+      foo: 1,
+    }: JsonApi$Link);
+  });
+
+  test('JsonApi$Links', () => {
+    ({}: JsonApi$Links);
+    ({
+      self: 'link',
+      related: {
+        href: 'test',
+      },
+      foo: 'link',
+    }: JsonApi$Links);
+
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      related: 1,
+    }: JsonApi$Links);
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      foo: 1,
+    }: JsonApi$Links);
+  });
+
+  test('JsonApi$PaginationLinks', () => {
+    ({ ...null }: JsonApi$PaginationLinks);
+    ({
+      first: 'test',
+      last: {
+        href: 'test',
+        meta: { a: null },
+      },
+      prev: {
+        href: 'test',
+      },
+      next: 'test',
+    }: JsonApi$PaginationLinks);
+
+    // $FlowExpectedError[prop-missing]
+    ({
+      foo: 'test',
+    }: JsonApi$PaginationLinks);
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      first: 1,
+    }: JsonApi$PaginationLinks);
   });
 });

--- a/definitions/environments/json-api/flow_v0.83.x-/test_json-api.js
+++ b/definitions/environments/json-api/flow_v0.83.x-/test_json-api.js
@@ -21,6 +21,8 @@ describe('json-api', () => {
     ({ a: '' }: JsonApi$Meta);
     ({ a: { a: { a: '' } } }: JsonApi$Meta);
 
+    (JSON.parse(''): JsonApi$Meta);
+
     // $FlowExpectedError[incompatible-cast]
     ('test': JsonApi$Meta);
   });
@@ -236,11 +238,51 @@ describe('json-api', () => {
   });
 
   test('JsonApi$Relationship', () => {
+    ({ ...null }: JsonApi$Relationship);
+    ({
+      links: {
+        self: {
+          href: 'test',
+        },
+        related: {
+          href: 'test',
+        },
+        foo: {
+          href: 'test',
+        },
+      },
+      data: [{
+        id: 'test',
+        type: 'test',
+      }],
+      meta: {
+        a: 'test',
+        b: 1,
+      },
+    }: JsonApi$Relationship);
 
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      links: 1,
+    }: JsonApi$Relationship);
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      data: 'test',
+    }: JsonApi$Relationship);
+    ({
+      // $FlowExpectedError[incompatible-cast]
+      meta: 'test',
+    }: JsonApi$Relationship);
   });
 
   test('JsonApi$Relationships', () => {
+    declare var relationship: JsonApi$Relationship;
 
+    ({}: JsonApi$Relationships);
+    ({ a: relationship, b: relationship }: JsonApi$Relationships);
+
+    // $FlowExpectedError[incompatible-cast]
+    ({ a: 'test' }: JsonApi$Relationships);
   });
 
   test('JsonApi$Resource', () => {

--- a/docs/env-definitions.md
+++ b/docs/env-definitions.md
@@ -1,10 +1,24 @@
 # Environment Definitions
 
-Flow is a static analysis tool that exposes a range of global definitions to help you type your application. But flow only supports for the most part, two types of environments, node and browser and sometimes you want something a little extra that flow just doesn't support and isn't quite right to have flow support as a core system.
+Flow is a static analysis tool that exposes a range of global definitions (core libs) to help you type your application. But flow only supports for the most part, two types of environments, node and browser. But sometimes you want something a little extra, but it's not the best fit for the flow core libs.
 
-That's where env definitions from flow-typed come into play, a home for all those global definitions to share and reuse and standardize for specific environments.
+That's where environment definitions™ from flow-typed come into play, a home for all those global definitions to share and reuse and standardize for specific environments.
 
-To make it more concrete, lets take a look at some examples of when you might want to create to leverage a core definition.
+## Usage
+
+You'll need to be version `>=3.8.0` and have a [flow-typed.config.json](flow-typed-config.md)
+
+```json
+{
+  env: ["jsx", "node", ...],
+}
+```
+
+You can find a full list of environments from the [definitions](https://github.com/flow-typed/flow-typed/tree/master/definitions/environments) project directory.
+
+## Examples
+
+To make it more concrete, lets take a look at some examples of when you might want to use an environment definition.
 
 ### jsx
 
@@ -20,7 +34,7 @@ Typically you'd expect the above to error in some capacity because `foo` is not 
 
 But with environment definitions serving reusable type definitions, at the minimum you can soundly type reusable components across your application.
 
-```
+```js
 type Props = {|
   ...$Exact<jsx$HTMLElement$Attributes>,
   foo: string,

--- a/docs/env-definitions.md
+++ b/docs/env-definitions.md
@@ -1,12 +1,12 @@
 # Environment Definitions
 
-Flow is a static analysis tool that exposes a range of global definitions (core libs) to help you type your application. But flow only supports for the most part, two types of environments, node and browser. But sometimes you want something a little extra, but it's not the best fit for the flow core libs.
+Flow is a static analysis tool that exposes a range of global definitions (core libs) to help you type your application. But flow only supports for the most part, two types of environments, node and browser. Sometimes you want something a little extra, but it's not the best fit for the flow core libs.
 
 That's where environment definitions™ from flow-typed come into play, a home for all those global definitions to share and reuse and standardize for specific environments.
 
 ## Usage
 
-You'll need to be version `>=3.8.0` and have a [flow-typed.config.json](flow-typed-config.md)
+If you're on version `>=3.8.0` you can make use of the `env` property in [flow-typed.config.json](flow-typed-config.md).
 
 ```json
 {
@@ -14,7 +14,7 @@ You'll need to be version `>=3.8.0` and have a [flow-typed.config.json](flow-typ
 }
 ```
 
-You can find a full list of environments from the [definitions](https://github.com/flow-typed/flow-typed/tree/master/definitions/environments) project directory.
+A full list of environments can be found in the [definitions](https://github.com/flow-typed/flow-typed/tree/master/definitions/environments) project directory.
 
 ## Examples
 

--- a/docs/flow-typed-config.md
+++ b/docs/flow-typed-config.md
@@ -1,6 +1,6 @@
 # flow-typed.config.json
 
-Flow-typed supports a config file to help you set various project level settings.
+Since version `>=3.8.0`, flow-typed supports a config file to help you set various project level settings.
 
 `<PROJECT_ROOT>/flow-typed.config.json`
 
@@ -8,9 +8,9 @@ Flow-typed supports a config file to help you set various project level settings
 
 `env` accepts an array of strings that map to environment definitions that you can you can find [here](https://github.com/flow-typed/flow-typed/tree/master/definitions/environments).
 
-```js
+```json
 {
-  env: ['jsx', 'node'],
+  env: ["jsx", "node"],
 }
 ```
 
@@ -20,8 +20,8 @@ Learn more about [environment definitions](env-definitions.md)
 
 When you have a dependencies you don't want updated or swapped out during the `install` command you can add this property which takes an array of strings referencing either package scopes or package names explicitly to ignore.
 
-```js
+```json
 {
-  ignore: ['@babel', '@custom/', 'eslint', 'eslint-plugin-ft-flow']
+  ignore: ["@babel", "@custom/", "eslint", "eslint-plugin-ft-flow"]
 }
 ```


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Closes #693 with environment definitions

- Links to documentation: https://jsonapi.org/
- Link to GitHub or NPM: https://github.com/json-api/json-api
- Type of contribution: new definition

Other notes: usage https://flow-typed.github.io/flow-typed/#/env-definitions

In https://flow-typed.github.io/flow-typed/#/flow-typed-config
```
{
  env: ['json-api', ...],
  ...
}
```

- Improve some docs on how to use env's


