### PR TITLE
[@octoki/rest] Add v19

### DIFF
--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -1887,9 +1887,9 @@ camelcase@^6.2.0:
   integrity sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
 
 caniuse-lite@^1.0.30001280:
-  version "1.0.30001283"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz#8573685bdae4d733ef18f78d44ba0ca5fe9e896b"
-  integrity sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==
+  version "1.0.30001434"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz"
+  integrity sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==
 
 chalk@^2.0.0:
   version "2.4.2"

--- a/definitions/npm/@octokit/rest_v19.x.x/flow_v0.83.x-/rest_v19.x.x.js
+++ b/definitions/npm/@octokit/rest_v19.x.x/flow_v0.83.x-/rest_v19.x.x.js
@@ -1,0 +1,182 @@
+declare module '@octokit/rest' {
+  /**
+   * Octokit-specific request options which are ignored for the actual request, but can be used by Octokit or plugins to manipulate how the request is sent or how a response is handled
+   */
+  declare type RequestRequestOptions = {|
+    /**
+     * Node only. Useful for custom proxy, certificate, or dns lookup.
+     *
+     * @see https://nodejs.org/api/http.html#http_class_http_agent
+     */
+    agent?: mixed,
+    /**
+     * Custom replacement for built-in fetch method. Useful for testing or request hooks.
+     */
+    fetch?: any,
+    /**
+     * Use an `AbortController` instance to cancel a request. In node you can only cancel streamed requests.
+     */
+    signal?: any,
+    /**
+     * Node only. Request/response timeout in ms, it resets on redirect. 0 to disable (OS limit applies). `options.request.signal` is recommended instead.
+     */
+    timeout?: number,
+    [option: string]: any,
+  |};
+
+  declare class Octokit {
+    constructor(options?: {|
+      authStrategy?: any,
+      auth?: any,
+      userAgent?: string,
+      previews?: Array<string>,
+      baseUrl?: string,
+      log?: {|
+        debug?: (message: string) => mixed;
+        info?: (message: string) => mixed;
+        warn?: (message: string) => mixed;
+        error?: (message: string) => mixed;
+      |},
+      request?: RequestRequestOptions,
+      timeZone?: string,
+      [option: string]: any,
+    |}): this;
+
+    static VERSION: string;
+
+    actions: {| [key: string]: any |},
+    activity: {| [key: string]: any |},
+    apps: {| [key: string]: any |},
+    auth: (...args: Array<any>) => Promise<{| [key: string]: any |}>,
+    billing: {| [key: string]: any |},
+    checks: {| [key: string]: any |},
+    codeScanning: {| [key: string]: any |},
+    codesOfConduct: {| [key: string]: any |},
+    emojis: {| [key: string]: any |},
+    enterpriseAdmin: {| [key: string]: any |},
+    gists: {| [key: string]: any |},
+    git: {| [key: string]: any |},
+    gitignore: {| [key: string]: any |},
+    graphql: (...args: Array<any>) => any,
+    hook: (...args: Array<any>) => any,
+    interactions: {| [key: string]: any |},
+    issues: {| [key: string]: any |},
+    licenses: {| [key: string]: any |},
+    log:{| [key: string]: any |},
+    markdown: {| [key: string]: any |},
+    meta: {| [key: string]: any |},
+    migrations: {| [key: string]: any |},
+    orgs: {| [key: string]: any |},
+    packages: {| [key: string]: any |},
+    paginate: (...args: Array<any>) => any,
+    projects: {| [key: string]: any |},
+    pulls: {| [key: string]: any |},
+    rateLimit: {| [key: string]: any |},
+    reactions: {| [key: string]: any |},
+    repos: {
+      getContent: ({|
+        owner: string,
+        repo: string,
+        path?: string,
+        ref?: string,
+      |}) => Promise<{|
+        headers: {| [key: string]: any |},
+        status: number,
+        url: string,
+        data: Array<{|
+          download_url: any,
+          git_url: string,
+          html_url: string,
+          name: string,
+          path: string,
+          sha: string,
+          size: number,
+          type: string,
+          url: string,
+          _links: {|
+            git: string,
+            html: string,
+            self: string,
+          |}
+        |}>,
+      |}>,
+      /**
+       * This returns a list of releases, which does not include regular Git tags that have not been associated with a release. To get a list of Git tags, use the Repository Tags API.
+       *
+       * Information about published releases are available to everyone. Only users with push access will receive listings for draft releases.
+       */
+      listReleases: ({|
+        /**
+         * The account owner of the repository. The name is not case sensitive.
+         */
+        owner: string,
+        /**
+         * The name of the repository. The name is not case sensitive.
+         */
+        repo: string,
+        /**
+         * The number of results per page (max 100).
+         */
+        page?: number,
+        /**
+         * Page number of the results to fetch.
+         */
+        per_page?: number,
+      |}) => Promise<{|
+        headers: {| [key: string]: any |},
+        status: number,
+        url: string,
+        data: Array<{|
+          url: string,
+          assets_url: string,
+          upload_url: string,
+          html_url: string,
+          id: number,
+          author: {|
+            login: string,
+            id: number,
+            node_id: string,
+            avatar_url: string,
+            gravatar_id: string,
+            url: string,
+            html_url: string,
+            followers_url: string,
+            following_url: string,
+            gists_url: string,
+            starred_url: string,
+            subscriptions_url: string,
+            organizations_url: string,
+            repos_url: string,
+            events_url: string,
+            received_events_url: string,
+            type: string,
+            site_admin: boolean,
+          |},
+          node_id: string,
+          tag_name: string,
+          target_commitish: string,
+          name: any,
+          draft: boolean,
+          prerelease: boolean,
+          created_at: string,
+          published_at: string,
+          assets: Array<any>,
+          tarball_url: string,
+          zipball_url: string,
+          body: string,
+        |}>,
+      |}>,
+      [key: string]: any,
+    },
+    request: (...args: Array<any>) => any,
+    rest: {| [key: string]: any |},
+    search: {| [key: string]: any |},
+    secretScanning: {| [key: string]: any |},
+    teams: {| [key: string]: any |},
+    users: {| [key: string]: any |},
+  }
+
+  declare module.exports: {|
+    Octokit: typeof Octokit,
+  |};
+}

--- a/definitions/npm/@octokit/rest_v19.x.x/flow_v0.83.x-/test_rest_v19.x.x.js
+++ b/definitions/npm/@octokit/rest_v19.x.x/flow_v0.83.x-/test_rest_v19.x.x.js
@@ -1,0 +1,171 @@
+// @flow
+import { describe, test } from 'flow-typed-test';
+import { Octokit } from '@octokit/rest';
+
+describe('@octokit/rest', () => {
+  const octokit = new Octokit();
+
+  test('constructor', () => {
+    new Octokit();
+    new Octokit({});
+    new Octokit({
+      auth: {
+        appId: 123,
+        privateKey: process.env.PRIVATE_KEY,
+        // optional: this will make appOctokit authenticate as app (JWT)
+        //           or installation (access token), depending on the request URL
+        installationId: 123,
+      },
+    });
+    new Octokit({
+      auth: '123',
+      userAgent: 'chrome something',
+      previews: ['', ''],
+      baseUrl: 'test',
+      log: {
+        debug: (message) => { message.toString() },
+        info: (message) => { message.toString() },
+        warn: (message) => { message.toString() },
+        error: (message) => { message.toString() },
+      },
+    });
+
+    // $FlowExpectedError[incompatible-call]
+    new Octokit(123);
+  });
+
+  test('static', () => {
+    Octokit.VERSION.toLowerCase();
+    // $FlowExpectedError[prop-missing]
+    Octokit.VERSION.toFixed(2);
+  });
+
+  describe('repos', () => {
+    const { repos } = octokit;
+
+    test('getContent', () => {
+      repos.getContent({
+        owner: 'flow-typed',
+        repo: 'eslint-plugin-ft-flow',
+      }).then((res) => {
+        res.data.forEach((file) => {
+          file.download_url.toLowerCase();
+          file.git_url.toLowerCase();
+          file.html_url.toLowerCase();
+          file.name.toLowerCase();
+          file.path.toLowerCase();
+          file.sha.toLowerCase();
+          file.size.toFixed(2);
+          file.type.toLowerCase();
+          file.url.toLowerCase();
+          file._links.git.toLowerCase();
+          file._links.html.toLowerCase();
+          file._links.self.toLowerCase();
+
+          // $FlowExpectedError[prop-missing]
+          file.foo();
+          // $FlowExpectedError[prop-missing]
+          file._links.foo();
+        });
+        res.headers.foo();
+        res.status.toFixed(2);
+        res.url.toLowerCase();
+      });
+      repos.getContent({
+        owner: 'flow-typed',
+        repo: 'eslint-plugin-ft-flow',
+        path: 'src/rules',
+      });
+      repos.getContent({
+        owner: 'flow-typed',
+        repo: 'eslint-plugin-ft-flow',
+        path: 'src/rules',
+        ref: 'master',
+      });
+
+      // $FlowExpectedError[incompatible-call]
+      repos.getContent();
+      // $FlowExpectedError[prop-missing]
+      repos.getContent({});
+      // $FlowExpectedError[prop-missing]
+      repos.getContent({
+        owner: 'flow-typed',
+      });
+      // $FlowExpectedError[prop-missing]
+      repos.getContent({
+        repo: 'flow-typed',
+      });
+    });
+
+    test('listReleases', () => {
+      repos.listReleases({
+        owner: 'flow-typed',
+        repo: 'eslint-plugin-ft-flow',
+      }).then((res) => {
+        res.data.forEach((file) => {
+          file.url.toLowerCase();
+          file.assets_url.toLowerCase();
+          file.upload_url.toLowerCase();
+          file.html_url.toLowerCase();
+          file.id.toFixed(2);
+          file.author.login.toLowerCase();
+          file.author.id.toFixed(2);
+          file.author.node_id.toLowerCase();
+          file.author.avatar_url.toLowerCase();
+          file.author.gravatar_id.toLowerCase();
+          file.author.url.toLowerCase();
+          file.author.html_url.toLowerCase();
+          file.author.followers_url.toLowerCase();
+          file.author.following_url.toLowerCase();
+          file.author.gists_url.toLowerCase();
+          file.author.starred_url.toLowerCase();
+          file.author.subscriptions_url.toLowerCase();
+          file.author.organizations_url.toLowerCase();
+          file.author.repos_url.toLowerCase();
+          file.author.events_url.toLowerCase();
+          file.author.received_events_url.toLowerCase();
+          file.author.type.toLowerCase();
+          file.author.site_admin.valueOf();
+          file.node_id.toLowerCase();
+          file.tag_name.toLowerCase();
+          file.target_commitish.toLowerCase();
+          file.name.toLowerCase();
+          file.draft.valueOf();
+          file.prerelease.valueOf();
+          file.created_at.toLowerCase();
+          file.published_at.toLowerCase();
+          file.assets[1]
+          file.tarball_url.toLowerCase();
+          file.zipball_url.toLowerCase();
+          file.body.toLowerCase();
+
+          // $FlowExpectedError[prop-missing]
+          file.foo();
+          // $FlowExpectedError[prop-missing]
+          file.author.foo();
+        });
+        res.headers.foo();
+        res.status.toFixed(2);
+        res.url.toLowerCase();
+      });
+      repos.listReleases({
+        owner: 'flow-typed',
+        repo: 'eslint-plugin-ft-flow',
+        page: 2,
+      });
+
+      // $FlowExpectedError[incompatible-call]
+      repos.listReleases();
+      // $FlowExpectedError[prop-missing]
+      repos.listReleases({});
+      // $FlowExpectedError[prop-missing]
+      repos.listReleases({
+        owner: 'flow-typed',
+      });
+      // $FlowExpectedError[prop-missing]
+      repos.listReleases({
+        repo: 'flow-typed',
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Copy v18 to v19 which was published to drop node support

- Links to documentation: https://github.com/octokit/rest.js/releases/tag/v19.0.0
- Link to GitHub or NPM: https://www.npmjs.com/package/@octokit/rest
- Type of contribution: new definition

Other notes:

