### PR TITLE
Add builtin intl libdef from flow into environment

### DIFF
--- a/definitions/environments/intl/flow_v0.261.x-/intl.js
+++ b/definitions/environments/intl/flow_v0.261.x-/intl.js
@@ -1,0 +1,222 @@
+declare var Intl: {
+  Collator: Class<Intl$Collator>,
+  DateTimeFormat: Class<Intl$DateTimeFormat>,
+  Locale: Class<Intl$LocaleClass>,
+  NumberFormat: Class<Intl$NumberFormat>,
+  PluralRules: ?Class<Intl$PluralRules>,
+  getCanonicalLocales?: (locales?: Intl$Locales) => Intl$Locale[],
+  ...
+}
+
+type Intl$Locale = string
+type Intl$Locales = Intl$Locale | Intl$Locale[]
+
+declare class Intl$Collator {
+  constructor (
+    locales?: Intl$Locales,
+    options?: Intl$CollatorOptions
+  ): Intl$Collator;
+
+  static (
+    locales?: Intl$Locales,
+    options?: Intl$CollatorOptions
+  ): Intl$Collator;
+
+  compare (string, string): number;
+
+  resolvedOptions (): {
+    locale: Intl$Locale,
+    usage: 'sort' | 'search',
+    sensitivity: 'base' | 'accent' | 'case' | 'variant',
+    ignorePunctuation: boolean,
+    collation: string,
+    numeric: boolean,
+    caseFirst?: 'upper' | 'lower' | 'false',
+    ...
+  };
+
+  static supportedLocalesOf (locales?: Intl$Locales): Intl$Locale[];
+}
+
+declare type Intl$CollatorOptions = {
+  localeMatcher?: 'lookup' | 'best fit',
+  usage?: 'sort' | 'search',
+  sensitivity?: 'base' | 'accent' | 'case' | 'variant',
+  ignorePunctuation?: boolean,
+  numeric?: boolean,
+  caseFirst?: 'upper' | 'lower' | 'false',
+  ...
+}
+
+type FormatToPartsType = | 'day' | 'dayPeriod' | 'era' | 'hour' | 'literal'
+  | 'minute' | 'month' | 'second' | 'timeZoneName' | 'weekday' | 'year';
+
+declare class Intl$DateTimeFormat {
+  constructor (
+    locales?: Intl$Locales,
+    options?: Intl$DateTimeFormatOptions
+  ): Intl$DateTimeFormat;
+
+  static (
+    locales?: Intl$Locales,
+    options?: Intl$DateTimeFormatOptions
+  ): Intl$DateTimeFormat;
+
+  format (value?: Date | number): string;
+
+  formatToParts (value?: Date | number): Array<{
+    type: FormatToPartsType,
+    value: string,
+    ...
+  }>;
+
+  resolvedOptions (): {
+    locale: Intl$Locale,
+    calendar: string,
+    numberingSystem: string,
+    timeZone?: string,
+    hour12: boolean,
+    weekday?: 'narrow' | 'short' | 'long',
+    era?: 'narrow' | 'short' | 'long',
+    year?: 'numeric' | '2-digit',
+    month?: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long',
+    day?: 'numeric' | '2-digit',
+    hour?: 'numeric' | '2-digit',
+    minute?: 'numeric' | '2-digit',
+    second?: 'numeric' | '2-digit',
+    timeZoneName?: 'short' | 'long',
+    ...
+  };
+
+  static supportedLocalesOf (locales?: Intl$Locales): Intl$Locale[];
+}
+
+declare type Intl$DateTimeFormatOptions = {
+  localeMatcher?: 'lookup' | 'best fit',
+  timeZone?: string,
+  hour12?: boolean,
+  formatMatcher?: 'basic' | 'best fit',
+  weekday?: 'narrow' | 'short' | 'long',
+  era?: 'narrow' | 'short' | 'long',
+  year?: 'numeric' | '2-digit',
+  month?: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long',
+  day?: 'numeric' | '2-digit',
+  hour?: 'numeric' | '2-digit',
+  minute?: 'numeric' | '2-digit',
+  second?: 'numeric' | '2-digit',
+  timeZoneName?: 'short' | 'long',
+  ...
+}
+
+declare class Intl$LocaleClass {
+  baseName: string,
+  calendar?: string,
+  caseFirst?: 'upper' | 'lower' | 'false',
+  collation?: string,
+  hourCycle?: 'h11' | 'h12' | 'h23' | 'h24',
+  language: string,
+  numberingSystem?: string,
+  numeric?: boolean,
+  region?: string,
+  script?: string,
+
+  constructor(
+    tag: string,
+    options?: Intl$LocaleOptions,
+  ): Intl$LocaleClass;
+
+  maximize(): Intl$LocaleClass;
+
+  minimize(): Intl$LocaleClass;
+}
+
+declare type Intl$LocaleOptions = {
+  calendar?: string,
+  caseFirst?: 'upper' | 'lower' | 'false',
+  collation?: string,
+  hourCycle?: 'h11' | 'h12' | 'h23' | 'h24',
+  numeric?: boolean,
+  numberingSystem?: string,
+  ...
+};
+
+declare class Intl$NumberFormat {
+  constructor (
+    locales?: Intl$Locales,
+    options?: Intl$NumberFormatOptions
+  ): Intl$NumberFormat;
+
+  static (
+    locales?: Intl$Locales,
+    options?: Intl$NumberFormatOptions
+  ): Intl$NumberFormat;
+
+  format (number): string;
+
+  resolvedOptions (): {
+    locale: Intl$Locale,
+    numberingSystem: string,
+    style: 'decimal' | 'currency' | 'percent' | 'unit',
+    currency?: string,
+    currencyDisplay?: 'symbol' | 'code' | 'name' | 'narrowSymbol',
+    useGrouping: boolean,
+    minimumIntegerDigits?: number,
+    minimumFractionDigits?: number,
+    maximumFractionDigits?: number,
+    minimumSignificantDigits?: number,
+    maximumSignificantDigits?: number,
+    ...
+  };
+
+  static supportedLocalesOf (locales?: Intl$Locales): Intl$Locale[];
+}
+
+declare type Intl$NumberFormatOptions = {
+  localeMatcher?: 'lookup' | 'best fit',
+  style?: 'decimal' | 'currency' | 'percent' | 'unit',
+  currency?: string,
+  currencyDisplay?: 'symbol' | 'code' | 'name' | 'narrowSymbol',
+  useGrouping?: boolean,
+  minimumIntegerDigits?: number,
+  minimumFractionDigits?: number,
+  maximumFractionDigits?: number,
+  minimumSignificantDigits?: number,
+  maximumSignificantDigits?: number,
+  ...
+}
+
+declare class Intl$PluralRules {
+  constructor (
+    locales?: Intl$Locales,
+    options?: Intl$PluralRulesOptions
+  ): Intl$PluralRules;
+
+  select (number): Intl$PluralRule;
+
+  resolvedOptions (): {
+    locale: Intl$Locale,
+    type: 'cardinal' | 'ordinal',
+    minimumIntegerDigits?: number,
+    minimumFractionDigits?: number,
+    maximumFractionDigits?: number,
+    minimumSignificantDigits?: number,
+    maximumSignificantDigits?: number,
+    pluralCategories: Intl$PluralRule[],
+    ...
+  };
+
+  static supportedLocalesOf (locales?: Intl$Locales): Intl$Locale[];
+}
+
+type Intl$PluralRule = 'zero' | 'one' | 'two' | 'few' | 'many' | 'other'
+
+declare type Intl$PluralRulesOptions = {
+  localeMatcher?: 'lookup' | 'best fit',
+  type?: 'cardinal' | 'ordinal',
+  minimumIntegerDigits?: number,
+  minimumFractionDigits?: number,
+  maximumFractionDigits?: number,
+  minimumSignificantDigits?: number,
+  maximumSignificantDigits?: number,
+  ...
+}

--- a/definitions/environments/intl/flow_v0.261.x-/test_intl.js
+++ b/definitions/environments/intl/flow_v0.261.x-/test_intl.js
@@ -1,0 +1,25 @@
+/* @flow */
+
+// $FlowExpectedError[incompatible-type]
+// $FlowExpectedError[not-a-function]
+const a: string = Intl.getCanonicalLocales(); // incorrect
+const getCanonicalLocales = Intl.getCanonicalLocales;
+if (getCanonicalLocales) {
+  // $FlowExpectedError[incompatible-type]
+  const b: string = getCanonicalLocales(); // incorrect
+  // $FlowExpectedError[incompatible-call]
+  const c: string[] = getCanonicalLocales(null); // incorrect
+  // $FlowExpectedError[incompatible-call]
+  const d: string[] = getCanonicalLocales([ 1, 2 ]); // incorrect
+  const e: string[] = getCanonicalLocales(); // correct
+  const f: string[] = getCanonicalLocales('ar'); // correct
+  const g: string[] = getCanonicalLocales([ 'en', 'pt-BR' ]); // correct
+}
+
+// $FlowExpectedError[prop-missing]
+const h = Intl.Unknown; // incorrect
+const i = Intl.Collator; // correct
+const j = Intl.DateTimeFormat; // correct
+const k = Intl.Locale; // correct
+const l = Intl.NumberFormat; // correct
+const m = Intl.PluralRules; // correct

--- a/definitions/environments/intl/flow_v0.261.x-/test_intl_collator.js
+++ b/definitions/environments/intl/flow_v0.261.x-/test_intl_collator.js
@@ -1,0 +1,49 @@
+/* @flow */
+
+const a: Intl$Collator = Intl.Collator() // correct
+const b: Intl$Collator = new Intl.Collator() // correct
+// $FlowExpectedError[incompatible-type]
+const c: Intl$PluralRules = new Intl.Collator() // incorrect
+// $FlowExpectedError[incompatible-call]
+Intl.Collator(1, {
+  // $FlowExpectedError[incompatible-call]
+  localeMatcher: 'look fit',
+  // $FlowExpectedError[incompatible-call]
+  usage: 'find',
+  // $FlowExpectedError[incompatible-call]
+  sensitivity: '',
+  // $FlowExpectedError[incompatible-call]
+  ignorePunctuation: null,
+  // $FlowExpectedError[incompatible-call]
+  numeric: 1,
+  // $FlowExpectedError[incompatible-call]
+  caseFirst: 'true'
+}) // incorrect
+Intl.Collator('en') // correct
+Intl.Collator([ 'en', 'en-GB' ], {
+  localeMatcher: 'best fit',
+  usage: 'sort',
+  sensitivity: 'accent',
+  ignorePunctuation: false,
+  numeric: true,
+  caseFirst: 'false'
+}) // correct
+const Collator = Intl.Collator;
+// $FlowExpectedError[prop-missing]
+new Collator().format() // incorrect
+// $FlowExpectedError[incompatible-call]
+new Collator().compare() // incorrect
+// $FlowExpectedError[incompatible-call]
+new Collator().compare('a') // incorrect
+
+new Collator().compare('a', 'b') // correct
+
+new Collator().resolvedOptions() // correct
+
+// $FlowExpectedError[prop-missing]
+Collator.getCanonicalLocales() // incorrect
+
+// $FlowExpectedError[incompatible-call]
+Collator.supportedLocalesOf(1) // incorrect
+Collator.supportedLocalesOf('en') // correct
+Collator.supportedLocalesOf([ 'en' ]) // correct

