### PR TITLE
Do not consider config file to be environment libdef file

### DIFF
--- a/cli/src/lib/envDefs.js
+++ b/cli/src/lib/envDefs.js
@@ -105,7 +105,6 @@ async function extractEnvDefs(
 
           // Is this the config file?
           if (flowDirItem === 'config.json') {
-            libDefFilePath = path.join(flowDirPath, flowDirItem);
             return;
           }
 


### PR DESCRIPTION
<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/main/CONTRIBUTING.md for details. --->

While #4609 tried to fix a breakage, it unfortunately introduces another one, where installing bom.js as environment libdef, it copies the `config.json` instead of `bom.js`. It only breaks for `bom.js` because it's the only one that's alphabetically before `config.json`.

Since the intention of the early return is not to fail the validation error, we don't need to set libDefFilePath in this case.

I have tested locally that with this fix, all the builtin env files can be installed correctly.

- Links to documentation:
- Link to GitHub or NPM:
- Type of contribution: fix

Other notes:

