### PR TITLE
[cli:test] Fix CI tests for environments

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -763,7 +763,7 @@ export async function run(argv: Args): Promise<number> {
   const cwdDefsEnvPath = path.join(basePath, 'definitions', 'environments');
   const envDirPath = (await fs.exists(cwdDefsEnvPath))
     ? cwdDefsEnvPath
-    : path.join(__dirname, '..', '..', '..', 'definitions', 'npm');
+    : path.join(__dirname, '..', '..', '..', 'definitions', 'environments');
 
   if (onlyChanged) {
     console.log(


### PR DESCRIPTION
I was wondering why in #4462 the tests passed just fine while there was many errors run locally.
See a6edf4ac0bb30f7daa6d4fcc79d62585c137b0f4 and 49a0defa9cbc27ca19b3a53a32d90891db39bc2a.


