### PR TITLE
[aphrodite]: Make StyleObject ReadOnly

### DIFF
--- a/definitions/npm/aphrodite_v2.x.x/flow_v0.83.x-/aphrodite_v2.x.x.js
+++ b/definitions/npm/aphrodite_v2.x.x/flow_v0.83.x-/aphrodite_v2.x.x.js
@@ -10,7 +10,7 @@ declare module 'aphrodite' {
       fontWeight?: string | number;
     |};
 
-  declare type StyleObject = {
+  declare type StyleObject = $ReadOnly<{
     '::-ms-clear'?: StyleObject,
     '::-ms-expand'?: StyleObject,
     '::-webkit-scrollbar'?: StyleObject,
@@ -765,7 +765,7 @@ declare module 'aphrodite' {
     zoom?: CSSWideKeyword | string | number,
     [key: string]: any,
     ...
-  };
+  }>;
 
   declare type SelectorCallback = (selector: string) => Array<string>;
 

--- a/definitions/npm/aphrodite_v2.x.x/flow_v0.83.x-/test_aphrodite_2.x.x.js
+++ b/definitions/npm/aphrodite_v2.x.x/flow_v0.83.x-/test_aphrodite_2.x.x.js
@@ -86,6 +86,14 @@ describe('aphrodite', () => {
     // $FlowExpectedError[incompatible-call]
     resetInjectedStyle();
   });
+
+  it('pass refined objects into the style', () => {
+    const test: {| color: string |} = { color: 'black' };
+
+    const styles = StyleSheet.create({
+      test: test,
+    });
+  });
 });
 
 describe('aphrodite/no-important', () => {


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Aphrodite's style object should have all properties readonly as this allows more refined objects to be passed in

- Links to documentation: https://www.npmjs.com/package/aphrodite
- Link to GitHub or NPM: https://www.npmjs.com/package/aphrodite
- Type of contribution: fix

Other notes:

