### PR TITLE
[mocha] Copy v9/10 defs

### DIFF
--- a/definitions/npm/mocha_v10.x.x/flow_v0.104.x-/mocha_v10.x.x.js
+++ b/definitions/npm/mocha_v10.x.x/flow_v0.104.x-/mocha_v10.x.x.js
@@ -1,0 +1,235 @@
+declare interface $npm$mocha$SetupOptions {
+  slow?: number;
+  timeout?: number;
+  ui?: string;
+  globals?: Array<any>;
+  reporter?: any;
+  bail?: boolean;
+  ignoreLeaks?: boolean;
+  grep?: any;
+}
+
+declare type $npm$mocha$done = (error?: any) => any;
+
+// declare interface $npm$mocha$SuiteCallbackContext {
+//   timeout(ms: number): void;
+//   retries(n: number): void;
+//   slow(ms: number): void;
+// }
+
+// declare interface $npm$mocha$TestCallbackContext {
+//   skip(): void;
+//   timeout(ms: number): void;
+//   retries(n: number): void;
+//   slow(ms: number): void;
+//   [index: string]: any;
+// }
+
+declare interface $npm$mocha$Suite {
+  parent: $npm$mocha$Suite;
+  title: string;
+  fullTitle(): string;
+}
+
+declare type $npm$mocha$ContextDefinition = {|
+  (description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): $npm$mocha$Suite;
+  only(description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): $npm$mocha$Suite;
+  skip(description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): void;
+  timeout(ms: number): void;
+|}
+
+declare type $npm$mocha$TestDefinition = {|
+  (expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): $npm$mocha$Test;
+  only(expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): $npm$mocha$Test;
+  skip(expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+  timeout(ms: number): void;
+  state: 'failed' | 'passed';
+|}
+
+declare interface $npm$mocha$Runner {}
+
+declare class $npm$mocha$BaseReporter {
+  stats: {
+    suites: number,
+    tests: number,
+    passes: number,
+    pending: number,
+    failures: number,
+    ...
+  };
+
+  constructor(runner: $npm$mocha$Runner): $npm$mocha$BaseReporter;
+}
+
+declare class $npm$mocha$DocReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$DotReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$HTMLReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$HTMLCovReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$JSONReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$JSONCovReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$JSONStreamReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$LandingReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$ListReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$MarkdownReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$MinReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$NyanReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$ProgressReporter extends $npm$mocha$BaseReporter {
+  constructor(runner: $npm$mocha$Runner, options?: {
+    open?: string,
+    complete?: string,
+    incomplete?: string,
+    close?: string,
+    ...
+  }): $npm$mocha$ProgressReporter;
+}
+declare class $npm$mocha$SpecReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$TAPReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$XUnitReporter extends $npm$mocha$BaseReporter {
+  constructor(runner: $npm$mocha$Runner, options?: any): $npm$mocha$XUnitReporter;
+}
+
+declare class $npm$mocha$Mocha {
+  currentTest: $npm$mocha$TestDefinition;
+  constructor(options?: {
+    grep?: RegExp,
+    ui?: string,
+    reporter?: string,
+    timeout?: number,
+    reporterOptions?: any,
+    slow?: number,
+    bail?: boolean,
+    ...
+  }): $npm$mocha$Mocha;
+  setup(options: $npm$mocha$SetupOptions): this;
+  bail(value?: boolean): this;
+  addFile(file: string): this;
+  reporter(name: string): this;
+  reporter(reporter: (runner: $npm$mocha$Runner, options: any) => any): this;
+  ui(value: string): this;
+  grep(value: string): this;
+  grep(value: RegExp): this;
+  invert(): this;
+  ignoreLeaks(value: boolean): this;
+  checkLeaks(): this;
+  throwError(error: Error): void;
+  growl(): this;
+  globals(value: string): this;
+  globals(values: Array<string>): this;
+  useColors(value: boolean): this;
+  useInlineDiffs(value: boolean): this;
+  timeout(value: number): this;
+  slow(value: number): this;
+  enableTimeouts(value: boolean): this;
+  asyncOnly(value: boolean): this;
+  noHighlighting(value: boolean): this;
+  run(onComplete?: (failures: number) => void): $npm$mocha$Runner;
+
+  static reporters: {
+    Doc: $npm$mocha$DocReporter,
+    Dot: $npm$mocha$DotReporter,
+    HTML: $npm$mocha$HTMLReporter,
+    HTMLCov: $npm$mocha$HTMLCovReporter,
+    JSON: $npm$mocha$JSONReporter,
+    JSONCov: $npm$mocha$JSONCovReporter,
+    JSONStream: $npm$mocha$JSONStreamReporter,
+    Landing: $npm$mocha$LandingReporter,
+    List: $npm$mocha$ListReporter,
+    Markdown: $npm$mocha$MarkdownReporter,
+    Min: $npm$mocha$MinReporter,
+    Nyan: $npm$mocha$NyanReporter,
+    Progress: $npm$mocha$ProgressReporter,
+    ...
+  };
+}
+
+// declare interface $npm$mocha$HookCallbackContext {
+//   skip(): void;
+//   timeout(ms: number): void;
+//   [index: string]: any;
+// }
+
+declare interface $npm$mocha$Runnable {
+  title: string;
+  fn: Function;
+  async: boolean;
+  sync: boolean;
+  timedOut: boolean;
+}
+
+declare interface $npm$mocha$Test extends $npm$mocha$Runnable {
+  parent: $npm$mocha$Suite;
+  pending: boolean;
+  state: 'failed' | 'passed' | void;
+  fullTitle(): string;
+  timeout(ms: number): void;
+}
+
+// declare interface $npm$mocha$BeforeAndAfterContext extends $npm$mocha$HookCallbackContext {
+//   currentTest: $npm$mocha$Test;
+// }
+
+declare var mocha: $npm$mocha$Mocha;
+declare var describe: $npm$mocha$ContextDefinition;
+declare var xdescribe: $npm$mocha$ContextDefinition;
+declare var context: $npm$mocha$ContextDefinition;
+declare var suite: $npm$mocha$ContextDefinition;
+declare var it: $npm$mocha$TestDefinition;
+declare var xit: $npm$mocha$TestDefinition;
+declare var test: $npm$mocha$TestDefinition;
+declare var specify: $npm$mocha$TestDefinition;
+
+type Run = () => void;
+
+declare var run: Run;
+
+type Setup = (callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void;
+type Teardown = (callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void;
+type SuiteSetup = (callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void;
+type SuiteTeardown = (callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void;
+type Before =
+  | (callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void
+  | (description: string, callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void;
+type After =
+  | (callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void
+  | (description: string, callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void;
+type BeforeEach =
+  | (callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void
+  | (description: string, callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void;
+type AfterEach =
+  | (callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void
+  | (description: string, callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void;
+
+
+declare var setup: Setup;
+declare var teardown: Teardown;
+declare var suiteSetup: SuiteSetup;
+declare var suiteTeardown: SuiteTeardown;
+declare var before: Before
+declare var after: After;
+declare var beforeEach: BeforeEach;
+declare var afterEach: AfterEach;
+
+declare module "mocha" {
+  declare export var mocha: $npm$mocha$TestDefinition;
+  declare export var describe: $npm$mocha$ContextDefinition;
+  declare export var xdescribe: $npm$mocha$ContextDefinition;
+  declare export var context: $npm$mocha$ContextDefinition;
+  declare export var suite: $npm$mocha$ContextDefinition;
+  declare export var it: $npm$mocha$TestDefinition;
+  declare export var xit: $npm$mocha$TestDefinition;
+  declare export var test: $npm$mocha$TestDefinition;
+  declare export var specify: $npm$mocha$TestDefinition;
+
+  declare export var run: Run;
+
+  declare export var setup: Setup;
+  declare export var teardown: Teardown;
+  declare export var suiteSetup: SuiteSetup;
+  declare export var suiteTeardown: SuiteTeardown;
+  declare export var before: Before;
+  declare export var after: After;
+  declare export var beforeEach: BeforeEach;
+  declare export var afterEach: AfterEach;
+
+  declare export default $npm$mocha$Mocha;
+}

--- a/definitions/npm/mocha_v10.x.x/flow_v0.28.x-v0.103.x/mocha_v10.x.x.js
+++ b/definitions/npm/mocha_v10.x.x/flow_v0.28.x-v0.103.x/mocha_v10.x.x.js
@@ -1,0 +1,219 @@
+declare interface $npm$mocha$SetupOptions {
+  slow?: number;
+  timeout?: number;
+  ui?: string;
+  globals?: Array<any>;
+  reporter?: any;
+  bail?: boolean;
+  ignoreLeaks?: boolean;
+  grep?: any;
+}
+
+declare type $npm$mocha$done = (error?: any) => any;
+
+// declare interface $npm$mocha$SuiteCallbackContext {
+//   timeout(ms: number): void;
+//   retries(n: number): void;
+//   slow(ms: number): void;
+// }
+
+// declare interface $npm$mocha$TestCallbackContext {
+//   skip(): void;
+//   timeout(ms: number): void;
+//   retries(n: number): void;
+//   slow(ms: number): void;
+//   [index: string]: any;
+// }
+
+declare interface $npm$mocha$Suite {
+  parent: $npm$mocha$Suite;
+  title: string;
+  fullTitle(): string;
+}
+
+declare interface $npm$mocha$ContextDefinition {
+  (description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): $npm$mocha$Suite;
+  only(description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): $npm$mocha$Suite;
+  skip(description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): void;
+  timeout(ms: number): void;
+}
+
+declare interface $npm$mocha$TestDefinition {
+  (expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): $npm$mocha$Test;
+  only(expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): $npm$mocha$Test;
+  skip(expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+  timeout(ms: number): void;
+  state: 'failed' | 'passed';
+}
+
+declare interface $npm$mocha$Runner {}
+
+declare class $npm$mocha$BaseReporter {
+  stats: {
+    suites: number;
+    tests: number;
+    passes: number;
+    pending: number;
+    failures: number;
+  };
+
+  constructor(runner: $npm$mocha$Runner): $npm$mocha$BaseReporter;
+}
+
+declare class $npm$mocha$DocReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$DotReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$HTMLReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$HTMLCovReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$JSONReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$JSONCovReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$JSONStreamReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$LandingReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$ListReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$MarkdownReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$MinReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$NyanReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$ProgressReporter extends $npm$mocha$BaseReporter {
+  constructor(runner: $npm$mocha$Runner, options?: {
+    open?: string;
+    complete?: string;
+    incomplete?: string;
+    close?: string;
+  }): $npm$mocha$ProgressReporter;
+}
+declare class $npm$mocha$SpecReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$TAPReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$XUnitReporter extends $npm$mocha$BaseReporter {
+  constructor(runner: $npm$mocha$Runner, options?: any): $npm$mocha$XUnitReporter;
+}
+
+declare class $npm$mocha$Mocha {
+  currentTest: $npm$mocha$TestDefinition;
+  constructor(options?: {
+    grep?: RegExp;
+    ui?: string;
+    reporter?: string;
+    timeout?: number;
+    reporterOptions?: any;
+    slow?: number;
+    bail?: boolean;
+  }): $npm$mocha$Mocha;
+  setup(options: $npm$mocha$SetupOptions): this;
+  bail(value?: boolean): this;
+  addFile(file: string): this;
+  reporter(name: string): this;
+  reporter(reporter: (runner: $npm$mocha$Runner, options: any) => any): this;
+  ui(value: string): this;
+  grep(value: string): this;
+  grep(value: RegExp): this;
+  invert(): this;
+  ignoreLeaks(value: boolean): this;
+  checkLeaks(): this;
+  throwError(error: Error): void;
+  growl(): this;
+  globals(value: string): this;
+  globals(values: Array<string>): this;
+  useColors(value: boolean): this;
+  useInlineDiffs(value: boolean): this;
+  timeout(value: number): this;
+  slow(value: number): this;
+  enableTimeouts(value: boolean): this;
+  asyncOnly(value: boolean): this;
+  noHighlighting(value: boolean): this;
+  run(onComplete?: (failures: number) => void): $npm$mocha$Runner;
+
+  static reporters: {
+    Doc: $npm$mocha$DocReporter,
+    Dot: $npm$mocha$DotReporter,
+    HTML: $npm$mocha$HTMLReporter,
+    HTMLCov: $npm$mocha$HTMLCovReporter,
+    JSON: $npm$mocha$JSONReporter,
+    JSONCov: $npm$mocha$JSONCovReporter,
+    JSONStream: $npm$mocha$JSONStreamReporter,
+    Landing: $npm$mocha$LandingReporter,
+    List: $npm$mocha$ListReporter,
+    Markdown: $npm$mocha$MarkdownReporter,
+    Min: $npm$mocha$MinReporter,
+    Nyan: $npm$mocha$NyanReporter,
+    Progress: $npm$mocha$ProgressReporter,
+  };
+}
+
+// declare interface $npm$mocha$HookCallbackContext {
+//   skip(): void;
+//   timeout(ms: number): void;
+//   [index: string]: any;
+// }
+
+declare interface $npm$mocha$Runnable {
+  title: string;
+  fn: Function;
+  async: boolean;
+  sync: boolean;
+  timedOut: boolean;
+}
+
+declare interface $npm$mocha$Test extends $npm$mocha$Runnable {
+  parent: $npm$mocha$Suite;
+  pending: boolean;
+  state: 'failed' | 'passed' | void;
+  fullTitle(): string;
+  timeout(ms: number): void;
+}
+
+// declare interface $npm$mocha$BeforeAndAfterContext extends $npm$mocha$HookCallbackContext {
+//   currentTest: $npm$mocha$Test;
+// }
+
+declare var mocha: $npm$mocha$Mocha;
+declare var describe: $npm$mocha$ContextDefinition;
+declare var xdescribe: $npm$mocha$ContextDefinition;
+declare var context: $npm$mocha$ContextDefinition;
+declare var suite: $npm$mocha$ContextDefinition;
+declare var it: $npm$mocha$TestDefinition;
+declare var xit: $npm$mocha$TestDefinition;
+declare var test: $npm$mocha$TestDefinition;
+declare var specify: $npm$mocha$TestDefinition;
+
+declare function run(): void;
+
+declare function setup(callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
+declare function teardown(callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
+declare function suiteSetup(callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+declare function suiteTeardown(callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+declare function before(callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+declare function before(description: string, callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+declare function after(callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+declare function after(description: string, callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+declare function beforeEach(callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
+declare function beforeEach(description: string, callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
+declare function afterEach(callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
+declare function afterEach(description: string, callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
+
+declare module "mocha" {
+  declare export var mocha: typeof mocha;
+  declare export var describe: typeof describe;
+  declare export var xdescribe: typeof xdescribe;
+  declare export var context: typeof context;
+  declare export var suite: typeof suite;
+  declare export var it: typeof it;
+  declare export var xit: typeof xit;
+  declare export var test: typeof test;
+  declare export var specify: typeof specify;
+
+  declare export var run: typeof run;
+
+  declare export var setup: typeof setup;
+  declare export var teardown: typeof teardown;
+  declare export var suiteSetup: typeof suiteSetup;
+  declare export var suiteTeardown: typeof suiteTeardown;
+  declare export var before: typeof before;
+  declare export var before: typeof before;
+  declare export var after: typeof after;
+  declare export var after: typeof after;
+  declare export var beforeEach: typeof beforeEach;
+  declare export var beforeEach: typeof beforeEach;
+  declare export var afterEach: typeof afterEach;
+  declare export var afterEach: typeof afterEach;
+
+  declare export default $npm$mocha$Mocha;
+}

--- a/definitions/npm/mocha_v10.x.x/test_mocha_v10.x.x_context.js
+++ b/definitions/npm/mocha_v10.x.x/test_mocha_v10.x.x_context.js
@@ -1,0 +1,50 @@
+/* @flow */
+
+/**
+ * context
+ */
+
+context('desc', () => {});
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+context('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with undefined.
+context('desc', () => 1);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+context(12, () => {});
+
+
+/**
+ * context.skip
+ */
+
+context.skip('desc', () => {});
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+context.skip('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with undefined.
+context.skip('desc', () => 1);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+context.skip(12, () => {});
+
+/**
+ * context.only
+ */
+
+context.only('desc', () => {});
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+context.only('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with undefined.
+context.only('desc', () => 1);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+context.only(12, () => {});
+
+/**
+ * context.timeout
+ */
+
+context.timeout(1000);
+
+// $FlowExpectedError[incompatible-call] string. This type is incompatible with number.
+context.timeout('1000');

--- a/definitions/npm/mocha_v10.x.x/test_mocha_v10.x.x_describe.js
+++ b/definitions/npm/mocha_v10.x.x/test_mocha_v10.x.x_describe.js
@@ -1,0 +1,50 @@
+/* @flow */
+
+/**
+ * describe
+ */
+
+describe('desc', () => {});
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+describe('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with undefined.
+describe('desc', () => 1);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+describe(12, () => {});
+
+
+/**
+ * describe.skip
+ */
+
+describe.skip('desc', () => {});
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+describe.skip('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with undefined.
+describe.skip('desc', () => 1);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+describe.skip(12, () => {});
+
+/**
+ * describe.only
+ */
+
+describe.only('desc', () => {});
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+describe.only('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with undefined.
+describe.only('desc', () => 1);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+describe.only(12, () => {});
+
+/**
+ * describe.timeout
+ */
+
+describe.timeout(1000);
+
+// $FlowExpectedError[incompatible-call] string. This type is incompatible with number.
+describe.timeout('1000');

--- a/definitions/npm/mocha_v10.x.x/test_mocha_v10.x.x_hooks.js
+++ b/definitions/npm/mocha_v10.x.x/test_mocha_v10.x.x_hooks.js
@@ -1,0 +1,46 @@
+/* @flow */
+
+/**
+ * before
+ */
+
+before(() => {});
+before((done : Function) => {});
+before(() => new Promise((res, rej) => {}));
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+before((done : number) => {});
+
+/**
+ * beforeEach
+ */
+
+beforeEach(() => {});
+beforeEach((done : Function) => {});
+beforeEach(() => new Promise((res, rej) => {}));
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+beforeEach((done : number) => {});
+
+
+/**
+ * after
+ */
+
+after(() => {});
+after((done : Function) => {});
+after(() => new Promise((res, rej) => {}));
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+after((done : number) => {});
+
+/**
+ * afterEach
+ */
+
+afterEach(() => {});
+afterEach((done : Function) => {});
+afterEach(() => new Promise((res, rej) => {}));
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+afterEach((done : number) => {});

--- a/definitions/npm/mocha_v10.x.x/test_mocha_v10.x.x_it.js
+++ b/definitions/npm/mocha_v10.x.x/test_mocha_v10.x.x_it.js
@@ -1,0 +1,60 @@
+/* @flow */
+
+/**
+ * it
+ */
+
+it('desc', () => {});
+it('desc', (e) => {});
+it('desc', (done : Function) => {});
+it('desc', () => new Promise((res, rej) => {}));
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+it('desc', (done : number) => {});
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+it('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+it(12, () => {});
+
+
+/**
+ * it.skip
+ */
+
+it.skip('desc', () => {});
+it.skip('desc', (done : Function) => {});
+it.skip('desc', () => new Promise((res, rej) => {}));
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+it.skip('desc', (done : number) => {});
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+it.skip('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+it.skip(12, () => {});
+
+// Can also skip a test by not providing a body
+it('desc');
+
+/**
+ * it.only
+ */
+
+it.only('desc', () => {});
+it.only('desc', (done : Function) => {});
+it.only('desc', () => new Promise((res, rej) => {}));
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+it.only('desc', (done : number) => {});
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+it.only('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+it.only(12, () => {});
+
+/**
+ * it.timeout
+ */
+
+it.timeout(1000);
+
+// $FlowExpectedError[incompatible-call] string. This type is incompatible with number.
+it.timeout('1000');

--- a/definitions/npm/mocha_v9.x.x/flow_v0.104.x-/mocha_v9.x.x.js
+++ b/definitions/npm/mocha_v9.x.x/flow_v0.104.x-/mocha_v9.x.x.js
@@ -1,0 +1,235 @@
+declare interface $npm$mocha$SetupOptions {
+  slow?: number;
+  timeout?: number;
+  ui?: string;
+  globals?: Array<any>;
+  reporter?: any;
+  bail?: boolean;
+  ignoreLeaks?: boolean;
+  grep?: any;
+}
+
+declare type $npm$mocha$done = (error?: any) => any;
+
+// declare interface $npm$mocha$SuiteCallbackContext {
+//   timeout(ms: number): void;
+//   retries(n: number): void;
+//   slow(ms: number): void;
+// }
+
+// declare interface $npm$mocha$TestCallbackContext {
+//   skip(): void;
+//   timeout(ms: number): void;
+//   retries(n: number): void;
+//   slow(ms: number): void;
+//   [index: string]: any;
+// }
+
+declare interface $npm$mocha$Suite {
+  parent: $npm$mocha$Suite;
+  title: string;
+  fullTitle(): string;
+}
+
+declare type $npm$mocha$ContextDefinition = {|
+  (description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): $npm$mocha$Suite;
+  only(description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): $npm$mocha$Suite;
+  skip(description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): void;
+  timeout(ms: number): void;
+|}
+
+declare type $npm$mocha$TestDefinition = {|
+  (expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): $npm$mocha$Test;
+  only(expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): $npm$mocha$Test;
+  skip(expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+  timeout(ms: number): void;
+  state: 'failed' | 'passed';
+|}
+
+declare interface $npm$mocha$Runner {}
+
+declare class $npm$mocha$BaseReporter {
+  stats: {
+    suites: number,
+    tests: number,
+    passes: number,
+    pending: number,
+    failures: number,
+    ...
+  };
+
+  constructor(runner: $npm$mocha$Runner): $npm$mocha$BaseReporter;
+}
+
+declare class $npm$mocha$DocReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$DotReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$HTMLReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$HTMLCovReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$JSONReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$JSONCovReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$JSONStreamReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$LandingReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$ListReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$MarkdownReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$MinReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$NyanReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$ProgressReporter extends $npm$mocha$BaseReporter {
+  constructor(runner: $npm$mocha$Runner, options?: {
+    open?: string,
+    complete?: string,
+    incomplete?: string,
+    close?: string,
+    ...
+  }): $npm$mocha$ProgressReporter;
+}
+declare class $npm$mocha$SpecReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$TAPReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$XUnitReporter extends $npm$mocha$BaseReporter {
+  constructor(runner: $npm$mocha$Runner, options?: any): $npm$mocha$XUnitReporter;
+}
+
+declare class $npm$mocha$Mocha {
+  currentTest: $npm$mocha$TestDefinition;
+  constructor(options?: {
+    grep?: RegExp,
+    ui?: string,
+    reporter?: string,
+    timeout?: number,
+    reporterOptions?: any,
+    slow?: number,
+    bail?: boolean,
+    ...
+  }): $npm$mocha$Mocha;
+  setup(options: $npm$mocha$SetupOptions): this;
+  bail(value?: boolean): this;
+  addFile(file: string): this;
+  reporter(name: string): this;
+  reporter(reporter: (runner: $npm$mocha$Runner, options: any) => any): this;
+  ui(value: string): this;
+  grep(value: string): this;
+  grep(value: RegExp): this;
+  invert(): this;
+  ignoreLeaks(value: boolean): this;
+  checkLeaks(): this;
+  throwError(error: Error): void;
+  growl(): this;
+  globals(value: string): this;
+  globals(values: Array<string>): this;
+  useColors(value: boolean): this;
+  useInlineDiffs(value: boolean): this;
+  timeout(value: number): this;
+  slow(value: number): this;
+  enableTimeouts(value: boolean): this;
+  asyncOnly(value: boolean): this;
+  noHighlighting(value: boolean): this;
+  run(onComplete?: (failures: number) => void): $npm$mocha$Runner;
+
+  static reporters: {
+    Doc: $npm$mocha$DocReporter,
+    Dot: $npm$mocha$DotReporter,
+    HTML: $npm$mocha$HTMLReporter,
+    HTMLCov: $npm$mocha$HTMLCovReporter,
+    JSON: $npm$mocha$JSONReporter,
+    JSONCov: $npm$mocha$JSONCovReporter,
+    JSONStream: $npm$mocha$JSONStreamReporter,
+    Landing: $npm$mocha$LandingReporter,
+    List: $npm$mocha$ListReporter,
+    Markdown: $npm$mocha$MarkdownReporter,
+    Min: $npm$mocha$MinReporter,
+    Nyan: $npm$mocha$NyanReporter,
+    Progress: $npm$mocha$ProgressReporter,
+    ...
+  };
+}
+
+// declare interface $npm$mocha$HookCallbackContext {
+//   skip(): void;
+//   timeout(ms: number): void;
+//   [index: string]: any;
+// }
+
+declare interface $npm$mocha$Runnable {
+  title: string;
+  fn: Function;
+  async: boolean;
+  sync: boolean;
+  timedOut: boolean;
+}
+
+declare interface $npm$mocha$Test extends $npm$mocha$Runnable {
+  parent: $npm$mocha$Suite;
+  pending: boolean;
+  state: 'failed' | 'passed' | void;
+  fullTitle(): string;
+  timeout(ms: number): void;
+}
+
+// declare interface $npm$mocha$BeforeAndAfterContext extends $npm$mocha$HookCallbackContext {
+//   currentTest: $npm$mocha$Test;
+// }
+
+declare var mocha: $npm$mocha$Mocha;
+declare var describe: $npm$mocha$ContextDefinition;
+declare var xdescribe: $npm$mocha$ContextDefinition;
+declare var context: $npm$mocha$ContextDefinition;
+declare var suite: $npm$mocha$ContextDefinition;
+declare var it: $npm$mocha$TestDefinition;
+declare var xit: $npm$mocha$TestDefinition;
+declare var test: $npm$mocha$TestDefinition;
+declare var specify: $npm$mocha$TestDefinition;
+
+type Run = () => void;
+
+declare var run: Run;
+
+type Setup = (callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void;
+type Teardown = (callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void;
+type SuiteSetup = (callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void;
+type SuiteTeardown = (callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void;
+type Before =
+  | (callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void
+  | (description: string, callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void;
+type After =
+  | (callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void
+  | (description: string, callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void;
+type BeforeEach =
+  | (callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void
+  | (description: string, callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void;
+type AfterEach =
+  | (callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void
+  | (description: string, callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void;
+
+
+declare var setup: Setup;
+declare var teardown: Teardown;
+declare var suiteSetup: SuiteSetup;
+declare var suiteTeardown: SuiteTeardown;
+declare var before: Before
+declare var after: After;
+declare var beforeEach: BeforeEach;
+declare var afterEach: AfterEach;
+
+declare module "mocha" {
+  declare export var mocha: $npm$mocha$TestDefinition;
+  declare export var describe: $npm$mocha$ContextDefinition;
+  declare export var xdescribe: $npm$mocha$ContextDefinition;
+  declare export var context: $npm$mocha$ContextDefinition;
+  declare export var suite: $npm$mocha$ContextDefinition;
+  declare export var it: $npm$mocha$TestDefinition;
+  declare export var xit: $npm$mocha$TestDefinition;
+  declare export var test: $npm$mocha$TestDefinition;
+  declare export var specify: $npm$mocha$TestDefinition;
+
+  declare export var run: Run;
+
+  declare export var setup: Setup;
+  declare export var teardown: Teardown;
+  declare export var suiteSetup: SuiteSetup;
+  declare export var suiteTeardown: SuiteTeardown;
+  declare export var before: Before;
+  declare export var after: After;
+  declare export var beforeEach: BeforeEach;
+  declare export var afterEach: AfterEach;
+
+  declare export default $npm$mocha$Mocha;
+}

--- a/definitions/npm/mocha_v9.x.x/flow_v0.28.x-v0.103.x/mocha_v9.x.x.js
+++ b/definitions/npm/mocha_v9.x.x/flow_v0.28.x-v0.103.x/mocha_v9.x.x.js
@@ -1,0 +1,219 @@
+declare interface $npm$mocha$SetupOptions {
+  slow?: number;
+  timeout?: number;
+  ui?: string;
+  globals?: Array<any>;
+  reporter?: any;
+  bail?: boolean;
+  ignoreLeaks?: boolean;
+  grep?: any;
+}
+
+declare type $npm$mocha$done = (error?: any) => any;
+
+// declare interface $npm$mocha$SuiteCallbackContext {
+//   timeout(ms: number): void;
+//   retries(n: number): void;
+//   slow(ms: number): void;
+// }
+
+// declare interface $npm$mocha$TestCallbackContext {
+//   skip(): void;
+//   timeout(ms: number): void;
+//   retries(n: number): void;
+//   slow(ms: number): void;
+//   [index: string]: any;
+// }
+
+declare interface $npm$mocha$Suite {
+  parent: $npm$mocha$Suite;
+  title: string;
+  fullTitle(): string;
+}
+
+declare interface $npm$mocha$ContextDefinition {
+  (description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): $npm$mocha$Suite;
+  only(description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): $npm$mocha$Suite;
+  skip(description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): void;
+  timeout(ms: number): void;
+}
+
+declare interface $npm$mocha$TestDefinition {
+  (expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): $npm$mocha$Test;
+  only(expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): $npm$mocha$Test;
+  skip(expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+  timeout(ms: number): void;
+  state: 'failed' | 'passed';
+}
+
+declare interface $npm$mocha$Runner {}
+
+declare class $npm$mocha$BaseReporter {
+  stats: {
+    suites: number;
+    tests: number;
+    passes: number;
+    pending: number;
+    failures: number;
+  };
+
+  constructor(runner: $npm$mocha$Runner): $npm$mocha$BaseReporter;
+}
+
+declare class $npm$mocha$DocReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$DotReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$HTMLReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$HTMLCovReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$JSONReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$JSONCovReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$JSONStreamReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$LandingReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$ListReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$MarkdownReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$MinReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$NyanReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$ProgressReporter extends $npm$mocha$BaseReporter {
+  constructor(runner: $npm$mocha$Runner, options?: {
+    open?: string;
+    complete?: string;
+    incomplete?: string;
+    close?: string;
+  }): $npm$mocha$ProgressReporter;
+}
+declare class $npm$mocha$SpecReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$TAPReporter extends $npm$mocha$BaseReporter {}
+declare class $npm$mocha$XUnitReporter extends $npm$mocha$BaseReporter {
+  constructor(runner: $npm$mocha$Runner, options?: any): $npm$mocha$XUnitReporter;
+}
+
+declare class $npm$mocha$Mocha {
+  currentTest: $npm$mocha$TestDefinition;
+  constructor(options?: {
+    grep?: RegExp;
+    ui?: string;
+    reporter?: string;
+    timeout?: number;
+    reporterOptions?: any;
+    slow?: number;
+    bail?: boolean;
+  }): $npm$mocha$Mocha;
+  setup(options: $npm$mocha$SetupOptions): this;
+  bail(value?: boolean): this;
+  addFile(file: string): this;
+  reporter(name: string): this;
+  reporter(reporter: (runner: $npm$mocha$Runner, options: any) => any): this;
+  ui(value: string): this;
+  grep(value: string): this;
+  grep(value: RegExp): this;
+  invert(): this;
+  ignoreLeaks(value: boolean): this;
+  checkLeaks(): this;
+  throwError(error: Error): void;
+  growl(): this;
+  globals(value: string): this;
+  globals(values: Array<string>): this;
+  useColors(value: boolean): this;
+  useInlineDiffs(value: boolean): this;
+  timeout(value: number): this;
+  slow(value: number): this;
+  enableTimeouts(value: boolean): this;
+  asyncOnly(value: boolean): this;
+  noHighlighting(value: boolean): this;
+  run(onComplete?: (failures: number) => void): $npm$mocha$Runner;
+
+  static reporters: {
+    Doc: $npm$mocha$DocReporter,
+    Dot: $npm$mocha$DotReporter,
+    HTML: $npm$mocha$HTMLReporter,
+    HTMLCov: $npm$mocha$HTMLCovReporter,
+    JSON: $npm$mocha$JSONReporter,
+    JSONCov: $npm$mocha$JSONCovReporter,
+    JSONStream: $npm$mocha$JSONStreamReporter,
+    Landing: $npm$mocha$LandingReporter,
+    List: $npm$mocha$ListReporter,
+    Markdown: $npm$mocha$MarkdownReporter,
+    Min: $npm$mocha$MinReporter,
+    Nyan: $npm$mocha$NyanReporter,
+    Progress: $npm$mocha$ProgressReporter,
+  };
+}
+
+// declare interface $npm$mocha$HookCallbackContext {
+//   skip(): void;
+//   timeout(ms: number): void;
+//   [index: string]: any;
+// }
+
+declare interface $npm$mocha$Runnable {
+  title: string;
+  fn: Function;
+  async: boolean;
+  sync: boolean;
+  timedOut: boolean;
+}
+
+declare interface $npm$mocha$Test extends $npm$mocha$Runnable {
+  parent: $npm$mocha$Suite;
+  pending: boolean;
+  state: 'failed' | 'passed' | void;
+  fullTitle(): string;
+  timeout(ms: number): void;
+}
+
+// declare interface $npm$mocha$BeforeAndAfterContext extends $npm$mocha$HookCallbackContext {
+//   currentTest: $npm$mocha$Test;
+// }
+
+declare var mocha: $npm$mocha$Mocha;
+declare var describe: $npm$mocha$ContextDefinition;
+declare var xdescribe: $npm$mocha$ContextDefinition;
+declare var context: $npm$mocha$ContextDefinition;
+declare var suite: $npm$mocha$ContextDefinition;
+declare var it: $npm$mocha$TestDefinition;
+declare var xit: $npm$mocha$TestDefinition;
+declare var test: $npm$mocha$TestDefinition;
+declare var specify: $npm$mocha$TestDefinition;
+
+declare function run(): void;
+
+declare function setup(callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
+declare function teardown(callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
+declare function suiteSetup(callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+declare function suiteTeardown(callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+declare function before(callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+declare function before(description: string, callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+declare function after(callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+declare function after(description: string, callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+declare function beforeEach(callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
+declare function beforeEach(description: string, callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
+declare function afterEach(callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
+declare function afterEach(description: string, callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
+
+declare module "mocha" {
+  declare export var mocha: typeof mocha;
+  declare export var describe: typeof describe;
+  declare export var xdescribe: typeof xdescribe;
+  declare export var context: typeof context;
+  declare export var suite: typeof suite;
+  declare export var it: typeof it;
+  declare export var xit: typeof xit;
+  declare export var test: typeof test;
+  declare export var specify: typeof specify;
+
+  declare export var run: typeof run;
+
+  declare export var setup: typeof setup;
+  declare export var teardown: typeof teardown;
+  declare export var suiteSetup: typeof suiteSetup;
+  declare export var suiteTeardown: typeof suiteTeardown;
+  declare export var before: typeof before;
+  declare export var before: typeof before;
+  declare export var after: typeof after;
+  declare export var after: typeof after;
+  declare export var beforeEach: typeof beforeEach;
+  declare export var beforeEach: typeof beforeEach;
+  declare export var afterEach: typeof afterEach;
+  declare export var afterEach: typeof afterEach;
+
+  declare export default $npm$mocha$Mocha;
+}

--- a/definitions/npm/mocha_v9.x.x/test_mocha_v9.x.x_context.js
+++ b/definitions/npm/mocha_v9.x.x/test_mocha_v9.x.x_context.js
@@ -1,0 +1,50 @@
+/* @flow */
+
+/**
+ * context
+ */
+
+context('desc', () => {});
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+context('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with undefined.
+context('desc', () => 1);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+context(12, () => {});
+
+
+/**
+ * context.skip
+ */
+
+context.skip('desc', () => {});
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+context.skip('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with undefined.
+context.skip('desc', () => 1);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+context.skip(12, () => {});
+
+/**
+ * context.only
+ */
+
+context.only('desc', () => {});
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+context.only('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with undefined.
+context.only('desc', () => 1);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+context.only(12, () => {});
+
+/**
+ * context.timeout
+ */
+
+context.timeout(1000);
+
+// $FlowExpectedError[incompatible-call] string. This type is incompatible with number.
+context.timeout('1000');

--- a/definitions/npm/mocha_v9.x.x/test_mocha_v9.x.x_describe.js
+++ b/definitions/npm/mocha_v9.x.x/test_mocha_v9.x.x_describe.js
@@ -1,0 +1,50 @@
+/* @flow */
+
+/**
+ * describe
+ */
+
+describe('desc', () => {});
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+describe('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with undefined.
+describe('desc', () => 1);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+describe(12, () => {});
+
+
+/**
+ * describe.skip
+ */
+
+describe.skip('desc', () => {});
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+describe.skip('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with undefined.
+describe.skip('desc', () => 1);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+describe.skip(12, () => {});
+
+/**
+ * describe.only
+ */
+
+describe.only('desc', () => {});
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+describe.only('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with undefined.
+describe.only('desc', () => 1);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+describe.only(12, () => {});
+
+/**
+ * describe.timeout
+ */
+
+describe.timeout(1000);
+
+// $FlowExpectedError[incompatible-call] string. This type is incompatible with number.
+describe.timeout('1000');

--- a/definitions/npm/mocha_v9.x.x/test_mocha_v9.x.x_hooks.js
+++ b/definitions/npm/mocha_v9.x.x/test_mocha_v9.x.x_hooks.js
@@ -1,0 +1,46 @@
+/* @flow */
+
+/**
+ * before
+ */
+
+before(() => {});
+before((done : Function) => {});
+before(() => new Promise((res, rej) => {}));
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+before((done : number) => {});
+
+/**
+ * beforeEach
+ */
+
+beforeEach(() => {});
+beforeEach((done : Function) => {});
+beforeEach(() => new Promise((res, rej) => {}));
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+beforeEach((done : number) => {});
+
+
+/**
+ * after
+ */
+
+after(() => {});
+after((done : Function) => {});
+after(() => new Promise((res, rej) => {}));
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+after((done : number) => {});
+
+/**
+ * afterEach
+ */
+
+afterEach(() => {});
+afterEach((done : Function) => {});
+afterEach(() => new Promise((res, rej) => {}));
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+afterEach((done : number) => {});

--- a/definitions/npm/mocha_v9.x.x/test_mocha_v9.x.x_it.js
+++ b/definitions/npm/mocha_v9.x.x/test_mocha_v9.x.x_it.js
@@ -1,0 +1,60 @@
+/* @flow */
+
+/**
+ * it
+ */
+
+it('desc', () => {});
+it('desc', (e) => {});
+it('desc', (done : Function) => {});
+it('desc', () => new Promise((res, rej) => {}));
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+it('desc', (done : number) => {});
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+it('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+it(12, () => {});
+
+
+/**
+ * it.skip
+ */
+
+it.skip('desc', () => {});
+it.skip('desc', (done : Function) => {});
+it.skip('desc', () => new Promise((res, rej) => {}));
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+it.skip('desc', (done : number) => {});
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+it.skip('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+it.skip(12, () => {});
+
+// Can also skip a test by not providing a body
+it('desc');
+
+/**
+ * it.only
+ */
+
+it.only('desc', () => {});
+it.only('desc', (done : Function) => {});
+it.only('desc', () => new Promise((res, rej) => {}));
+
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+it.only('desc', (done : number) => {});
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with function type.
+it.only('desc', 12);
+// $FlowExpectedError[incompatible-call] number. This type is incompatible with string.
+it.only(12, () => {});
+
+/**
+ * it.timeout
+ */
+
+it.timeout(1000);
+
+// $FlowExpectedError[incompatible-call] string. This type is incompatible with number.
+it.timeout('1000');


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Copy v9 and v10 definitions from v8

- Links to documentation: https://github.com/mochajs/mocha/releases
- Link to GitHub or NPM: https://www.npmjs.com/package/mocha
- Type of contribution: new definition

Other notes: New versions over time have had new options added but nothing noteworthy in regards to major versions with just dropping older node version support

