### PR TITLE
Update node-fetch_v2.x.x.js

### DIFF
--- a/definitions/npm/node-fetch_v2.x.x/flow_v0.104.x-/node-fetch_v2.x.x.js
+++ b/definitions/npm/node-fetch_v2.x.x/flow_v0.104.x-/node-fetch_v2.x.x.js
@@ -130,7 +130,7 @@ declare module 'node-fetch' {
   }
 
   declare type HeaderInit = Headers | Array<string>;
-  declare type BodyInit = string | null | Buffer | Blob | Readable;
+  declare type BodyInit = string | null | Buffer | Blob | Readable | URLSearchParams;
 
   declare export default function fetch(url: string | Request, init?: RequestInit): Promise<Response>
 }

--- a/definitions/npm/node-fetch_v2.x.x/flow_v0.104.x-/test_node-fetch_v2.x.x_init.js
+++ b/definitions/npm/node-fetch_v2.x.x/flow_v0.104.x-/test_node-fetch_v2.x.x_init.js
@@ -21,13 +21,14 @@ describe('RequestInit', () => {
     // $FlowExpectedError[incompatible-call]
     fetch('http://github.com', { headers: { 'Accept-Encoding': 3 } });
   });
-  it('should accept body option', (stream: Readable, blob: Blob) => {
+  it('should accept body option', (stream: Readable, blob: Blob, urlSearchParams: URLSearchParams) => {
     fetch('http://github.com', { body: 'Hello World' });
     fetch('http://github.com', { body: null });
     fetch('http://github.com', { body: Buffer.from('Hello World') });
     fetch('http://github.com', { body: blob });
     // $FlowExpectedError[incompatible-call]
     fetch('http://github.com', { body: 34 });
+    fetch('http://github.com', { body: urlSearchParams });
   });
   it('should accept redirect option', () => {
     fetch('http://github.com', { redirect: 'error' });


### PR DESCRIPTION
URLSearchParams is valid for the `body` initializer in the spec for both Response https://developer.mozilla.org/en-US/docs/Web/API/Response/Response and Request https://developer.mozilla.org/en-US/docs/Web/API/Request/Request . It is handled in `node-fetch` in  https://github.com/node-fetch/node-fetch/blob/e87b093fd678a9ea39c5b17b2a1bdfc4691eedc7/src/body.js#L40

- Links to documentation: 
- Link to GitHub or NPM: 
- Type of contribution: fix

