### PR TITLE
[yargs] Add `hidden` option property

### DIFF
--- a/definitions/npm/yargs_v16.x.x/flow_v0.104.x-/yargs_v16.x.x.js
+++ b/definitions/npm/yargs_v16.x.x/flow_v0.104.x-/yargs_v16.x.x.js
@@ -24,6 +24,7 @@ declare module "yargs" {
     description: string,
     global: boolean,
     group: string,
+    hidden: boolean,
     implies: string | { [key: string]: string, ... },
     nargs: number,
     normalize: boolean,

--- a/definitions/npm/yargs_v16.x.x/flow_v0.104.x-/yargs_v16.x.x.js
+++ b/definitions/npm/yargs_v16.x.x/flow_v0.104.x-/yargs_v16.x.x.js
@@ -268,11 +268,13 @@ declare module "yargs" {
 
     showHelpOnFail(enable: boolean, message?: string): this;
 
-    strict(): this;
-
     skipValidation(key: string): this;
 
-    strict(global?: boolean): this;
+    strict(enabled?: boolean): this;
+
+    strictCommands(enabled?: boolean): this;
+
+    strictOptions(enabled?: boolean): this;
 
     string(key: string | Array<string>): this;
 

--- a/definitions/npm/yargs_v16.x.x/flow_v0.98.x-v0.103.x/yargs_v16.x.x.js
+++ b/definitions/npm/yargs_v16.x.x/flow_v0.98.x-v0.103.x/yargs_v16.x.x.js
@@ -23,6 +23,7 @@ declare module "yargs" {
     description: string,
     global: boolean,
     group: string,
+    hidden: boolean,
     implies: string | { [key: string]: string },
     nargs: number,
     normalize: boolean,

--- a/definitions/npm/yargs_v16.x.x/flow_v0.98.x-v0.103.x/yargs_v16.x.x.js
+++ b/definitions/npm/yargs_v16.x.x/flow_v0.98.x-v0.103.x/yargs_v16.x.x.js
@@ -265,11 +265,13 @@ declare module "yargs" {
 
     showHelpOnFail(enable: boolean, message?: string): this;
 
-    strict(): this;
-
     skipValidation(key: string): this;
 
-    strict(global?: boolean): this;
+    strict(enabled?: boolean): this;
+
+    strictCommands(enabled?: boolean): this;
+
+    strictOptions(enabled?: boolean): this;
 
     string(key: string | Array<string>): this;
 

--- a/definitions/npm/yargs_v16.x.x/test_yargs.js
+++ b/definitions/npm/yargs_v16.x.x/test_yargs.js
@@ -83,7 +83,8 @@ const argv2 = yargs(["-x"])
           return resolve(file);
         }
         return file;
-      }
+      },
+      hidden: false,
     }
   })
   .string(["user", "pass"])


### PR DESCRIPTION
- Links to documentation:
  - https://github.com/yargs/yargs/blob/f91d9b334ad9cfce79a89c08ff210c622b7c528f/lib/yargs-factory.ts#L2331
  - https://github.com/yargs/yargs/blame/f91d9b334ad9cfce79a89c08ff210c622b7c528f/lib/yargs-factory.ts#L1351-L1360
- Type of contribution: addition

Other notes:
The `hidden` property seems to have existed either forever or since a very long time ago, and can be seen in the TypeScript types of the `yargs` implementation. Similar deal (but less far back) for `strictCommands()` and `strictOptions()`.