### PR TITLE
Add `signal` property to Axios request config

### DIFF
--- a/definitions/npm/axios_v0.22.x/flow_v0.83.x-/axios_v0.22.x.js
+++ b/definitions/npm/axios_v0.22.x/flow_v0.83.x-/axios_v0.22.x.js
@@ -78,6 +78,7 @@ declare module 'axios' {
     httpsAgent?: HttpsAgent,
     maxContentLength?: number,
     maxRedirects?: number,
+    signal?: AbortSignal,
     socketPath?: string | null,
     params?: { [key: string]: mixed, ...},
     paramsSerializer?: (params: { [key: string]: mixed, ...}) => string,

--- a/definitions/npm/axios_v0.22.x/flow_v0.83.x-/test_axios_v0.22.x.js
+++ b/definitions/npm/axios_v0.22.x/flow_v0.83.x-/test_axios_v0.22.x.js
@@ -84,6 +84,7 @@ const config: $AxiosXHRConfigBase<RequestDataUser, User> = {
   maxContentLength: 2000,
   validateStatus: (status: number) => status >= 200 && status < 300,
   maxRedirects: 5,
+  signal: (new AbortController()).signal,
   proxy: {
     host: '127.0.0.1',
     port: 9000,

--- a/definitions/npm/axios_v0.23.x/flow_v0.83.x-/axios_v0.23.x.js
+++ b/definitions/npm/axios_v0.23.x/flow_v0.83.x-/axios_v0.23.x.js
@@ -78,6 +78,7 @@ declare module 'axios' {
     httpsAgent?: HttpsAgent,
     maxContentLength?: number,
     maxRedirects?: number,
+    signal?: AbortSignal,
     socketPath?: string | null,
     params?: { [key: string]: mixed, ...},
     paramsSerializer?: (params: { [key: string]: mixed, ...}) => string,

--- a/definitions/npm/axios_v0.23.x/flow_v0.83.x-/test_axios_v0.23.x.js
+++ b/definitions/npm/axios_v0.23.x/flow_v0.83.x-/test_axios_v0.23.x.js
@@ -84,6 +84,7 @@ const config: $AxiosXHRConfigBase<RequestDataUser, User> = {
   maxContentLength: 2000,
   validateStatus: (status: number) => status >= 200 && status < 300,
   maxRedirects: 5,
+  signal: (new AbortController()).signal,
   proxy: {
     host: '127.0.0.1',
     port: 9000,

--- a/definitions/npm/axios_v0.24.x/flow_v0.83.x-/axios_v0.24.x.js
+++ b/definitions/npm/axios_v0.24.x/flow_v0.83.x-/axios_v0.24.x.js
@@ -78,6 +78,7 @@ declare module 'axios' {
     httpsAgent?: HttpsAgent,
     maxContentLength?: number,
     maxRedirects?: number,
+    signal?: AbortSignal,
     socketPath?: string | null,
     params?: { [key: string]: mixed, ...},
     paramsSerializer?: (params: { [key: string]: mixed, ...}) => string,

--- a/definitions/npm/axios_v0.24.x/flow_v0.83.x-/test_axios_v0.24.x.js
+++ b/definitions/npm/axios_v0.24.x/flow_v0.83.x-/test_axios_v0.24.x.js
@@ -84,6 +84,7 @@ const config: $AxiosXHRConfigBase<RequestDataUser, User> = {
   maxContentLength: 2000,
   validateStatus: (status: number) => status >= 200 && status < 300,
   maxRedirects: 5,
+  signal: (new AbortController()).signal,
   proxy: {
     host: '127.0.0.1',
     port: 9000,

--- a/definitions/npm/axios_v0.25.x/flow_v0.83.x-/axios_v0.25.x.js
+++ b/definitions/npm/axios_v0.25.x/flow_v0.83.x-/axios_v0.25.x.js
@@ -78,6 +78,7 @@ declare module 'axios' {
     httpsAgent?: HttpsAgent,
     maxContentLength?: number,
     maxRedirects?: number,
+    signal?: AbortSignal,
     socketPath?: string | null,
     params?: { [key: string]: mixed, ...},
     paramsSerializer?: (params: { [key: string]: mixed, ...}) => string,

--- a/definitions/npm/axios_v0.25.x/flow_v0.83.x-/test_axios_v0.25.x.js
+++ b/definitions/npm/axios_v0.25.x/flow_v0.83.x-/test_axios_v0.25.x.js
@@ -84,6 +84,7 @@ const config: $AxiosXHRConfigBase<RequestDataUser, User> = {
   maxContentLength: 2000,
   validateStatus: (status: number) => status >= 200 && status < 300,
   maxRedirects: 5,
+  signal: (new AbortController()).signal,
   proxy: {
     host: '127.0.0.1',
     port: 9000,

--- a/definitions/npm/axios_v0.26.x/flow_v0.201.x-/axios_v0.26.x.js
+++ b/definitions/npm/axios_v0.26.x/flow_v0.201.x-/axios_v0.26.x.js
@@ -78,6 +78,7 @@ declare module 'axios' {
     httpsAgent?: HttpsAgent,
     maxContentLength?: number,
     maxRedirects?: number,
+    signal?: AbortSignal,
     socketPath?: string | null,
     params?: { [key: string]: mixed, ...},
     paramsSerializer?: (params: { [key: string]: mixed, ...}) => string,

--- a/definitions/npm/axios_v0.26.x/flow_v0.201.x-/test_axios_v0.26.x.js
+++ b/definitions/npm/axios_v0.26.x/flow_v0.201.x-/test_axios_v0.26.x.js
@@ -85,6 +85,7 @@ const config: $AxiosXHRConfigBase<RequestDataUser, User> = {
   maxContentLength: 2000,
   validateStatus: (status: number) => status >= 200 && status < 300,
   maxRedirects: 5,
+  signal: (new AbortController()).signal,
   proxy: {
     host: '127.0.0.1',
     port: 9000,

--- a/definitions/npm/axios_v0.26.x/flow_v0.83.x-v0.200.x/axios_v0.26.x.js
+++ b/definitions/npm/axios_v0.26.x/flow_v0.83.x-v0.200.x/axios_v0.26.x.js
@@ -78,6 +78,7 @@ declare module 'axios' {
     httpsAgent?: HttpsAgent,
     maxContentLength?: number,
     maxRedirects?: number,
+    signal?: AbortSignal,
     socketPath?: string | null,
     params?: { [key: string]: mixed, ...},
     paramsSerializer?: (params: { [key: string]: mixed, ...}) => string,

--- a/definitions/npm/axios_v0.26.x/flow_v0.83.x-v0.200.x/test_axios_v0.26.x.js
+++ b/definitions/npm/axios_v0.26.x/flow_v0.83.x-v0.200.x/test_axios_v0.26.x.js
@@ -85,6 +85,7 @@ const config: $AxiosXHRConfigBase<RequestDataUser, User> = {
   maxContentLength: 2000,
   validateStatus: (status: number) => status >= 200 && status < 300,
   maxRedirects: 5,
+  signal: (new AbortController()).signal,
   proxy: {
     host: '127.0.0.1',
     port: 9000,

--- a/definitions/npm/axios_v0.27.x/flow_v0.201.x-/axios_v0.27.x.js
+++ b/definitions/npm/axios_v0.27.x/flow_v0.201.x-/axios_v0.27.x.js
@@ -73,6 +73,7 @@ declare module 'axios' {
     httpsAgent?: HttpsAgent,
     maxContentLength?: number,
     maxRedirects?: number,
+    signal?: AbortSignal,
     socketPath?: string | null,
     params?: { [key: string]: mixed, ...},
     paramsSerializer?: (params: { [key: string]: mixed, ...}) => string,

--- a/definitions/npm/axios_v0.27.x/flow_v0.201.x-/test_axios_v0.27.x.js
+++ b/definitions/npm/axios_v0.27.x/flow_v0.201.x-/test_axios_v0.27.x.js
@@ -85,6 +85,7 @@ const config: $AxiosXHRConfigBase<RequestDataUser, User> = {
   maxContentLength: 2000,
   validateStatus: (status: number) => status >= 200 && status < 300,
   maxRedirects: 5,
+  signal: (new AbortController()).signal,
   proxy: {
     host: '127.0.0.1',
     port: 9000,

--- a/definitions/npm/axios_v0.27.x/flow_v0.83.x-v0.200.x/axios_v0.27.x.js
+++ b/definitions/npm/axios_v0.27.x/flow_v0.83.x-v0.200.x/axios_v0.27.x.js
@@ -73,6 +73,7 @@ declare module 'axios' {
     httpsAgent?: HttpsAgent,
     maxContentLength?: number,
     maxRedirects?: number,
+    signal?: AbortSignal,
     socketPath?: string | null,
     params?: { [key: string]: mixed, ...},
     paramsSerializer?: (params: { [key: string]: mixed, ...}) => string,

--- a/definitions/npm/axios_v0.27.x/flow_v0.83.x-v0.200.x/test_axios_v0.27.x.js
+++ b/definitions/npm/axios_v0.27.x/flow_v0.83.x-v0.200.x/test_axios_v0.27.x.js
@@ -85,6 +85,7 @@ const config: $AxiosXHRConfigBase<RequestDataUser, User> = {
   maxContentLength: 2000,
   validateStatus: (status: number) => status >= 200 && status < 300,
   maxRedirects: 5,
+  signal: (new AbortController()).signal,
   proxy: {
     host: '127.0.0.1',
     port: 9000,

--- a/definitions/npm/axios_v1.x.x/flow_v0.201.x-/axios_v1.x.x.js
+++ b/definitions/npm/axios_v1.x.x/flow_v0.201.x-/axios_v1.x.x.js
@@ -73,6 +73,7 @@ declare module 'axios' {
     httpsAgent?: HttpsAgent,
     maxContentLength?: number,
     maxRedirects?: number,
+    signal?: AbortSignal,
     socketPath?: string | null,
     params?: { [key: string]: mixed, ...},
     paramsSerializer?: (params: { [key: string]: mixed, ...}) => string,

--- a/definitions/npm/axios_v1.x.x/flow_v0.201.x-/test_axios_v1.x.x.js
+++ b/definitions/npm/axios_v1.x.x/flow_v0.201.x-/test_axios_v1.x.x.js
@@ -85,6 +85,7 @@ const config: $AxiosXHRConfigBase<RequestDataUser, User> = {
   maxContentLength: 2000,
   validateStatus: (status: number) => status >= 200 && status < 300,
   maxRedirects: 5,
+  signal: (new AbortController()).signal,
   proxy: {
     host: '127.0.0.1',
     port: 9000,

--- a/definitions/npm/axios_v1.x.x/flow_v0.83.x-v0.200.x/axios_v1.x.x.js
+++ b/definitions/npm/axios_v1.x.x/flow_v0.83.x-v0.200.x/axios_v1.x.x.js
@@ -73,6 +73,7 @@ declare module 'axios' {
     httpsAgent?: HttpsAgent,
     maxContentLength?: number,
     maxRedirects?: number,
+    signal?: AbortSignal,
     socketPath?: string | null,
     params?: { [key: string]: mixed, ...},
     paramsSerializer?: (params: { [key: string]: mixed, ...}) => string,

--- a/definitions/npm/axios_v1.x.x/flow_v0.83.x-v0.200.x/test_axios_v1.x.x.js
+++ b/definitions/npm/axios_v1.x.x/flow_v0.83.x-v0.200.x/test_axios_v1.x.x.js
@@ -85,6 +85,7 @@ const config: $AxiosXHRConfigBase<RequestDataUser, User> = {
   maxContentLength: 2000,
   validateStatus: (status: number) => status >= 200 && status < 300,
   maxRedirects: 5,
+  signal: (new AbortController()).signal,
   proxy: {
     host: '127.0.0.1',
     port: 9000,


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://github.com/axios/axios?tab=readme-ov-file#abortcontroller
- Link to GitHub or NPM: https://www.npmjs.com/package/axios
- Type of contribution: **addition**

This adds the `signal` field to Axios request configuration. I added it from versions 0.22.x to 1.x.x. Closes #4546.