### PR TITLE
fix(lodash): correct chunk type definition for flow_v0.232.x

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.201.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.201.x-/lodash_v4.x.x.js
@@ -1733,8 +1733,8 @@ declare module "lodash/fp" {
   declare type Lodash = {|
     // Array
     chunk:
-      & (<T>(size: number) => ((array: $ReadOnlyArray<T>) => Array<Array<T>>))
-      & (<T>(size: number, array: $ReadOnlyArray<T>) => Array<Array<T>>);
+      & (<T>(array: $ReadOnlyArray<T>, size?: number) => Array<Array<T>>)
+      & (<T>(array: void | null, size?: number) => Array<[]>);
     compact<T, N: ?T>(array?: ?$ReadOnlyArray<N>): Array<T>;
     concat:
       & (<T, U, A: Array<T> | T, B: Array<U> | U>(


### PR DESCRIPTION
### Summary
Updated the `chunk` type definition in `lodash_v4.x.x.js` for Flow v0.232.x to ensure accurate typing and compatibility.

### Changes
- Fixed the `chunk` function overloads to correctly handle generics and return type.
- Verified using:
  ```bash
  ./quick_run_def_tests.sh lodash_v4.x.x/flow_v0.232.x
  ```
  ✅ All tests passed successfully.

### Type of contribution
Fix

### Motivation
Older type definition caused mismatched type errors in newer Flow versions. This update ensures consistency with lodash’s real behavior.

### Notes
Allow edits by maintainers ✅