### PR TITLE
[react-router-dom]  navlink, renderMatches & matchRoutes

### DIFF
--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
@@ -26,7 +26,6 @@ declare module "react-router-dom" {
     +to: string | LocationShape,
     +className?: string | (props: {| isActive: boolean, isPending: boolean |}) => string | void,
     +style?: { +[string]: mixed, ... } | (props: {| isActive: boolean, isPending: boolean|}) => { +[string]: mixed, ... } | void,
-    +isActive?: (match: Match, location: Location) => boolean,
     +children?: React$Node,
     +end?: boolean,
     +strict?: boolean,

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
@@ -461,28 +461,23 @@ declare module "react-router-dom" {
 
   declare export type RouteObject = IndexRouteObject | NonIndexRouteObject;
 
-  declare export function createRoutesFromChildren(
-    children: React$Node,
-  ): Array<RouteObject>;
+  declare export function createRoutesFromElements(elements: React$Node): RouteObject[]
+  declare export var createRoutesFromChildren: typeof createRoutesFromElements;
 
   declare export type Params<Key: string> = {
     +[key: Key]: string | void;
   };
 
-  declare type RouteMatch<ParamKey: string> = {|
-    params: Params<ParamKey>,
-    pathname: string,
-    route: RouteObject,
-  |};
+  declare export type RouteMatch<ParamKey: string = string, RouteObjectType: RouteObject = RouteObject> = AgnosticRouteMatch<ParamKey, RouteObjectType>
 
-  declare export function matchRoutes(
+  declare export function matchRoutes<RouteObjectType: RouteObject = RouteObject>(
     routes: Array<RouteObject>,
     location: LocationShape | string,
     basename?: string,
-  ): Array<RouteMatch<string>> | null;
+  ): Array<AgnosticRouteMatch<string, RouteObjectType>> | null;
 
-  declare export function renderMatches(
-    matches: Array<RouteMatch<string>> | null,
+  declare export function renderMatches<RouteObjectType = RouteObject>(
+    matches: Array<RouteMatch<string, RouteObjectType>> | null,
   ): React$Element<any> | null;
 
   declare type PathPattern = {|

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
@@ -24,10 +24,8 @@ declare module "react-router-dom" {
 
   declare export var NavLink: React$ComponentType<{
     +to: string | LocationShape,
-    +activeClassName?: string,
-    +className?: string,
-    +activeStyle?: { +[string]: mixed, ... },
-    +style?: { +[string]: mixed, ... },
+    +className?: string | (props: {| isActive: boolean, isPending: boolean |}) => string | void,
+    +style?: { +[string]: mixed, ... } | (props: {| isActive: boolean, isPending: boolean|}) => { +[string]: mixed, ... } | void,
     +isActive?: (match: Match, location: Location) => boolean,
     +children?: React$Node,
     +exact?: boolean,

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
@@ -26,7 +26,7 @@ declare module "react-router-dom" {
     +to: string | LocationShape,
     +className?: string | (props: {| isActive: boolean, isPending: boolean |}) => string | void,
     +style?: { +[string]: mixed, ... } | (props: {| isActive: boolean, isPending: boolean|}) => { +[string]: mixed, ... } | void,
-    +children?: React$Node,
+    +children?: React$Node | ({| isActive: boolean, isPending: boolean |}) => React$Node,
     +end?: boolean,
     +strict?: boolean,
     ...

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/react-router-dom_v6.x.x.js
@@ -28,7 +28,7 @@ declare module "react-router-dom" {
     +style?: { +[string]: mixed, ... } | (props: {| isActive: boolean, isPending: boolean|}) => { +[string]: mixed, ... } | void,
     +isActive?: (match: Match, location: Location) => boolean,
     +children?: React$Node,
-    +exact?: boolean,
+    +end?: boolean,
     +strict?: boolean,
     ...
   }>

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
@@ -126,7 +126,7 @@ describe("react-router-dom", () => {
         style={{ color: "blue" }}
         isActive={(match, location) => true}
         strict
-        exact
+        end
       >
         About
       </NavLink>;
@@ -163,11 +163,12 @@ describe("react-router-dom", () => {
       // $FlowExpectedError[incompatible-type] - to prop must be a string or LocationShape
       <NavLink to={[]} />;
 
-      // activeClassName and activeStyle have been dropped unfortunately props cannot be strict so no errors can be expected
+      // activeClassName, activeStyle and end have been dropped unfortunately props cannot be strict so no errors can be expected
       <NavLink
         to="/about"
         activeClassName="active"
         activeStyle={{ color: "red" }}
+        end
       >
         About
       </NavLink>;

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
@@ -6,6 +6,8 @@ import {
   Link,
   NavLink,
   matchPath,
+  matchRoutes,
+  renderMatches,
   withRouter,
   Navigate,
   Outlet,
@@ -21,6 +23,8 @@ import {
   useMatches,
 } from "react-router-dom";
 import type {
+  AgnosticRouteMatch,
+  RouteObject,
   Location,
   ContextRouter,
   Match,
@@ -230,6 +234,58 @@ describe("react-router-dom", () => {
       const matchError: string = matchPath("/the/pathname", {
         path: "the/:dynamicId"
       });
+    });
+  });
+
+  describe('renderMatches', () => {
+    it('works', () => {
+      renderMatches([]);
+
+      renderMatches<RouteObject>([]);
+
+      const contentWithEmptyMatches: null|React$Element<any> = renderMatches([]);
+
+      const contentWithMatches: null|React$Element<any> = renderMatches([{
+        params: {},
+        pathname: '/',
+        pathnameBase: '',
+        route: {
+          index: false,
+          children: [{
+            index: true,
+          }],
+        },
+      }]);
+    });
+
+    it('raises', () => {
+      // $FlowExpectedError[incompatible-call]
+      renderMatches(5);
+
+      // $FlowExpectedError[incompatible-type]
+      const contentWithEmptyMatches: number = renderMatches([]);
+    });
+  });
+
+  describe('matchRoutes', () => {
+    it('works', () => {
+      matchRoutes([], '/');
+
+      matchRoutes<RouteObject>([], '/');
+
+      const contentWithEmptyMatches: Array<AgnosticRouteMatch<string, RouteObject>> | null = matchRoutes([], '/');
+
+      const contentWithMatches: Array<AgnosticRouteMatch<string, RouteObject>> | null = matchRoutes([{
+        id: 'bar',
+        path: 'bar',
+        index: false,
+        children: [],
+      }], '/');
+    });
+
+    it('raises an error with invalid arguments', () => {
+      // $FlowExpectedError[incompatible-call]
+      matchRoutes(5, '/');
     });
   });
 

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
@@ -122,9 +122,7 @@ describe("react-router-dom", () => {
 
       <NavLink
         to="/about"
-        activeClassName="active"
         className="link"
-        activeStyle={{ color: "red" }}
         style={{ color: "blue" }}
         isActive={(match, location) => true}
         strict
@@ -164,7 +162,35 @@ describe("react-router-dom", () => {
 
       // $FlowExpectedError[incompatible-type] - to prop must be a string or LocationShape
       <NavLink to={[]} />;
+
+      // activeClassName and activeStyle have been dropped unfortunately props cannot be strict so no errors can be expected
+      <NavLink
+        to="/about"
+        activeClassName="active"
+        activeStyle={{ color: "red" }}
+      >
+        About
+      </NavLink>;
     });
+
+    it('supports enhanced className & style props', () => {
+      <NavLink
+        to="/about"
+        className={({ isActive, isPending}) =>
+          isPending ? "pending" : isActive ? "active" : undefined
+        }
+        style={({ isActive, isPending}) =>
+          isPending ? { color: "red" } : isActive ? { color: "blue" } : undefined
+        }
+      >
+        About
+      </NavLink>;
+
+      // $FlowExpectedError[incompatible-type]
+      <NavLink to="/about" className={{'invalid': ''}} />;
+      // $FlowExpectedError[incompatible-type]
+      <NavLink to="/about" style={3} />;
+    })
   });
 
   describe("matchPath", () => {

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
@@ -124,7 +124,6 @@ describe("react-router-dom", () => {
         to="/about"
         className="link"
         style={{ color: "blue" }}
-        isActive={(match, location) => true}
         strict
         end
       >
@@ -163,11 +162,12 @@ describe("react-router-dom", () => {
       // $FlowExpectedError[incompatible-type] - to prop must be a string or LocationShape
       <NavLink to={[]} />;
 
-      // activeClassName, activeStyle and end have been dropped unfortunately props cannot be strict so no errors can be expected
+      // activeClassName, activeStyle, end, isActive have been dropped unfortunately props cannot be strict so no errors can be expected
       <NavLink
         to="/about"
         activeClassName="active"
         activeStyle={{ color: "red" }}
+        isActive={(match: any, location: any) => true}
         end
       >
         About
@@ -191,7 +191,7 @@ describe("react-router-dom", () => {
       <NavLink to="/about" className={{'invalid': ''}} />;
       // $FlowExpectedError[incompatible-type]
       <NavLink to="/about" style={3} />;
-    })
+    });
   });
 
   describe("matchPath", () => {

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.104.x-/test_react-router-dom.js
@@ -192,6 +192,14 @@ describe("react-router-dom", () => {
       // $FlowExpectedError[incompatible-type]
       <NavLink to="/about" style={3} />;
     });
+
+    it('supports render prop as children', () => {
+      <NavLink to="/about">
+        {({ isActive, isPending }) => (
+          <span className={isActive ? "active" : ""}>Tasks</span>
+        )}
+      </NavLink>
+    });
   });
 
   describe("matchPath", () => {


### PR DESCRIPTION
- Links to documentation: https://reactrouter.com/en/main
- Link to GitHub or NPM: https://www.npmjs.com/package/react-router-dom
- Type of contribution: fix

Other notes:

reviewing commit by commit should be easier:

- drop outdated support of Navlink props `activeClassName` & `activeStyle`
    also improve type className & style then add tests
    cf. https://reactrouter.com/en/main/upgrading/v5#remove-activeclassname-and-activestyle-props-from-navlink-

- Navlink prop `exact` renamed to `end`
    cf. https://reactrouter.com/en/main/upgrading/v5#rename-navlink-exact-to-navlink-end

- Navlink's `isActive` has been removed between versions 5 & 6 without notice:
    v5: https://v5.reactrouter.com/web/api/NavLink/isactive-func
    latest: https://reactrouter.com/en/main/components/nav-link#navlink

- Navlink accepts render prop
    cf. https://reactrouter.com/en/main/components/nav-link#children

- refactor `renderMatches` & `matchRoutes` types
    improve types to make it more precise and more close to typescript definition
    cf.
    matchRoute https://github.com/remix-run/react-router/blob/d19c2c221c9f53b8273033f31b0ee94734719f47/packages/router/utils.ts#L374
    renderRoutes https://github.com/remix-run/react-router/blob/d19c2c221c9f53b8273033f31b0ee94734719f47/packages/react-router/lib/components.tsx#L630