--- a/definitions/environments/intl/flow_v0.261.x-/test_intl_date_time_format.js
+++ b/definitions/environments/intl/flow_v0.261.x-/test_intl_date_time_format.js
@@ -1,0 +1,72 @@
+/* @flow */
+
+const a: Intl$DateTimeFormat = Intl.DateTimeFormat() // correct
+const b: Intl$DateTimeFormat = new Intl.DateTimeFormat() // correct
+// $FlowExpectedError[incompatible-type]
+const c: Intl$NumberFormat = new Intl.DateTimeFormat() // incorrect
+// $FlowExpectedError[incompatible-call]
+Intl.DateTimeFormat(1, {
+  // $FlowExpectedError[incompatible-call]
+  localeMatcher: 'look',
+  // $FlowExpectedError[incompatible-call]
+  timeZone: 1,
+  // $FlowExpectedError[incompatible-call]
+  hour12: '',
+  // $FlowExpectedError[incompatible-call]
+  formatMatcher: 'basic fit',
+  // $FlowExpectedError[incompatible-call]
+  weekday: '2-digit',
+  // $FlowExpectedError[incompatible-call]
+  era: '',
+  // $FlowExpectedError[incompatible-call]
+  year: '',
+  // $FlowExpectedError[incompatible-call]
+  month: '',
+  // $FlowExpectedError[incompatible-call]
+  day: '',
+  // $FlowExpectedError[incompatible-call]
+  hour: '',
+  // $FlowExpectedError[incompatible-call]
+  minute: 'long',
+  // $FlowExpectedError[incompatible-call]
+  second: 'short',
+  // $FlowExpectedError[incompatible-call]
+  timeZoneName: 'narrow'
+}) // incorrect
+Intl.DateTimeFormat('en') // correct
+Intl.DateTimeFormat([ 'en', 'en-GB' ], {
+  localeMatcher: 'best fit',
+  timeZone: 'America/Pacific',
+  hour12: true,
+  formatMatcher: 'best fit',
+  weekday: 'long',
+  era: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: '2-digit',
+  hour: 'numeric',
+  minute: '2-digit',
+  second: '2-digit',
+  timeZoneName: 'long'
+}) // correct
+const DateTimeFormat = Intl.DateTimeFormat;
+// $FlowExpectedError[prop-missing]
+new DateTimeFormat().select() // incorrect
+
+new DateTimeFormat().format() // correct
+new DateTimeFormat().format(1) // correct
+new DateTimeFormat().format(new Date(2018, 3, 17)) // correct
+
+new DateTimeFormat().formatToParts();
+new DateTimeFormat().formatToParts(1) // correct
+new DateTimeFormat().formatToParts(new Date(2018, 3, 17)) // correct
+
+new DateTimeFormat().resolvedOptions() // correct
+
+// $FlowExpectedError[prop-missing]
+DateTimeFormat.getCanonicalLocales() // incorrect
+
+// $FlowExpectedError[incompatible-call]
+DateTimeFormat.supportedLocalesOf(1) // incorrect
+DateTimeFormat.supportedLocalesOf('en') // correct
+DateTimeFormat.supportedLocalesOf([ 'en' ]) // correct

--- a/definitions/environments/intl/flow_v0.261.x-/test_intl_locale.js
+++ b/definitions/environments/intl/flow_v0.261.x-/test_intl_locale.js
@@ -1,0 +1,27 @@
+/** @flow */
+
+// $FlowExpectedError[incompatible-call]
+new Intl.Locale(); // incorrect
+new Intl.Locale('en-US'); // correct
+new Intl.Locale('en-US', {
+  calendar: 'gregory',
+  caseFirst: 'upper',
+  collation: 'phone-sensitive',
+  hourCycle: 'h11',
+  numberingSystem: 'latn',
+  numeric: true,
+}); // correct
+// $FlowExpectedError[incompatible-call]
+new Intl.Locale('en-US', { calendar: 0 }); // incorrect
+// $FlowExpectedError[incompatible-call]
+new Intl.Locale('en-US', { caseFirst: 'aaa' }); // incorrect
+// $FlowExpectedError[incompatible-call]
+new Intl.Locale('en-US', { collation: 0 }); // incorrect
+// $FlowExpectedError[incompatible-call]
+new Intl.Locale('en-US', { hourCycle: 'aaa' }); // incorrect
+// $FlowExpectedError[incompatible-call]
+new Intl.Locale('en-US', { numeric: '' }); // incorrect
+// $FlowExpectedError[incompatible-call]
+new Intl.Locale('en-US', { numberingSystem: 0 }); // incorrect
+const a: Intl$LocaleClass = new Intl.Locale('en-US').maximize(); // correct
+const b: Intl$LocaleClass = new Intl.Locale('en-US').minimize(); // correct

