### PR TITLE
Fix jest mockResolveValue typing

### DIFF
--- a/definitions/npm/jest_v24.x.x/flow_v0.61.x-v0.103.x/jest_v24.x.x.js
+++ b/definitions/npm/jest_v24.x.x/flow_v0.61.x-v0.103.x/jest_v24.x.x.js
@@ -82,7 +82,7 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
    * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
    */
   mockResolvedValueOnce(
-    value: TReturn
+    value: Depromisify<TReturn>
   ): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))

--- a/definitions/npm/jest_v25.x.x/flow_v0.104.x-v0.133.x/jest_v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.104.x-v0.133.x/jest_v25.x.x.js
@@ -1,3 +1,6 @@
+type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<PromiseMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
  (...args: TArguments): TReturn,
  /**

--- a/definitions/npm/jest_v25.x.x/flow_v0.104.x-v0.133.x/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.104.x-v0.133.x/test_jest-v25.x.x.js
@@ -746,3 +746,17 @@ expect(wrapper).toHaveDisplayName(true);
   // No type hint means we return any
   const FooModule3: boolean = jest.requireActual('FooModule');
 }
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise.resolve('pineapple'))
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(3)
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(Promise.resolve('out of fruit ideas'))
+  // $FlowExpectedError[incompatible-call]
+  .mockReturnValue('got one: plum')

--- a/definitions/npm/jest_v25.x.x/flow_v0.134.x-/jest_v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.134.x-/jest_v25.x.x.js
@@ -1,3 +1,6 @@
+type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<PromiseMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
  (...args: TArguments): TReturn,
  /**

--- a/definitions/npm/jest_v25.x.x/flow_v0.134.x-/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.134.x-/test_jest-v25.x.x.js
@@ -758,3 +758,17 @@ it.each`
       // perform tests
   }
 );
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise.resolve('pineapple'))
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(3)
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(Promise.resolve('out of fruit ideas'))
+  // $FlowExpectedError[incompatible-call]
+  .mockReturnValue('got one: plum')

--- a/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/jest_v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/jest_v25.x.x.js
@@ -1,3 +1,6 @@
+type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<PromiseMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   (...args: TArguments): TReturn,
   /**
@@ -77,12 +80,12 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
    */
-  mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+  mockResolvedValue(value: Depromisify<TReturn>): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
    */
   mockResolvedValueOnce(
-    value: TReturn
+    value: Depromisify<TReturn>
   ): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))

--- a/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/test_jest-v25.x.x.js
+++ b/definitions/npm/jest_v25.x.x/flow_v0.61.x-v0.103.x/test_jest-v25.x.x.js
@@ -739,3 +739,17 @@ expect(wrapper).toHaveDisplayName(true);
   // No type hint means we return any
   const FooModule3: boolean = jest.requireActual('FooModule');
 }
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise.resolve('pineapple'))
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(3)
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(Promise.resolve('out of fruit ideas'))
+  // $FlowExpectedError[incompatible-call]
+  .mockReturnValue('got one: plum')

--- a/definitions/npm/jest_v26.x.x/flow_v0.104.x-v0.133.x/jest_v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.104.x-v0.133.x/jest_v26.x.x.js
@@ -1,3 +1,6 @@
+type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<PromiseMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   (...args: TArguments): TReturn,
   /**
@@ -82,12 +85,12 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
    */
-  mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+  mockResolvedValue(value: Depromisify<TReturn>): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
    */
   mockResolvedValueOnce(
-    value: TReturn
+    value: Depromisify<TReturn>
   ): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))

--- a/definitions/npm/jest_v26.x.x/flow_v0.104.x-v0.133.x/test_jest-v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.104.x-v0.133.x/test_jest-v26.x.x.js
@@ -771,3 +771,17 @@ expect(wrapper).toHaveDisplayName(true);
   // No type hint means we return any
   const FooModule3: boolean = jest.requireActual('FooModule');
 }
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise.resolve('pineapple'))
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(3)
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(Promise.resolve('out of fruit ideas'))
+  // $FlowExpectedError[incompatible-call]
+  .mockReturnValue('got one: plum')

--- a/definitions/npm/jest_v26.x.x/flow_v0.134.x-/jest_v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.134.x-/jest_v26.x.x.js
@@ -1,3 +1,6 @@
+type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<PromiseMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   (...args: TArguments): TReturn,
   /**
@@ -82,12 +85,12 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
    */
-  mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+  mockResolvedValue(value: Depromisify<TReturn>): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
    */
   mockResolvedValueOnce(
-    value: TReturn
+    value: Depromisify<TReturn>
   ): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))

--- a/definitions/npm/jest_v26.x.x/flow_v0.134.x-/test_jest-v26.x.x.js
+++ b/definitions/npm/jest_v26.x.x/flow_v0.134.x-/test_jest-v26.x.x.js
@@ -800,3 +800,18 @@ it.each`
       // perform tests
   }
 );
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise.resolve('pineapple'))
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(3)
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(Promise.resolve('out of fruit ideas'))
+  // $FlowExpectedError[incompatible-call]
+  .mockReturnValue('got one: plum')
+

--- a/definitions/npm/jest_v27.x.x/flow_v0.104.x-v0.133.x/jest_v27.x.x.js
+++ b/definitions/npm/jest_v27.x.x/flow_v0.104.x-v0.133.x/jest_v27.x.x.js
@@ -1,3 +1,6 @@
+type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<PromiseMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   (...args: TArguments): TReturn,
   /**
@@ -82,12 +85,12 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
    */
-  mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+  mockResolvedValue(value:  Depromisify<TReturn>): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
    */
   mockResolvedValueOnce(
-    value: TReturn
+    value: Depromisify<TReturn>
   ): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))
@@ -831,10 +834,14 @@ type JestObjectType = {
    */
   isMockFunction(fn: Function): boolean,
   /**
+   * Alias of `createMockFromModule`.
+   */
+  genMockFromModule(moduleName: string): any,
+  /**
    * Given the name of a module, use the automatic mocking system to generate a
    * mocked version of the module for you.
    */
-  genMockFromModule(moduleName: string): any,
+  createMockFromModule(moduleName: string): any,
   /**
    * Mocks a module with an auto-mocked version when it is being required.
    *
@@ -1033,11 +1040,20 @@ declare var it: {
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
-  skip(
-    name: JestTestName,
-    fn?: (done: JestDoneFn) => ?Promise<mixed>,
-    timeout?: number
-  ): void,
+  skip: {|
+    (
+      name: JestTestName,
+      fn?: (done: JestDoneFn) => ?Promise<mixed>,
+      timeout?: number
+    ): void,
+    each(
+      ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+    ): (
+      name: JestTestName,
+      fn?: (...args: Array<any>) => ?Promise<mixed>,
+      timeout?: number
+    ) => void,
+  |},
   /**
    * Highlight planned tests in the summary output
    *

--- a/definitions/npm/jest_v27.x.x/flow_v0.104.x-v0.133.x/test_jest-v27.x.x.js
+++ b/definitions/npm/jest_v27.x.x/flow_v0.104.x-v0.133.x/test_jest-v27.x.x.js
@@ -770,3 +770,19 @@ expect(wrapper).toHaveDisplayName(true);
   // No type hint means we return any
   const FooModule3: boolean = jest.requireActual('FooModule');
 }
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise.resolve('pineapple'))
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(3)
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(Promise.resolve('out of fruit ideas'))
+  // $FlowExpectedError[incompatible-call]
+  .mockReturnValue('got one: plum')
+
+

--- a/definitions/npm/jest_v27.x.x/flow_v0.134.x-/jest_v27.x.x.js
+++ b/definitions/npm/jest_v27.x.x/flow_v0.134.x-/jest_v27.x.x.js
@@ -1,3 +1,6 @@
+type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<PromiseMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   (...args: TArguments): TReturn,
   /**
@@ -82,12 +85,12 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
    */
-  mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+  mockResolvedValue(value:  Depromisify<TReturn>): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
    */
   mockResolvedValueOnce(
-    value: TReturn
+    value: Depromisify<TReturn>
   ): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))

--- a/definitions/npm/jest_v27.x.x/flow_v0.134.x-/test_jest-v27.x.x.js
+++ b/definitions/npm/jest_v27.x.x/flow_v0.134.x-/test_jest-v27.x.x.js
@@ -798,3 +798,17 @@ it.each`
       // perform tests
   }
 );
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise.resolve('pineapple'))
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(3)
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(Promise.resolve('out of fruit ideas'))
+  // $FlowExpectedError[incompatible-call]
+  .mockReturnValue('got one: plum')

--- a/definitions/npm/jest_v28.x.x/flow_v0.134.x-/jest_v28.x.x.js
+++ b/definitions/npm/jest_v28.x.x/flow_v0.134.x-/jest_v28.x.x.js
@@ -1,3 +1,6 @@
+type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<PromiseMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<any>, TReturn> = {
   (...args: TArguments): TReturn,
   /**
@@ -88,12 +91,12 @@ type JestMockFn<TArguments: $ReadOnlyArray<any>, TReturn> = {
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
    */
-  mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+  mockResolvedValue(value: Depromisify<TReturn>): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
    */
   mockResolvedValueOnce(
-    value: TReturn
+    value: Depromisify<TReturn>
   ): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))

--- a/definitions/npm/jest_v28.x.x/flow_v0.134.x-/test_jest_v28.x.x.js
+++ b/definitions/npm/jest_v28.x.x/flow_v0.134.x-/test_jest_v28.x.x.js
@@ -801,3 +801,17 @@ it.each`
 `('x=$x, y=$y, and z=$z', ({ x, y, z }) => {
   // perform tests
 });
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise.resolve('pineapple'))
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(3)
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(Promise.resolve('out of fruit ideas'))
+  // $FlowExpectedError[incompatible-call]
+  .mockReturnValue('got one: plum')

--- a/definitions/npm/jest_v29.x.x/flow_v0.134.x-/jest_v29.x.x.js
+++ b/definitions/npm/jest_v29.x.x/flow_v0.134.x-/jest_v29.x.x.js
@@ -1,3 +1,6 @@
+type DepromisifyMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
+type Depromisify<X> = $Call<DepromisifyMatcher, X, X>;
+
 type JestMockFn<TArguments: $ReadOnlyArray<any>, TReturn> = {
   (...args: TArguments): TReturn,
   /**
@@ -88,12 +91,12 @@ type JestMockFn<TArguments: $ReadOnlyArray<any>, TReturn> = {
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
    */
-  mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+  mockResolvedValue(value: DepromisifyMatcher<TReturn>): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
    */
   mockResolvedValueOnce(
-    value: TReturn
+    value: DepromisifyMatcher<TReturn>
   ): JestMockFn<TArguments, Promise<TReturn>>,
   /**
    * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))

--- a/definitions/npm/jest_v29.x.x/flow_v0.134.x-/test_jest_v29.x.x.js
+++ b/definitions/npm/jest_v29.x.x/flow_v0.134.x-/test_jest_v29.x.x.js
@@ -801,3 +801,18 @@ it.each`
 `('x=$x, y=$y, and z=$z', ({ x, y, z }) => {
   // perform tests
 });
+
+const mock = jest.fn().mockImplementation(async (): Promise<string> => 'banana');
+
+mock
+  .mockResolvedValue('orange')
+  .mockReturnValue(Promise.resolve('apple'))
+  .mockResolvedValueOnce('tomato')
+  .mockImplementation(() => Promise.resolve('pineapple'))
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(3)
+  // $FlowExpectedError[incompatible-call]
+  .mockResolvedValue(Promise.resolve('out of fruit ideas'))
+  // $FlowExpectedError[incompatible-call]
+  .mockReturnValue('got one: plum')
+


### PR DESCRIPTION
- Links to documentation: https://jestjs.io/docs/mock-function-api/#mockfnmockresolvedvaluevalue
- Type of contribution: Fix

**Problem:**
Jest definitions for **mockResolvedValue** (and **mockResolvedValueOnce**) are incorrect:
- current definition forces you to use a Promise as input, which is incorrect
- the fact that there are no tests for **mockResolvedValue** also hints to a problem in the typing

**Solution:**
- Use the following util to "depromisify" the return value of a mocked function, and use that as input for **mockResolvedValue**

```
type PromiseMatcher = (<T>(Promise<T>, any) => T) & (<T>(any, T) => T);
type Depromisify<X> = $Call<PromiseMatcher, X, X>;
```