### PR TITLE
[react-router-dom] fix & add missing hook definition

### DIFF
--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
@@ -261,6 +261,14 @@ declare module "react-router-dom" {
     pattern: PathPattern | string
   ): PathMatch<ParamKey> | null;
 
+  declare export function useMatches<Data = mixed, Handle = mixed>(): Array<{|
+    id: string;
+    pathname: string;
+    params: Params<string>;
+    data: Data;
+    handle: Handle;
+  |}>;
+
   declare export function useOutlet<T = any>(): React$Element<T> | null;
 
   declare export function useRoutes<T = any>(

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
@@ -201,7 +201,7 @@ declare module "react-router-dom" {
     children: React$Node,
   ): Array<RouteObject>;
 
-  declare type Params<Key: string> = {
+  declare export type Params<Key: string> = {
     +[key: Key]: string | void;
   };
 

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
@@ -272,7 +272,7 @@ describe("react-router-dom", () => {
     describe("Class Components", () => {
       it("passes if the component is passed required props", () => {
         class Comp extends React.Component<Props> {
-          render() {
+          render(): React$Element<'div'> {
             return <div />;
           }
         }
@@ -285,7 +285,7 @@ describe("react-router-dom", () => {
 
       it("errors if the component is not passed the correct props", () => {
         class Comp extends React.Component<Props> {
-          render() {
+          render(): React$Element<'div'> {
             return <div />;
           }
         }
@@ -303,11 +303,15 @@ describe("react-router-dom", () => {
       });
 
       it("passes if a required prop is handled by defaultProps", () => {
+        type OwnProps = {|
+          s: string,
+        |};
+
         class Comp extends React.Component<Props> {
-          static defaultProps = {
+          static defaultProps: OwnProps = {
             s: "defaultS"
           };
-          render() {
+          render(): React$Element<'div'> {
             return <div />;
           }
         }
@@ -321,11 +325,15 @@ describe("react-router-dom", () => {
       });
 
       it("errors if a required prop that has a defaultProp is passed the wrong type", () => {
+        type OwnProps = {|
+          s: string,
+        |};
+
         class Comp extends React.Component<Props> {
-          static defaultProps = {
+          static defaultProps: OwnProps = {
             s: "defaultS"
           };
-          render() {
+          render(): React$Element<'div'> {
             return <div />;
           }
         }
@@ -389,7 +397,7 @@ describe("react-router-dom", () => {
 
   describe("Route", () => {
     it("works", () => {
-      const Component = ({}) => <div>Hi!</div>;
+      const Component = () => <div>Hi!</div>;
       <Route path="/login" />;
 
       <Route path="/login" element={<Component />} />;
@@ -411,7 +419,7 @@ describe("react-router-dom", () => {
 
   describe('Routes', () => {
     it('works', () => {
-      const Component = ({}) => <div>Hi!</div>;
+      const Component = () => <div>Hi!</div>;
       <Routes>
         <Route path="/login" element={<Component />} />
       </Routes>;

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
@@ -17,6 +17,7 @@ import {
   useOutletContext,
   useParams,
   useRouteMatch,
+  useMatches,
 } from "react-router-dom";
 import type {
   Location,
@@ -483,6 +484,60 @@ describe("react-router-dom", () => {
       const matchObject2: Match = useRouteMatch({
         sensitive: 'foo',
       });
+    });
+
+    it('useMatches', () => {
+      type Params<Key: string> = {
+        +[key: Key]: string | void,
+      };
+
+      type Matches = Array<{|
+        id: string,
+        pathname: string,
+        params: Params<string>,
+        data: mixed,
+        handle: {|
+          custom: string,
+        |},
+      |}>;
+      const matches: Matches = useMatches();
+
+      type MatchesWithHandle = Array<{|
+        id: string,
+        pathname: string,
+        params: Params<string>,
+        data: mixed,
+        handle: {|
+          custom: string,
+        |},
+      |}>;
+      const matchesWithHandle: MatchesWithHandle = useMatches<
+        mixed,
+        {|
+          custom: string,
+        |}
+      >();
+
+      type InvalidMatchesMissingPathname = Array<{|
+        id: string,
+        params: Params<string>,
+        data: mixed,
+        handle: mixed,
+      |}>;
+      // $FlowExpectedError[prop-missing]
+      const matchesMissingPathname: InvalidMatchesMissingPathname = useMatches();
+
+      type InvalidMatchesIcompatibleParams = Array<{|
+        id: string,
+        pathname: string,
+        params: Params<number>,
+        data: mixed,
+        handle: mixed,
+      |}>;
+
+      // $FlowExpectedError[incompatible-type]
+      // $FlowExpectedError[incompatible-type-arg]
+      const matchesIncompatibleParams: InvalidMatchesIcompatibleParams = useMatches();
     });
   });
 });

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
@@ -25,6 +25,7 @@ import type {
   Match,
   StaticRouterContext,
   RouterHistory,
+  Params,
 } from "react-router-dom";
 import { it, describe } from "flow-typed-test";
 
@@ -487,10 +488,6 @@ describe("react-router-dom", () => {
     });
 
     it('useMatches', () => {
-      type Params<Key: string> = {
-        +[key: Key]: string | void,
-      };
-
       type Matches = Array<{|
         id: string,
         pathname: string,
@@ -535,7 +532,6 @@ describe("react-router-dom", () => {
         handle: mixed,
       |}>;
 
-      // $FlowExpectedError[incompatible-type]
       // $FlowExpectedError[incompatible-type-arg]
       const matchesIncompatibleParams: InvalidMatchesIcompatibleParams = useMatches();
     });


### PR DESCRIPTION
- Links to documentation: 
  - https://reactrouter.com/en/main/hooks/use-matches
- Link to GitHub or NPM: 
  - https://github.com/remix-run/react-router/blob/main/packages/react-router-dom/index.tsx#L154
  - https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/hooks.tsx#L739-L760
  - https://github.com/remix-run/react-router/blob/main/packages/router/router.ts#L249
  - https://github.com/remix-run/react-router/blob/main/packages/router/utils.ts#L245-L265
- Type of contribution: addition & fix 

Other notes:

Actually `useMatches` is a re-export from `react-router` that uses the router's state from `@remix-run/router`
