### PR TITLE
Declare node:crypto and node:readline modules

### DIFF
--- a/definitions/environments/node/flow_v0.261.x-/node.js
+++ b/definitions/environments/node/flow_v0.261.x-/node.js
@@ -3555,6 +3555,10 @@ declare module 'node:process' {
   declare module.exports: $Exports<'process'>;
 }
 
+declare module 'node:readline' {
+  declare module.exports: $Exports<'readline'>;
+}
+
 declare module 'node:util' {
   declare module.exports: $Exports<'util'>;
 }

--- a/definitions/environments/node/flow_v0.261.x-/test_node.js
+++ b/definitions/environments/node/flow_v0.261.x-/test_node.js
@@ -7,6 +7,7 @@ import events from 'events';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import readline from 'readline';
 import util from 'util';
 import url from 'url';
 import {
@@ -25,6 +26,7 @@ import nodeFs from 'node:fs';
 import nodeFsPromises from 'node:fs/promises';
 import nodeOs from 'node:os';
 import nodePath from 'node:path';
+import nodeReadline from 'node:readline';
 import nodeUtil from 'node:util';
 import nodeUrl from 'node:url';
 import {
@@ -112,6 +114,12 @@ describe('node', () => {
   describe('node:path', () => {
     it('should retrieve the corresponding Flow core types', () => {
       (nodePath.resolve: typeof path.resolve);
+    });
+  });
+
+  describe('node:readline', () => {
+    it('should retrieve the corresponding Flow core types', () => {
+      (nodeReadline.createInterface: typeof readline.createInterface);
     });
   });
 


### PR DESCRIPTION
- Links to documentation: https://nodejs.org/api/esm.html#node-imports
- Type of contribution: addition

I only added them to the flow_v0.261.x- definitions. I noticed there's already some stuff missing from the flow_v0.155.x-flow_v0.260.x ones.