### PR TITLE
[cli][defs] Enforce Yarn version

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -13,6 +13,7 @@
   "version": "3.9.0",
   "main": "dist/cli.js",
   "bin": "dist/cli.js",
+  "packageManager": "yarn@1.22.19",
   "engines": {
     "node": ">=10.0.0"
   },

--- a/definitions/package.json
+++ b/definitions/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "test": "eslint **/**/test_* --quiet"
   },
+  "packageManager": "yarn@1.22.19",
   "devDependencies": {
     "babel-eslint": "^10.0.2",
     "eslint": "^6.1.0",


### PR DESCRIPTION
The current repo is using Yarn 1, which is the legacy version or Yarn.
Current Yarn version is Yarn berry 3, with 4 around the corner.
Those are totally different beasts, and if a contributor tries to run yarn with a recent version, Yarn will try to upgrade to Yarn berry, and applies a lot of modifications.

By using the packageManager key, we can enforce the desired Yarn version, which will be used automatically by corepack.
See https://nodejs.org/docs/latest-v18.x/api/corepack.html#corepack_configuring_a_package

I choose the 1.22.19 version which is the latest of the 1.x branch.
