### PR TITLE
[tua-body-scroll] Add definition

### DIFF
--- a/cli/src/commands/create-def.js
+++ b/cli/src/commands/create-def.js
@@ -35,6 +35,11 @@ export async function run({libName, ver}: Args): Promise<number> {
     return 1;
   }
 
+  if (ver.startsWith('v')) {
+    console.error("ERROR: You don't need to specify `v` with your version");
+    return 1;
+  }
+
   const scope = libName.startsWith('@') ? libName.split('/')[0] : '';
   const packageName = scope ? libName.split('/')[1] : libName;
   const definitionsPath = path.join(

--- a/definitions/npm/tua-body-scroll_v1.x.x/flow_v0.83.x-/test_tua-body-scroll_v1.x.x.js
+++ b/definitions/npm/tua-body-scroll_v1.x.x/flow_v0.83.x-/test_tua-body-scroll_v1.x.x.js
@@ -1,0 +1,44 @@
+// @flow
+import { describe, test } from 'flow-typed-test';
+import {
+  lock,
+  unlock,
+  clearBodyLocks,
+} from 'tua-body-scroll';
+
+describe('tua-body-scroll', () => {
+  test('lock', () => {
+    declare var htmlElement: HTMLElement;
+
+    (lock(): void);
+    lock(null);
+    lock(htmlElement);
+    lock([htmlElement]);
+
+    // $FlowExpectedError[incompatible-call]
+    lock('');
+    // $FlowExpectedError[incompatible-cast]
+    (unlock(): number);
+  });
+
+  test('unlock', () => {
+    declare var htmlElement: HTMLElement;
+
+    (unlock(): void);
+    unlock(null);
+    unlock(htmlElement);
+    unlock([htmlElement]);
+
+    // $FlowExpectedError[incompatible-call]
+    unlock('');
+    // $FlowExpectedError[incompatible-cast]
+    (unlock(): number);
+  });
+
+  test('clearBodyLocks', () => {
+    (clearBodyLocks(): void);
+
+    // $FlowExpectedError[extra-arg]
+    clearBodyLocks('');
+  });
+});

--- a/definitions/npm/tua-body-scroll_v1.x.x/flow_v0.83.x-/tua-body-scroll_v1.x.x.js
+++ b/definitions/npm/tua-body-scroll_v1.x.x/flow_v0.83.x-/tua-body-scroll_v1.x.x.js
@@ -1,0 +1,9 @@
+declare module 'tua-body-scroll' {
+  declare type AcceptedElement = HTMLElement | Array<HTMLElement> | null | void;
+
+  declare module.exports: {|
+    lock(targetElement?: AcceptedElement): void,
+    unlock(targetElement?: AcceptedElement): void,
+    clearBodyLocks(): void,
+  |};
+}


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://www.npmjs.com/package/tua-body-scroll-lock
- Link to GitHub or NPM: https://www.npmjs.com/package/tua-body-scroll-lock
- Type of contribution: new definition

Other notes: Made an improvement to the create-def script because I always forget whether I need to add `v`

