### PR TITLE
[cli] workspaces in flow-typed.config.json

### DIFF
--- a/cli/src/commands/__tests__/__install-fixtures__/workspace/flow-config-workspaces/flow-typed.config.json
+++ b/cli/src/commands/__tests__/__install-fixtures__/workspace/flow-config-workspaces/flow-typed.config.json
@@ -1,0 +1,3 @@
+{
+  "workspaces": ["packages/*"]
+}

--- a/cli/src/commands/__tests__/__install-fixtures__/workspace/flow-config-workspaces/package.json
+++ b/cli/src/commands/__tests__/__install-fixtures__/workspace/flow-config-workspaces/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "root-workspace",
+	"private": true,
+	"devDependencies": {
+		"flow-bin": "^0.43.0"
+	}
+}

--- a/cli/src/commands/__tests__/__install-fixtures__/workspace/flow-config-workspaces/packages/a/package.json
+++ b/cli/src/commands/__tests__/__install-fixtures__/workspace/flow-config-workspaces/packages/a/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "a",
+	"version": "0.0.0",
+	"peerDependencies": {
+		"c": "*",
+		"foo": "^1.0.0"
+	}
+}

--- a/cli/src/commands/__tests__/__install-fixtures__/workspace/flow-config-workspaces/packages/b/package.json
+++ b/cli/src/commands/__tests__/__install-fixtures__/workspace/flow-config-workspaces/packages/b/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "b",
+	"version": "0.0.0",
+	"dependencies": {
+		"a": "*"
+	},
+	"devDependencies": {
+		"c": "*",
+		"foo": "^1.0.0"
+	}
+}

--- a/cli/src/commands/__tests__/__install-fixtures__/workspace/flow-config-workspaces/packages/c/package.json
+++ b/cli/src/commands/__tests__/__install-fixtures__/workspace/flow-config-workspaces/packages/c/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "c",
+	"version": "0.0.0",
+	"devDependencies": {
+		"bar": "^1.0.0"
+	}
+}

--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -1717,11 +1717,13 @@ declare type jsx$HTMLElementProps = {||}`;
     const origConsoleLog = console.log;
     const origConsoleError = console.error;
     const origConsoleWarn = console.warn;
+
     beforeEach(() => {
       (console: any).log = jest.fn();
       (console: any).error = jest.fn();
       (console: any).warn = jest.fn();
     });
+
     afterEach(() => {
       (console: any).log = origConsoleLog;
       (console: any).error = origConsoleError;
@@ -1861,6 +1863,40 @@ declare type jsx$HTMLElementProps = {||}`;
           '^1.1.0',
           '^2.0.0',
         );
+      });
+    });
+
+    it('supports flow-typed.config.json workspaces', () => {
+      return fakeProjectEnv(async FLOWPROJ_DIR => {
+        await copyDir(
+          path.join(FIXTURE_ROOT, 'flow-config-workspaces'),
+          FLOWPROJ_DIR,
+        );
+
+        // Run the install command
+        await run({
+          ...defaultRunProps,
+          ignoreDeps: [],
+        });
+
+        // Installs libdefs
+        expect(
+          await fs.readdir(path.join(FLOWPROJ_DIR, 'flow-typed', 'npm')),
+        ).toEqual([
+          'a_vx.x.x.js',
+          'bar_v1.x.x.js',
+          'c_vx.x.x.js',
+          'flow-bin_v0.x.x.js',
+          'foo_v1.x.x.js',
+        ]);
+
+        // Signs installed libdefs
+        const fooLibDefContents = await fs.readFile(
+          path.join(FLOWPROJ_DIR, 'flow-typed', 'npm', 'foo_v1.x.x.js'),
+          'utf8',
+        );
+        expect(fooLibDefContents).toContain('// flow-typed signature: ');
+        expect(fooLibDefContents).toContain('// flow-typed version: ');
       });
     });
   });

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -394,7 +394,10 @@ async function installNpmLibDefs({
       const termMatches = term.match(/(@[^@\/]+\/)?([^@]+)@(.+)/);
       if (termMatches == null) {
         const pkgJsonData = await getPackageJsonData(cwd);
-        const workspacesPkgJsonData = await findWorkspacesPackages(pkgJsonData);
+        const workspacesPkgJsonData = await findWorkspacesPackages(
+          pkgJsonData,
+          ftConfig,
+        );
         const pkgJsonDeps = workspacesPkgJsonData.reduce((acc, pckData) => {
           return mergePackageJsonDependencies(
             acc,
@@ -420,7 +423,10 @@ async function installNpmLibDefs({
     console.log(`• Searching for ${libdefsToSearchFor.size} libdefs...`);
   } else {
     const pkgJsonData = await getPackageJsonData(cwd);
-    const workspacesPkgJsonData = await findWorkspacesPackages(pkgJsonData);
+    const workspacesPkgJsonData = await findWorkspacesPackages(
+      pkgJsonData,
+      ftConfig,
+    );
     const pkgJsonDeps = workspacesPkgJsonData.reduce((acc, pckData) => {
       return mergePackageJsonDependencies(
         acc,

--- a/cli/src/lib/ftConfig.js
+++ b/cli/src/lib/ftConfig.js
@@ -4,6 +4,7 @@ import {fs, path} from './node';
 export type FtConfig = {
   env?: mixed, // Array<string>,
   ignore?: Array<string>,
+  workspaces?: Array<string>,
 };
 
 export const getFtConfig = (cwd: string): FtConfig | void => {

--- a/docs/flow-typed-config.md
+++ b/docs/flow-typed-config.md
@@ -2,9 +2,13 @@
 
 Since version `>=3.8.0`, flow-typed supports a config file to help you set various project level settings.
 
+**To get started, create a config file at the root of your project, generally as a sibling t `.flowconfig`**
+
 `<PROJECT_ROOT>/flow-typed.config.json`
 
-## env
+## Properties
+
+### env
 
 `env` accepts an array of strings that map to environment definitions that you can you can find [here](https://github.com/flow-typed/flow-typed/tree/main/definitions/environments).
 
@@ -16,12 +20,22 @@ Since version `>=3.8.0`, flow-typed supports a config file to help you set vario
 
 Learn more about [environment definitions](env-definitions.md)
 
-## ignore
+### ignore
 
 When you have a dependencies you don't want updated or swapped out during the `install` command you can add this property which takes an array of strings referencing either package scopes or package names explicitly to ignore.
 
 ```json
 {
   ignore: ["@babel", "@custom/", "eslint", "eslint-plugin-ft-flow"]
+}
+```
+
+### workspaces
+
+Flow-typed works out of the box with yarn or npm workspaces to install sub project dependencies. But if your monorepo uses neither you can still let flow-typed know where to pull dependencies to search for definitions from with the `workspaces` key.
+
+```json
+{
+  workspaces: ["web", "packages/*"]
 }
 ```

--- a/docs/flow-typed-config.md
+++ b/docs/flow-typed-config.md
@@ -2,7 +2,7 @@
 
 Since version `>=3.8.0`, flow-typed supports a config file to help you set various project level settings.
 
-**To get started, create a config file at the root of your project, generally as a sibling t `.flowconfig`**
+**To get started, create a config file at the root of your project, generally as a sibling to `.flowconfig`**
 
 `<PROJECT_ROOT>/flow-typed.config.json`
 
@@ -32,7 +32,7 @@ When you have a dependencies you don't want updated or swapped out during the `i
 
 ### workspaces
 
-Flow-typed works out of the box with yarn or npm workspaces to install sub project dependencies. But if your monorepo uses neither you can still let flow-typed know where to pull dependencies to search for definitions from with the `workspaces` key.
+Flow-typed works out of the box with yarn or npm workspaces to install sub project dependencies. But if your monorepo uses neither you can still let flow-typed know where to pull dependencies to search for definitions from with the `workspaces` key which follows the same glob format as yarn or npm.
 
 ```json
 {


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
## Context

Creating feature for my own use case. I'm creating a project where I have a monorepo but the root doesn't use yarn workspaces, instead it has a package.json that only has `flow-bin` atm. So I need a way of specifying where it search for definitions, I'm opting to use `flow-typed.config.json` for this.

I believe this is a valuable feature as the JS ecosystem evolves and root level tooling eventually shifts to run off rust instead of JS.

## Example
Usage and docs added in the PR itself

**note** I'm merging this into `main`, I hope this can be included in that Christmas release you promised me @GAntoine 😈 
