### PR TITLE
Fix libdef-override errors among environment libdefs

### DIFF
--- a/definitions/environments/bom/flow_v0.261.x-/test_bom_StorageManager.js
+++ b/definitions/environments/bom/flow_v0.261.x-/test_bom_StorageManager.js
@@ -5,8 +5,7 @@ if (navigator.storage) {
   // $FlowExpectedError[incompatible-use]
   const persisted: Promise<boolean> = navigator.storage.persisted(); // correct
 
-  // $FlowExpectedError[incompatible-type]
-  if (navigator.storage.estimate) {
+  if (navigator.storage?.estimate) {
     navigator.storage.estimate().then((estimate: StorageEstimate) => {
       const usage: number = estimate.usage; // correct
       const quota: number = estimate.quota; // correct 

--- a/definitions/environments/cssom/flow_v0.261.x-/cssom.js
+++ b/definitions/environments/cssom/flow_v0.261.x-/cssom.js
@@ -410,12 +410,6 @@ declare class CSSStyleDeclaration {
   setPropertyPriority(property: string, priority: string): void;
 }
 
-declare class TransitionEvent extends Event {
-  elapsedTime: number; // readonly
-  pseudoElement: string; // readonly
-  propertyName: string; // readonly
-}
-
 type AnimationPlayState = 'idle' | 'running' | 'paused' | 'finished'
 type AnimationReplaceState = 'active' | 'removed' | 'persisted'
 type FillMode = 'none' | 'forwards' | 'backwards' | 'both' | 'auto'

--- a/definitions/environments/dom/flow_v0.261.x-/dom.js
+++ b/definitions/environments/dom/flow_v0.261.x-/dom.js
@@ -4460,7 +4460,6 @@ declare var localStorage: Storage;
 declare var devicePixelRatio: number;
 declare function focus(): void;
 declare function onfocus(ev: Event): any;
-declare function onmessage(ev: MessageEvent): any;
 declare function open(url?: string, target?: string, features?: string, replace?: boolean): any;
 declare var parent: WindowProxy;
 declare function print(): void;

--- a/definitions/environments/indexeddb/flow_v0.261.x-/config.json
+++ b/definitions/environments/indexeddb/flow_v0.261.x-/config.json
@@ -1,0 +1,11 @@
+{
+  "deps": {},
+  "envDeps": {
+    "bom": ["v0.261.x-"],
+    "cssom": ["v0.261.x-"],
+    "dom": ["v0.261.x-"],
+    "node": ["v0.261.x-"],
+    "serviceworkers": ["v0.261.x-"],
+    "streams": ["v0.261.x-"]
+  }
+}

--- a/definitions/environments/intl/flow_v0.261.x-/config.json
+++ b/definitions/environments/intl/flow_v0.261.x-/config.json
@@ -1,0 +1,11 @@
+{
+  "deps": {},
+  "envDeps": {
+    "bom": ["v0.261.x-"],
+    "cssom": ["v0.261.x-"],
+    "dom": ["v0.261.x-"],
+    "node": ["v0.261.x-"],
+    "serviceworkers": ["v0.261.x-"],
+    "streams": ["v0.261.x-"]
+  }
+}

--- a/definitions/environments/streams/flow_v0.261.x-/streams.js
+++ b/definitions/environments/streams/flow_v0.261.x-/streams.js
@@ -1,9 +1,5 @@
 type TextEncodeOptions = { options?: boolean, ... };
 
-declare class TextEncoder {
-  encode(buffer: string, options?: TextEncodeOptions): Uint8Array,
-}
-
 declare class ReadableStreamController {
   constructor(
     stream: ReadableStream,

--- a/definitions/environments/webassembly/flow_v0.261.x-/config.json
+++ b/definitions/environments/webassembly/flow_v0.261.x-/config.json
@@ -1,0 +1,11 @@
+{
+  "deps": {},
+  "envDeps": {
+    "bom": ["v0.261.x-"],
+    "cssom": ["v0.261.x-"],
+    "dom": ["v0.261.x-"],
+    "node": ["v0.261.x-"],
+    "serviceworkers": ["v0.261.x-"],
+    "streams": ["v0.261.x-"]
+  }
+}


### PR DESCRIPTION
Starting from Flow 0.265, we start to error on libdef overrides. Due to lack of previous enforcement, we end up with two versions of `TransitionEvent`, `onmessage`, and `TextEncoder` among previously builtin libdefs. This PR removes the overrides  

- Links to documentation:
- Link to GitHub or NPM:
- Type of contribution: fix


