### PR TITLE
[react-redux] Fix missing-local-annot errors

### DIFF
--- a/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/test_connect.js
+++ b/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/test_connect.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import * as React from "react";
 import { connect } from "react-redux";
 import type { ConnectedComponent } from "react-redux";
 
@@ -17,8 +17,8 @@ function testPassingPropsToConnectedComponent() {
     ...
   };
   class Com extends React.Component<Props> {
-    static defaultProps = { passthroughWithDefaultProp: 123 };
-    render() {
+    static defaultProps: { passthroughWithDefaultProp: number, ... } = { passthroughWithDefaultProp: 123 };
+    render(): React.Node {
       return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
     }
   }
@@ -161,7 +161,7 @@ function testExactProps() {
   |};
 
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
     }
   }
@@ -208,7 +208,7 @@ function testInexactOwnProps() {
   };
 
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
     }
   }
@@ -288,7 +288,7 @@ function testMapStateToPropsDoesNotNeedProps() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough}</div>;
     }
   }
@@ -320,7 +320,7 @@ function testMapDispatchToProps() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>
         {this.props.passthrough}
         {this.props.fromMapDispatchToProps}
@@ -356,7 +356,7 @@ function testMapDispatchToPropsDoesNotPassDispatch() {
   type OwnProps = {||};
   type Props = {| ...OwnProps, fromMapDispatchToProps: string, dispatch: Dispatch |};
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.fromMapDispatchToProps}</div>;
     }
   }
@@ -383,7 +383,7 @@ function testMapDispatchToPropsWithoutMapStateToProps() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>
         {this.props.passthrough}
         {this.props.fromMapDispatchToProps}
@@ -415,7 +415,7 @@ function testMapDispatchToPropsPassesActionCreators() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough}</div>;
     }
   }
@@ -461,7 +461,7 @@ function testMapDispatchToPropsPassesActionCreatorsWithMapStateToProps() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough}</div>;
     }
   }
@@ -510,7 +510,7 @@ function testMapDispatchToPropsPassesActionCreatorsWithMapStateToPropsAndMergePr
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough}</div>;
     }
   }
@@ -525,7 +525,11 @@ function testMapDispatchToPropsPassesActionCreatorsWithMapStateToPropsAndMergePr
     dispatch1: () => {},
     dispatch2: () => {}
   };
-  const mergeProps = (stateProps, dispatchProps, ownProps: { forMergeProps: number, ... }) => {
+  const mergeProps = (
+    stateProps: { ... },
+    dispatchProps: { ... },
+    ownProps: { forMergeProps: number, ... },
+  ) => {
     return Object.assign({}, stateProps, dispatchProps, { fromMergeProps: 123 });
   }
   const Connected = connect<Props, OwnProps1, _,_,_,_>(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
@@ -557,7 +561,7 @@ function testMergeProps() {
   |};
   type Props = { fromMergeProps: number, ... };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>
         {this.props.fromMergeProps}
       </div>;
@@ -575,7 +579,7 @@ function testMergeProps() {
   const mapDispatchToProps = (dispatch: any, ownProps: MapDispatchToPropsProps) => {
     return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
   }
-  const mergeProps = (stateProps, dispatchProps, ownProps: { forMergeProps: number, ... }) => {
+  const mergeProps = (stateProps: { ... }, dispatchProps: { ... }, ownProps: { forMergeProps: number, ... }) => {
     return {fromMergeProps: 123};
   }
   const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
@@ -593,7 +597,7 @@ function testMergeProps() {
 
 function testOptions() {
   class Com extends React.Component<{...}> {
-    render() {
+    render(): React.Node {
       return <div></div>;
     }
   }
@@ -612,7 +616,7 @@ function testOptions() {
 function testDispatch() {
   type Props = { dispatch: empty => empty, ... }
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div></div>;
     }
   }
@@ -621,7 +625,7 @@ function testDispatch() {
 function testNoDispatch() {
   type Props = {||}
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div></div>;
     }
   }
@@ -641,10 +645,10 @@ function testHoistConnectedComponent() {
     ...
   };
   class Com extends React.Component<Props> {
-    static defaultProps = { passthroughWithDefaultProp: 123 };
+    static defaultProps: { passthroughWithDefaultProp: number, ... } = { passthroughWithDefaultProp: 123 };
     static myStatic = 1;
 
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
     }
   }
@@ -729,7 +733,7 @@ function checkIfStateTypeIsRespectedAgain() {
   type Props = { str: string, ... };
 
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.str}</div>;
     }
   }
@@ -745,7 +749,7 @@ function testPassingDispatchPropWithoutDispatchFunction() {
   type OwnProps = {||}
   type Props = {| ...OwnProps, dispatch: Dispatch |};
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div />;
     }
   }
@@ -766,7 +770,7 @@ function testPassingDispatchTypeIsPassedThrough() {
   type OwnProps = {||}
   type Props = {| ...OwnProps, dispatch: string |};
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div />;
     }
   }

--- a/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/test_connectAdvanced.js
+++ b/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/test_connectAdvanced.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import * as React from "react";
 import { connectAdvanced } from "react-redux";
 
 function testConnectAdvanced() {
@@ -9,7 +9,7 @@ function testConnectAdvanced() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.fromInputProps} {this.props.fromStateToProps}</div>;
     }
   }

