### PR TITLE
Add support for format Range

### DIFF
--- a/definitions/environments/intl/flow_v0.261.x-/intl.js
+++ b/definitions/environments/intl/flow_v0.261.x-/intl.js
@@ -64,6 +64,8 @@ declare class Intl$DateTimeFormat {
 
   format (value?: Date | number): string;
 
+  formatRange(startDate?: Date | number, endDate?: Date | number): string;
+
   formatToParts (value?: Date | number): Array<{
     type: FormatToPartsType,
     value: string,


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatRange

should be supported by most browsers

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/main/CONTRIBUTING.md for details. --->

- Links to documentation:
- Link to GitHub or NPM:
- Type of contribution: new definition | addition | fix | refactor

Other notes:

