### PR TITLE
Unbreak environment definition install

### DIFF
--- a/cli/src/lib/envDefs.js
+++ b/cli/src/lib/envDefs.js
@@ -103,6 +103,12 @@ async function extractEnvDefs(
             return;
           }
 
+          // Is this the config file?
+          if (flowDirItem === 'config.json') {
+            libDefFilePath = path.join(flowDirPath, flowDirItem);
+            return;
+          }
+
           // Is this the env def file?
           if (flowDirItem === envDefFileName) {
             libDefFilePath = path.join(flowDirPath, flowDirItem);


### PR DESCRIPTION
https://github.com/flow-typed/flow-typed/commit/bb4cb83b7ad16d5c60a60c16760af299a63980f8 introduces support for dependency config files for environments for testing. Unfortunately, it breaks the assumption of the validation that the environment directory only contains definition file and test files. It has caused breakages like https://github.com/flow-typed/flow-typed/issues/4608

This PR allows it during validation.

Fixes: https://github.com/flow-typed/flow-typed/issues/4608

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/main/CONTRIBUTING.md for details. --->

- Links to documentation:
- Link to GitHub or NPM:
- Type of contribution: fix

Other notes:

