### PR TITLE
[cli] Fix a bug from flow that stopped testing for ambiguous obj exactness 

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -350,7 +350,10 @@ async function writeFlowConfig(repoDirPath, testDirPath, libDefPath, version) {
     path.join(testDirPath, '..', '..', 'node_modules'),
     '',
     '[lints]',
-    semver.gte(version, '0.104.0') ? 'implicit-inexact-object=error' : '',
+    semver.gte(version, '0.104.0') && semver.lt(version, '0.201.0')
+      ? 'implicit-inexact-object=error'
+      : '',
+    semver.gte(version, '0.201.0') ? 'ambiguous-object-type=error' : '',
   ].join('\n');
   await fs.writeFile(destFlowConfigPath, flowConfigData);
 }


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
note: `master` branch isn't properly tested. Validated locally and will test when merging into `main`