--- a/definitions/environments/intl/flow_v0.261.x-/test_intl_number_format.js
+++ b/definitions/environments/intl/flow_v0.261.x-/test_intl_number_format.js
@@ -1,0 +1,59 @@
+/* @flow */
+
+const a: Intl$NumberFormat = Intl.NumberFormat() // correct
+const b: Intl$NumberFormat = new Intl.NumberFormat() // correct
+// $FlowExpectedError[incompatible-type]
+const c: Intl$DateTimeFormat = new Intl.NumberFormat() // incorrect
+// $FlowExpectedError[incompatible-call]
+Intl.NumberFormat(1, {
+  // $FlowExpectedError[incompatible-call]
+  localeMatcher: 'best',
+  // $FlowExpectedError[incompatible-call]
+  style: 'octal',
+  // $FlowExpectedError[incompatible-call]
+  currency: 123,
+  // $FlowExpectedError[incompatible-call]
+  currencyDisplay: 'sym',
+  // $FlowExpectedError[incompatible-call]
+  useGrouping: 5,
+  // $FlowExpectedError[incompatible-call]
+  minimumIntegerDigits: {},
+  // $FlowExpectedError[incompatible-call]
+  minimumFractionDigits: '',
+  // $FlowExpectedError[incompatible-call]
+  maximumFractionDigits: null,
+  // $FlowExpectedError[incompatible-call]
+  minimumSignificantDigits: '',
+  // $FlowExpectedError[incompatible-call]
+  maximumSignificantDigits: null
+}) // incorrect
+Intl.NumberFormat('en') // correct
+Intl.NumberFormat([ 'en', 'en-GB' ], {
+  localeMatcher: 'best fit',
+  style: 'currency',
+  currency: 'GBP',
+  currencyDisplay: 'code',
+  useGrouping: true,
+  minimumIntegerDigits: 1,
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 21,
+  minimumSignificantDigits: 1,
+  maximumSignificantDigits: 21
+}) // correct
+const NumberFormat = Intl.NumberFormat;
+// $FlowExpectedError[prop-missing]
+new NumberFormat().select() // incorrect
+// $FlowExpectedError[incompatible-call]
+new NumberFormat().format() // incorrect
+
+new NumberFormat().format(1) // correct
+
+new NumberFormat().resolvedOptions() // correct
+
+// $FlowExpectedError[prop-missing]
+NumberFormat.getCanonicalLocales() // incorrect
+
+// $FlowExpectedError[incompatible-call]
+NumberFormat.supportedLocalesOf(1) // incorrect
+NumberFormat.supportedLocalesOf('en') // correct
+NumberFormat.supportedLocalesOf([ 'en' ]) // correct

--- a/definitions/environments/intl/flow_v0.261.x-/test_intl_plural_rules.js
+++ b/definitions/environments/intl/flow_v0.261.x-/test_intl_plural_rules.js
@@ -1,0 +1,55 @@
+/* @flow */
+
+// $FlowExpectedError[not-a-function]
+  // $FlowExpectedError[prop-missing]
+const a = Intl.PluralRules(); // incorrect
+const PluralRules = Intl.PluralRules
+if (PluralRules) { 
+  // $FlowExpectedError[prop-missing]
+  const b = PluralRules(); // incorrect
+  const c = new PluralRules(); // correct
+  // $FlowExpectedError[incompatible-call]
+  new PluralRules(1); // incorrect
+  new PluralRules('en'); // correct
+  new PluralRules([ 'en', 'pt' ]); // correct
+  new PluralRules('en', {
+    // $FlowExpectedError[incompatible-call]
+    localeMatcher: 'best one',
+    // $FlowExpectedError[incompatible-call]
+    type: 'count',
+    // $FlowExpectedError[incompatible-call]
+    minimumIntegerDigits: '',
+    minimumFractionDigits: a,
+    maximumFractionDigits: b,
+    // $FlowExpectedError[incompatible-call]
+    minimumSignificantDigits: c,
+    // $FlowExpectedError[incompatible-call]
+    maximumSignificantDigits: '' 
+  }); // all kinds of incorrect
+  new PluralRules('en', {
+    localeMatcher: 'lookup',
+    type: 'ordinal',
+    minimumIntegerDigits: 2,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+    minimumSignificantDigits: 4,
+    maximumSignificantDigits: 6
+  }); // correct
+
+  // $FlowExpectedError[prop-missing]
+  new PluralRules().format() // incorrect
+  // $FlowExpectedError[incompatible-call]
+  new PluralRules().select() // incorrect
+
+  new PluralRules().select(1) // correct
+
+  new PluralRules().resolvedOptions() // correct
+
+  // $FlowExpectedError[prop-missing]
+  PluralRules.getCanonicalLocales() // incorrect
+
+  // $FlowExpectedError[incompatible-call]
+  PluralRules.supportedLocalesOf(1) // incorrect
+  PluralRules.supportedLocalesOf('en') // correct
+  PluralRules.supportedLocalesOf([ 'en' ]) // correct
+}


### PR DESCRIPTION
This is the third PR in a series to implement the proposal in https://github.com/flow-typed/flow-typed/issues/4588. This PR focuses on the `intl.js` libdef. I also copied over the same test in the Flow repo

- Link to GitHub or NPM: Copied from https://github.com/facebook/flow/tree/main/lib/intl.js
- Type of contribution: new definition
