### PR TITLE
[environments] Add a few prefixed node core libs

### DIFF
--- a/definitions/environments/node/flow_v0.155.x-/node.js
+++ b/definitions/environments/node/flow_v0.155.x-/node.js
@@ -1,0 +1,35 @@
+// https://nodejs.org/api/fs.html#promises-api
+
+declare module 'fs/promises' {
+  declare module.exports: $Exports<'fs'>['promises'];
+}
+
+// https://nodejs.org/api/esm.html#node-imports
+
+declare module 'node:events' {
+  declare module.exports: $Exports<'events'>;
+}
+
+declare module 'node:fs' {
+  declare module.exports: $Exports<'fs'>;
+}
+
+declare module 'node:fs/promises' {
+  declare module.exports: $Exports<'fs'>['promises'];
+}
+
+declare module 'node:os' {
+  declare module.exports: $Exports<'os'>;
+}
+
+declare module 'node:path' {
+  declare module.exports: $Exports<'path'>;
+}
+
+declare module 'node:util' {
+  declare module.exports: $Exports<'util'>;
+}
+
+declare module 'node:url' {
+  declare module.exports: $Exports<'url'>;
+}

--- a/definitions/environments/node/flow_v0.155.x-/test_node.js
+++ b/definitions/environments/node/flow_v0.155.x-/test_node.js
@@ -1,0 +1,68 @@
+// @flow
+import { describe, it } from 'flow-typed-test';
+
+import events from 'events';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import util from 'util';
+import url from 'url';
+
+import nodeEvents from 'node:events';
+import fsPromises from 'fs/promises';
+import nodeFs from 'node:fs';
+import nodeFsPromises from 'node:fs/promises';
+import nodeOs from 'node:os';
+import nodePath from 'node:path';
+import nodeUtil from 'node:util';
+import nodeUrl from 'node:url';
+
+describe('node', () => {
+  describe('node:events', () => {
+    it('should retrieve the corresponding Flow core types', () => {
+      (nodeEvents.EventEmitter: typeof events.EventEmitter);
+    });
+  });
+
+  describe('fs/promises', () => {
+    it('should retrieve the corresponding Flow core types', () => {
+      (fsPromises.writeFile: typeof fs.promises.writeFile);
+    });
+  });
+
+  describe('node:fs', () => {
+    it('should retrieve the corresponding Flow core types', () => {
+      (nodeFs.writeFile: typeof fs.writeFile);
+    });
+  });
+
+  describe('node:os', () => {
+    it('should retrieve the corresponding Flow core types', () => {
+      (nodeOs.cpus: typeof os.cpus);
+    });
+  });
+
+  describe('node:fs/promises', () => {
+    it('should retrieve the corresponding Flow core types', () => {
+      (nodeFsPromises.writeFile: typeof fs.promises.writeFile);
+    });
+  });
+
+  describe('node:path', () => {
+    it('should retrieve the corresponding Flow core types', () => {
+      (nodePath.resolve: typeof path.resolve);
+    });
+  });
+
+  describe('node:util', () => {
+    it('should retrieve the corresponding Flow core types', () => {
+      (nodeUtil.inspect: typeof util.inspect);
+    });
+  });
+
+  describe('node:url', () => {
+    it('should retrieve the corresponding Flow core types', () => {
+      (nodeUrl.pathToFileURL: typeof url.pathToFileURL);
+    });
+  });
+});


### PR DESCRIPTION
- Links to documentation: https://nodejs.org/api/esm.html#node-imports
- Type of contribution: addition

Other notes:
Following a discussion on Discord, adding a few common prefixed node core libs aliases. 
More will be added as needed I guess? Or should we dump the whole thing at once?
`flow_v0155.x-` because of indexed access.    



