### PR TITLE
[react-redux] Definition fix matching action inexact type

### DIFF
--- a/definitions/npm/react-redux_v8.x.x/flow_v0.201.x-/react-redux_v8.x.x.js
+++ b/definitions/npm/react-redux_v8.x.x/flow_v0.201.x-/react-redux_v8.x.x.js
@@ -216,7 +216,8 @@ declare module "react-redux" {
 
   declare export type AnyAction = {
     ...Action<any>,
-    [string]: any
+    [string]: any,
+    ...
   }
 
   declare export type Dispatch<-A: Action<any>> = (action: A, ...extraArgs: any[]) => mixed


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
```
declare export type Action<T> = {
    type: T,
    ...
  }
```

`Action` is declared as an inexact object which means when spread over `AnyAction` they must both be of the same type constraint. Though there is no usability difference with indexer objects flow sees these as incompatible. 


- Links to documentation: https://www.npmjs.com/package/react-redux
- Link to GitHub or NPM: https://www.npmjs.com/package/react-redux
- Type of contribution: fix

Other notes: The tests are throwing lots of errors mainly around unconstrained generic usage that I don't have the effort to fix at this stage

