### PR TITLE
[punycode.js_v2.1.x] Add definitions

### DIFF
--- a/definitions/npm/punycode.js_v2.1.x/flow_v0.104.x-/punycode.js_v2.1.x.js
+++ b/definitions/npm/punycode.js_v2.1.x/flow_v0.104.x-/punycode.js_v2.1.x.js
@@ -1,0 +1,80 @@
+declare module 'punycode.js' {
+  /**
+   * Creates an array containing the numeric code points of each Unicode
+   * character in the string. While JavaScript uses UCS-2 internally,
+   * this function will convert a pair of surrogate halves (each of which
+   * UCS-2 exposes as separate characters) into a single code point,
+   * matching UTF-16.
+   * @param {String} string The Unicode input string (UCS-2).
+   * @returns {Array} The new array of code points.
+   */
+  declare function ucs2decode(string: string): Array<number>;
+
+  /**
+   * Creates a string based on an array of numeric code points.
+   * @param {Array} codePoints The array of numeric code points.
+   * @returns {String} The new Unicode string (UCS-2).
+   */
+  declare function ucs2encode(codePoints: Array<number>): string;
+
+  /**
+   * Converts a Punycode string of ASCII-only symbols to a string of Unicode
+   * symbols.
+   * @param {String} input The Punycode string of ASCII-only symbols.
+   * @returns {String} The resulting string of Unicode symbols.
+   */
+  declare function decode(input: string): string;
+
+  /**
+   * Converts a string of Unicode symbols (e.g. a domain name label) to a
+   * Punycode string of ASCII-only symbols.
+   * @param {String} input The string of Unicode symbols.
+   * @returns {String} The resulting Punycode string of ASCII-only symbols.
+   */
+  declare function encode(input: string): string;
+
+  /**
+   * Converts a Punycode string representing a domain name or an email address
+   * to Unicode. Only the Punycoded parts of the input will be converted, i.e.
+   * it doesn't matter if you call it on a string that has already been
+   * converted to Unicode.
+   * @param {String} input The Punycoded domain name or email address to
+   * convert to Unicode.
+   * @returns {String} The Unicode representation of the given Punycode
+   * string.
+   */
+  declare function toUnicode(input: string): string;
+
+  /**
+   * Converts a Unicode string representing a domain name or an email address to
+   * Punycode. Only the non-ASCII parts of the domain name will be converted,
+   * i.e. it doesn't matter if you call it with a domain that's already in
+   * ASCII.
+   * @param {String} input The domain name or email address to convert, as a
+   * Unicode string.
+   * @returns {String} The Punycode representation of the given domain name or
+   * email address.
+   */
+  declare function toASCII(input: string): string;
+
+  declare module.exports: {
+    /**
+     * A string representing the current Punycode.js version number.
+     */
+    version: string,
+    /**
+     * An object of methods to convert from JavaScript's internal character
+     * representation (UCS-2) to Unicode code points, and back.
+     */
+    ucs2: {
+      decode: typeof ucs2decode,
+      encode: typeof ucs2encode,
+      ...
+    },
+    decode: typeof decode,
+    encode: typeof encode,
+    toASCII: typeof toASCII,
+    toUnicode: typeof toUnicode,
+    ...
+  };
+}

--- a/definitions/npm/punycode.js_v2.1.x/flow_v0.30.x-v0.103.x/punycode.js_v2.1.x.js
+++ b/definitions/npm/punycode.js_v2.1.x/flow_v0.30.x-v0.103.x/punycode.js_v2.1.x.js
@@ -1,0 +1,78 @@
+declare module 'punycode.js' {
+  /**
+   * Creates an array containing the numeric code points of each Unicode
+   * character in the string. While JavaScript uses UCS-2 internally,
+   * this function will convert a pair of surrogate halves (each of which
+   * UCS-2 exposes as separate characters) into a single code point,
+   * matching UTF-16.
+   * @param {String} string The Unicode input string (UCS-2).
+   * @returns {Array} The new array of code points.
+   */
+  declare function ucs2decode(string: string): Array<number>;
+
+  /**
+   * Creates a string based on an array of numeric code points.
+   * @param {Array} codePoints The array of numeric code points.
+   * @returns {String} The new Unicode string (UCS-2).
+   */
+  declare function ucs2encode(codePoints: Array<number>): string;
+
+  /**
+   * Converts a Punycode string of ASCII-only symbols to a string of Unicode
+   * symbols.
+   * @param {String} input The Punycode string of ASCII-only symbols.
+   * @returns {String} The resulting string of Unicode symbols.
+   */
+  declare function decode(input: string): string;
+
+  /**
+   * Converts a string of Unicode symbols (e.g. a domain name label) to a
+   * Punycode string of ASCII-only symbols.
+   * @param {String} input The string of Unicode symbols.
+   * @returns {String} The resulting Punycode string of ASCII-only symbols.
+   */
+  declare function encode(input: string): string;
+
+  /**
+   * Converts a Punycode string representing a domain name or an email address
+   * to Unicode. Only the Punycoded parts of the input will be converted, i.e.
+   * it doesn't matter if you call it on a string that has already been
+   * converted to Unicode.
+   * @param {String} input The Punycoded domain name or email address to
+   * convert to Unicode.
+   * @returns {String} The Unicode representation of the given Punycode
+   * string.
+   */
+  declare function toUnicode(input: string): string;
+
+  /**
+   * Converts a Unicode string representing a domain name or an email address to
+   * Punycode. Only the non-ASCII parts of the domain name will be converted,
+   * i.e. it doesn't matter if you call it with a domain that's already in
+   * ASCII.
+   * @param {String} input The domain name or email address to convert, as a
+   * Unicode string.
+   * @returns {String} The Punycode representation of the given domain name or
+   * email address.
+   */
+  declare function toASCII(input: string): string;
+
+  declare module.exports: {
+    /**
+     * A string representing the current Punycode.js version number.
+     */
+    version: string,
+    /**
+     * An object of methods to convert from JavaScript's internal character
+     * representation (UCS-2) to Unicode code points, and back.
+     */
+    ucs2: {
+      decode: typeof ucs2decode,
+      encode: typeof ucs2encode,
+    },
+    decode: typeof decode,
+    encode: typeof encode,
+    toASCII: typeof toASCII,
+    toUnicode: typeof toUnicode,
+  };
+}

