### PR TITLE
[cli] Install a dependency's environment definitions

### DIFF
--- a/cli/src/commands/__tests__/__install-fixtures__/end-to-end/fakeCacheRepo/definitions/environments/react/flow_v0.83.x-/react.js
+++ b/cli/src/commands/__tests__/__install-fixtures__/end-to-end/fakeCacheRepo/definitions/environments/react/flow_v0.83.x-/react.js
@@ -1,0 +1,3 @@
+declare type jsx$HTMLElementProps = {|
+  test: boolean,
+|};

--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -67,7 +67,7 @@ describe('install (command)', () => {
 
     it('errors if unable to find a project root (.flowconfig)', () => {
       return testProject(async ROOT_DIR => {
-        const result = await installNpmLibDefs({
+        const {status} = await installNpmLibDefs({
           cwd: ROOT_DIR,
           flowVersion: parseFlowDirString('flow_v0.40.0'),
           explicitLibDefs: [],
@@ -79,7 +79,7 @@ describe('install (command)', () => {
           ignoreDeps: [],
           useCacheUntil: 1000 * 60,
         });
-        expect(result).toBe(1);
+        expect(status).toBe(1);
         expect(_mock(console.error).mock.calls).toEqual([
           [
             'Error: Unable to find a flow project in the current dir or any of ' +
@@ -102,7 +102,7 @@ describe('install (command)', () => {
               'flow-bin': '^0.40.0',
             },
           });
-          const result = await installNpmLibDefs({
+          const {status} = await installNpmLibDefs({
             cwd: ROOT_DIR,
             flowVersion: parseFlowDirString('flow_v0.40.0'),
             explicitLibDefs: ['INVALID'],
@@ -114,7 +114,7 @@ describe('install (command)', () => {
             ignoreDeps: [],
             useCacheUntil: 1000 * 60,
           });
-          expect(result).toBe(1);
+          expect(status).toBe(1);
           expect(_mock(console.error).mock.calls).toEqual([
             [
               'ERROR: Package not found from package.json.\n' +
@@ -133,7 +133,7 @@ describe('install (command)', () => {
             name: 'test',
           }),
         ]);
-        const result = await installNpmLibDefs({
+        const {status} = await installNpmLibDefs({
           cwd: ROOT_DIR,
           flowVersion: parseFlowDirString('flow_v0.40.0'),
           explicitLibDefs: [],
@@ -145,7 +145,7 @@ describe('install (command)', () => {
           ignoreDeps: [],
           useCacheUntil: 1000 * 60,
         });
-        expect(result).toBe(0);
+        expect(status).toBe(0);
         expect(_mock(console.error).mock.calls).toEqual([
           ["No dependencies were found in this project's package.json!"],
         ]);

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -198,9 +198,9 @@ export async function run(args: Args): Promise<number> {
   }
 
   // Must be after `installNpmLibDefs` to ensure cache is updated first
-  if (ftConfig) {
+  if (ftConfig?.env || dependencyEnvs.length > 0) {
     const envLibDefResult = await installEnvLibDefs(
-      [...new Set([...(ftConfig.env ?? []), ...dependencyEnvs])],
+      [...new Set([...(ftConfig?.env ?? []), ...dependencyEnvs])],
       flowVersion,
       cwd,
       libdefDir,

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -200,7 +200,7 @@ export async function run(args: Args): Promise<number> {
   // Must be after `installNpmLibDefs` to ensure cache is updated first
   if (ftConfig) {
     const envLibDefResult = await installEnvLibDefs(
-      ftConfig,
+      [...new Set([...(ftConfig.env ?? []), ...dependencyEnvs])],
       flowVersion,
       cwd,
       libdefDir,
@@ -226,7 +226,7 @@ export async function run(args: Args): Promise<number> {
 }
 
 async function installEnvLibDefs(
-  {env}: FtConfig,
+  env: Array<string>,
   flowVersion: FlowVersion,
   flowProjectRoot,
   libdefDir,

--- a/cli/src/lib/ftConfig.js
+++ b/cli/src/lib/ftConfig.js
@@ -2,7 +2,7 @@
 import {fs, path} from './node';
 
 export type FtConfig = {
-  env?: mixed, // Array<string>,
+  env?: Array<string>,
   ignore?: Array<string>,
   workspaces?: Array<string>,
 };

--- a/cli/src/lib/stubUtils.js
+++ b/cli/src/lib/stubUtils.js
@@ -377,8 +377,8 @@ export async function pkgHasFlowFiles(
   pnpjs: PnpResolver | null,
   workspacesPkgJsonData: Array<PkgJson>,
 ): Promise<{|
-  flowTyped: boolean,
-  path?: string,
+  isFlowTyped: boolean,
+  pkgPath?: string,
 |}> {
   const findTypedFiles = async (path: string): Promise<void | string> => {
     try {
@@ -401,8 +401,8 @@ export async function pkgHasFlowFiles(
 
   if (rootTypedPath) {
     return {
-      flowTyped: true,
-      path: rootTypedPath,
+      isFlowTyped: true,
+      pkgPath: rootTypedPath,
     };
   }
 
@@ -414,13 +414,13 @@ export async function pkgHasFlowFiles(
   const workspacePath = typedWorkspacePaths.find(o => !!o);
   if (workspacePath) {
     return {
-      flowTyped: true,
-      path: path.dirname(workspacePath),
+      isFlowTyped: true,
+      pkgPath: workspacePath,
     };
   }
 
   return {
-    flowTyped: false,
+    isFlowTyped: false,
   };
 }
 


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Closes #4445. For any dependency that ships flow type definitions check if they have a `flow-typed.config.json` and if so, read their `env` to check if they depend on any environment definitions.

If so install them along side any environment definitions the project installing might need. This allows a library to be developed with flow-typed knowing it will behave the same when consumed by a consumer using flow.

Not very common for open source, but very useful when developing a stack of internal npm libraries all shipping flow types.