### PR TITLE
[react-router-dom] fix test after migrating flow to ^0.200.0

### DIFF
--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
@@ -441,7 +441,7 @@ declare module "react-router-dom" {
 
   declare export function useHistory(): $PropertyType<ContextRouter, 'history'>;
   declare export function useLocation(): $PropertyType<ContextRouter, 'location'>;
-  declare export function useOutletContext<T>(): T;
+  declare export function useOutletContext<T = any>(): T;
   declare export function useParams<Params = $PropertyType<$PropertyType<ContextRouter, 'match'>, 'params'>>(): Params;
   declare export function useRouteMatch(path?: MatchPathOptions | string | string[]): $PropertyType<ContextRouter, 'match'>;
 

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
@@ -14,6 +14,7 @@ import {
   useHistory,
   useLocation,
   useNavigate,
+  useOutlet,
   useOutletContext,
   useParams,
   useRouteMatch,
@@ -496,12 +497,34 @@ describe("react-router-dom", () => {
     });
 
     it('useOutlet', () => {
+      useOutlet()
+
+      const Component = () => <div>Hi!</div>;
+
+      useOutlet<typeof Component>()
+
+      // $FlowExpectedError[extra-arg]
+      useOutlet('')
+    })
+
+    it('useOutletContext', () => {
       const [count, setCount] = useOutletContext();
       const increment = () => setCount((c) => c + 1);
       <button onClick={increment}>{count}</button>;
 
       // $FlowExpectedError[extra-arg]
       useOutletContext('');
+
+      const t1: number = useOutletContext<number>();
+
+      type Tuple = [string, (foo: string) => void];
+
+      const [foo, setFoo] = useOutletContext<Tuple>();
+      (foo: string);
+      (setFoo: (foo: string) => void);
+
+      // $FlowExpectedError[incompatible-type]
+      const t2: string = useOutletContext<Tuple>();
     });
 
     it('useParams', () => {


### PR DESCRIPTION
fix test after migrating flow to ^0.200.0

also improve test saying testing `useOutlet` and test `useOutletContext`

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: 
  - https://reactrouter.com/en/main/hooks/use-outlet
  - https://reactrouter.com/en/main/hooks/use-outlet-context
- Type of contribution: fix

Other notes:

It ~~probably~~ requires #4423 in order to pass CI
