### PR TITLE
Replace `$Rest<EffectTiming, {...}>` with `Partial<EffectTiming>` in cssom

### DIFF
--- a/definitions/environments/cssom/flow_v0.261.x-/cssom.js
+++ b/definitions/environments/cssom/flow_v0.261.x-/cssom.js
@@ -443,7 +443,7 @@ type EffectTiming = {
   ...
 }
 
-type OptionalEffectTiming = $Rest<EffectTiming, {...}>
+type OptionalEffectTiming = Partial<EffectTiming>
 
 type ComputedEffectTiming = EffectTiming & {
   endTime: number;
@@ -485,7 +485,7 @@ type PropertyIndexedKeyframes = {
   ...
 }
 
-type KeyframeEffectOptions = $Rest<EffectTiming, {...}> & {
+type KeyframeEffectOptions = Partial<EffectTiming> & {
   iterationComposite?: IterationCompositeOperation;
   composite?: CompositeOperation;
   ...


### PR DESCRIPTION
…

This is just a hack to get `Partial` before Flow supported `Partial`. Now that Flow has `Partial` for a long time, we should just replace it. This enables Flow to eventually remove the legacy `$Rest`

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/main/CONTRIBUTING.md for details. --->

- Links to documentation:
- Link to GitHub or NPM:
- Type of contribution: fix

Other notes:

