### PR TITLE
[flow-typed|prettier] Only apply flow parser to JS files

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,7 @@
 ---
 singleQuote: true
-trailingComma: "es5"
-parser: "flow"
+trailingComma: 'es5'
+overrides:
+  - files: '*.js'
+    options:
+      parser: 'flow'


### PR DESCRIPTION
We are applying the flow parser to all files, which prevents it from detecting other languages such as JSON. Limit the flow parser to only "*.js" files (let me know if I should include more patterns).

Test Plan:
- Edit a `config.json` file in `environments/`
- Save, observe prettier format file automatically
- Observe error before

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/main/CONTRIBUTING.md for details. --->

- Links to documentation:
- Link to GitHub or NPM:
- Type of contribution: new definition | addition | fix | refactor

Other notes:

