### PR TITLE
[rimraf] Add definition v5

### DIFF
--- a/definitions/npm/rimraf_v5.x.x/flow_v0.104.x-/rimraf_v5.x.x.js
+++ b/definitions/npm/rimraf_v5.x.x/flow_v0.104.x-/rimraf_v5.x.x.js
@@ -1,0 +1,13 @@
+declare module 'rimraf' {
+  declare type Options = {
+    maxRetries?: number,
+    glob?: boolean,
+    ...
+  };
+
+  declare module.exports: {
+    (f: string, opts?: Options): Promise<boolean>,
+    sync(path: string, opts?: Options): boolean,
+    ...
+  };
+}

--- a/definitions/npm/rimraf_v5.x.x/flow_v0.25.0-v0.103.x/rimraf_v5.x.x.js
+++ b/definitions/npm/rimraf_v5.x.x/flow_v0.25.0-v0.103.x/rimraf_v5.x.x.js
@@ -1,0 +1,12 @@
+declare module 'rimraf' {
+  declare type Options = {
+    maxRetries?: number,
+    glob?: boolean
+  };
+
+  declare module.exports: {
+    (f: string, opts?: Options): Promise<boolean>,
+    sync(path: string, opts?: Options): boolean,
+    ...
+  };
+}

--- a/definitions/npm/rimraf_v5.x.x/test_rimraf_v3.x.x.js
+++ b/definitions/npm/rimraf_v5.x.x/test_rimraf_v3.x.x.js
@@ -1,0 +1,7 @@
+import rimraf from 'rimraf';
+
+rimraf('/tmp/foo/bar/baz', {glob: true});
+rimraf('/tmp/foo/bar/baz');
+
+// $FlowExpectedError[incompatible-call]
+rimraf(1);


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: 
	- https://unpkg.com/browse/rimraf@5.0.5/dist/esm/index.js
	- https://unpkg.com/browse/rimraf@5.0.5/dist/esm/opt-arg.d.ts
- Link to GitHub or NPM: https://github.com/isaacs/rimraf
- Type of contribution: add new version of existing definition

Other notes:

Changes I did compared to v3:
```patch
diff --git definitions/npm/rimraf_v3.x.x/flow_v0.104.x-/rimraf_v3.x.x.js definitions/npm/rimraf_v5.x.x/flow_v0.104.x-/rimraf_v5.x.x.js
index 23b03d2b..c29437f9 100644
--- definitions/npm/rimraf_v3.x.x/flow_v0.104.x-/rimraf_v3.x.x.js
+++ definitions/npm/rimraf_v5.x.x/flow_v0.104.x-/rimraf_v5.x.x.js
@@ -1,17 +1,13 @@
 declare module 'rimraf' {
   declare type Options = {
-    maxBusyTries?: number,
-    emfileWait?: number,
+    maxRetries?: number,
     glob?: boolean,
-    disableGlob?: boolean,
     ...
   };
-
-  declare type Callback = (err: ?Error, path: ?string) => void;

   declare module.exports: {
-    (f: string, opts?: Options | Callback, callback?: Callback): void,
-    sync(path: string, opts?: Options): void,
+    (f: string, opts?: Options): Promise<boolean>,
+    sync(path: string, opts?: Options): boolean,
     ...
   };
 }
```
