### PR TITLE
[cli] Fix running definition tests locally on MacOS

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -678,7 +678,6 @@ async function runTests(
           numberOfFlowVersions,
         );
       } catch (e) {
-        console.log(e);
         orderedFlowVersions = await getCachedFlowBinVersions(
           numberOfFlowVersions,
         );


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
If you look at the list of [releases](https://github.com/facebook/flow/releases), previously up to version [v0.200.1](https://github.com/facebook/flow/releases/tag/v0.200.1) flow used to release only a x86 binary

<img width="935" alt="Screen Shot 2023-05-14 at 9 19 44 am" src="https://github.com/flow-typed/flow-typed/assets/12436524/6aeb00e3-3ecb-4ad4-a349-e8ebccfcc2fd">

After this, from [v0.201.0](https://github.com/facebook/flow/releases/tag/v0.201.0) onward flow started releasing osx arm binaries.

<img width="950" alt="Screen Shot 2023-05-14 at 9 20 41 am" src="https://github.com/flow-typed/flow-typed/assets/12436524/48ef968f-4f10-46fb-aae0-2d214f641623">

The original flow-typed fetching binary logic never anticipated arm, so the logic was never handled and when it found 2 binaries for macos it crashed silently.

## What was fixed

- More logic to binary selection
- Refined regex expression so that it will never find multiple binaries