### PR TITLE
Drop duplicate declaration of lodash-es/create module

### DIFF
--- a/definitions/npm/lodash-es_v4.x.x/flow_v0.104.x-/lodash-es_v4.x.x.js
+++ b/definitions/npm/lodash-es_v4.x.x/flow_v0.104.x-/lodash-es_v4.x.x.js
@@ -1989,9 +1989,6 @@ declare module "lodash-es/at" {
 declare module "lodash-es/create" {
   declare export default $PropertyType<$Exports<"lodash-es">, "create">;
 }
-declare module "lodash-es/create" {
-  declare export default $PropertyType<$Exports<"lodash-es">, "create">;
-}
 declare module "lodash-es/defaults" {
   declare export default $PropertyType<$Exports<"lodash-es">, "defaults">;
 }


### PR DESCRIPTION
In current versions of Flow this duplicate cause flow to crash with "Should have been excluded: .$module__lodash-es/create"

I found the log entry when running flow server with --temp-dir flag and looking at the log file generated in this temp dir:

Unhandled exception: (Failure "Should have been excluded: .$module__lodash-es/create") Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33 Called from Env.init_builtins_from_libdef.(fun) in file "src/typing/env.ml", line 917, characters 6-35

- Type of contribution: fix
