### PR TITLE
Add role property to Element

### DIFF
--- a/definitions/environments/dom/flow_v0.261.x-/dom.js
+++ b/definitions/environments/dom/flow_v0.261.x-/dom.js
@@ -1387,6 +1387,7 @@ declare class Element extends Node mixins mixin$Animatable {
   scrollLeft: number;
   scrollTop: number;
   scrollWidth: number;
+  role: string | null;
   +tagName: string;
 
   // TODO: a lot more ARIA properties


### PR DESCRIPTION
role property is missing in Element

- Link to documentation: https://developer.mozilla.org/en-US/docs/Web/API/Element/role
- Type of contribution: addition
