### PR TITLE
[yargs] .example(): allow array arguments

### DIFF
--- a/definitions/npm/yargs_v17.x.x/flow_v0.104.x-/yargs_v17.x.x.js
+++ b/definitions/npm/yargs_v17.x.x/flow_v0.104.x-/yargs_v17.x.x.js
@@ -186,6 +186,7 @@ declare module "yargs" {
     epilogue(text: string): this;
 
     example(cmd: string, desc?: string): this;
+    example(Array<[string, string]>): this;
 
     exitProcess(enable: boolean): this;
 

--- a/definitions/npm/yargs_v17.x.x/flow_v0.98.x-v0.103.x/yargs_v17.x.x.js
+++ b/definitions/npm/yargs_v17.x.x/flow_v0.98.x-v0.103.x/yargs_v17.x.x.js
@@ -183,6 +183,7 @@ declare module "yargs" {
     epilogue(text: string): this;
 
     example(cmd: string, desc?: string): this;
+    example(Array<[string, string]>): this;
 
     exitProcess(enable: boolean): this;
 

--- a/definitions/npm/yargs_v17.x.x/test_yargs.js
+++ b/definitions/npm/yargs_v17.x.x/test_yargs.js
@@ -36,6 +36,7 @@ describe('command()', () => {
 
   it('example', () => {
     yargs.example('fetch', 'fetch [...files]');
+    yargs.example([['fetch', 'fetch [...files]']]);
   });
 });
 


### PR DESCRIPTION
- Links to documentation: https://yargs.js.org/docs/#api-reference-examplecmd1-desc1-cmd2-desc2
- Link to GitHub or NPM: https://github.com/yargs/yargs/blob/2e0ef3c965dd788ec4af0735ce96d66ed9f91cc0/lib/usage.ts#L111
- Type of contribution: addition

