### PR TITLE
[cli] Bump semver solves VULN

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -41,7 +41,7 @@
     "node-stream-zip": "^1.15.0",
     "prettier": "^1.19.1",
     "rimraf": "^3.0.2",
-    "semver": "7.3.2",
+    "semver": "^7.5.4",
     "table": "^6.7.3",
     "which": "^2.0.2",
     "yargs": "^15.1.0"

--- a/cli/src/lib/__tests__/semver-test.js
+++ b/cli/src/lib/__tests__/semver-test.js
@@ -1,6 +1,10 @@
 // @flow
 
-import {stringToVersion, getRangeLowerBound} from '../semver.js';
+import {
+  stringToVersion,
+  getRangeLowerBound,
+  getRangeUpperBound,
+} from '../semver.js';
 import {Range} from 'semver';
 
 describe('semver', () => {
@@ -44,16 +48,32 @@ describe('semver', () => {
       });
     });
   });
+
   describe('getRangeLowerBound', () => {
     it('gets correct lower bound for string', () => {
       expect(getRangeLowerBound('v1.2.x')).toEqual('1.2.0');
       expect(getRangeLowerBound('v1.x.x')).toEqual('1.0.0');
       expect(getRangeLowerBound('^v0.x.x')).toEqual('0.0.0');
     });
+
     it('gets correct lower bound for string', () => {
       expect(getRangeLowerBound(new Range('v1.2.x'))).toEqual('1.2.0');
       expect(getRangeLowerBound(new Range('v1.x.x'))).toEqual('1.0.0');
       expect(getRangeLowerBound(new Range('^v0.x.x'))).toEqual('0.0.0');
+    });
+  });
+
+  describe('getRangeUpperBound', () => {
+    it('gets correct upper bound for string', () => {
+      expect(getRangeUpperBound('v1.2.x')).toEqual('1.3.0-0');
+      expect(getRangeUpperBound('v1.x.x')).toEqual('2.0.0-0');
+      expect(getRangeUpperBound('^v0.x.x')).toEqual('1.0.0-0');
+    });
+
+    it('gets correct upper bound for string', () => {
+      expect(getRangeUpperBound(new Range('v1.2.x'))).toEqual('1.3.0-0');
+      expect(getRangeUpperBound(new Range('v1.x.x'))).toEqual('2.0.0-0');
+      expect(getRangeUpperBound(new Range('^v0.x.x'))).toEqual('1.0.0-0');
     });
   });
 });

--- a/cli/src/lib/semver.js
+++ b/cli/src/lib/semver.js
@@ -22,13 +22,29 @@ export function emptyVersion(): Version {
   };
 }
 
+/**
+ * Find the lowest compatible explicit version based on a version range
+ * of a flow-typed definition
+ * ie: a type definition is 1.2.x, and the lower bound of that would be 1.2.0
+ */
 export function getRangeLowerBound(rangeRaw: string | semver.Range): string {
   const range =
     typeof rangeRaw === 'string' ? new semver.Range(rangeRaw) : rangeRaw;
-  // Fix for semver returning a bad comparator when the range is 'v0.x.x'
-  return range.set[0][0].semver.version || '0.0.0';
+
+  // When the range only has one object in the set, it implicitly means
+  // there is a range of anything up to the upper bound.
+  // Therefore we return `'0.0.0'`.
+  if (range.set[0].length === 1) {
+    return '0.0.0';
+  }
+  return range.set[0][0].semver.version;
 }
 
+/**
+ * Find the highest compatible explicit version based on a version range
+ * of a flow-typed definition
+ * ie: a type definition is 1.2.x, and the upper bound of that would be 1.3.0
+ */
 export function getRangeUpperBound(rangeRaw: string | semver.Range): string {
   const range =
     typeof rangeRaw === 'string' ? new semver.Range(rangeRaw) : rangeRaw;

--- a/cli/src/lib/semver.js
+++ b/cli/src/lib/semver.js
@@ -48,6 +48,13 @@ export function getRangeLowerBound(rangeRaw: string | semver.Range): string {
 export function getRangeUpperBound(rangeRaw: string | semver.Range): string {
   const range =
     typeof rangeRaw === 'string' ? new semver.Range(rangeRaw) : rangeRaw;
+
+  // When the range only has one object in the set, it implicitly means
+  // there is a range of anything up to the upper bound.
+  // So we'll return the first object version representing the upper bound.
+  if (range.set[0].length === 1) {
+    return range.set[0][0].semver.version;
+  }
   return range.set[0][1].semver.version;
 }
 

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -4060,14 +4060,7 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.2:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^7.5.4:
+semver@^7.5.4, semver@^7.2.1, semver@^7.3.2:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -1887,9 +1887,9 @@ camelcase@^6.2.0:
   integrity sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
 
 caniuse-lite@^1.0.30001280:
-  version "1.0.30001434"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz"
-  integrity sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==
+  version "1.0.30001517"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz#90fabae294215c3495807eb24fc809e11dc2f0a8"
+  integrity sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -4050,11 +4050,6 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
-
 semver@^5.4.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -4069,6 +4064,13 @@ semver@^7.2.1, semver@^7.3.2:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Closes #4460 by fixing the lower and upper bound semver functions which previously relied on logic from `semver` where it's lower bound was returned as an undefined object if the lower bound was anything but in newer versions the lower bound is simply missing.

This allows us to now update semver and keep it updated.