### PR TITLE
[flow-enums-runtime] Add definition

### DIFF
--- a/definitions/npm/flow-enums-runtime_v0.x.x/flow_v0.83.x-/flow-enums-runtime_v0.x.x.js
+++ b/definitions/npm/flow-enums-runtime_v0.x.x/flow_v0.83.x-/flow-enums-runtime_v0.x.x.js
@@ -1,0 +1,17 @@
+declare module 'flow-enums-runtime' {
+  declare type Members = { +[key: string]: string };
+
+  declare type EnumPrototype<T> = {|
+    isValid: (x: $Keys<T>) => boolean,
+    cast: <V>(x: V) => V | void,
+    members: () => Array<$Keys<T>>,
+    getName: (value: string) => string,
+  |};
+
+  declare type Enum = {|
+    <T: Members>(members?: T): {| ...EnumPrototype<T>, ...T |},
+    Mirrored: <T: Members>(members: Array<$Keys<T>>) => {| ...Members, ...EnumPrototype<T> |},
+  |};
+
+  declare module.exports: Enum;
+}

--- a/definitions/npm/flow-enums-runtime_v0.x.x/flow_v0.83.x-/test_flow-enums-runtime_v0.x.x.js
+++ b/definitions/npm/flow-enums-runtime_v0.x.x/flow_v0.83.x-/test_flow-enums-runtime_v0.x.x.js
@@ -1,0 +1,39 @@
+// @flow
+import { describe, test } from 'flow-typed-test';
+import flowEnumRuntime from 'flow-enums-runtime';
+
+describe('flow-enums-runtime', () => {
+  test('default function', () => {
+    const obj = { a: 'a' }
+
+    const res = flowEnumRuntime(obj);
+
+    res.a;
+    res.isValid('a');
+    const valid = res.cast('a');
+    // $FlowExpectedError[incompatible-use]
+    valid.toLowerCase();
+    if (valid) {
+      valid.toLowerCase();
+    }
+    (res.members(): Array<$Keys<typeof obj>>);
+
+    // $FlowExpectedError[prop-missing]
+    res.b;
+  });
+
+  test('Mirrored', () => {
+    const { Mirrored } = flowEnumRuntime;
+
+    const obj = { a: 'b' };
+
+    Mirrored<typeof obj>(([]: Array<$Keys<typeof obj>>));
+    Mirrored<{| a: 'a', b: 'b' |}>(['a', 'b']);
+    // $FlowExpectedError[prop-missing]
+    Mirrored<{| a: 'a', b: 'b' |}>(['a', 'b', 'c']);
+    // $FlowExpectedError[incompatible-call]
+    Mirrored();
+    // $FlowExpectedError[incompatible-call]
+    Mirrored<{| a: 'a', b: 'b' |}>([1]);
+  });
+});


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/master/CONTRIBUTING.md for details. --->
Makes sense a core flow library to be typed, though is probably never expected to be used directly :) 

- Links to documentation: https://www.npmjs.com/package/flow-enums-runtime
- Link to GitHub or NPM: https://www.npmjs.com/package/flow-enums-runtime
- Type of contribution: new definition

Other notes:

