### PR TITLE
[@octokit/rest] Add constructor and listRepo

### DIFF
--- a/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/rest_v18.x.x.js
+++ b/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/rest_v18.x.x.js
@@ -43,7 +43,6 @@ declare module '@octokit/rest' {
     |}): this;
 
     static VERSION: string;
-    static defaults: this;
 
     actions: {| [key: string]: any |},
     activity: {| [key: string]: any |},

--- a/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/rest_v18.x.x.js
+++ b/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/rest_v18.x.x.js
@@ -42,6 +42,9 @@ declare module '@octokit/rest' {
         path?: string,
         ref?: string,
       |}) => Promise<{|
+        headers: {| [key: string]: any |},
+        status: number,
+        url: string,
         data: Array<{|
           download_url: any,
           git_url: string,
@@ -58,9 +61,6 @@ declare module '@octokit/rest' {
             self: string,
           |}
         |}>,
-        headers: {| [key: string]: any |},
-        status: number,
-        url: string,
       |}>,
       /**
        * This returns a list of releases, which does not include regular Git tags that have not been associated with a release. To get a list of Git tags, use the Repository Tags API.
@@ -85,6 +85,9 @@ declare module '@octokit/rest' {
          */
         per_page?: number,
       |}) => Promise<{|
+        headers: {| [key: string]: any |},
+        status: number,
+        url: string,
         data: Array<{|
           url: string,
           assets_url: string,

--- a/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/rest_v18.x.x.js
+++ b/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/rest_v18.x.x.js
@@ -42,7 +42,8 @@ declare module '@octokit/rest' {
       [option: string]: any,
     |}): this;
 
-    (options?: {| [key: string]: any |}): this;
+    static VERSION: string;
+    static defaults: this;
 
     actions: {| [key: string]: any |},
     activity: {| [key: string]: any |},

--- a/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/rest_v18.x.x.js
+++ b/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/rest_v18.x.x.js
@@ -1,7 +1,45 @@
 declare module '@octokit/rest' {
+  /**
+   * Octokit-specific request options which are ignored for the actual request, but can be used by Octokit or plugins to manipulate how the request is sent or how a response is handled
+   */
+  declare type RequestRequestOptions = {|
+    /**
+     * Node only. Useful for custom proxy, certificate, or dns lookup.
+     *
+     * @see https://nodejs.org/api/http.html#http_class_http_agent
+     */
+    agent?: mixed,
+    /**
+     * Custom replacement for built-in fetch method. Useful for testing or request hooks.
+     */
+    fetch?: any,
+    /**
+     * Use an `AbortController` instance to cancel a request. In node you can only cancel streamed requests.
+     */
+    signal?: any,
+    /**
+     * Node only. Request/response timeout in ms, it resets on redirect. 0 to disable (OS limit applies). `options.request.signal` is recommended instead.
+     */
+    timeout?: number,
+    [option: string]: any,
+  |};
+
   declare class Octokit {
     constructor(options?: {|
-      auth?: string,
+      authStrategy?: any,
+      auth?: any,
+      userAgent?: string,
+      previews?: Array<string>,
+      baseUrl?: string,
+      log?: {|
+        debug?: (message: string) => mixed;
+        info?: (message: string) => mixed;
+        warn?: (message: string) => mixed;
+        error?: (message: string) => mixed;
+      |},
+      request?: RequestRequestOptions,
+      timeZone?: string,
+      [option: string]: any,
     |}): this;
 
     (options?: {| [key: string]: any |}): this;

--- a/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/rest_v18.x.x.js
+++ b/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/rest_v18.x.x.js
@@ -1,5 +1,9 @@
 declare module '@octokit/rest' {
   declare class Octokit {
+    constructor(options?: {|
+      auth?: string,
+    |}): this;
+
     (options?: {| [key: string]: any |}): this;
 
     actions: {| [key: string]: any |},
@@ -57,6 +61,69 @@ declare module '@octokit/rest' {
         headers: {| [key: string]: any |},
         status: number,
         url: string,
+      |}>,
+      /**
+       * This returns a list of releases, which does not include regular Git tags that have not been associated with a release. To get a list of Git tags, use the Repository Tags API.
+       *
+       * Information about published releases are available to everyone. Only users with push access will receive listings for draft releases.
+       */
+      listReleases: ({|
+        /**
+         * The account owner of the repository. The name is not case sensitive.
+         */
+        owner: string,
+        /**
+         * The name of the repository. The name is not case sensitive.
+         */
+        repo: string,
+        /**
+         * The number of results per page (max 100).
+         */
+        page?: number,
+        /**
+         * Page number of the results to fetch.
+         */
+        per_page?: number,
+      |}) => Promise<{|
+        data: Array<{|
+          url: string,
+          assets_url: string,
+          upload_url: string,
+          html_url: string,
+          id: number,
+          author: {|
+            login: string,
+            id: number,
+            node_id: string,
+            avatar_url: string,
+            gravatar_id: string,
+            url: string,
+            html_url: string,
+            followers_url: string,
+            following_url: string,
+            gists_url: string,
+            starred_url: string,
+            subscriptions_url: string,
+            organizations_url: string,
+            repos_url: string,
+            events_url: string,
+            received_events_url: string,
+            type: string,
+            site_admin: boolean,
+          |},
+          node_id: string,
+          tag_name: string,
+          target_commitish: string,
+          name: any,
+          draft: boolean,
+          prerelease: boolean,
+          created_at: string,
+          published_at: string,
+          assets: Array<any>,
+          tarball_url: string,
+          zipball_url: string,
+          body: string,
+        |}>,
       |}>,
       [key: string]: any,
     },

--- a/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/test_rest_v18.x.x.js
+++ b/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/test_rest_v18.x.x.js
@@ -73,7 +73,74 @@ describe('@octokit/rest', () => {
     });
 
     test('listReleases', () => {
+      repos.listReleases({
+        owner: 'flow-typed',
+        repo: 'eslint-plugin-ft-flow',
+      }).then((res) => {
+        res.data.forEach((file) => {
+          file.url.toLowerCase();
+          file.assets_url.toLowerCase();
+          file.upload_url.toLowerCase();
+          file.html_url.toLowerCase();
+          file.id.toFixed(2);
+          file.author.login.toLowerCase();
+          file.author.id.toFixed(2);
+          file.author.node_id.toLowerCase();
+          file.author.avatar_url.toLowerCase();
+          file.author.gravatar_id.toLowerCase();
+          file.author.url.toLowerCase();
+          file.author.html_url.toLowerCase();
+          file.author.followers_url.toLowerCase();
+          file.author.following_url.toLowerCase();
+          file.author.gists_url.toLowerCase();
+          file.author.starred_url.toLowerCase();
+          file.author.subscriptions_url.toLowerCase();
+          file.author.organizations_url.toLowerCase();
+          file.author.repos_url.toLowerCase();
+          file.author.events_url.toLowerCase();
+          file.author.received_events_url.toLowerCase();
+          file.author.type.toLowerCase();
+          file.author.site_admin.valueOf();
+          file.node_id.toLowerCase();
+          file.tag_name.toLowerCase();
+          file.target_commitish.toLowerCase();
+          file.name.toLowerCase();
+          file.draft.valueOf();
+          file.prerelease.valueOf();
+          file.created_at.toLowerCase();
+          file.published_at.toLowerCase();
+          file.assets[1]
+          file.tarball_url.toLowerCase();
+          file.zipball_url.toLowerCase();
+          file.body.toLowerCase();
 
+          // $FlowExpectedError[prop-missing]
+          file.foo();
+          // $FlowExpectedError[prop-missing]
+          file.author.foo();
+        });
+        res.headers.foo();
+        res.status.toFixed(2);
+        res.url.toLowerCase();
+      });
+      repos.listReleases({
+        owner: 'flow-typed',
+        repo: 'eslint-plugin-ft-flow',
+        page: 2,
+      });
+
+      // $FlowExpectedError[incompatible-call]
+      repos.listReleases();
+      // $FlowExpectedError[prop-missing]
+      repos.listReleases({});
+      // $FlowExpectedError[prop-missing]
+      repos.listReleases({
+        owner: 'flow-typed',
+      });
+      // $FlowExpectedError[prop-missing]
+      repos.listReleases({
+        repo: 'flow-typed',
+      });
     });
   });
 });

--- a/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/test_rest_v18.x.x.js
+++ b/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/test_rest_v18.x.x.js
@@ -1,14 +1,24 @@
 // @flow
-import { describe, it } from 'flow-typed-test';
+import { describe, test } from 'flow-typed-test';
 import { Octokit } from '@octokit/rest';
 
 describe('@octokit/rest', () => {
   const octokit = new Octokit();
 
+  test('constructor', () => {
+    new Octokit();
+    new Octokit({ auth: '123' });
+
+    // $FlowExpectedError[incompatible-call]
+    new Octokit(123);
+    // $FlowExpectedError[incompatible-call]
+    new Octokit({ auth: 1 });
+  });
+
   describe('repos', () => {
     const { repos } = octokit;
 
-    it('getContent', () => {
+    test('getContent', () => {
       repos.getContent({
         owner: 'flow-typed',
         repo: 'eslint-plugin-ft-flow',
@@ -60,6 +70,10 @@ describe('@octokit/rest', () => {
       repos.getContent({
         repo: 'flow-typed',
       });
+    });
+
+    test('listReleases', () => {
+
     });
   });
 });

--- a/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/test_rest_v18.x.x.js
+++ b/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/test_rest_v18.x.x.js
@@ -34,6 +34,12 @@ describe('@octokit/rest', () => {
     new Octokit(123);
   });
 
+  test('static', () => {
+    Octokit.VERSION.toLowerCase();
+    // $FlowExpectedError[prop-missing]
+    Octokit.VERSION.toFixed(2);
+  });
+
   describe('repos', () => {
     const { repos } = octokit;
 

--- a/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/test_rest_v18.x.x.js
+++ b/definitions/npm/@octokit/rest_v18.x.x/flow_v0.83.x-/test_rest_v18.x.x.js
@@ -7,12 +7,31 @@ describe('@octokit/rest', () => {
 
   test('constructor', () => {
     new Octokit();
-    new Octokit({ auth: '123' });
+    new Octokit({});
+    new Octokit({
+      auth: {
+        appId: 123,
+        privateKey: process.env.PRIVATE_KEY,
+        // optional: this will make appOctokit authenticate as app (JWT)
+        //           or installation (access token), depending on the request URL
+        installationId: 123,
+      },
+    });
+    new Octokit({
+      auth: '123',
+      userAgent: 'chrome something',
+      previews: ['', ''],
+      baseUrl: 'test',
+      log: {
+        debug: (message) => { message.toString() },
+        info: (message) => { message.toString() },
+        warn: (message) => { message.toString() },
+        error: (message) => { message.toString() },
+      },
+    });
 
     // $FlowExpectedError[incompatible-call]
     new Octokit(123);
-    // $FlowExpectedError[incompatible-call]
-    new Octokit({ auth: 1 });
   });
 
   describe('repos', () => {


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Minor incremental improvements to the octokit rest definitions to better serve end users.

These are directly derived from the TS shipped definitions and I'll be slowly adding them hopefully over the next few weeks in small PRs

- Links to documentation: https://octokit.github.io/rest.js/
- Link to GitHub or NPM: https://www.npmjs.com/package/@octokit/rest
- Type of contribution: addition

Other notes:

