### PR TITLE
[cli] Ignore non-prod definitions when installing defs of depepndecies

### DIFF
--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -1098,6 +1098,12 @@ describe('install (command)', () => {
             dependencies: {
               foo: '^1.2.3',
             },
+            peerDependencies: {
+              'a-override': '^1.0.0',
+            },
+            devDependencies: {
+              'a-override': '^1.0.0',
+            },
           },
         );
         await touchFile(
@@ -1125,6 +1131,17 @@ describe('install (command)', () => {
             ),
           ),
         ).toEqual(true);
+        expect(
+          await fs.exists(
+            path.join(
+              FLOWPROJ_DIR,
+              'src',
+              'flow-typed',
+              'npm',
+              'a-override_v1.x.x.js',
+            ),
+          ),
+        ).toEqual(false);
       });
     });
 

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -552,7 +552,9 @@ async function installNpmLibDefs({
         );
         const pkgJsonDeps = getPackageJsonDependencies(
           pkgJsonData,
-          ignoreDeps,
+          // Only get their production dependencies
+          // as the rest aren't installed anyways
+          ['dev', 'peer', ...ignoreDeps],
           ignoreDefs,
         );
         for (const pkgName in pkgJsonDeps) {

--- a/cli/src/lib/npm/npmProjectUtils.js
+++ b/cli/src/lib/npm/npmProjectUtils.js
@@ -142,6 +142,8 @@ export function getPackageJsonDependencies(
   pkgJson: PkgJson,
   /**
    * dependency groups to ignore
+   *
+   * eg: dev, optional, bundled, peer, etc
    */
   ignoreDeps: Array<string>,
   /**
@@ -150,7 +152,7 @@ export function getPackageJsonDependencies(
   ignoreDefs: Array<string>,
 ): {[depName: string]: string} {
   const depFields = PKG_JSON_DEP_FIELDS.filter(field => {
-    return ignoreDeps.indexOf(field.slice(0, -12)) === -1;
+    return ignoreDeps.indexOf(field.slice(0, -'Dependencies'.length)) === -1;
   });
 
   return depFields.reduce((deps, section) => {


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Closes #4510

