### PR TITLE
Fix jest mockResolveValue typing

### DIFF
--- a/definitions/npm/jest_v25.x.x/flow_v0.104.x-v0.133.x/jest_v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.104.x-v0.133.x/jest_v25.x.x.js
@@ -1,3 +1,6 @@
+type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<PromiseMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
  (...args: TArguments): TReturn,
  /**
@@ -82,12 +85,12 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
  /**
   * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
   */
- mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+ mockResolvedValue(value: Depromisify<TReturn>): JestMockFn<TArguments, Promise<TReturn>>,
  /**
   * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
   */
  mockResolvedValueOnce(
-   value: TReturn
+   value: Depromisify<TReturn>
  ): JestMockFn<TArguments, Promise<TReturn>>,
  /**
   * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))

--- a/definitions/npm/jest_v25.x.x/flow_v0.104.x-v0.133.x/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.104.x-v0.133.x/test_jest-v25.x.x.js
@@ -746,3 +746,12 @@ expect(wrapper).toHaveDisplayName(true);
   // No type hint means we return any
   const FooModule3: boolean = jest.requireActual('FooModule');
 }
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise<'pineapple'>)
+

--- a/definitions/npm/jest_v25.x.x/flow_v0.134.x-/jest_v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.134.x-/jest_v25.x.x.js
@@ -1,3 +1,6 @@
+type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<PromiseMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
  (...args: TArguments): TReturn,
  /**
@@ -82,12 +85,12 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
  /**
   * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
   */
- mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+ mockResolvedValue(value: Depromisify<TReturn>): JestMockFn<TArguments, Promise<TReturn>>,
  /**
   * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
   */
  mockResolvedValueOnce(
-   value: TReturn
+   value: Depromisify<TReturn>
  ): JestMockFn<TArguments, Promise<TReturn>>,
  /**
   * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))

--- a/definitions/npm/jest_v25.x.x/flow_v0.134.x-/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.134.x-/test_jest-v25.x.x.js
@@ -758,3 +758,12 @@ it.each`
       // perform tests
   }
 );
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise<'pineapple'>)
+

--- a/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/jest_v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/jest_v25.x.x.js
@@ -1,126 +1,136 @@
+type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<PromiseMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
-  (...args: TArguments): TReturn,
+ (...args: TArguments): TReturn,
+ /**
+  * An object for introspecting mock calls
+  */
+ mock: {
   /**
-   * An object for introspecting mock calls
+   * An array that represents all calls that have been made into this mock
+   * function. Each call is represented by an array of arguments that were
+   * passed during the call.
    */
-  mock: {
-    /**
-     * An array that represents all calls that have been made into this mock
-     * function. Each call is represented by an array of arguments that were
-     * passed during the call.
-     */
-    calls: Array<TArguments>,
-    /**
-     * An array that contains all the object instances that have been
-     * instantiated from this mock function.
-     */
-    instances: Array<TReturn>,
-    /**
-     * An array that contains all the object results that have been
-     * returned by this mock function call
-     */
-    results: Array<{ isThrow: boolean, value: TReturn }>,
-  },
+  calls: Array<TArguments>,
   /**
-   * Resets all information stored in the mockFn.mock.calls and
-   * mockFn.mock.instances arrays. Often this is useful when you want to clean
-   * up a mock's usage data between two assertions.
+   * An array that contains all the object instances that have been
+   * instantiated from this mock function.
    */
-  mockClear(): void,
+  instances: Array<TReturn>,
   /**
-   * Resets all information stored in the mock. This is useful when you want to
-   * completely restore a mock back to its initial state.
+   * An array that contains all the object results that have been
+   * returned by this mock function call
    */
-  mockReset(): void,
-  /**
-   * Removes the mock and restores the initial implementation. This is useful
-   * when you want to mock functions in certain test cases and restore the
-   * original implementation in others. Beware that mockFn.mockRestore only
-   * works when mock was created with jest.spyOn. Thus you have to take care of
-   * restoration yourself when manually assigning jest.fn().
-   */
-  mockRestore(): void,
-  /**
-   * Accepts a function that should be used as the implementation of the mock.
-   * The mock itself will still record all calls that go into and instances
-   * that come from itself -- the only difference is that the implementation
-   * will also be executed when the mock is called.
-   */
-  mockImplementation(
-    fn: (...args: TArguments) => TReturn
-  ): JestMockFn<TArguments, TReturn>,
-  /**
-   * Accepts a function that will be used as an implementation of the mock for
-   * one call to the mocked function. Can be chained so that multiple function
-   * calls produce different results.
-   */
-  mockImplementationOnce(
-    fn: (...args: TArguments) => TReturn
-  ): JestMockFn<TArguments, TReturn>,
-  /**
-   * Accepts a string to use in test result output in place of "jest.fn()" to
-   * indicate which mock function is being referenced.
-   */
-  mockName(name: string): JestMockFn<TArguments, TReturn>,
-  /**
-   * Just a simple sugar function for returning `this`
-   */
-  mockReturnThis(): void,
-  /**
-   * Accepts a value that will be returned whenever the mock function is called.
-   */
-  mockReturnValue(value: TReturn): JestMockFn<TArguments, TReturn>,
-  /**
-   * Sugar for only returning a value once inside your mock
-   */
-  mockReturnValueOnce(value: TReturn): JestMockFn<TArguments, TReturn>,
-  /**
-   * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
-   */
-  mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
-  /**
-   * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
-   */
-  mockResolvedValueOnce(
-    value: TReturn
-  ): JestMockFn<TArguments, Promise<TReturn>>,
-  /**
-   * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))
-   */
-  mockRejectedValue(value: TReturn): JestMockFn<TArguments, Promise<any>>,
-  /**
-   * Sugar for jest.fn().mockImplementationOnce(() => Promise.reject(value))
-   */
-  mockRejectedValueOnce(value: TReturn): JestMockFn<TArguments, Promise<any>>,
+  results: Array<{
+   isThrow: boolean,
+   value: TReturn,
+   ...
+  }>,
+  ...
+ },
+ /**
+  * Resets all information stored in the mockFn.mock.calls and
+  * mockFn.mock.instances arrays. Often this is useful when you want to clean
+  * up a mock's usage data between two assertions.
+  */
+ mockClear(): void,
+ /**
+  * Resets all information stored in the mock. This is useful when you want to
+  * completely restore a mock back to its initial state.
+  */
+ mockReset(): void,
+ /**
+  * Removes the mock and restores the initial implementation. This is useful
+  * when you want to mock functions in certain test cases and restore the
+  * original implementation in others. Beware that mockFn.mockRestore only
+  * works when mock was created with jest.spyOn. Thus you have to take care of
+  * restoration yourself when manually assigning jest.fn().
+  */
+ mockRestore(): void,
+ /**
+  * Accepts a function that should be used as the implementation of the mock.
+  * The mock itself will still record all calls that go into and instances
+  * that come from itself -- the only difference is that the implementation
+  * will also be executed when the mock is called.
+  */
+ mockImplementation(
+   fn: (...args: TArguments) => TReturn
+ ): JestMockFn<TArguments, TReturn>,
+ /**
+  * Accepts a function that will be used as an implementation of the mock for
+  * one call to the mocked function. Can be chained so that multiple function
+  * calls produce different results.
+  */
+ mockImplementationOnce(
+   fn: (...args: TArguments) => TReturn
+ ): JestMockFn<TArguments, TReturn>,
+ /**
+  * Accepts a string to use in test result output in place of "jest.fn()" to
+  * indicate which mock function is being referenced.
+  */
+ mockName(name: string): JestMockFn<TArguments, TReturn>,
+ /**
+  * Just a simple sugar function for returning `this`
+  */
+ mockReturnThis(): void,
+ /**
+  * Accepts a value that will be returned whenever the mock function is called.
+  */
+ mockReturnValue(value: TReturn): JestMockFn<TArguments, TReturn>,
+ /**
+  * Sugar for only returning a value once inside your mock
+  */
+ mockReturnValueOnce(value: TReturn): JestMockFn<TArguments, TReturn>,
+ /**
+  * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
+  */
+ mockResolvedValue(value: Depromisify<TReturn>): JestMockFn<TArguments, Promise<TReturn>>,
+ /**
+  * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
+  */
+ mockResolvedValueOnce(
+   value: Depromisify<TReturn>
+ ): JestMockFn<TArguments, Promise<TReturn>>,
+ /**
+  * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))
+  */
+ mockRejectedValue(value: TReturn): JestMockFn<TArguments, Promise<any>>,
+ /**
+  * Sugar for jest.fn().mockImplementationOnce(() => Promise.reject(value))
+  */
+ mockRejectedValueOnce(value: TReturn): JestMockFn<TArguments, Promise<any>>,
+ ...
 };
 
-type JestAsymmetricEqualityType = {
-  /**
-   * A custom Jasmine equality tester
-   */
-  asymmetricMatch(value: mixed): boolean,
-};
+type JestAsymmetricEqualityType = { /**
+ * A custom Jasmine equality tester
+ */
+asymmetricMatch(value: mixed): boolean, ... };
 
 type JestCallsType = {
-  allArgs(): mixed,
-  all(): mixed,
-  any(): boolean,
-  count(): number,
-  first(): mixed,
-  mostRecent(): mixed,
-  reset(): void,
+ allArgs(): mixed,
+ all(): mixed,
+ any(): boolean,
+ count(): number,
+ first(): mixed,
+ mostRecent(): mixed,
+ reset(): void,
+ ...
 };
 
 type JestClockType = {
-  install(): void,
-  mockDate(date: Date): void,
-  tick(milliseconds?: number): void,
-  uninstall(): void,
+ install(): void,
+ mockDate(date: Date): void,
+ tick(milliseconds?: number): void,
+ uninstall(): void,
+ ...
 };
 
 type JestMatcherResult = {
-  message?: string | (() => string),
-  pass: boolean,
+ message?: string | (() => string),
+ pass: boolean,
+ ...
 };
 
 type JestMatcher = (
@@ -129,16 +139,17 @@ type JestMatcher = (
 ) => JestMatcherResult | Promise<JestMatcherResult>;
 
 type JestPromiseType = {
-  /**
-   * Use rejects to unwrap the reason of a rejected promise so any other
-   * matcher can be chained. If the promise is fulfilled the assertion fails.
-   */
-  rejects: JestExpectType,
-  /**
-   * Use resolves to unwrap the value of a fulfilled promise so any other
-   * matcher can be chained. If the promise is rejected the assertion fails.
-   */
-  resolves: JestExpectType,
+ /**
+  * Use rejects to unwrap the reason of a rejected promise so any other
+  * matcher can be chained. If the promise is fulfilled the assertion fails.
+  */
+ rejects: JestExpectType,
+ /**
+  * Use resolves to unwrap the value of a fulfilled promise so any other
+  * matcher can be chained. If the promise is rejected the assertion fails.
+  */
+ resolves: JestExpectType,
+ ...
 };
 
 /**
@@ -158,417 +169,374 @@ type JestStyledComponentsMatcherValue =
   | typeof undefined;
 
 type JestStyledComponentsMatcherOptions = {
-  media?: string,
-  modifier?: string,
-  supports?: string,
+ media?: string,
+ modifier?: string,
+ supports?: string,
+ ...
 };
 
-type JestStyledComponentsMatchersType = {
-  toHaveStyleRule(
-    property: string,
-    value: JestStyledComponentsMatcherValue,
-    options?: JestStyledComponentsMatcherOptions
-  ): void,
-};
+type JestStyledComponentsMatchersType = { toHaveStyleRule(
+  property: string,
+  value: JestStyledComponentsMatcherValue,
+  options?: JestStyledComponentsMatcherOptions
+): void, ... };
 
 /**
  *  Plugin: jest-enzyme
  */
 type EnzymeMatchersType = {
-  // 5.x
-  toBeEmpty(): void,
-  toBePresent(): void,
-  // 6.x
-  toBeChecked(): void,
-  toBeDisabled(): void,
-  toBeEmptyRender(): void,
-  toContainMatchingElement(selector: string): void,
-  toContainMatchingElements(n: number, selector: string): void,
-  toContainExactlyOneMatchingElement(selector: string): void,
-  toContainReact(element: React$Element<any>): void,
-  toExist(): void,
-  toHaveClassName(className: string): void,
-  toHaveHTML(html: string): void,
-  toHaveProp: ((propKey: string, propValue?: any) => void) &
-    ((props: {}) => void),
-  toHaveRef(refName: string): void,
-  toHaveState: ((stateKey: string, stateValue?: any) => void) &
-    ((state: {}) => void),
-  toHaveStyle: ((styleKey: string, styleValue?: any) => void) &
-    ((style: {}) => void),
-  toHaveTagName(tagName: string): void,
-  toHaveText(text: string): void,
-  toHaveValue(value: any): void,
-  toIncludeText(text: string): void,
-  toMatchElement(
-    element: React$Element<any>,
-    options?: {| ignoreProps?: boolean, verbose?: boolean |}
-  ): void,
-  toMatchSelector(selector: string): void,
-  // 7.x
-  toHaveDisplayName(name: string): void,
+ // 5.x
+ toBeEmpty(): void,
+ toBePresent(): void,
+ // 6.x
+ toBeChecked(): void,
+ toBeDisabled(): void,
+ toBeEmptyRender(): void,
+ toContainMatchingElement(selector: string): void,
+ toContainMatchingElements(n: number, selector: string): void,
+ toContainExactlyOneMatchingElement(selector: string): void,
+ toContainReact(element: React$Element<any>): void,
+ toExist(): void,
+ toHaveClassName(className: string): void,
+ toHaveHTML(html: string): void,
+ toHaveProp: ((propKey: string, propValue?: any) => void) &
+   ((props: {...}) => void),
+ toHaveRef(refName: string): void,
+ toHaveState: ((stateKey: string, stateValue?: any) => void) &
+   ((state: {...}) => void),
+ toHaveStyle: ((styleKey: string, styleValue?: any) => void) &
+   ((style: {...}) => void),
+ toHaveTagName(tagName: string): void,
+ toHaveText(text: string): void,
+ toHaveValue(value: any): void,
+ toIncludeText(text: string): void,
+ toMatchElement(
+   element: React$Element<any>,
+   options?: {| ignoreProps?: boolean, verbose?: boolean |}
+ ): void,
+ toMatchSelector(selector: string): void,
+ // 7.x
+ toHaveDisplayName(name: string): void,
+ ...
 };
 
 // DOM testing library extensions (jest-dom)
 // https://github.com/testing-library/jest-dom
 type DomTestingLibraryType = {
-  /**
-   * @deprecated
-   */
-  toBeInTheDOM(container?: HTMLElement): void,
+ /**
+  * @deprecated
+  */
+ toBeInTheDOM(container?: HTMLElement): void,
 
-  toBeInTheDocument(): void,
-  toBeVisible(): void,
-  toBeEmpty(): void,
-  toBeDisabled(): void,
-  toBeEnabled(): void,
-  toBeInvalid(): void,
-  toBeRequired(): void,
-  toBeValid(): void,
-  toContainElement(element: HTMLElement | null): void,
-  toContainHTML(htmlText: string): void,
-  toHaveAttribute(attr: string, value?: any): void,
-  toHaveClass(...classNames: string[]): void,
-  toHaveFocus(): void,
-  toHaveFormValues(expectedValues: { [name: string]: any }): void,
-  toHaveStyle(css: string): void,
-  toHaveTextContent(
-    text: string | RegExp,
-    options?: { normalizeWhitespace: boolean }
-  ): void,
-  toHaveValue(value?: string | string[] | number): void,
+ // 4.x
+ toBeInTheDocument(): void,
+ toBeVisible(): void,
+ toBeEmpty(): void,
+ toBeDisabled(): void,
+ toBeEnabled(): void,
+ toBeInvalid(): void,
+ toBeRequired(): void,
+ toBeValid(): void,
+ toContainElement(element: HTMLElement | null): void,
+ toContainHTML(htmlText: string): void,
+ toHaveAttribute(attr: string, value?: any): void,
+ toHaveClass(...classNames: string[]): void,
+ toHaveFocus(): void,
+ toHaveFormValues(expectedValues: { [name: string]: any, ... }): void,
+ toHaveStyle(css: string | { [name: string]: any, ... }): void,
+ toHaveTextContent(
+   text: string | RegExp,
+   options?: {| normalizeWhitespace: boolean |}
+ ): void,
+ toHaveValue(value?: string | string[] | number): void,
+
+ // 5.x
+ toHaveDisplayValue(value: string | string[]): void,
+ toBeChecked(): void,
+ ...
 };
 
 // Jest JQuery Matchers: https://github.com/unindented/custom-jquery-matchers
 type JestJQueryMatchersType = {
-  toExist(): void,
-  toHaveLength(len: number): void,
-  toHaveId(id: string): void,
-  toHaveClass(className: string): void,
-  toHaveTag(tag: string): void,
-  toHaveAttr(key: string, val?: any): void,
-  toHaveProp(key: string, val?: any): void,
-  toHaveText(text: string | RegExp): void,
-  toHaveData(key: string, val?: any): void,
-  toHaveValue(val: any): void,
-  toHaveCss(css: { [key: string]: any }): void,
-  toBeChecked(): void,
-  toBeDisabled(): void,
-  toBeEmpty(): void,
-  toBeHidden(): void,
-  toBeSelected(): void,
-  toBeVisible(): void,
-  toBeFocused(): void,
-  toBeInDom(): void,
-  toBeMatchedBy(sel: string): void,
-  toHaveDescendant(sel: string): void,
-  toHaveDescendantWithText(sel: string, text: string | RegExp): void,
+ toExist(): void,
+ toHaveLength(len: number): void,
+ toHaveId(id: string): void,
+ toHaveClass(className: string): void,
+ toHaveTag(tag: string): void,
+ toHaveAttr(key: string, val?: any): void,
+ toHaveProp(key: string, val?: any): void,
+ toHaveText(text: string | RegExp): void,
+ toHaveData(key: string, val?: any): void,
+ toHaveValue(val: any): void,
+ toHaveCss(css: { [key: string]: any, ... }): void,
+ toBeChecked(): void,
+ toBeDisabled(): void,
+ toBeEmpty(): void,
+ toBeHidden(): void,
+ toBeSelected(): void,
+ toBeVisible(): void,
+ toBeFocused(): void,
+ toBeInDom(): void,
+ toBeMatchedBy(sel: string): void,
+ toHaveDescendant(sel: string): void,
+ toHaveDescendantWithText(sel: string, text: string | RegExp): void,
+ ...
 };
 
 // Jest Extended Matchers: https://github.com/jest-community/jest-extended
 type JestExtendedMatchersType = {
-  /**
-   * Note: Currently unimplemented
-   * Passing assertion
-   *
-   * @param {String} message
-   */
-  //  pass(message: string): void;
+ /**
+  * Note: Currently unimplemented
+  * Passing assertion
+  *
+  * @param {String} message
+  */
+ //  pass(message: string): void;
 
-  /**
-   * Note: Currently unimplemented
-   * Failing assertion
-   *
-   * @param {String} message
-   */
-  //  fail(message: string): void;
+ /**
+  * Note: Currently unimplemented
+  * Failing assertion
+  *
+  * @param {String} message
+  */
+ //  fail(message: string): void;
 
-  /**
-   * Use .toBeEmpty when checking if a String '', Array [] or Object {} is empty.
-   */
-  toBeEmpty(): void,
-
-  /**
-   * Use .toBeOneOf when checking if a value is a member of a given Array.
-   * @param {Array.<*>} members
-   */
-  toBeOneOf(members: any[]): void,
-
-  /**
-   * Use `.toBeNil` when checking a value is `null` or `undefined`.
-   */
-  toBeNil(): void,
-
-  /**
-   * Use `.toSatisfy` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean`.
-   * @param {Function} predicate
-   */
-  toSatisfy(predicate: (n: any) => boolean): void,
-
-  /**
-   * Use `.toBeArray` when checking if a value is an `Array`.
-   */
-  toBeArray(): void,
-
-  /**
-   * Use `.toBeArrayOfSize` when checking if a value is an `Array` of size x.
-   * @param {Number} x
-   */
-  toBeArrayOfSize(x: number): void,
-
-  /**
-   * Use `.toIncludeAllMembers` when checking if an `Array` contains all of the same members of a given set.
-   * @param {Array.<*>} members
-   */
-  toIncludeAllMembers(members: any[]): void,
-
-  /**
-   * Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.
-   * @param {Array.<*>} members
-   */
-  toIncludeAnyMembers(members: any[]): void,
-
-  /**
-   * Use `.toIncludeSameMembers` when checking if two arrays contain equal values, in any order.
-   * @param {Array.<*>} members
-   */
-  toIncludeSameMembers(members: any[]): void,
-
-  /**
-   * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
-   * @param {Function} predicate
-   */
-  toSatisfyAll(predicate: (n: any) => boolean): void,
-
-  /**
-   * Use `.toBeBoolean` when checking if a value is a `Boolean`.
-   */
-  toBeBoolean(): void,
-
-  /**
-   * Use `.toBeTrue` when checking a value is equal (===) to `true`.
-   */
-  toBeTrue(): void,
-
-  /**
-   * Use `.toBeFalse` when checking a value is equal (===) to `false`.
-   */
-  toBeFalse(): void,
-
-  /**
-   * Use .toBeDate when checking if a value is a Date.
-   */
-  toBeDate(): void,
-
-  /**
-   * Use `.toBeFunction` when checking if a value is a `Function`.
-   */
-  toBeFunction(): void,
-
-  /**
-   * Use `.toHaveBeenCalledBefore` when checking if a `Mock` was called before another `Mock`.
-   *
-   * Note: Required Jest version >22
-   * Note: Your mock functions will have to be asynchronous to cause the timestamps inside of Jest to occur in a differentJS event loop, otherwise the mock timestamps will all be the same
-   *
-   * @param {Mock} mock
-   */
-  toHaveBeenCalledBefore(mock: JestMockFn<any, any>): void,
-
-  /**
-   * Use `.toBeNumber` when checking if a value is a `Number`.
-   */
-  toBeNumber(): void,
-
-  /**
-   * Use `.toBeNaN` when checking a value is `NaN`.
-   */
-  toBeNaN(): void,
-
-  /**
-   * Use `.toBeFinite` when checking if a value is a `Number`, not `NaN` or `Infinity`.
-   */
-  toBeFinite(): void,
-
-  /**
-   * Use `.toBePositive` when checking if a value is a positive `Number`.
-   */
-  toBePositive(): void,
-
-  /**
-   * Use `.toBeNegative` when checking if a value is a negative `Number`.
-   */
-  toBeNegative(): void,
-
-  /**
-   * Use `.toBeEven` when checking if a value is an even `Number`.
-   */
-  toBeEven(): void,
-
-  /**
-   * Use `.toBeOdd` when checking if a value is an odd `Number`.
-   */
-  toBeOdd(): void,
-
-  /**
-   * Use `.toBeWithin` when checking if a number is in between the given bounds of: start (inclusive) and end (exclusive).
-   *
-   * @param {Number} start
-   * @param {Number} end
-   */
-  toBeWithin(start: number, end: number): void,
-
-  /**
-   * Use `.toBeObject` when checking if a value is an `Object`.
-   */
-  toBeObject(): void,
-
-  /**
-   * Use `.toContainKey` when checking if an object contains the provided key.
-   *
-   * @param {String} key
-   */
-  toContainKey(key: string): void,
-
-  /**
-   * Use `.toContainKeys` when checking if an object has all of the provided keys.
-   *
-   * @param {Array.<String>} keys
-   */
-  toContainKeys(keys: string[]): void,
-
-  /**
-   * Use `.toContainAllKeys` when checking if an object only contains all of the provided keys.
-   *
-   * @param {Array.<String>} keys
-   */
-  toContainAllKeys(keys: string[]): void,
-
-  /**
-   * Use `.toContainAnyKeys` when checking if an object contains at least one of the provided keys.
-   *
-   * @param {Array.<String>} keys
-   */
-  toContainAnyKeys(keys: string[]): void,
-
-  /**
-   * Use `.toContainValue` when checking if an object contains the provided value.
-   *
-   * @param {*} value
-   */
-  toContainValue(value: any): void,
-
-  /**
-   * Use `.toContainValues` when checking if an object contains all of the provided values.
-   *
-   * @param {Array.<*>} values
-   */
-  toContainValues(values: any[]): void,
-
-  /**
-   * Use `.toContainAllValues` when checking if an object only contains all of the provided values.
-   *
-   * @param {Array.<*>} values
-   */
-  toContainAllValues(values: any[]): void,
-
-  /**
-   * Use `.toContainAnyValues` when checking if an object contains at least one of the provided values.
-   *
-   * @param {Array.<*>} values
-   */
-  toContainAnyValues(values: any[]): void,
-
-  /**
-   * Use `.toContainEntry` when checking if an object contains the provided entry.
-   *
-   * @param {Array.<String, String>} entry
-   */
-  toContainEntry(entry: [string, string]): void,
-
-  /**
-   * Use `.toContainEntries` when checking if an object contains all of the provided entries.
-   *
-   * @param {Array.<Array.<String, String>>} entries
-   */
-  toContainEntries(entries: [string, string][]): void,
-
-  /**
-   * Use `.toContainAllEntries` when checking if an object only contains all of the provided entries.
-   *
-   * @param {Array.<Array.<String, String>>} entries
-   */
-  toContainAllEntries(entries: [string, string][]): void,
-
-  /**
-   * Use `.toContainAnyEntries` when checking if an object contains at least one of the provided entries.
-   *
-   * @param {Array.<Array.<String, String>>} entries
-   */
-  toContainAnyEntries(entries: [string, string][]): void,
-
-  /**
-   * Use `.toBeExtensible` when checking if an object is extensible.
-   */
-  toBeExtensible(): void,
-
-  /**
-   * Use `.toBeFrozen` when checking if an object is frozen.
-   */
-  toBeFrozen(): void,
-
-  /**
-   * Use `.toBeSealed` when checking if an object is sealed.
-   */
-  toBeSealed(): void,
-
-  /**
-   * Use `.toBeString` when checking if a value is a `String`.
-   */
-  toBeString(): void,
-
-  /**
-   * Use `.toEqualCaseInsensitive` when checking if a string is equal (===) to another ignoring the casing of both strings.
-   *
-   * @param {String} string
-   */
-  toEqualCaseInsensitive(string: string): void,
-
-  /**
-   * Use `.toStartWith` when checking if a `String` starts with a given `String` prefix.
-   *
-   * @param {String} prefix
-   */
-  toStartWith(prefix: string): void,
-
-  /**
-   * Use `.toEndWith` when checking if a `String` ends with a given `String` suffix.
-   *
-   * @param {String} suffix
-   */
-  toEndWith(suffix: string): void,
-
-  /**
-   * Use `.toInclude` when checking if a `String` includes the given `String` substring.
-   *
-   * @param {String} substring
-   */
-  toInclude(substring: string): void,
-
-  /**
-   * Use `.toIncludeRepeated` when checking if a `String` includes the given `String` substring the correct number of times.
-   *
-   * @param {String} substring
-   * @param {Number} times
-   */
-  toIncludeRepeated(substring: string, times: number): void,
-
-  /**
-   * Use `.toIncludeMultiple` when checking if a `String` includes all of the given substrings.
-   *
-   * @param {Array.<String>} substring
-   */
-  toIncludeMultiple(substring: string[]): void,
+ /**
+  * Use .toBeEmpty when checking if a String '', Array [] or Object {} is empty.
+  */
+ toBeEmpty(): void,
+ /**
+  * Use .toBeOneOf when checking if a value is a member of a given Array.
+  * @param {Array.<*>} members
+  */
+ toBeOneOf(members: any[]): void,
+ /**
+  * Use `.toBeNil` when checking a value is `null` or `undefined`.
+  */
+ toBeNil(): void,
+ /**
+  * Use `.toSatisfy` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean`.
+  * @param {Function} predicate
+  */
+ toSatisfy(predicate: (n: any) => boolean): void,
+ /**
+  * Use `.toBeArray` when checking if a value is an `Array`.
+  */
+ toBeArray(): void,
+ /**
+  * Use `.toBeArrayOfSize` when checking if a value is an `Array` of size x.
+  * @param {Number} x
+  */
+ toBeArrayOfSize(x: number): void,
+ /**
+  * Use `.toIncludeAllMembers` when checking if an `Array` contains all of the same members of a given set.
+  * @param {Array.<*>} members
+  */
+ toIncludeAllMembers(members: any[]): void,
+ /**
+  * Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.
+  * @param {Array.<*>} members
+  */
+ toIncludeAnyMembers(members: any[]): void,
+ /**
+  * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
+  * @param {Function} predicate
+  */
+ toSatisfyAll(predicate: (n: any) => boolean): void,
+ /**
+  * Use `.toBeBoolean` when checking if a value is a `Boolean`.
+  */
+ toBeBoolean(): void,
+ /**
+  * Use `.toBeTrue` when checking a value is equal (===) to `true`.
+  */
+ toBeTrue(): void,
+ /**
+  * Use `.toBeFalse` when checking a value is equal (===) to `false`.
+  */
+ toBeFalse(): void,
+ /**
+  * Use .toBeDate when checking if a value is a Date.
+  */
+ toBeDate(): void,
+ /**
+  * Use `.toBeFunction` when checking if a value is a `Function`.
+  */
+ toBeFunction(): void,
+ /**
+  * Use `.toHaveBeenCalledBefore` when checking if a `Mock` was called before another `Mock`.
+  *
+  * Note: Required Jest version >22
+  * Note: Your mock functions will have to be asynchronous to cause the timestamps inside of Jest to occur in a differentJS event loop, otherwise the mock timestamps will all be the same
+  *
+  * @param {Mock} mock
+  */
+ toHaveBeenCalledBefore(mock: JestMockFn<any, any>): void,
+ /**
+  * Use `.toBeNumber` when checking if a value is a `Number`.
+  */
+ toBeNumber(): void,
+ /**
+  * Use `.toBeNaN` when checking a value is `NaN`.
+  */
+ toBeNaN(): void,
+ /**
+  * Use `.toBeFinite` when checking if a value is a `Number`, not `NaN` or `Infinity`.
+  */
+ toBeFinite(): void,
+ /**
+  * Use `.toBePositive` when checking if a value is a positive `Number`.
+  */
+ toBePositive(): void,
+ /**
+  * Use `.toBeNegative` when checking if a value is a negative `Number`.
+  */
+ toBeNegative(): void,
+ /**
+  * Use `.toBeEven` when checking if a value is an even `Number`.
+  */
+ toBeEven(): void,
+ /**
+  * Use `.toBeOdd` when checking if a value is an odd `Number`.
+  */
+ toBeOdd(): void,
+ /**
+  * Use `.toBeWithin` when checking if a number is in between the given bounds of: start (inclusive) and end (exclusive).
+  *
+  * @param {Number} start
+  * @param {Number} end
+  */
+ toBeWithin(start: number, end: number): void,
+ /**
+  * Use `.toBeObject` when checking if a value is an `Object`.
+  */
+ toBeObject(): void,
+ /**
+  * Use `.toContainKey` when checking if an object contains the provided key.
+  *
+  * @param {String} key
+  */
+ toContainKey(key: string): void,
+ /**
+  * Use `.toContainKeys` when checking if an object has all of the provided keys.
+  *
+  * @param {Array.<String>} keys
+  */
+ toContainKeys(keys: string[]): void,
+ /**
+  * Use `.toContainAllKeys` when checking if an object only contains all of the provided keys.
+  *
+  * @param {Array.<String>} keys
+  */
+ toContainAllKeys(keys: string[]): void,
+ /**
+  * Use `.toContainAnyKeys` when checking if an object contains at least one of the provided keys.
+  *
+  * @param {Array.<String>} keys
+  */
+ toContainAnyKeys(keys: string[]): void,
+ /**
+  * Use `.toContainValue` when checking if an object contains the provided value.
+  *
+  * @param {*} value
+  */
+ toContainValue(value: any): void,
+ /**
+  * Use `.toContainValues` when checking if an object contains all of the provided values.
+  *
+  * @param {Array.<*>} values
+  */
+ toContainValues(values: any[]): void,
+ /**
+  * Use `.toContainAllValues` when checking if an object only contains all of the provided values.
+  *
+  * @param {Array.<*>} values
+  */
+ toContainAllValues(values: any[]): void,
+ /**
+  * Use `.toContainAnyValues` when checking if an object contains at least one of the provided values.
+  *
+  * @param {Array.<*>} values
+  */
+ toContainAnyValues(values: any[]): void,
+ /**
+  * Use `.toContainEntry` when checking if an object contains the provided entry.
+  *
+  * @param {Array.<String, String>} entry
+  */
+ toContainEntry(entry: [string, string]): void,
+ /**
+  * Use `.toContainEntries` when checking if an object contains all of the provided entries.
+  *
+  * @param {Array.<Array.<String, String>>} entries
+  */
+ toContainEntries(entries: [string, string][]): void,
+ /**
+  * Use `.toContainAllEntries` when checking if an object only contains all of the provided entries.
+  *
+  * @param {Array.<Array.<String, String>>} entries
+  */
+ toContainAllEntries(entries: [string, string][]): void,
+ /**
+  * Use `.toContainAnyEntries` when checking if an object contains at least one of the provided entries.
+  *
+  * @param {Array.<Array.<String, String>>} entries
+  */
+ toContainAnyEntries(entries: [string, string][]): void,
+ /**
+  * Use `.toBeExtensible` when checking if an object is extensible.
+  */
+ toBeExtensible(): void,
+ /**
+  * Use `.toBeFrozen` when checking if an object is frozen.
+  */
+ toBeFrozen(): void,
+ /**
+  * Use `.toBeSealed` when checking if an object is sealed.
+  */
+ toBeSealed(): void,
+ /**
+  * Use `.toBeString` when checking if a value is a `String`.
+  */
+ toBeString(): void,
+ /**
+  * Use `.toEqualCaseInsensitive` when checking if a string is equal (===) to another ignoring the casing of both strings.
+  *
+  * @param {String} string
+  */
+ toEqualCaseInsensitive(string: string): void,
+ /**
+  * Use `.toStartWith` when checking if a `String` starts with a given `String` prefix.
+  *
+  * @param {String} prefix
+  */
+ toStartWith(prefix: string): void,
+ /**
+  * Use `.toEndWith` when checking if a `String` ends with a given `String` suffix.
+  *
+  * @param {String} suffix
+  */
+ toEndWith(suffix: string): void,
+ /**
+  * Use `.toInclude` when checking if a `String` includes the given `String` substring.
+  *
+  * @param {String} substring
+  */
+ toInclude(substring: string): void,
+ /**
+  * Use `.toIncludeRepeated` when checking if a `String` includes the given `String` substring the correct number of times.
+  *
+  * @param {String} substring
+  * @param {Number} times
+  */
+ toIncludeRepeated(substring: string, times: number): void,
+ /**
+  * Use `.toIncludeMultiple` when checking if a `String` includes all of the given substrings.
+  *
+  * @param {Array.<String>} substring
+  */
+ toIncludeMultiple(substring: string[]): void,
+ ...
 };
 
 // Diffing snapshot utility for Jest (snapshot-diff)
@@ -589,7 +557,8 @@ type SnapshotDiffType = {
       bAnnotation?: string;
     |},
     testName?: string
-  ): void
+  ): void,
+  ...
 }
 
 interface JestExpectType {
@@ -785,183 +754,180 @@ interface JestExpectType {
 }
 
 type JestObjectType = {
-  /**
-   *  Disables automatic mocking in the module loader.
-   *
-   *  After this method is called, all `require()`s will return the real
-   *  versions of each module (rather than a mocked version).
-   */
-  disableAutomock(): JestObjectType,
-  /**
-   * An un-hoisted version of disableAutomock
-   */
-  autoMockOff(): JestObjectType,
-  /**
-   * Enables automatic mocking in the module loader.
-   */
-  enableAutomock(): JestObjectType,
-  /**
-   * An un-hoisted version of enableAutomock
-   */
-  autoMockOn(): JestObjectType,
-  /**
-   * Clears the mock.calls and mock.instances properties of all mocks.
-   * Equivalent to calling .mockClear() on every mocked function.
-   */
-  clearAllMocks(): JestObjectType,
-  /**
-   * Resets the state of all mocks. Equivalent to calling .mockReset() on every
-   * mocked function.
-   */
-  resetAllMocks(): JestObjectType,
-  /**
-   * Restores all mocks back to their original value.
-   */
-  restoreAllMocks(): JestObjectType,
-  /**
-   * Removes any pending timers from the timer system.
-   */
-  clearAllTimers(): void,
-  /**
-   * Returns the number of fake timers still left to run.
-   */
-  getTimerCount(): number,
-  /**
-   * The same as `mock` but not moved to the top of the expectation by
-   * babel-jest.
-   */
-  doMock(moduleName: string, moduleFactory?: any): JestObjectType,
-  /**
-   * The same as `unmock` but not moved to the top of the expectation by
-   * babel-jest.
-   */
-  dontMock(moduleName: string): JestObjectType,
-  /**
-   * Returns a new, unused mock function. Optionally takes a mock
-   * implementation.
-   */
-  fn<TArguments: $ReadOnlyArray<*>, TReturn>(
-    implementation?: (...args: TArguments) => TReturn
-  ): JestMockFn<TArguments, TReturn>,
-  /**
-   * Determines if the given function is a mocked function.
-   */
-  isMockFunction(fn: Function): boolean,
-  /**
-   * Given the name of a module, use the automatic mocking system to generate a
-   * mocked version of the module for you.
-   */
-  genMockFromModule(moduleName: string): any,
-  /**
-   * Mocks a module with an auto-mocked version when it is being required.
-   *
-   * The second argument can be used to specify an explicit module factory that
-   * is being run instead of using Jest's automocking feature.
-   *
-   * The third argument can be used to create virtual mocks -- mocks of modules
-   * that don't exist anywhere in the system.
-   */
-  mock(
-    moduleName: string,
-    moduleFactory?: any,
-    options?: Object
-  ): JestObjectType,
-  /**
-   * Returns the actual module instead of a mock, bypassing all checks on
-   * whether the module should receive a mock implementation or not.
-   */
-  requireActual<T>(m: $Flow$ModuleRef<T> | string): T,
-  /**
-   * Returns a mock module instead of the actual module, bypassing all checks
-   * on whether the module should be required normally or not.
-   */
-  requireMock(moduleName: string): any,
-  /**
-   * Resets the module registry - the cache of all required modules. This is
-   * useful to isolate modules where local state might conflict between tests.
-   */
-  resetModules(): JestObjectType,
-
-  /**
-   * Creates a sandbox registry for the modules that are loaded inside the
-   * callback function. This is useful to isolate specific modules for every
-   * test so that local module state doesn't conflict between tests.
-   */
-  isolateModules(fn: () => void): JestObjectType,
-
-  /**
-   * Exhausts the micro-task queue (usually interfaced in node via
-   * process.nextTick).
-   */
-  runAllTicks(): void,
-  /**
-   * Exhausts the macro-task queue (i.e., all tasks queued by setTimeout(),
-   * setInterval(), and setImmediate()).
-   */
-  runAllTimers(): void,
-  /**
-   * Exhausts all tasks queued by setImmediate().
-   */
-  runAllImmediates(): void,
-  /**
-   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
-   * or setInterval() and setImmediate()).
-   */
-  advanceTimersByTime(msToRun: number): void,
-  /**
-   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
-   * or setInterval() and setImmediate()).
-   *
-   * Renamed to `advanceTimersByTime`.
-   */
-  runTimersToTime(msToRun: number): void,
-  /**
-   * Executes only the macro-tasks that are currently pending (i.e., only the
-   * tasks that have been queued by setTimeout() or setInterval() up to this
-   * point)
-   */
-  runOnlyPendingTimers(): void,
-  /**
-   * Explicitly supplies the mock object that the module system should return
-   * for the specified module. Note: It is recommended to use jest.mock()
-   * instead.
-   */
-  setMock(moduleName: string, moduleExports: any): JestObjectType,
-  /**
-   * Indicates that the module system should never return a mocked version of
-   * the specified module from require() (e.g. that it should always return the
-   * real module).
-   */
-  unmock(moduleName: string): JestObjectType,
-  /**
-   * Instructs Jest to use fake versions of the standard timer functions
-   * (setTimeout, setInterval, clearTimeout, clearInterval, nextTick,
-   * setImmediate and clearImmediate).
-   */
-  useFakeTimers(): JestObjectType,
-  /**
-   * Instructs Jest to use the real versions of the standard timer functions.
-   */
-  useRealTimers(): JestObjectType,
-  /**
-   * Creates a mock function similar to jest.fn but also tracks calls to
-   * object[methodName].
-   */
-  spyOn(
-    object: Object,
-    methodName: string,
-    accessType?: 'get' | 'set'
-  ): JestMockFn<any, any>,
-  /**
-   * Set the default timeout interval for tests and before/after hooks in milliseconds.
-   * Note: The default timeout interval is 5 seconds if this method is not called.
-   */
-  setTimeout(timeout: number): JestObjectType,
+ /**
+  *  Disables automatic mocking in the module loader.
+  *
+  *  After this method is called, all `require()`s will return the real
+  *  versions of each module (rather than a mocked version).
+  */
+ disableAutomock(): JestObjectType,
+ /**
+  * An un-hoisted version of disableAutomock
+  */
+ autoMockOff(): JestObjectType,
+ /**
+  * Enables automatic mocking in the module loader.
+  */
+ enableAutomock(): JestObjectType,
+ /**
+  * An un-hoisted version of enableAutomock
+  */
+ autoMockOn(): JestObjectType,
+ /**
+  * Clears the mock.calls and mock.instances properties of all mocks.
+  * Equivalent to calling .mockClear() on every mocked function.
+  */
+ clearAllMocks(): JestObjectType,
+ /**
+  * Resets the state of all mocks. Equivalent to calling .mockReset() on every
+  * mocked function.
+  */
+ resetAllMocks(): JestObjectType,
+ /**
+  * Restores all mocks back to their original value.
+  */
+ restoreAllMocks(): JestObjectType,
+ /**
+  * Removes any pending timers from the timer system.
+  */
+ clearAllTimers(): void,
+ /**
+  * Returns the number of fake timers still left to run.
+  */
+ getTimerCount(): number,
+ /**
+  * The same as `mock` but not moved to the top of the expectation by
+  * babel-jest.
+  */
+ doMock(moduleName: string, moduleFactory?: any): JestObjectType,
+ /**
+  * The same as `unmock` but not moved to the top of the expectation by
+  * babel-jest.
+  */
+ dontMock(moduleName: string): JestObjectType,
+ /**
+  * Returns a new, unused mock function. Optionally takes a mock
+  * implementation.
+  */
+ fn<TArguments: $ReadOnlyArray<*>, TReturn>(
+   implementation?: (...args: TArguments) => TReturn
+ ): JestMockFn<TArguments, TReturn>,
+ /**
+  * Determines if the given function is a mocked function.
+  */
+ isMockFunction(fn: Function): boolean,
+ /**
+  * Given the name of a module, use the automatic mocking system to generate a
+  * mocked version of the module for you.
+  */
+ genMockFromModule(moduleName: string): any,
+ /**
+  * Mocks a module with an auto-mocked version when it is being required.
+  *
+  * The second argument can be used to specify an explicit module factory that
+  * is being run instead of using Jest's automocking feature.
+  *
+  * The third argument can be used to create virtual mocks -- mocks of modules
+  * that don't exist anywhere in the system.
+  */
+ mock(
+   moduleName: string,
+   moduleFactory?: any,
+   options?: Object
+ ): JestObjectType,
+ /**
+  * Returns the actual module instead of a mock, bypassing all checks on
+  * whether the module should receive a mock implementation or not.
+  */
+ requireActual<T>(m: $Flow$ModuleRef<T> | string): T,
+ /**
+  * Returns a mock module instead of the actual module, bypassing all checks
+  * on whether the module should be required normally or not.
+  */
+ requireMock(moduleName: string): any,
+ /**
+  * Resets the module registry - the cache of all required modules. This is
+  * useful to isolate modules where local state might conflict between tests.
+  */
+ resetModules(): JestObjectType,
+ /**
+  * Creates a sandbox registry for the modules that are loaded inside the
+  * callback function. This is useful to isolate specific modules for every
+  * test so that local module state doesn't conflict between tests.
+  */
+ isolateModules(fn: () => void): JestObjectType,
+ /**
+  * Exhausts the micro-task queue (usually interfaced in node via
+  * process.nextTick).
+  */
+ runAllTicks(): void,
+ /**
+  * Exhausts the macro-task queue (i.e., all tasks queued by setTimeout(),
+  * setInterval(), and setImmediate()).
+  */
+ runAllTimers(): void,
+ /**
+  * Exhausts all tasks queued by setImmediate().
+  */
+ runAllImmediates(): void,
+ /**
+  * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+  * or setInterval() and setImmediate()).
+  */
+ advanceTimersByTime(msToRun: number): void,
+ /**
+  * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+  * or setInterval() and setImmediate()).
+  *
+  * Renamed to `advanceTimersByTime`.
+  */
+ runTimersToTime(msToRun: number): void,
+ /**
+  * Executes only the macro-tasks that are currently pending (i.e., only the
+  * tasks that have been queued by setTimeout() or setInterval() up to this
+  * point)
+  */
+ runOnlyPendingTimers(): void,
+ /**
+  * Explicitly supplies the mock object that the module system should return
+  * for the specified module. Note: It is recommended to use jest.mock()
+  * instead.
+  */
+ setMock(moduleName: string, moduleExports: any): JestObjectType,
+ /**
+  * Indicates that the module system should never return a mocked version of
+  * the specified module from require() (e.g. that it should always return the
+  * real module).
+  */
+ unmock(moduleName: string): JestObjectType,
+ /**
+  * Instructs Jest to use fake versions of the standard timer functions
+  * (setTimeout, setInterval, clearTimeout, clearInterval, nextTick,
+  * setImmediate and clearImmediate).
+  */
+ useFakeTimers(): JestObjectType,
+ /**
+  * Instructs Jest to use the real versions of the standard timer functions.
+  */
+ useRealTimers(): JestObjectType,
+ /**
+  * Creates a mock function similar to jest.fn but also tracks calls to
+  * object[methodName].
+  */
+ spyOn(
+   object: Object,
+   methodName: string,
+   accessType?: 'get' | 'set'
+ ): JestMockFn<any, any>,
+ /**
+  * Set the default timeout interval for tests and before/after hooks in milliseconds.
+  * Note: The default timeout interval is 5 seconds if this method is not called.
+  */
+ setTimeout(timeout: number): JestObjectType,
+ ...
 };
 
-type JestSpyType = {
-  calls: JestCallsType,
-};
+type JestSpyType = { calls: JestCallsType, ... };
 
 type JestDoneFn = {|
   (error?: Error): void,
@@ -991,117 +957,111 @@ declare function beforeAll(
 
 /** A context for grouping tests together */
 declare var describe: {
-  /**
-   * Creates a block that groups together several related tests in one "test suite"
-   */
-  (name: JestTestName, fn: () => void): void,
-
-  /**
-   * Only run this describe block
-   */
-  only(name: JestTestName, fn: () => void): void,
-
-  /**
-   * Skip running this describe block
-   */
-  skip(name: JestTestName, fn: () => void): void,
-
-  /**
-   * each runs this test against array of argument arrays per each run
-   *
-   * @param {table} table of Test
-   */
-  each(
-    ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
-  ): (
-    name: JestTestName,
-    fn?: (...args: Array<any>) => ?Promise<mixed>,
-    timeout?: number
-  ) => void,
+ /**
+  * Creates a block that groups together several related tests in one "test suite"
+  */
+ (name: JestTestName, fn: () => void): void,
+ /**
+  * Only run this describe block
+  */
+ only(name: JestTestName, fn: () => void): void,
+ /**
+  * Skip running this describe block
+  */
+ skip(name: JestTestName, fn: () => void): void,
+ /**
+  * each runs this test against array of argument arrays per each run
+  *
+  * @param {table} table of Test
+  */
+ each(
+   ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+ ): (
+   name: JestTestName,
+   fn?: (...args: Array<any>) => ?Promise<mixed>,
+   timeout?: number
+ ) => void,
+ ...
 };
 
 /** An individual test unit */
 declare var it: {
-  /**
-   * An individual test unit
-   *
-   * @param {JestTestName} Name of Test
-   * @param {Function} Test
-   * @param {number} Timeout for the test, in milliseconds.
-   */
-  (
-    name: JestTestName,
-    fn?: (done: JestDoneFn) => ?Promise<mixed>,
-    timeout?: number
-  ): void,
-
-  /**
-   * Only run this test
-   *
-   * @param {JestTestName} Name of Test
-   * @param {Function} Test
-   * @param {number} Timeout for the test, in milliseconds.
-   */
-  only: {|
-    (
-      name: JestTestName,
-      fn?: (done: JestDoneFn) => ?Promise<mixed>,
-      timeout?: number
-    ): void,
-    each(
-      ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
-    ): (
-      name: JestTestName,
-      fn?: (...args: Array<any>) => ?Promise<mixed>,
-      timeout?: number
-    ) => void
-  |},
-
-  /**
-   * Skip running this test
-   *
-   * @param {JestTestName} Name of Test
-   * @param {Function} Test
-   * @param {number} Timeout for the test, in milliseconds.
-   */
-  skip(
-    name: JestTestName,
-    fn?: (done: JestDoneFn) => ?Promise<mixed>,
-    timeout?: number
-  ): void,
-
-  /**
-   * Highlight planned tests in the summary output
-   *
-   * @param {String} Name of Test to do
-   */
-  todo(name: string): void,
-
-  /**
-   * Run the test concurrently
-   *
-   * @param {JestTestName} Name of Test
-   * @param {Function} Test
-   * @param {number} Timeout for the test, in milliseconds.
-   */
-  concurrent(
-    name: JestTestName,
-    fn?: (done: JestDoneFn) => ?Promise<mixed>,
-    timeout?: number
-  ): void,
-
-  /**
-   * each runs this test against array of argument arrays per each run
-   *
-   * @param {table} table of Test
-   */
-  each(
-    ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
-  ): (
-    name: JestTestName,
-    fn?: (...args: Array<any>) => ?Promise<mixed>,
-    timeout?: number
-  ) => void,
+ /**
+  * An individual test unit
+  *
+  * @param {JestTestName} Name of Test
+  * @param {Function} Test
+  * @param {number} Timeout for the test, in milliseconds.
+  */
+ (
+   name: JestTestName,
+   fn?: (done: JestDoneFn) => ?Promise<mixed>,
+   timeout?: number
+ ): void,
+ /**
+  * Only run this test
+  *
+  * @param {JestTestName} Name of Test
+  * @param {Function} Test
+  * @param {number} Timeout for the test, in milliseconds.
+  */
+ only: {|
+   (
+     name: JestTestName,
+     fn?: (done: JestDoneFn) => ?Promise<mixed>,
+     timeout?: number
+   ): void,
+   each(
+     ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+   ): (
+     name: JestTestName,
+     fn?: (...args: Array<any>) => ?Promise<mixed>,
+     timeout?: number
+   ) => void
+ |},
+ /**
+  * Skip running this test
+  *
+  * @param {JestTestName} Name of Test
+  * @param {Function} Test
+  * @param {number} Timeout for the test, in milliseconds.
+  */
+ skip(
+   name: JestTestName,
+   fn?: (done: JestDoneFn) => ?Promise<mixed>,
+   timeout?: number
+ ): void,
+ /**
+  * Highlight planned tests in the summary output
+  *
+  * @param {String} Name of Test to do
+  */
+ todo(name: string): void,
+ /**
+  * Run the test concurrently
+  *
+  * @param {JestTestName} Name of Test
+  * @param {Function} Test
+  * @param {number} Timeout for the test, in milliseconds.
+  */
+ concurrent(
+   name: JestTestName,
+   fn?: (done: JestDoneFn) => ?Promise<mixed>,
+   timeout?: number
+ ): void,
+ /**
+  * each runs this test against array of argument arrays per each run
+  *
+  * @param {table} table of Test
+  */
+ each(
+   ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+ ): (
+   name: JestTestName,
+   fn?: (...args: Array<any>) => ?Promise<mixed>,
+   timeout?: number
+ ) => void,
+ ...
 };
 
 declare function fit(
@@ -1121,11 +1081,32 @@ declare var xit: typeof it;
 declare var xtest: typeof it;
 
 type JestPrettyFormatColors = {
-  comment: { close: string, open: string },
-  content: { close: string, open: string },
-  prop: { close: string, open: string },
-  tag: { close: string, open: string },
-  value: { close: string, open: string },
+ comment: {
+  close: string,
+  open: string,
+  ...
+ },
+ content: {
+  close: string,
+  open: string,
+  ...
+ },
+ prop: {
+  close: string,
+  open: string,
+  ...
+ },
+ tag: {
+  close: string,
+  open: string,
+  ...
+ },
+ value: {
+  close: string,
+  open: string,
+  ...
+ },
+ ...
 };
 
 type JestPrettyFormatIndent = string => string;
@@ -1154,51 +1135,53 @@ type JestPrettyFormatOptions = {|
 |};
 
 type JestPrettyFormatPlugin = {
-  print: (
-    val: any,
-    serialize: JestPrettyFormatPrint,
-    indent: JestPrettyFormatIndent,
-    opts: JestPrettyFormatOptions,
-    colors: JestPrettyFormatColors
-  ) => string,
-  test: any => boolean,
+ print: (
+   val: any,
+   serialize: JestPrettyFormatPrint,
+   indent: JestPrettyFormatIndent,
+   opts: JestPrettyFormatOptions,
+   colors: JestPrettyFormatColors
+ ) => string,
+ test: any => boolean,
+ ...
 };
 
 type JestPrettyFormatPlugins = Array<JestPrettyFormatPlugin>;
 
 /** The expect function is used every time you want to test a value */
 declare var expect: {
-  /** The object that you want to make assertions against */
-  (
-    value: any
-  ): JestExpectType &
-    JestPromiseType &
-    EnzymeMatchersType &
-    DomTestingLibraryType &
-    JestJQueryMatchersType &
-    JestStyledComponentsMatchersType &
-    JestExtendedMatchersType &
-    SnapshotDiffType,
-
-  /** Add additional Jasmine matchers to Jest's roster */
-  extend(matchers: { [name: string]: JestMatcher }): void,
-  /** Add a module that formats application-specific data structures. */
-  addSnapshotSerializer(pluginModule: JestPrettyFormatPlugin): void,
-  assertions(expectedAssertions: number): void,
-  hasAssertions(): void,
-  any(value: mixed): JestAsymmetricEqualityType,
-  anything(): any,
-  arrayContaining(value: Array<mixed>): Array<mixed>,
-  objectContaining(value: Object): Object,
-  /** Matches any received string that contains the exact expected string. */
-  stringContaining(value: string): string,
-  stringMatching(value: string | RegExp): string,
-  not: {
-    arrayContaining: (value: $ReadOnlyArray<mixed>) => Array<mixed>,
-    objectContaining: (value: {}) => Object,
-    stringContaining: (value: string) => string,
-    stringMatching: (value: string | RegExp) => string,
-  },
+ /** The object that you want to make assertions against */
+ (
+   value: any
+ ): JestExpectType &
+   JestPromiseType &
+   EnzymeMatchersType &
+   DomTestingLibraryType &
+   JestJQueryMatchersType &
+   JestStyledComponentsMatchersType &
+   JestExtendedMatchersType &
+   SnapshotDiffType,
+ /** Add additional Jasmine matchers to Jest's roster */
+ extend(matchers: { [name: string]: JestMatcher, ... }): void,
+ /** Add a module that formats application-specific data structures. */
+ addSnapshotSerializer(pluginModule: JestPrettyFormatPlugin): void,
+ assertions(expectedAssertions: number): void,
+ hasAssertions(): void,
+ any(value: mixed): JestAsymmetricEqualityType,
+ anything(): any,
+ arrayContaining(value: Array<mixed>): Array<mixed>,
+ objectContaining(value: Object): Object,
+ /** Matches any received string that contains the exact expected string. */
+ stringContaining(value: string): string,
+ stringMatching(value: string | RegExp): string,
+ not: {
+  arrayContaining: (value: $ReadOnlyArray<mixed>) => Array<mixed>,
+  objectContaining: (value: {...}) => Object,
+  stringContaining: (value: string) => string,
+  stringMatching: (value: string | RegExp) => string,
+  ...
+ },
+ ...
 };
 
 // TODO handle return type
@@ -1213,16 +1196,17 @@ declare var jest: JestObjectType;
  * using features inside here could break in later versions of Jest.
  */
 declare var jasmine: {
-  DEFAULT_TIMEOUT_INTERVAL: number,
-  any(value: mixed): JestAsymmetricEqualityType,
-  anything(): any,
-  arrayContaining(value: Array<mixed>): Array<mixed>,
-  clock(): JestClockType,
-  createSpy(name: string): JestSpyType,
-  createSpyObj(
-    baseName: string,
-    methodNames: Array<string>
-  ): { [methodName: string]: JestSpyType },
-  objectContaining(value: Object): Object,
-  stringMatching(value: string): string,
+ DEFAULT_TIMEOUT_INTERVAL: number,
+ any(value: mixed): JestAsymmetricEqualityType,
+ anything(): any,
+ arrayContaining(value: Array<mixed>): Array<mixed>,
+ clock(): JestClockType,
+ createSpy(name: string): JestSpyType,
+ createSpyObj(
+   baseName: string,
+   methodNames: Array<string>
+ ): { [methodName: string]: JestSpyType, ... },
+ objectContaining(value: Object): Object,
+ stringMatching(value: string): string,
+ ...
 };

--- a/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/test_jest-v25.x.x.js
@@ -739,3 +739,12 @@ expect(wrapper).toHaveDisplayName(true);
   // No type hint means we return any
   const FooModule3: boolean = jest.requireActual('FooModule');
 }
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise<'pineapple'>)
+

--- a/definitions/npm/jest_v26.x.x/flow_v0.104.x-v0.133.x/jest_v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.104.x-v0.133.x/jest_v26.x.x.js
@@ -1,3 +1,6 @@
+type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<PromiseMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   (...args: TArguments): TReturn,
   /**

--- a/definitions/npm/jest_v26.x.x/flow_v0.104.x-v0.133.x/test_jest-v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.104.x-v0.133.x/test_jest-v26.x.x.js
@@ -771,3 +771,11 @@ expect(wrapper).toHaveDisplayName(true);
   // No type hint means we return any
   const FooModule3: boolean = jest.requireActual('FooModule');
 }
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise<'pineapple'>)

--- a/definitions/npm/jest_v26.x.x/flow_v0.134.x-/jest_v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.134.x-/jest_v26.x.x.js
@@ -1,3 +1,6 @@
+type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<PromiseMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   (...args: TArguments): TReturn,
   /**

--- a/definitions/npm/jest_v26.x.x/flow_v0.134.x-/test_jest-v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.134.x-/test_jest-v26.x.x.js
@@ -800,3 +800,12 @@ it.each`
       // perform tests
   }
 );
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise<'pineapple'>)
+

--- a/definitions/npm/jest_v27.x.x/flow_v0.104.x-v0.133.x/jest_v27.x.x.js
+++ b/definitions/npm/jest_v27.x.x/flow_v0.104.x-v0.133.x/jest_v27.x.x.js
@@ -1,3 +1,6 @@
+type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<PromiseMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   (...args: TArguments): TReturn,
   /**
@@ -82,12 +85,12 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
    */
-  mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+  mockResolvedValue(value:  Depromisify<TReturn>): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
    */
   mockResolvedValueOnce(
-    value: TReturn
+    value: Depromisify<TReturn>
   ): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))
@@ -831,10 +834,14 @@ type JestObjectType = {
    */
   isMockFunction(fn: Function): boolean,
   /**
+   * Alias of `createMockFromModule`.
+   */
+  genMockFromModule(moduleName: string): any,
+  /**
    * Given the name of a module, use the automatic mocking system to generate a
    * mocked version of the module for you.
    */
-  genMockFromModule(moduleName: string): any,
+  createMockFromModule(moduleName: string): any,
   /**
    * Mocks a module with an auto-mocked version when it is being required.
    *
@@ -1033,11 +1040,20 @@ declare var it: {
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
-  skip(
-    name: JestTestName,
-    fn?: (done: JestDoneFn) => ?Promise<mixed>,
-    timeout?: number
-  ): void,
+  skip: {|
+    (
+      name: JestTestName,
+      fn?: (done: JestDoneFn) => ?Promise<mixed>,
+      timeout?: number
+    ): void,
+    each(
+      ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+    ): (
+      name: JestTestName,
+      fn?: (...args: Array<any>) => ?Promise<mixed>,
+      timeout?: number
+    ) => void,
+  |},
   /**
    * Highlight planned tests in the summary output
    *

--- a/definitions/npm/jest_v27.x.x/flow_v0.104.x-v0.133.x/test_jest-v27.x.x.js
+++ b/definitions/npm/jest_v27.x.x/flow_v0.104.x-v0.133.x/test_jest-v27.x.x.js
@@ -770,3 +770,13 @@ expect(wrapper).toHaveDisplayName(true);
   // No type hint means we return any
   const FooModule3: boolean = jest.requireActual('FooModule');
 }
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise<'pineapple'>)
+
+

--- a/definitions/npm/jest_v27.x.x/flow_v0.134.x-/jest_v27.x.x.js
+++ b/definitions/npm/jest_v27.x.x/flow_v0.134.x-/jest_v27.x.x.js
@@ -1,3 +1,6 @@
+type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<PromiseMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   (...args: TArguments): TReturn,
   /**
@@ -82,12 +85,12 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
    */
-  mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+  mockResolvedValue(value:  Depromisify<TReturn>): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
    */
   mockResolvedValueOnce(
-    value: TReturn
+    value: Depromisify<TReturn>
   ): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))

--- a/definitions/npm/jest_v27.x.x/flow_v0.134.x-/test_jest-v27.x.x.js
+++ b/definitions/npm/jest_v27.x.x/flow_v0.134.x-/test_jest-v27.x.x.js
@@ -798,3 +798,11 @@ it.each`
       // perform tests
   }
 );
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise<'pineapple'>)

--- a/definitions/npm/jest_v28.x.x/flow_v0.134.x-/jest_v28.x.x.js
+++ b/definitions/npm/jest_v28.x.x/flow_v0.134.x-/jest_v28.x.x.js
@@ -1,3 +1,6 @@
+type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<PromiseMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<any>, TReturn> = {
   (...args: TArguments): TReturn,
   /**
@@ -88,12 +91,12 @@ type JestMockFn<TArguments: $ReadOnlyArray<any>, TReturn> = {
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
    */
-  mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+  mockResolvedValue(value: Depromisify<TReturn>): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
    */
   mockResolvedValueOnce(
-    value: TReturn
+    value: Depromisify<TReturn>
   ): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))

--- a/definitions/npm/jest_v28.x.x/flow_v0.134.x-/test_jest_v28.x.x.js
+++ b/definitions/npm/jest_v28.x.x/flow_v0.134.x-/test_jest_v28.x.x.js
@@ -801,3 +801,17 @@ it.each`
 `('x=$x, y=$y, and z=$z', ({ x, y, z }) => {
   // perform tests
 });
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise.resolve('pineapple'))
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(3)
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(Promise.resolve('out of fruit ideas'))
+  // $FlowExpectedError[incompatible-call]
+  .mockReturnValue('got one: plum')

--- a/definitions/npm/jest_v29.x.x/flow_v0.134.x-/jest_v29.x.x.js
+++ b/definitions/npm/jest_v29.x.x/flow_v0.134.x-/jest_v29.x.x.js
@@ -1,3 +1,6 @@
+type DepromisifyMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<DepromisifyMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<any>, TReturn> = {
   (...args: TArguments): TReturn,
   /**
@@ -88,12 +91,12 @@ type JestMockFn<TArguments: $ReadOnlyArray<any>, TReturn> = {
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
    */
-  mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+  mockResolvedValue(value: DepromisifyMatcher<TReturn>): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
    */
   mockResolvedValueOnce(
-    value: TReturn
+    value: DepromisifyMatcher<TReturn>
   ): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))

--- a/definitions/npm/jest_v29.x.x/flow_v0.134.x-/test_jest_v29.x.x.js
+++ b/definitions/npm/jest_v29.x.x/flow_v0.134.x-/test_jest_v29.x.x.js
@@ -801,3 +801,12 @@ it.each`
 `('x=$x, y=$y, and z=$z', ({ x, y, z }) => {
   // perform tests
 });
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise.resolve('pineapple'))
+


### PR DESCRIPTION
- Links to documentation: https://jestjs.io/docs/mock-function-api/#mockfnmockresolvedvaluevalue
- Type of contribution: Fix

**Problem:**
Jest definitions for **mockResolvedValue** (and **mockResolvedValueOnce**) are incorrect:
- current definition forces you to use a Promise as input, which is incorrect
- the fact that there are no tests for **mockResolvedValue** also hints to a problem in the typing

**Solution:**
- Use the following util to "depromisify" the return value of a mocked function, and use that as input for **mockResolvedValue**

```
type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
type Depromisify<X> = $Call<PromiseMatcher, X, X>;
```