--- a/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/test_connectInfer.js
+++ b/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/test_connectInfer.js
@@ -4,7 +4,7 @@
   This helps keep the usage of Flow amazing type inferent on the good level.
 */
 // @flow
-import React from "react";
+import * as React from "react";
 import { connect } from "react-redux";
 
 function testPassingPropsToConnectedComponent() {
@@ -19,8 +19,8 @@ function testPassingPropsToConnectedComponent() {
     ...
   };
   class Com extends React.Component<Props> {
-    static defaultProps = { passthroughWithDefaultProp: 123 };
-    render() {
+    static defaultProps: { passthroughWithDefaultProp: number, ... } = { passthroughWithDefaultProp: 123 };
+    render(): React.Node {
       return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
     }
   }
@@ -118,7 +118,7 @@ function testMapStateToPropsDoesNotNeedProps() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough}</div>;
     }
   }
@@ -147,7 +147,7 @@ function testMapDispatchToProps() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>
         {this.props.passthrough}
         {this.props.fromMapDispatchToProps}
@@ -187,7 +187,7 @@ function testMapDispatchToPropsWithoutMapStateToProps() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>
         {this.props.passthrough}
         {this.props.fromMapDispatchToProps}
@@ -218,7 +218,7 @@ function testMapDispatchToPropsPassesActionCreators() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough}</div>;
     }
   }
@@ -267,7 +267,7 @@ function testMapDispatchToPropsPassesActionCreatorsWithMapStateToProps() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough}</div>;
     }
   }
@@ -311,7 +311,7 @@ function testMapDispatchToPropsPassesActionCreatorsWithMapStateToPropsAndMergePr
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough}</div>;
     }
   }
@@ -326,7 +326,7 @@ function testMapDispatchToPropsPassesActionCreatorsWithMapStateToPropsAndMergePr
     dispatch1: () => {},
     dispatch2: () => {}
   };
-  const mergeProps = (stateProps, dispatchProps, ownProps: { forMergeProps: number, ... }) => {
+  const mergeProps = (stateProps: { ... }, dispatchProps: { ... }, ownProps: { forMergeProps: number, ... }) => {
     return Object.assign({}, stateProps, dispatchProps, { fromMergeProps: 123 });
   }
   const Connected = connect(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
@@ -357,7 +357,7 @@ function testMapDispatchToPropsPassesActionCreatorsWithMapStateToPropsAndMergePr
 function testMergeProps() {
   type Props = { fromMergeProps: number, ... };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>
         {this.props.fromMergeProps}
       </div>;
@@ -375,7 +375,7 @@ function testMergeProps() {
   const mapDispatchToProps = (dispatch: any, ownProps: MapDispatchToPropsProps) => {
     return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
   }
-  const mergeProps = (stateProps, dispatchProps, ownProps: { forMergeProps: number, ... }) => {
+  const mergeProps = (stateProps: { ... }, dispatchProps: { ... }, ownProps: { forMergeProps: number, ... }) => {
     return {fromMergeProps: 123};
   }
   const Connected = connect(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
@@ -392,7 +392,7 @@ function testMergeProps() {
 
 function testOptions() {
   class Com extends React.Component<{...}> {
-    render() {
+    render(): React.Node {
       return <div></div>;
     }
   }
@@ -415,10 +415,10 @@ function testHoistConnectedComponent() {
     ...
   };
   class Com extends React.Component<Props> {
-    static defaultProps = { passthroughWithDefaultProp: 123 };
+    static defaultProps: { passthroughWithDefaultProp: number, ... } = { passthroughWithDefaultProp: 123 };
     static myStatic = 1;
 
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
     }
   }
@@ -458,7 +458,7 @@ function checkIfStateTypeIsRespectedAgain() {
   type Props = { str: string, ... };
 
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.str}</div>;
     }
   }
@@ -477,7 +477,7 @@ function testAllowsKnownPropInMapStateToProps() {
   type Props = { str: string, ... };
 
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.str}</div>;
     }
   }
@@ -503,7 +503,7 @@ function testForbidsLiteralOfInvalidTypeInMapStateToProps() {
   str: string, ... };
 
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.str}</div>;
     }
   }
@@ -529,7 +529,7 @@ function testForbidsStateProperyOfInvalidTypeInMapStateToProps() {
   type Props = { str: string, ... };
 
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.str}</div>;
     }
   }
@@ -558,7 +558,7 @@ function testForbidsSelectorWithInvalidReturnTypeInMapStateToProps() {
   type Props = { str: string, ... };
 
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.str}</div>;
     }
   }

