### PR TITLE
[cli] Add .gitattributes to root

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# So that definition hashes are always consistent across OS
+*.js text eol=lf


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
When my colleagues machine installs definitions they have a different hash to me.

I'm fairly certain this is because of the cloning behaviour they have set by default which on windows is CRLF and the way that flow-typed updates the flow-typed cache is to have a copy of flow-typed cloned and pulled in the root dir of someones machine `~/.flow-typed`.

By fixing the clone behaviour of `*.js` files to LF on the repo config it ensures consistency regardless of someone's local environment and fortunately it doesn't need a CLI release.