### PR TITLE
[react-router-dom] Add future object to NavigatorProvider object

### DIFF
--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.201.x-/react-router-dom_v6.x.x.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.201.x-/react-router-dom_v6.x.x.js
@@ -597,6 +597,7 @@ declare module 'react-router-dom' {
     basename: string,
     navigator: Navigator,
     static: boolean,
+    future: {| v7_relativeSplatPath: boolean |},
   |};
 
   declare export var UNSAFE_NavigationContext: React$Context<NavigationContextObject>;

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.201.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.201.x-/test_react-router-dom.js
@@ -1114,7 +1114,7 @@ describe('react-router-dom', () => {
         context={{
           basename: 'test',
           navigator: nav,
-          static: 123,
+          static: false,
           // $FlowExpectedError[prop-missing]
           future: {},
         }}

--- a/definitions/npm/react-router-dom_v6.x.x/flow_v0.201.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v6.x.x/flow_v0.201.x-/test_react-router-dom.js
@@ -1068,6 +1068,9 @@ describe('react-router-dom', () => {
           basename: 'test',
           navigator: nav,
           static: false,
+          future: {
+            v7_relativeSplatPath: true,
+          },
         }}
       />);
       const B = (<Comp
@@ -1080,6 +1083,9 @@ describe('react-router-dom', () => {
           basename: 123,
           navigator: nav,
           static: false,
+          future: {
+            v7_relativeSplatPath: true,
+          },
         }}
       />);
       const D = (<Comp
@@ -1088,6 +1094,9 @@ describe('react-router-dom', () => {
           // $FlowExpectedError[incompatible-type]
           navigator: 'test',
           static: false,
+          future: {
+            v7_relativeSplatPath: true,
+          },
         }}
       />);
       const E = (<Comp
@@ -1096,6 +1105,18 @@ describe('react-router-dom', () => {
           navigator: nav,
           // $FlowExpectedError[incompatible-type]
           static: 123,
+          future: {
+            v7_relativeSplatPath: true,
+          },
+        }}
+      />);
+      const F = (<Comp
+        context={{
+          basename: 'test',
+          navigator: nav,
+          static: 123,
+          // $FlowExpectedError[prop-missing]
+          future: {},
         }}
       />);
     });


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->

- Links to documentation: https://reactrouter.com/en/main/routers/create-browser-router#future
- Link to GitHub or NPM: https://www.npmjs.com/package/react-router-dom
- Type of contribution: addition

Other notes:

