### PR TITLE
match semantics for expect methods

### DIFF
--- a/definitions/npm/jest_v29.x.x/flow_v0.201.x-/jest_v29.x.x.js
+++ b/definitions/npm/jest_v29.x.x/flow_v0.201.x-/jest_v29.x.x.js
@@ -1221,8 +1221,8 @@ declare var expect: {
   hasAssertions(): void,
   any(value: mixed): JestAsymmetricEqualityType,
   anything(): any,
-  arrayContaining(value: Array<mixed>): Array<mixed>,
-  objectContaining(value: Object): Object,
+  arrayContaining(value: $ReadOnlyArray<mixed>): Array<mixed>,
+  objectContaining(value: { ... }): Object,
   /** Matches any received string that contains the exact expected string. */
   stringContaining(value: string): string,
   stringMatching(value: string | RegExp): string,

--- a/definitions/npm/jest_v29.x.x/flow_v0.201.x-/test_jest_v29.x.x.js
+++ b/definitions/npm/jest_v29.x.x/flow_v0.201.x-/test_jest_v29.x.x.js
@@ -15,11 +15,16 @@ jest.atoMockOff();
 const mockFn = jest.fn();
 mockFn.mock.calls.map(String).map((a) => a + a);
 
-type Value = {
+type ExactType = {|
+  value: number
+|};
+
+type InexactType = {
   value: number,
+  ...
 };
 
-const valueArray: Array<Value> = [
+const valueArray: Array<ExactType | InexactType> = [
   {
     value: 0,
   },

--- a/definitions/npm/jest_v29.x.x/flow_v0.201.x-/test_jest_v29.x.x.js
+++ b/definitions/npm/jest_v29.x.x/flow_v0.201.x-/test_jest_v29.x.x.js
@@ -15,6 +15,19 @@ jest.atoMockOff();
 const mockFn = jest.fn();
 mockFn.mock.calls.map(String).map((a) => a + a);
 
+type Value = {
+  value: number,
+};
+
+const valueArray: Array<Value> = [
+  {
+    value: 0,
+  },
+  {
+    value: 1,
+  },
+];
+
 type Foo = {
   doStuff: (string) => number,
   doAsyncStuff: (string) => Promise<number>,
@@ -368,13 +381,14 @@ expect.hasAssertions();
 
 expect.anything();
 expect.any(Error);
-expect.objectContaining({
-  foo: 'bar',
-});
 expect.arrayContaining(['red', 'blue']);
+expect.arrayContaining(valueArray);
+expect.objectContaining({ foo: 'bar' });
+expect.stringContaining('foobar');
 expect.stringMatching('*this part*');
 
 expect.not.arrayContaining(['red', 'blue']);
+expect.not.arrayContaining(valueArray);
 expect.not.objectContaining({ foo: 'bar' });
 expect.not.stringContaining('foobar');
 expect.not.stringMatching(/foobar/);


### PR DESCRIPTION
These functions pairs should match in their type restrictions and semantics (they are just inversions of each other):

expect.arrayContaining, expect.not.arrayContaining
expect.objectContaining, expect.not.objectContaining

The Flow types for the 'not' versions were already correct: allowing typed instances of objects to be passed into the methods, not just inlined literal objects.

This pull request updates the normal versions of the functions to match.