--- a/definitions/npm/punycode.js_v2.1.x/test_punycode.js_v2.1.x.js
+++ b/definitions/npm/punycode.js_v2.1.x/test_punycode.js_v2.1.x.js
@@ -1,0 +1,120 @@
+// @flow
+
+import { describe, it } from 'flow-typed-test';
+import punycode from 'punycode.js';
+
+describe('The `punycode.decode` function', () => {
+  it('should accept a string as parameter', () => {
+    punycode.decode('maana-pta');
+    punycode.decode('--dqo34k');
+    // $FlowExpectedError[incompatible-call]
+    punycode.decode();
+    // $FlowExpectedError[incompatible-call]
+    punycode.decode(0x61);
+  });
+
+  it('should return a string', () => {
+    (punycode.decode(''): string);
+    // $FlowExpectedError[incompatible-cast]
+    (punycode.decode(''): void);
+    // $FlowExpectedError[incompatible-cast]
+    (punycode.decode(''): number);
+  });
+});
+
+describe('The `punycode.encode` function', () => {
+  it('should accept a string as parameter', () => {
+    punycode.encode('mañana');
+    punycode.encode('☃-⌘');
+    // $FlowExpectedError[incompatible-call]
+    punycode.encode();
+    // $FlowExpectedError[incompatible-call]
+    punycode.encode(0x61);
+  });
+
+  it('should return a string', () => {
+    (punycode.encode(''): string);
+    // $FlowExpectedError[incompatible-cast]
+    (punycode.encode(''): void);
+    // $FlowExpectedError[incompatible-cast]
+    (punycode.encode(''): number);
+  });
+});
+
+describe('The `punycode.toUnicode` function', () => {
+  it('should accept a string as parameter', () => {
+    punycode.toUnicode('xn--maana-pta.com');
+    punycode.toUnicode('xn----dqo34k.com');
+    punycode.toUnicode('джумла@xn--p-8sbkgc5ag7bhce.xn--ba-lmcq');
+    // $FlowExpectedError[incompatible-call]
+    punycode.toUnicode();
+    // $FlowExpectedError[incompatible-call]
+    punycode.toUnicode(0x61);
+  });
+
+  it('should return a string', () => {
+    (punycode.toUnicode(''): string);
+    // $FlowExpectedError[incompatible-cast]
+    (punycode.toUnicode(''): void);
+    // $FlowExpectedError[incompatible-cast]
+    (punycode.toUnicode(''): number);
+  });
+});
+
+describe('The `punycode.toASCII` function', () => {
+  it('should accept a string as parameter', () => {
+    punycode.toASCII('mañana.com');
+    punycode.toASCII('☃-⌘.com');
+    punycode.toASCII('джумла@джpумлатест.bрфa');
+    // $FlowExpectedError[incompatible-call]
+    punycode.toASCII();
+    // $FlowExpectedError[incompatible-call]
+    punycode.toASCII(0x61);
+  });
+
+  it('should return a string', () => {
+    (punycode.toASCII(''): string);
+    // $FlowExpectedError[incompatible-cast]
+    (punycode.toASCII(''): void);
+    // $FlowExpectedError[incompatible-cast]
+    (punycode.toASCII(''): number);
+  });
+});
+
+describe('The `punycode.ucs2.decode` function', () => {
+  it('should accept a sring as parameter', () => {
+    punycode.ucs2.decode('abc');
+    punycode.ucs2.decode('\uD834\uDF06');
+    // $FlowExpectedError[incompatible-call]
+    punycode.ucs2.decode();
+    // $FlowExpectedError[incompatible-call]
+    punycode.ucs2.decode(0x61);
+  });
+
+  it('should return an Array of codePoints', () => {
+    (punycode.ucs2.decode(''): Array<number>);
+    // $FlowExpectedError[incompatible-cast]
+    (punycode.ucs2.decode(''): void);
+    // $FlowExpectedError[incompatible-cast]
+    (punycode.ucs2.decode(''): string);
+  });
+});
+
+describe('The `punycode.ucs2.encode` function', () => {
+  it('should accept an Array of codePoints as parameter', () => {
+    punycode.ucs2.encode([0x61, 0x62, 0x63]);
+    punycode.ucs2.encode([0x1d306]);
+    // $FlowExpectedError[incompatible-call]
+    punycode.ucs2.encode(0x61);
+    // $FlowExpectedError[incompatible-call]
+    punycode.ucs2.encode('');
+  });
+
+  it('should return a string', () => {
+    (punycode.ucs2.encode([0x61]): string);
+    // $FlowExpectedError[incompatible-cast]
+    (punycode.ucs2.encode([0x61]): void);
+    // $FlowExpectedError[incompatible-cast]
+    (punycode.ucs2.encode([0x61]): number);
+  });
+});


### PR DESCRIPTION
- Links to documentation: https://github.com/mathiasbynens/punycode.js/pull/136
- Link to GitHub or NPM: https://github.com/mathiasbynens/punycode.js
- Type of contribution: new definition

Other notes:
Using `punycode` is problematic as it conflict with the Node.js builtin and it's easy to loose track of which modules is used. So it's now recommanded to use `unicode.js`.   
Just a copy of the `punycode` definitions, which is the same package. Only added error codes to tests suppression comments. 