### PR TITLE
Add type argument default and bound to useDispatch

### DIFF
--- a/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/react-redux_v7.x.x.js
+++ b/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/react-redux_v7.x.x.js
@@ -203,7 +203,29 @@ declare module "react-redux" {
   // Typings for Hooks
   // ------------------------------------------------------------
 
-  declare export function useDispatch<D>(): (
+  /* Action and AnyAction are taken from the redux TypeScript types defined here:
+   * https://github.com/reduxjs/redux/blob/d794c56f78eccb56ba3c67971c26df8ee34dacc1/src/types/actions.ts
+   *
+   * We turn them into objects so that they can be spread.
+   *
+   * We use AnyAction as the default for useDispatch as DefinitelyTyped does:
+   * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f7ec78508c6797e42f87a4390735bc2c650a1bfd/types/react-redux/index.d.ts#L540
+   */
+  declare export type Action<T> = {
+    type: T,
+    ...
+  }
+
+  declare export type AnyAction = {
+    ...Action<any>,
+    [string]: any
+  }
+
+  declare export type Dispatch<-A: Action<any>> = (action: A, ...extraArgs: any[]) => mixed
+
+  // Since A is contravariant in Dispatch, empty is a reasonable bound here. This is equivalent
+  // to using mixed as a default in a read-only position.
+  declare export function useDispatch<D: Dispatch<empty> = Dispatch<AnyAction>>(): (
     & (<T: { [key: string]: any }>(T) => T)
     // Supports thunks at their various lengths and use cases depending if user has typed them as tuple vs array
     & (<T>((...args: [any]) => T) => T)

--- a/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/test_useDispatch.js
+++ b/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/test_useDispatch.js
@@ -25,6 +25,11 @@ describe('useDispatch', () => {
     dispatch();
   });
 
+  it('errors if given invalid type argument', () => {
+    // $FlowExpectedError[incompatible-call]: string incompatible with Dispatch
+    useDispatch<string>()
+  });
+
   it('handles action creator passed in and is typed', () => {
     const dispatch = useDispatch();
 

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/react-redux_v8.x.x.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/react-redux_v8.x.x.js
@@ -201,7 +201,29 @@ declare module "react-redux" {
   // Typings for Hooks
   // ------------------------------------------------------------
 
-  declare export function useDispatch<D>(): (
+  /* Action and AnyAction are taken from the redux TypeScript types defined here:
+    * https://github.com/reduxjs/redux/blob/d794c56f78eccb56ba3c67971c26df8ee34dacc1/src/types/actions.ts
+    *
+    * We turn them into objects so that they can be spread.
+    *
+    * We use AnyAction as the default for useDispatch as DefinitelyTyped does:
+    * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f7ec78508c6797e42f87a4390735bc2c650a1bfd/types/react-redux/index.d.ts#L540
+    */
+  declare export type Action<T> = {
+    type: T,
+    ...
+  }
+
+  declare export type AnyAction = {
+    ...Action<any>,
+    [string]: any
+  }
+
+  declare export type Dispatch<-A: Action<any>> = (action: A, ...extraArgs: any[]) => mixed
+
+  // Since A is contravariant in Dispatch, empty is a reasonable bound here. This is equivalent
+  // to using mixed as a default in a read-only position.
+  declare export function useDispatch<D: Dispatch<empty> = Dispatch<AnyAction>>(): (
     & (<T: { [key: string]: any }>(T) => T)
     // Supports thunks at their various lengths and use cases depending if user has typed them as tuple vs array
     & (<T>((...args: [any]) => T) => T)

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_useDispatch.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_useDispatch.js
@@ -25,6 +25,11 @@ describe('useDispatch', () => {
     dispatch();
   });
 
+  it('errors if given invalid type argument', () => {
+    // $FlowExpectedError[incompatible-call]: string incompatible with Dispatch
+    useDispatch<string>()
+  });
+
   it('handles action creator passed in and is typed', () => {
     const dispatch = useDispatch();
 


### PR DESCRIPTION
As part of the local type inference project of Flow, we will require all the type arguments to be inferable from local context. In the react-redux libdef, `useDispatch` has an under-constrained type argument D, that will require a lot of annotation burden for users.

In this PR, I added default and bound to useDispatch so that:

1. You will now actually get a dispatch function instead of anything you want, and only can dispatch an action instead of arbitrary stuff.
2. If you don't care about limiting the actions you can dispatch, you don't need to annotate anything. This is necessary to upgrading Meta's internal codebase.

@jbrown215 first created this fix and tested it our internal codebase, which works extremely well.

- Links to documentation: https://medium.com/flow-type/introducing-local-type-inference-for-flow-6af65b7830aa
- Type of contribution: fix