### PR TITLE
Remove types in intl environment that are still available in flow

### DIFF
--- a/definitions/environments/intl/flow_v0.261.x-/intl.js
+++ b/definitions/environments/intl/flow_v0.261.x-/intl.js
@@ -38,16 +38,6 @@ declare class Intl$Collator {
   static supportedLocalesOf (locales?: Intl$Locales): Intl$Locale[];
 }
 
-declare type Intl$CollatorOptions = {
-  localeMatcher?: 'lookup' | 'best fit',
-  usage?: 'sort' | 'search',
-  sensitivity?: 'base' | 'accent' | 'case' | 'variant',
-  ignorePunctuation?: boolean,
-  numeric?: boolean,
-  caseFirst?: 'upper' | 'lower' | 'false',
-  ...
-}
-
 type FormatToPartsType = | 'day' | 'dayPeriod' | 'era' | 'hour' | 'literal'
   | 'minute' | 'month' | 'second' | 'timeZoneName' | 'weekday' | 'year';
 
@@ -91,23 +81,6 @@ declare class Intl$DateTimeFormat {
   };
 
   static supportedLocalesOf (locales?: Intl$Locales): Intl$Locale[];
-}
-
-declare type Intl$DateTimeFormatOptions = {
-  localeMatcher?: 'lookup' | 'best fit',
-  timeZone?: string,
-  hour12?: boolean,
-  formatMatcher?: 'basic' | 'best fit',
-  weekday?: 'narrow' | 'short' | 'long',
-  era?: 'narrow' | 'short' | 'long',
-  year?: 'numeric' | '2-digit',
-  month?: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long',
-  day?: 'numeric' | '2-digit',
-  hour?: 'numeric' | '2-digit',
-  minute?: 'numeric' | '2-digit',
-  second?: 'numeric' | '2-digit',
-  timeZoneName?: 'short' | 'long',
-  ...
 }
 
 declare class Intl$LocaleClass {
@@ -171,20 +144,6 @@ declare class Intl$NumberFormat {
   };
 
   static supportedLocalesOf (locales?: Intl$Locales): Intl$Locale[];
-}
-
-declare type Intl$NumberFormatOptions = {
-  localeMatcher?: 'lookup' | 'best fit',
-  style?: 'decimal' | 'currency' | 'percent' | 'unit',
-  currency?: string,
-  currencyDisplay?: 'symbol' | 'code' | 'name' | 'narrowSymbol',
-  useGrouping?: boolean,
-  minimumIntegerDigits?: number,
-  minimumFractionDigits?: number,
-  maximumFractionDigits?: number,
-  minimumSignificantDigits?: number,
-  maximumSignificantDigits?: number,
-  ...
 }
 
 declare class Intl$PluralRules {


### PR DESCRIPTION
These types are still available in Flow because they are referenced in core libdefs. e.g. https://github.com/facebook/flow/blob/5b688ab78398b1d9840c0c2655df4d84abfd822f/lib/core.js#L1244

This diff removes them to avoid triggering `libdef-override` error in the next release.

- Link to GitHub or NPM: https://github.com/facebook/flow/blob/main/lib/intl.js
- Type of contribution: fix