### PR TITLE
[react-router-dom] update Route component type (simple)

### DIFF
--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
@@ -125,13 +125,66 @@ declare module "react-router-dom" {
     children?: React$Node
   |}>
 
-  declare export var Route: React$ComponentType<{|
-    caseSensitive?: boolean,
-    children?: React$Node,
-    element?: React$Element<any> | null,
-    index?: boolean,
-    path?: string,
-  |}>
+
+  declare type DataFunctionArgs = {|
+    request: Request;
+    params: Params<string>;
+    context?: any;
+  |}
+
+  declare export type LoaderFunction = (args: DataFunctionArgs) => Promise<Response> | Response | Promise<any> | any;
+
+  declare export type ActionFunction  = (args: DataFunctionArgs) => Promise<Response> | Response | Promise<any> | any;
+
+  declare export class DeferredData {
+    (data: mixed, responseInit?: ResponseOptions): void;
+    subscribe: mixed,
+    cancel: mixed,
+    resolveData: mixed,
+    done: mixed,
+    unwrappedData: mixed,
+    pendingKeys: mixed,
+  }
+
+  declare export type ShouldRevalidateFunction = (args: {|
+    currentUrl: URL;
+    currentParams: Params<string>;
+    nextUrl: URL;
+    nextParams: Params<string>;
+    formMethod?: "get" | "post" | "put" | "patch" | "delete";
+    formAction?: string;
+    formEncType?: "application/x-www-form-urlencoded" | "multipart/form-data";
+    formData?: FormData;
+    actionResult?: {|
+      type: 'data'|'deferred'|'redirect'|'error';
+      data?: any;
+      statusCode?: number;
+      headers?: Headers;
+      deferredData?: DeferredData;
+      status?: Number;
+      location?: string;
+      revalidate?: boolean;
+      error?: any;
+    |};
+    defaultShouldRevalidate: boolean;
+  |}) => boolean;
+
+  declare export type RouteProps = {|
+    caseSensitive?: boolean;
+    path?: string;
+    id?: string;
+    loader?: LoaderFunction;
+    action?: ActionFunction;
+    hasErrorBoundary?: boolean;
+    shouldRevalidate?: ShouldRevalidateFunction;
+    handle?: mixed;
+    index?: boolean;
+    children?: React$Node;
+    element?: React$Node | null;
+    errorElement?: React$Node | null;
+  |}
+
+  declare export var Route: React$ComponentType<RouteProps>
 
   declare export var Prompt: React$ComponentType<{|
     message: string | ((location: Location) => string | boolean),

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
@@ -408,6 +408,25 @@ describe("react-router-dom", () => {
         index
         caseSensitive
       />;
+
+      <Route><div>Hi!</div></Route>;
+
+      <Route
+        caseSensitive
+        path="/login"
+        id="login"
+        loader={({ request, params }) => {
+          const myRequest: Request = request;
+          const myParams: Params<string> = params;
+        }}
+        action={() => {}}
+        hasErrorBoundary
+        shouldRevalidate={() => false}
+        handle={{ breadcrumb: 'login'}}
+        index={false}
+        element={<Component />}
+        errorElement={<Component />}
+      />;
     });
 
     it("raises error if passed incorrect props", () => {
@@ -416,6 +435,35 @@ describe("react-router-dom", () => {
 
       // $FlowExpectedError[prop-missing] - unexpected prop xxx
       <Route xxx="1" />;
+
+      // $FlowExpectedError[incompatible-type]
+      <Route action={(invalid: number) => true} />;
+
+      // $FlowExpectedError[incompatible-type]
+      <Route caseSensitive="123" />;
+
+      <Route loader={({ request, params, ...loaderArgs}) => {
+        // $FlowExpectedError[incompatible-type]
+        const myRequest: string = request;
+
+        // $FlowExpectedError[incompatible-type]
+        const myParams: string = params;
+
+        // $FlowExpectedError[prop-missing]
+        const missing: any = loaderArgs.missing;
+
+        return false;
+      }} />;
+
+      // $FlowExpectedError[incompatible-type]
+      <Route hasErrorBoundary="invalid" />;
+
+      // $FlowExpectedError[incompatible-type]
+      // $FlowExpectedError[prop-missing]
+      <Route shouldRevalidate={({ currentUrl }: {| currentUrl: number |}) => true} />;
+
+      // $FlowExpectedError[incompatible-type]
+      <Route index="invalid" />;
     });
   });
 


### PR DESCRIPTION
- Links to documentation: 
  - RouteObject: https://reactrouter.com/en/main/route/route#type-declaration
- Link to GitHub or NPM: 
  -  RouteObject: https://github.com/remix-run/react-router/blob/0ce0e4c728129efe214521a22fb902fa652bac70/packages/router/utils.ts#L145
- Type of contribution:  addition

Other notes:

I've provided two versions in order to improve `react-router-dom`'s Route Props
- https://github.com/flow-typed/flow-typed/pull/4418 is the advanced PR for Route component
- current is the simple PR for Route component

This PR:
- adds missing props
- updates test as well
