### PR TITLE
[docs] Fix jsx env code sample

### DIFF
--- a/docs/env-definitions.md
+++ b/docs/env-definitions.md
@@ -36,7 +36,7 @@ But with environment definitions serving reusable type definitions, at the minim
 
 ```js
 type Props = {|
-  ...$Exact<jsx$HTMLElement$Attributes>,
+  ...$Exact<jsx$HTMLElement>,
   foo: string,
 |};
 


### PR DESCRIPTION
- Type of contribution: fix

Other notes:
Within the `jsx` environment there's no `$Attributes`  type associated with `jsx$HTMLElement`. 
Depending on the initial implementation idea should we:
- remove it from the docs?
- Add it to the env?