--- a/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/test_connectMergeProps.js
+++ b/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/test_connectMergeProps.js
@@ -97,7 +97,7 @@ function onlyStateProps_ok() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapStateToProps = state => ({state1: state.state1})
+  const mapStateToProps = (state: StateProps) => ({state1: state.state1})
 
   const mergeProps = (stateProps: StateProps, dispatchProps: {|dispatch: Dispatch|}, ownProps: OwnProps) => {
     return {
@@ -131,7 +131,7 @@ function onlyStateProps_wrongDispatch() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state: StateProps) => ({
     state1: state.state1
   })
 
@@ -252,7 +252,7 @@ function onlyDispatchPropsFunction_ok() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapDispatchToPropsFn = dispatch => ({
+  const mapDispatchToPropsFn = (dispatch: Dispatch) => ({
     action1: () => dispatch(action1())
   })
 
@@ -328,7 +328,7 @@ function onlyDispatchPropsFunction_wrongDispatchProp() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapDispatchToPropsFn = dispatch => ({
+  const mapDispatchToPropsFn = (dispatch: Dispatch) => ({
     action1: () => 123
   })
 
@@ -374,11 +374,11 @@ function stateAndDispatchPropsFunction_ok() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state: StateProps) => ({
     state1: state.state1
   })
 
-  const mapDispatchToPropsFn = dispatch => ({
+  const mapDispatchToPropsFn = (dispatch: Dispatch) => ({
     action1: () => dispatch(action1())
   })
 
@@ -424,11 +424,11 @@ function stateAndDispatchPropsFunction_wrongState() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state: StateProps) => ({
     state1: state.state1
   })
 
-  const mapDispatchToPropsFn = dispatch => ({
+  const mapDispatchToPropsFn = (dispatch: Dispatch) => ({
     action1: () => dispatch(action1())
   })
 
@@ -480,11 +480,11 @@ function stateAndDispatchPropsFunction_wrongDispatch() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state: StateProps) => ({
     state1: state.state1
   })
 
-  const mapDispatchToPropsFn = dispatch => ({
+  const mapDispatchToPropsFn = (dispatch: Dispatch) => ({
     action1: () => 123
   })
 
@@ -531,11 +531,11 @@ function returnsTotallyDifferentProps() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state: StateProps) => ({
     state1: state.state1
   })
 
-  const mapDispatchToPropsFn = dispatch => ({
+  const mapDispatchToPropsFn = (dispatch: Dispatch) => ({
     action1: () => dispatch(action1())
   })
 
@@ -582,11 +582,11 @@ function returnsTotallyDifferentPropsWithError() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state: StateProps) => ({
     state1: state.state1
   })
 
-  const mapDispatchToPropsFn = dispatch => ({
+  const mapDispatchToPropsFn = (dispatch: Dispatch) => ({
     action1: () => dispatch(action1())
   })
 

--- a/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/test_connectThunk.js
+++ b/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/test_connectThunk.js
@@ -125,7 +125,7 @@ function stateAndDispatchObject_differentDispatchPropsAreOK() {
   type StateProps = {|
     state1: 'state1',
   |};
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state: State) => ({
     state1: state.state1
   })
 
@@ -170,7 +170,7 @@ function stateAndDispatchObject_sameDispatchPropsAreErroneous() {
   type StateProps = {|
     state1: 'state1',
   |};
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state: StateProps) => ({
     state1: state.state1
   })
 

--- a/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/test_useDispatch.js
+++ b/definitions/npm/react-redux_v7.x.x/flow_v0.142.x-/test_useDispatch.js
@@ -35,7 +35,7 @@ describe('useDispatch', () => {
   });
 
   it('handles thunks being passed to return the right value', () => {
-    const thunkAction = () => (dispatch) => {
+    const thunkAction = () => (dispatch: Dispatch) => {
       return '';
     }
     const dispatch = useDispatch();
@@ -47,7 +47,7 @@ describe('useDispatch', () => {
   });
 
   it('handles thunks defined as a promise to keep their type', () => {
-    const thunkPromiseAction = () => (dispatch) => new Promise((resolve) => {
+    const thunkPromiseAction = () => (dispatch: Dispatch) => new Promise((resolve) => {
       resolve('');
     });
     const dispatch = useDispatch();

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connect.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connect.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import * as React from "react";
 import { connect } from "react-redux";
 import type { ConnectedComponent } from "react-redux";
 
@@ -17,8 +17,8 @@ function testPassingPropsToConnectedComponent() {
     ...
   };
   class Com extends React.Component<Props> {
-    static defaultProps = { passthroughWithDefaultProp: 123 };
-    render() {
+    static defaultProps: { passthroughWithDefaultProp: number, ... } = { passthroughWithDefaultProp: 123 };
+    render(): React.Node {
       return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
     }
   }
@@ -161,7 +161,7 @@ function testExactProps() {
   |};
 
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
     }
   }
@@ -208,7 +208,7 @@ function testInexactOwnProps() {
   };
 
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
     }
   }
@@ -288,7 +288,7 @@ function testMapStateToPropsDoesNotNeedProps() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough}</div>;
     }
   }
@@ -320,7 +320,7 @@ function testMapDispatchToProps() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>
         {this.props.passthrough}
         {this.props.fromMapDispatchToProps}
@@ -356,7 +356,7 @@ function testMapDispatchToPropsDoesNotPassDispatch() {
   type OwnProps = {||};
   type Props = {| ...OwnProps, fromMapDispatchToProps: string, dispatch: Dispatch |};
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.fromMapDispatchToProps}</div>;
     }
   }
@@ -383,7 +383,7 @@ function testMapDispatchToPropsWithoutMapStateToProps() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>
         {this.props.passthrough}
         {this.props.fromMapDispatchToProps}
@@ -415,7 +415,7 @@ function testMapDispatchToPropsPassesActionCreators() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough}</div>;
     }
   }
@@ -461,7 +461,7 @@ function testMapDispatchToPropsPassesActionCreatorsWithMapStateToProps() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough}</div>;
     }
   }
@@ -510,7 +510,7 @@ function testMapDispatchToPropsPassesActionCreatorsWithMapStateToPropsAndMergePr
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough}</div>;
     }
   }
@@ -525,7 +525,11 @@ function testMapDispatchToPropsPassesActionCreatorsWithMapStateToPropsAndMergePr
     dispatch1: () => {},
     dispatch2: () => {}
   };
-  const mergeProps = (stateProps, dispatchProps, ownProps: { forMergeProps: number, ... }) => {
+  const mergeProps = (
+    stateProps: { ... },
+    dispatchProps: { ... },
+    ownProps: { forMergeProps: number, ... },
+  ) => {
     return Object.assign({}, stateProps, dispatchProps, { fromMergeProps: 123 });
   }
   const Connected = connect<Props, OwnProps1, _,_,_,_>(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
@@ -557,7 +561,7 @@ function testMergeProps() {
   |};
   type Props = { fromMergeProps: number, ... };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>
         {this.props.fromMergeProps}
       </div>;
@@ -575,7 +579,7 @@ function testMergeProps() {
   const mapDispatchToProps = (dispatch: any, ownProps: MapDispatchToPropsProps) => {
     return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
   }
-  const mergeProps = (stateProps, dispatchProps, ownProps: { forMergeProps: number, ... }) => {
+  const mergeProps = (stateProps: { ... }, dispatchProps: { ... }, ownProps: { forMergeProps: number, ... }) => {
     return {fromMergeProps: 123};
   }
   const Connected = connect<Props, OwnProps, _,_,_,_>(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
@@ -593,7 +597,7 @@ function testMergeProps() {
 
 function testOptions() {
   class Com extends React.Component<{...}> {
-    render() {
+    render(): React.Node {
       return <div></div>;
     }
   }
@@ -612,7 +616,7 @@ function testOptions() {
 function testDispatch() {
   type Props = { dispatch: empty => empty, ... }
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div></div>;
     }
   }
@@ -621,7 +625,7 @@ function testDispatch() {
 function testNoDispatch() {
   type Props = {||}
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div></div>;
     }
   }
@@ -641,10 +645,10 @@ function testHoistConnectedComponent() {
     ...
   };
   class Com extends React.Component<Props> {
-    static defaultProps = { passthroughWithDefaultProp: 123 };
+    static defaultProps: { passthroughWithDefaultProp: number, ... } = { passthroughWithDefaultProp: 123 };
     static myStatic = 1;
 
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
     }
   }
@@ -729,7 +733,7 @@ function checkIfStateTypeIsRespectedAgain() {
   type Props = { str: string, ... };
 
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.str}</div>;
     }
   }
@@ -745,7 +749,7 @@ function testPassingDispatchPropWithoutDispatchFunction() {
   type OwnProps = {||}
   type Props = {| ...OwnProps, dispatch: Dispatch |};
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div />;
     }
   }
@@ -766,7 +770,7 @@ function testPassingDispatchTypeIsPassedThrough() {
   type OwnProps = {||}
   type Props = {| ...OwnProps, dispatch: string |};
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div />;
     }
   }

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectInfer.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectInfer.js
@@ -4,7 +4,7 @@
   This helps keep the usage of Flow amazing type inferent on the good level.
 */
 // @flow
-import React from "react";
+import * as React from "react";
 import { connect } from "react-redux";
 
 function testPassingPropsToConnectedComponent() {
@@ -19,8 +19,8 @@ function testPassingPropsToConnectedComponent() {
     ...
   };
   class Com extends React.Component<Props> {
-    static defaultProps = { passthroughWithDefaultProp: 123 };
-    render() {
+    static defaultProps: { passthroughWithDefaultProp: number, ... } = { passthroughWithDefaultProp: 123 };
+    render(): React.Node {
       return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
     }
   }
@@ -118,7 +118,7 @@ function testMapStateToPropsDoesNotNeedProps() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough}</div>;
     }
   }
@@ -147,7 +147,7 @@ function testMapDispatchToProps() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>
         {this.props.passthrough}
         {this.props.fromMapDispatchToProps}
@@ -187,7 +187,7 @@ function testMapDispatchToPropsWithoutMapStateToProps() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>
         {this.props.passthrough}
         {this.props.fromMapDispatchToProps}
@@ -218,7 +218,7 @@ function testMapDispatchToPropsPassesActionCreators() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough}</div>;
     }
   }
