### PR TITLE
Fix some invalid JSON regarding flow-typed.config.json docs [master branch]

### DIFF
--- a/docs/env-definitions.md
+++ b/docs/env-definitions.md
@@ -10,7 +10,7 @@ If you're on version `>=3.8.0` you can make use of the `env` property in [flow-t
 
 ```json
 {
-  env: ["jsx", "node", ...],
+  "env": ["jsx", "node", ...],
 }
 ```
 

--- a/docs/flow-typed-config.md
+++ b/docs/flow-typed-config.md
@@ -10,7 +10,7 @@ Since version `>=3.8.0`, flow-typed supports a config file to help you set vario
 
 ```json
 {
-  env: ["jsx", "node"],
+  "env": ["jsx", "node"],
 }
 ```
 
@@ -22,6 +22,6 @@ When you have a dependencies you don't want updated or swapped out during the `i
 
 ```json
 {
-  ignore: ["@babel", "@custom/", "eslint", "eslint-plugin-ft-flow"]
+  "ignore": ["@babel", "@custom/", "eslint", "eslint-plugin-ft-flow"]
 }
 ```


### PR DESCRIPTION
Hi! I spotted that the docs for `flow-typed.config.json` had invalid JSON in them and that caused them to render in red in GitHub.

It seems like valid JSON is required if I understood the code correctly:

https://github.com/flow-typed/flow-typed/blob/f9f840d2893c461e1b150dfb8b279e7ddf97f28b/cli/src/lib/ftConfig.js#L9-L15

> **Note**
>
> I also opened a pull request against `main` branch here:
>
> * #4516
>
> I don't know which pull request you'd want to have, if either, so feel free to close the other one if it is redundant ☺️ 