### PR TITLE
Add Popover API to DOM environment definitions

### DIFF
--- a/definitions/environments/dom/flow_v0.261.x-/dom.js
+++ b/definitions/environments/dom/flow_v0.261.x-/dom.js
@@ -214,7 +214,7 @@ type BeforeUnloadEventTypes = 'beforeunload';
 type StorageEventTypes = 'storage';
 type SecurityPolicyViolationEventTypes = 'securitypolicyviolation';
 type USBConnectionEventTypes = 'connect' | 'disconnect';
-
+type ToggleEventTypes = 'beforetoggle' | 'toggle';
 type EventListenerOptionsOrUseCapture = boolean | {
        capture?: boolean,
        once?: boolean,
@@ -950,6 +950,19 @@ declare class SecurityPolicyViolationEvent extends Event {
 // https://developer.mozilla.org/en-US/docs/Web/API/USBConnectionEvent
 declare class USBConnectionEvent extends Event {
   device: USBDevice,
+}
+
+type ToggleEvent$Init = {
+  ...Event$Init,
+  oldState: string,
+  newState: string,
+  ...
+}
+
+declare class ToggleEvent extends Event {
+  constructor(type: ToggleEventTypes, eventInit?: ToggleEvent$Init): void;
+  +oldState: string;
+  +newState: string;
 }
 
 // TODO: *Event
@@ -2064,6 +2077,11 @@ declare class HTMLElement extends Element {
   focus(options?: FocusOptions): void;
   getBoundingClientRect(): DOMRect;
   forceSpellcheck(): void;
+
+  showPopover(options?: {| source?: HTMLElement |}): void;
+  hidePopover(): void;
+  togglePopover(options?: boolean | {| force?: boolean, source?: HTMLElement |}): boolean;
+
   accessKey: string;
   accessKeyLabel: string;
   contentEditable: string;
@@ -2147,6 +2165,7 @@ declare class HTMLElement extends Element {
   onsuspend: ?Function;
   ontimeupdate: ?Function;
   ontoggle: ?Function;
+  onbeforetoggle: ?Function;
   onvolumechange: ?Function;
   onwaiting: ?Function;
   properties: any;
@@ -2155,6 +2174,11 @@ declare class HTMLElement extends Element {
   tabIndex: number;
   title: string;
   translate: boolean;
+  popover: '' | 'auto' | 'manual' | 'hint';
+
+  +popoverVisibilityState: 'hidden' | 'showing';
+
+  +popoverInvoker: HTMLElement | null;
 }
 
 declare class HTMLSlotElement extends HTMLElement {
@@ -3772,6 +3796,8 @@ declare class HTMLInputElement extends HTMLElement {
   vspace: number;
   width: string;
   willValidate: boolean;
+  popoverTargetElement: Element | null;
+  popoverTargetAction: 'toggle' | 'show' | 'hide';
 
   checkValidity(): boolean;
   reportValidity(): boolean;
@@ -3802,6 +3828,8 @@ declare class HTMLButtonElement extends HTMLElement {
   checkValidity(): boolean;
   reportValidity(): boolean;
   setCustomValidity(error: string): void;
+  popoverTargetElement: Element | null;
+  popoverTargetAction: 'toggle' | 'show' | 'hide';
 }
 
 // https://w3c.github.io/html/sec-forms.html#the-textarea-element

--- a/definitions/environments/dom/flow_v0.261.x-/test_dom_popover.js
+++ b/definitions/environments/dom/flow_v0.261.x-/test_dom_popover.js
@@ -1,0 +1,66 @@
+// @flow
+
+let tests = [
+  // popover attribute
+  function(element: HTMLElement) {
+    element.popover = 'auto';
+    element.popover = 'manual';
+    element.popover = 'hint';
+    element.popover = '';
+    
+    // fails
+    // $FlowExpectedError[incompatible-type]
+    element.popover = 'invalid';
+  },
+  
+  // popover methods
+  function(element: HTMLElement) {
+    element.showPopover();
+    element.showPopover({ source: document.createElement('button') });
+    
+    element.hidePopover();
+    
+    let isOpen: boolean = element.togglePopover();
+    isOpen = element.togglePopover(true);
+    isOpen = element.togglePopover({ force: true });
+    isOpen = element.togglePopover({ force: false, source: document.createElement('button') });
+    
+    // fails
+    // $FlowExpectedError[incompatible-call]
+    element.showPopover('invalid');
+    // $FlowExpectedError[incompatible-call]
+    element.togglePopover({ force: 'invalid' });
+  },
+  
+  // popover invoker attributes
+  function(button: HTMLButtonElement) {
+    const element: HTMLElement = document.createElement('div');
+    button.popoverTargetElement = element;
+    button.popoverTargetAction = 'toggle';
+    button.popoverTargetAction = 'show';
+    button.popoverTargetAction = 'hide';
+    
+    // fails
+    // $FlowExpectedError[incompatible-type]
+    button.popoverTargetAction = 'invalid';
+  },
+  
+  // popover state properties
+  function(element: HTMLElement) {
+    (element.popoverVisibilityState: 'hidden' | 'showing');
+    (element.popoverInvoker: HTMLElement | null);
+    
+    // fails
+    // $FlowExpectedError[cannot-write]
+    element.popoverVisibilityState = 'hidden';
+    // $FlowExpectedError[cannot-write]
+    element.popoverInvoker = document.createElement('button');
+  },
+];
+
+document.addEventListener('toggle', (event) => {
+  if (event instanceof ToggleEvent) {
+    const oldState: string = event.oldState;
+    const newState: string = event.newState;
+  }
+});


### PR DESCRIPTION
  - Links to documentation: 
    - https://developer.mozilla.org/en-US/docs/Web/API/Popover_API
  - Link to GitHub or NPM:  
    - https://html.spec.whatwg.org/multipage/popover.html
    - https://html.spec.whatwg.org/multipage/interaction.html#the-toggleevent-interfac
  - Type of contribution: addition

  ## Summary
  This PR adds type definitions for the Popover API to the DOM environment definitions. The Popover API is part of the WHATWG HTML Living Standard and provides a standardized way to build popup UI elements.

  Key additions:
  - Added popover attribute and methods (showPopover, hidePopover, togglePopover) to HTMLElement
  - Added popoverTargetElement and popoverTargetAction to HTMLButtonElement and HTMLInputElement
  - Added ToggleEvent interface for events fired during popover state changes
  - Added comprehensive test file that validates the API types

  ## Testing
  Tests are included in `test_dom_popover.js` and follow the recommended `tests` array pattern. The tests validate all aspects of the Popover API, including valid and invalid usage patterns.

  Other notes:
  - This implementation closely follows the current WHATWG spec
  - All tests pass across all supported Flow versions