@@ -267,7 +267,7 @@ function testMapDispatchToPropsPassesActionCreatorsWithMapStateToProps() {
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough}</div>;
     }
   }
@@ -311,7 +311,7 @@ function testMapDispatchToPropsPassesActionCreatorsWithMapStateToPropsAndMergePr
     ...
   };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough}</div>;
     }
   }
@@ -326,7 +326,7 @@ function testMapDispatchToPropsPassesActionCreatorsWithMapStateToPropsAndMergePr
     dispatch1: () => {},
     dispatch2: () => {}
   };
-  const mergeProps = (stateProps, dispatchProps, ownProps: { forMergeProps: number, ... }) => {
+  const mergeProps = (stateProps: { ... }, dispatchProps: { ... }, ownProps: { forMergeProps: number, ... }) => {
     return Object.assign({}, stateProps, dispatchProps, { fromMergeProps: 123 });
   }
   const Connected = connect(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
@@ -357,7 +357,7 @@ function testMapDispatchToPropsPassesActionCreatorsWithMapStateToPropsAndMergePr
 function testMergeProps() {
   type Props = { fromMergeProps: number, ... };
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>
         {this.props.fromMergeProps}
       </div>;
@@ -375,7 +375,7 @@ function testMergeProps() {
   const mapDispatchToProps = (dispatch: any, ownProps: MapDispatchToPropsProps) => {
     return {fromMapDispatchToProps: ownProps.forMapDispatchToProps}
   }
-  const mergeProps = (stateProps, dispatchProps, ownProps: { forMergeProps: number, ... }) => {
+  const mergeProps = (stateProps: { ... }, dispatchProps: { ... }, ownProps: { forMergeProps: number, ... }) => {
     return {fromMergeProps: 123};
   }
   const Connected = connect(mapStateToProps, mapDispatchToProps, mergeProps)(Com);
@@ -392,7 +392,7 @@ function testMergeProps() {
 
 function testOptions() {
   class Com extends React.Component<{...}> {
-    render() {
+    render(): React.Node {
       return <div></div>;
     }
   }
@@ -415,10 +415,10 @@ function testHoistConnectedComponent() {
     ...
   };
   class Com extends React.Component<Props> {
-    static defaultProps = { passthroughWithDefaultProp: 123 };
+    static defaultProps: { passthroughWithDefaultProp: number, ... } = { passthroughWithDefaultProp: 123 };
     static myStatic = 1;
 
-    render() {
+    render(): React.Node {
       return <div>{this.props.passthrough} {this.props.fromStateToProps}</div>;
     }
   }
@@ -458,7 +458,7 @@ function checkIfStateTypeIsRespectedAgain() {
   type Props = { str: string, ... };
 
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.str}</div>;
     }
   }
@@ -477,7 +477,7 @@ function testAllowsKnownPropInMapStateToProps() {
   type Props = { str: string, ... };
 
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.str}</div>;
     }
   }
@@ -503,7 +503,7 @@ function testForbidsLiteralOfInvalidTypeInMapStateToProps() {
   str: string, ... };
 
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.str}</div>;
     }
   }
@@ -529,7 +529,7 @@ function testForbidsStateProperyOfInvalidTypeInMapStateToProps() {
   type Props = { str: string, ... };
 
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.str}</div>;
     }
   }
@@ -558,7 +558,7 @@ function testForbidsSelectorWithInvalidReturnTypeInMapStateToProps() {
   type Props = { str: string, ... };
 
   class Com extends React.Component<Props> {
-    render() {
+    render(): React.Node {
       return <div>{this.props.str}</div>;
     }
   }

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectMergeProps.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectMergeProps.js
@@ -97,7 +97,7 @@ function onlyStateProps_ok() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapStateToProps = state => ({state1: state.state1})
+  const mapStateToProps = (state: StateProps) => ({state1: state.state1})
 
   const mergeProps = (stateProps: StateProps, dispatchProps: {|dispatch: Dispatch|}, ownProps: OwnProps) => {
     return {
@@ -131,7 +131,7 @@ function onlyStateProps_wrongDispatch() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state: StateProps) => ({
     state1: state.state1
   })
 
@@ -252,7 +252,7 @@ function onlyDispatchPropsFunction_ok() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapDispatchToPropsFn = dispatch => ({
+  const mapDispatchToPropsFn = (dispatch: Dispatch) => ({
     action1: () => dispatch(action1())
   })
 
@@ -328,7 +328,7 @@ function onlyDispatchPropsFunction_wrongDispatchProp() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapDispatchToPropsFn = dispatch => ({
+  const mapDispatchToPropsFn = (dispatch: Dispatch) => ({
     action1: () => 123
   })
 
@@ -374,11 +374,11 @@ function stateAndDispatchPropsFunction_ok() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state: StateProps) => ({
     state1: state.state1
   })
 
-  const mapDispatchToPropsFn = dispatch => ({
+  const mapDispatchToPropsFn = (dispatch: Dispatch) => ({
     action1: () => dispatch(action1())
   })
 
@@ -424,11 +424,11 @@ function stateAndDispatchPropsFunction_wrongState() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state: StateProps) => ({
     state1: state.state1
   })
 
-  const mapDispatchToPropsFn = dispatch => ({
+  const mapDispatchToPropsFn = (dispatch: Dispatch) => ({
     action1: () => dispatch(action1())
   })
 
@@ -480,11 +480,11 @@ function stateAndDispatchPropsFunction_wrongDispatch() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state: StateProps) => ({
     state1: state.state1
   })
 
-  const mapDispatchToPropsFn = dispatch => ({
+  const mapDispatchToPropsFn = (dispatch: Dispatch) => ({
     action1: () => 123
   })
 
@@ -531,11 +531,11 @@ function returnsTotallyDifferentProps() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state: StateProps) => ({
     state1: state.state1
   })
 
-  const mapDispatchToPropsFn = dispatch => ({
+  const mapDispatchToPropsFn = (dispatch: Dispatch) => ({
     action1: () => dispatch(action1())
   })
 
@@ -582,11 +582,11 @@ function returnsTotallyDifferentPropsWithError() {
   };
   class Com extends React.Component<Props> {}
 
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state: StateProps) => ({
     state1: state.state1
   })
 
-  const mapDispatchToPropsFn = dispatch => ({
+  const mapDispatchToPropsFn = (dispatch: Dispatch) => ({
     action1: () => dispatch(action1())
   })
 

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectThunk.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_connectThunk.js
@@ -125,7 +125,7 @@ function stateAndDispatchObject_differentDispatchPropsAreOK() {
   type StateProps = {|
     state1: 'state1',
   |};
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state: State) => ({
     state1: state.state1
   })
 
@@ -170,7 +170,7 @@ function stateAndDispatchObject_sameDispatchPropsAreErroneous() {
   type StateProps = {|
     state1: 'state1',
   |};
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state: StateProps) => ({
     state1: state.state1
   })
 

--- a/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_useDispatch.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.142.x-/test_useDispatch.js
@@ -35,7 +35,7 @@ describe('useDispatch', () => {
   });
 
   it('handles thunks being passed to return the right value', () => {
-    const thunkAction = () => (dispatch) => {
+    const thunkAction = () => (dispatch: Dispatch) => {
       return '';
     }
     const dispatch = useDispatch();
@@ -47,7 +47,7 @@ describe('useDispatch', () => {
   });
 
   it('handles thunks defined as a promise to keep their type', () => {
-    const thunkPromiseAction = () => (dispatch) => new Promise((resolve) => {
+    const thunkPromiseAction = () => (dispatch: Dispatch) => new Promise((resolve) => {
       resolve('');
     });
     const dispatch = useDispatch();


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
To support https://github.com/flow-typed/flow-typed/pull/4392 newer flow versions are throwing a new error type `[missing-local-annot]`. Preventing the pull request from being properly testable and passable.

Luckily the fixes are just adding annotations to test files

- Links to documentation: https://www.npmjs.com/package/react-redux
- Link to GitHub or NPM: https://www.npmjs.com/package/react-redux
- Type of contribution: fix

Other notes:

