### PR TITLE
Make nativeEvent read-only

### DIFF
--- a/definitions/environments/jsx/flow_v0.261.x-/jsx.js
+++ b/definitions/environments/jsx/flow_v0.261.x-/jsx.js
@@ -24,7 +24,7 @@ declare class SyntheticEvent<+T: EventTarget = EventTarget, +E: Event = Event> {
   isDefaultPrevented(): boolean;
   isPropagationStopped(): boolean;
   isTrusted: boolean;
-  nativeEvent: E;
+  +nativeEvent: E;
   persist(): void;
   preventDefault(): void;
   stopPropagation(): void;


### PR DESCRIPTION
- Type of contribution: fix

Other notes:

This otherwise causes an incompatible-variance Flow error.

Making nativeEvent read-only to match currentTarget (T).
