### PR TITLE
Remove undefined `AbortSignalReason` in `dom.js`

### DIFF
--- a/definitions/environments/dom/flow_v0.261.x-/dom.js
+++ b/definitions/environments/dom/flow_v0.261.x-/dom.js
@@ -838,7 +838,7 @@ declare class Scheduler {
     callback: () => T,
     options?: SchedulerPostTaskOptions,
   ): Promise<T>;
-  yield(): Promise<void | AbortSignalReason>;
+  yield(): Promise<void>;
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone


### PR DESCRIPTION
This is not defined anywhere

<!--- # Please remember to use `describe` and `it`in the tests! see https://github.com/flow-typed/flow-typed/blob/main/CONTRIBUTING.md for details. --->

- Links to documentation:
- Link to GitHub or NPM:
- Type of contribution: fix

Other notes:

