### PR TITLE
Add jsonwebtoken_v9.x.x libdef

### DIFF
--- a/definitions/npm/jsonwebtoken_v9.x.x/flow_v0.201.x-/jsonwebtoken_v9.x.x.js
+++ b/definitions/npm/jsonwebtoken_v9.x.x/flow_v0.201.x-/jsonwebtoken_v9.x.x.js
@@ -1,0 +1,128 @@
+declare module 'jsonwebtoken' {
+  declare type Algorithm =
+    | 'HS256'
+    | 'HS384'
+    | 'HS512'
+    | 'RS256'
+    | 'RS384'
+    | 'RS512'
+    | 'ES256'
+    | 'ES384'
+    | 'ES512'
+    | 'PS256'
+    | 'PS384'
+    | 'PS512'
+    | 'none';
+
+  declare class JsonWebTokenError extends Error {
+    inner: Error;
+  }
+
+  declare class TokenExpiredError extends JsonWebTokenError {
+    expiredAt: Date;
+  }
+
+  declare class NotBeforeError extends JsonWebTokenError {
+    date: Date;
+  }
+
+  declare type Secret =
+    | string
+    | Buffer
+    | { key: string | Buffer, passphrase: string, ... };
+
+  declare type SignOptions = {
+    algorithm?: Algorithm,
+    keyid?: string,
+    expiresIn?: string | number,
+    notBefore?: string | number,
+    audience?: string | Array<string>,
+    subject?: string,
+    issuer?: string,
+    jwtid?: string,
+    mutatePayload?: boolean,
+    noTimestamp?: boolean,
+    header?: { ... },
+    encoding?: string,
+    allowInsecureKeySizes?: boolean,
+    allowInvalidAsymmetricKeyTypes?: boolean,
+    ...
+  };
+
+  declare type VerifyOptions = {
+    algorithms?: Array<Algorithm>,
+    audience?: string | RegExp | Array<string | RegExp>,
+    clockTimestamp?: number,
+    clockTolerance?: number,
+    complete?: boolean,
+    issuer?: string | Array<string>,
+    ignoreExpiration?: boolean,
+    ignoreNotBefore?: boolean,
+    jwtid?: string,
+    nonce?: string,
+    subject?: string,
+    maxAge?: string | number,
+    allowInvalidAsymmetricKeyTypes?: boolean,
+    ...
+  };
+
+  declare type DecodeOptions = {
+    complete?: boolean,
+    json?: boolean,
+    ...
+  };
+
+  declare type JwtHeader = {
+    alg: string,
+    typ?: string,
+    kid?: string,
+    ...
+  };
+
+  declare type JwtPayload = { [string]: mixed };
+
+  declare type Jwt = {
+    header: JwtHeader,
+    payload: JwtPayload | string,
+    signature: string,
+    ...
+  };
+
+  declare type SignCallback = (
+    error: Error | null,
+    encoded: string | void,
+  ) => void;
+
+  declare type VerifyCallback = (
+    error: JsonWebTokenError | NotBeforeError | TokenExpiredError | null,
+    decoded: mixed,
+  ) => void;
+
+  declare type GetPublicKeyOrSecret = (
+    header: JwtHeader,
+    callback: (err: Error | null, secret?: Secret) => void,
+  ) => void;
+
+  declare module.exports: {
+    sign(
+      payload: string | Buffer | { ... },
+      secretOrPrivateKey: Secret,
+      optionsOrCallback?: SignOptions | SignCallback,
+      callback?: SignCallback,
+    ): string,
+    verify(
+      token: string,
+      secretOrPublicKey: Secret | GetPublicKeyOrSecret,
+      optionsOrCallback?: VerifyOptions | VerifyCallback,
+      callback?: VerifyCallback,
+    ): JwtPayload | string,
+    decode(
+      token: string,
+      options?: DecodeOptions,
+    ): JwtPayload | string | null,
+    JsonWebTokenError: typeof JsonWebTokenError,
+    NotBeforeError: typeof NotBeforeError,
+    TokenExpiredError: typeof TokenExpiredError,
+    ...
+  };
+}

--- a/definitions/npm/jsonwebtoken_v9.x.x/flow_v0.201.x-/jsonwebtoken_v9.x.x.js
+++ b/definitions/npm/jsonwebtoken_v9.x.x/flow_v0.201.x-/jsonwebtoken_v9.x.x.js
@@ -26,10 +26,7 @@ declare module 'jsonwebtoken' {
     date: Date;
   }
 
-  declare type Secret =
-    | string
-    | Buffer
-    | { key: string | Buffer, passphrase: string, ... };
+  declare type Secret = string | { key: string, passphrase: string, ... };
 
   declare type SignOptions = {
     algorithm?: Algorithm,
@@ -105,7 +102,7 @@ declare module 'jsonwebtoken' {
 
   declare module.exports: {
     sign(
-      payload: string | Buffer | { ... },
+      payload: string | { ... },
       secretOrPrivateKey: Secret,
       optionsOrCallback?: SignOptions | SignCallback,
       callback?: SignCallback,

--- a/definitions/npm/jsonwebtoken_v9.x.x/flow_v0.201.x-/test_jsonwebtoken_v9.x.x.js
+++ b/definitions/npm/jsonwebtoken_v9.x.x/flow_v0.201.x-/test_jsonwebtoken_v9.x.x.js
@@ -1,0 +1,72 @@
+// @flow
+import jwt from 'jsonwebtoken';
+import {
+  sign,
+  verify,
+  decode,
+  JsonWebTokenError,
+  TokenExpiredError,
+  NotBeforeError,
+} from 'jsonwebtoken';
+
+const KEY = 'secret';
+
+// --- sign (valid) ---
+const token: string = jwt.sign({ foo: 'bar' }, KEY);
+const s2: string = sign('a-string-payload', KEY);
+const s3: string = sign({ foo: 'bar' }, KEY, {
+  algorithm: 'HS256',
+  expiresIn: '1h',
+});
+const s4: string = sign({ foo: 'bar' }, KEY, {
+  algorithm: 'ES256',
+  expiresIn: 3600,
+  issuer: 'me',
+  audience: ['a', 'b'],
+  keyid: 'kid-1',
+  header: { kid: 'kid-1' },
+});
+sign({ foo: 'bar' }, KEY, (err, encoded) => {
+  const e: Error | null = err;
+  const en: string | void = encoded;
+});
+sign({ foo: 'bar' }, KEY, { algorithm: 'RS256' }, (err, encoded) => {});
+
+// --- verify (valid) ---
+verify(token, KEY);
+verify(token, KEY, { algorithms: ['RS256'], issuer: 'me' });
+verify(
+  token,
+  (header, cb) => {
+    const kid: string | void = header.kid;
+    cb(null, 'pem-string');
+  },
+  { algorithms: ['RS256'] },
+  (err, payload) => {
+    const e: JsonWebTokenError | NotBeforeError | TokenExpiredError | null = err;
+  },
+);
+
+// --- decode (valid) ---
+decode(token);
+decode(token, { complete: true });
+
+// --- error classes (received, not constructed) ---
+const maybeError: mixed = null;
+if (maybeError instanceof TokenExpiredError) {
+  const expiredAt: Date = maybeError.expiredAt;
+}
+if (maybeError instanceof NotBeforeError) {
+  const date: Date = maybeError.date;
+}
+if (maybeError instanceof JsonWebTokenError) {
+  const inner: Error = maybeError.inner;
+}
+
+// --- intended type errors ---
+// $FlowExpectedError - token must be a string
+verify(123, KEY);
+// $FlowExpectedError - invalid algorithm
+sign({ foo: 'bar' }, KEY, { algorithm: 'NOPE' });
+// $FlowExpectedError - secret/key is required
+sign({ foo: 'bar' });

--- a/definitions/npm/jsonwebtoken_v9.x.x/flow_v0.201.x-/test_jsonwebtoken_v9.x.x.js
+++ b/definitions/npm/jsonwebtoken_v9.x.x/flow_v0.201.x-/test_jsonwebtoken_v9.x.x.js
@@ -11,7 +11,6 @@ import {
 
 const KEY = 'secret';
 
-// --- sign (valid) ---
 const token: string = jwt.sign({ foo: 'bar' }, KEY);
 const s2: string = sign('a-string-payload', KEY);
 const s3: string = sign({ foo: 'bar' }, KEY, {
@@ -32,7 +31,6 @@ sign({ foo: 'bar' }, KEY, (err, encoded) => {
 });
 sign({ foo: 'bar' }, KEY, { algorithm: 'RS256' }, (err, encoded) => {});
 
-// --- verify (valid) ---
 verify(token, KEY);
 verify(token, KEY, { algorithms: ['RS256'], issuer: 'me' });
 verify(
@@ -47,11 +45,9 @@ verify(
   },
 );
 
-// --- decode (valid) ---
 decode(token);
 decode(token, { complete: true });
 
-// --- error classes (received, not constructed) ---
 const maybeError: mixed = null;
 if (maybeError instanceof TokenExpiredError) {
   const expiredAt: Date = maybeError.expiredAt;
@@ -63,10 +59,9 @@ if (maybeError instanceof JsonWebTokenError) {
   const inner: Error = maybeError.inner;
 }
 
-// --- intended type errors ---
-// $FlowExpectedError - token must be a string
+// $FlowExpectedError[incompatible-type] - token must be a string
 verify(123, KEY);
-// $FlowExpectedError - invalid algorithm
+// $FlowExpectedError[incompatible-type] - invalid algorithm
 sign({ foo: 'bar' }, KEY, { algorithm: 'NOPE' });
-// $FlowExpectedError - secret/key is required
+// $FlowExpectedError[incompatible-type] - secret/key is required
 sign({ foo: 'bar' });


### PR DESCRIPTION
Adds a Flow libdef for **jsonwebtoken v9** (`jsonwebtoken_v9.x.x`).

### Why
There is currently no v9 definition — the newest is `jsonwebtoken_v8.5.x`, which:
- targets `flow_v0.56.x-v0.103.x` (very old Flow),
- relies on the deprecated `$Shape` utility (errors on modern Flow), and
- contains duplicate `TokenExpiredError` / `NotBeforeError` class declarations.

jsonwebtoken v9 is the current major and is widely used (e.g. it's the JWT engine behind `apple-signin-auth`), so a modern, exact-by-default-safe def is useful.

### What
- `flow_v0.201.x-/jsonwebtoken_v9.x.x.js` — covers `sign`, `verify` (incl. the `getKey` callback form), `decode`, the `SignOptions`/`VerifyOptions`/`DecodeOptions` shapes, `Secret`/`Jwt`/`JwtPayload`/`JwtHeader`, and the `JsonWebTokenError` / `TokenExpiredError` / `NotBeforeError` classes.
- `flow_v0.201.x-/test_jsonwebtoken_v9.x.x.js` — exercises valid usage (sync + callback forms, getKey verification, `instanceof` error narrowing) and asserts the expected type errors via `$FlowExpectedError[incompatible-type]`.

### Notes
- Modern, exact-by-default-safe (inexact object types use `...`); no `$Shape`.
- Keys/payloads are typed as `string` rather than `string | Buffer`, since the per-def test harness loads only Flow's `core`/`react` libs (no `Buffer` global).

### CI note
The failing `Build` checks are **not** from this def. Every reported error is `[ambiguous-object-type]` inside Flow's own bundled `<BUILTINS>/core.js` and `react.js` under Flow **0.315–0.317** — the same errors appear for unrelated defs (e.g. `regression-1385`) and on `main`. This def and its test produce **zero** Flow errors across the tested versions; the suite is red because of the builtins lint on recent Flow, independent of this change.