### PR TITLE
[flow-typed] Fix environment tests

### DIFF
--- a/definitions/environments/bom/flow_v0.261.x-/config.json
+++ b/definitions/environments/bom/flow_v0.261.x-/config.json
@@ -3,6 +3,7 @@
   "envDeps": {
     "cssom": ["v0.261.x-"],
     "dom": ["v0.261.x-"],
+    "html": ["v0.261.x-"],
     "node": ["v0.261.x-"],
     "serviceworkers": ["v0.261.x-"],
     "streams": ["v0.261.x-"]


### PR DESCRIPTION
Summary:
- We are only including environment tests when using the "only changed" option. This makes them always run instead.
- There is another release with no attached assets, which causes the script to silently run no tests: https://api.github.com/repos/facebook/flow/releases/223729443

Test Plan:
- `./build.sh`
- `node cli/dist/cli.js run-tests ^dom_`
  - Observe that `dom` environment tests get run
  - Observe that we make it past flow binary step
- Add an intentional flow error into dom test, re-run above command
  - Observe test correctly fails

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/main/CONTRIBUTING.md for details. --->

- Links to documentation:
- Link to GitHub or NPM:
- Type of contribution: fix

Other notes:

